### PR TITLE
[phpstan] Forbid entity manager getRepository() with entity class constant

### DIFF
--- a/app/bundles/ApiBundle/Config/config.php
+++ b/app/bundles/ApiBundle/Config/config.php
@@ -68,6 +68,7 @@ return [
                 'class'     => Mautic\ApiBundle\EventListener\PreAuthorizationEventListener::class,
                 'arguments' => [
                     'doctrine.orm.entity_manager',
+                    'mautic.user.repository',
                     'mautic.security',
                     'translator',
                 ],

--- a/app/bundles/ApiBundle/EventListener/PreAuthorizationEventListener.php
+++ b/app/bundles/ApiBundle/EventListener/PreAuthorizationEventListener.php
@@ -6,7 +6,7 @@ use Doctrine\ORM\EntityManager;
 use FOS\OAuthServerBundle\Event\OAuthEvent;
 use Mautic\ApiBundle\Entity\oAuth2\Client;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
-use Mautic\UserBundle\Entity\User;
+use Mautic\UserBundle\Entity\UserRepository;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -14,6 +14,7 @@ class PreAuthorizationEventListener
 {
     public function __construct(
         private readonly EntityManager $em,
+        private readonly UserRepository $userRepository,
         private readonly CorePermissions $mauticSecurity,
         private readonly TranslatorInterface $translator,
     ) {
@@ -57,6 +58,6 @@ class PreAuthorizationEventListener
      */
     protected function getUser(OAuthEvent $event)
     {
-        return $this->em->getRepository(User::class)->findOneByUsername($event->getUser()->getUserIdentifier());
+        return $this->userRepository->findOneByUsername($event->getUser()->getUserIdentifier());
     }
 }

--- a/app/bundles/AssetBundle/EventListener/AssetImportExportSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/AssetImportExportSubscriber.php
@@ -6,6 +6,7 @@ namespace Mautic\AssetBundle\EventListener;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Mautic\AssetBundle\Entity\Asset;
+use Mautic\AssetBundle\Entity\AssetRepository;
 use Mautic\AssetBundle\Model\AssetModel;
 use Mautic\CoreBundle\Event\EntityExportEvent;
 use Mautic\CoreBundle\Event\EntityImportAnalyzeEvent;
@@ -24,6 +25,7 @@ final class AssetImportExportSubscriber implements EventSubscriberInterface
     public function __construct(
         private AssetModel $assetModel,
         private EntityManagerInterface $entityManager,
+        private AssetRepository $assetRepository,
         private AuditLogModel $auditLogModel,
         private IpLookupHelper $ipLookupHelper,
         private DenormalizerInterface $serializer,
@@ -96,7 +98,7 @@ final class AssetImportExportSubscriber implements EventSubscriberInterface
         ];
 
         foreach ($event->getEntityData() as $element) {
-            $object = $this->entityManager->getRepository(Asset::class)->findOneBy(['uuid' => $element['uuid']]);
+            $object = $this->assetRepository->findOneBy(['uuid' => $element['uuid']]);
             $isNew  = !$object;
 
             $object ??= new Asset();
@@ -139,7 +141,7 @@ final class AssetImportExportSubscriber implements EventSubscriberInterface
             return;
         }
         foreach ($summary['ids'] as $id) {
-            $entity = $this->entityManager->getRepository(Asset::class)->find($id);
+            $entity = $this->assetRepository->find($id);
 
             if ($entity) {
                 $this->entityManager->remove($entity);

--- a/app/bundles/AssetBundle/EventListener/DetermineWinnerSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/DetermineWinnerSubscriber.php
@@ -2,9 +2,8 @@
 
 namespace Mautic\AssetBundle\EventListener;
 
-use Doctrine\ORM\EntityManagerInterface;
 use Mautic\AssetBundle\AssetEvents;
-use Mautic\AssetBundle\Entity\Download;
+use Mautic\AssetBundle\Entity\DownloadRepository;
 use Mautic\CoreBundle\Event\DetermineWinnerEvent;
 use Mautic\EmailBundle\Entity\Email;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -13,7 +12,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 final readonly class DetermineWinnerSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private EntityManagerInterface $em,
+        private DownloadRepository $downloadRepository,
         private TranslatorInterface $translator,
     ) {
     }
@@ -30,7 +29,6 @@ final readonly class DetermineWinnerSubscriber implements EventSubscriberInterfa
      */
     public function onDetermineDownloadRateWinner(DetermineWinnerEvent $event): void
     {
-        $repo       = $this->em->getRepository(Download::class);
         $parameters = $event->getParameters();
         $parent     = $parameters['parent'];
         $children   = $parameters['children'];
@@ -50,7 +48,7 @@ final readonly class DetermineWinnerSubscriber implements EventSubscriberInterfa
 
         $startDate = $parent->getVariantStartDate();
         if (null != $startDate) {
-            $counts = ('page' === $type) ? $repo->getDownloadCountsByPage($ids, $startDate) : $repo->getDownloadCountsByEmail($ids, $startDate, $parent->getVariantEndDate());
+            $counts = ('page' === $type) ? $this->downloadRepository->getDownloadCountsByPage($ids, $startDate) : $this->downloadRepository->getDownloadCountsByEmail($ids, $startDate, $parent->getVariantEndDate());
 
             if ($counts) {
                 $downloads  = $support  = $data  = [];

--- a/app/bundles/AssetBundle/Tests/EventListener/DetermineWinnerSubscriberTest.php
+++ b/app/bundles/AssetBundle/Tests/EventListener/DetermineWinnerSubscriberTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\AssetBundle\Tests\EventListener;
 
-use Doctrine\ORM\EntityManagerInterface;
 use Mautic\AssetBundle\Entity\DownloadRepository;
 use Mautic\AssetBundle\EventListener\DetermineWinnerSubscriber;
 use Mautic\CoreBundle\Event\DetermineWinnerEvent;
@@ -15,9 +14,9 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 final class DetermineWinnerSubscriberTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var MockObject&EntityManagerInterface
+     * @var MockObject&DownloadRepository
      */
-    private MockObject $em;
+    private MockObject $downloadRepository;
 
     /**
      * @var MockObject&TranslatorInterface
@@ -30,9 +29,9 @@ final class DetermineWinnerSubscriberTest extends \PHPUnit\Framework\TestCase
     {
         parent::setUp();
 
-        $this->em         = $this->createMock(EntityManagerInterface::class);
-        $this->translator = $this->createMock(TranslatorInterface::class);
-        $this->subscriber = new DetermineWinnerSubscriber($this->em, $this->translator);
+        $this->downloadRepository = $this->createMock(DownloadRepository::class);
+        $this->translator         = $this->createMock(TranslatorInterface::class);
+        $this->subscriber         = new DetermineWinnerSubscriber($this->downloadRepository, $this->translator);
     }
 
     public function testOnDetermineDownloadRateWinner(): void
@@ -40,7 +39,6 @@ final class DetermineWinnerSubscriberTest extends \PHPUnit\Framework\TestCase
         $parentMock    = $this->createMock(Page::class);
         $childMock     = $this->createMock(Page::class);
         $children      = [2 => $childMock];
-        $repoMock      = $this->createMock(DownloadRepository::class);
         $parameters    = ['parent' => $parentMock, 'children' => $children];
         $event         = new DetermineWinnerEvent($parameters);
         $startDate     = new \DateTime();
@@ -66,10 +64,6 @@ final class DetermineWinnerSubscriberTest extends \PHPUnit\Framework\TestCase
         $this->translator->method('trans')
             ->willReturnOnConsecutiveCalls($transDownloads, $transHits);
 
-        $this->em->expects($this->once())
-            ->method('getRepository')
-            ->willReturn($repoMock);
-
         $parentMock
             ->method('isPublished')
             ->willReturn(true);
@@ -90,7 +84,7 @@ final class DetermineWinnerSubscriberTest extends \PHPUnit\Framework\TestCase
             ->method('getVariantStartDate')
             ->willReturn($startDate);
 
-        $repoMock->expects($this->once())
+        $this->downloadRepository->expects($this->once())
             ->method('getDownloadCountsByPage')
             ->with([1, 2], $startDate)
             ->willReturn($counts);

--- a/app/bundles/CampaignBundle/EventListener/CampaignEventImportExportSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/CampaignEventImportExportSubscriber.php
@@ -7,6 +7,7 @@ namespace Mautic\CampaignBundle\EventListener;
 use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CampaignBundle\Entity\Campaign;
 use Mautic\CampaignBundle\Entity\Event;
+use Mautic\CampaignBundle\Entity\EventRepository;
 use Mautic\CampaignBundle\Model\CampaignModel;
 use Mautic\CampaignBundle\Model\EventModel;
 use Mautic\CoreBundle\Event\EntityExportEvent;
@@ -29,6 +30,7 @@ final readonly class CampaignEventImportExportSubscriber implements EventSubscri
     public function __construct(
         private CampaignModel $campaignModel,
         private EntityManagerInterface $entityManager,
+        private EventRepository $eventRepository,
         private AuditLogModel $auditLogModel,
         private IpLookupHelper $ipLookupHelper,
         private EventDispatcherInterface $dispatcher,
@@ -238,7 +240,7 @@ final readonly class CampaignEventImportExportSubscriber implements EventSubscri
                 continue;
             }
 
-            $campaignEvent = $this->entityManager->getRepository(Event::class)->findOneBy(['uuid' => $element['uuid'] ?? null]);
+            $campaignEvent = $this->eventRepository->findOneBy(['uuid' => $element['uuid'] ?? null]);
             $isNew         = !$campaignEvent;
 
             $campaignEvent ??= new Event();
@@ -307,7 +309,7 @@ final readonly class CampaignEventImportExportSubscriber implements EventSubscri
                 break;
             }
 
-            $existing = $this->entityManager->getRepository(Event::class)->findOneBy(['uuid' => $element['uuid'] ?? null]);
+            $existing = $this->eventRepository->findOneBy(['uuid' => $element['uuid'] ?? null]);
 
             if ($existing) {
                 $summary[EntityImportEvent::UPDATE]['names'][]   = $existing->getName();
@@ -342,8 +344,8 @@ final readonly class CampaignEventImportExportSubscriber implements EventSubscri
 
                 if ($newParentId) {
                     $campaignEventId = $idMap[(int) $element['id']];
-                    $campaignEvent   = $this->entityManager->getRepository(Event::class)->find($campaignEventId);
-                    $parentEvent     = $this->entityManager->getRepository(Event::class)->find($newParentId);
+                    $campaignEvent   = $this->eventRepository->find($campaignEventId);
+                    $parentEvent     = $this->eventRepository->find($newParentId);
 
                     if ($campaignEvent && $parentEvent) {
                         $campaignEvent->setParent($parentEvent);
@@ -357,7 +359,7 @@ final readonly class CampaignEventImportExportSubscriber implements EventSubscri
 
                 if ($newJumpToEventId) {
                     $campaignEventId = $idMap[(int) $element['id']];
-                    $campaignEvent   = $this->entityManager->getRepository(Event::class)->find($campaignEventId);
+                    $campaignEvent   = $this->eventRepository->find($campaignEventId);
 
                     $element['properties']['jumpToEvent'] = $newJumpToEventId;
                     if ($campaignEvent) {
@@ -383,10 +385,10 @@ final readonly class CampaignEventImportExportSubscriber implements EventSubscri
             return;
         }
         foreach ($summary['ids'] as $id) {
-            $entity = $this->entityManager->getRepository(Event::class)->find($id);
+            $entity = $this->eventRepository->find($id);
 
             if ($entity) {
-                $dependentEvents = $this->entityManager->getRepository(Event::class)->findBy(['parent' => $id]);
+                $dependentEvents = $this->eventRepository->findBy(['parent' => $id]);
 
                 foreach ($dependentEvents as $dependentEvent) {
                     // Set parent_id to null

--- a/app/bundles/CampaignBundle/EventListener/CampaignImportExportSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/CampaignImportExportSubscriber.php
@@ -6,6 +6,7 @@ namespace Mautic\CampaignBundle\EventListener;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CampaignBundle\Entity\Campaign;
+use Mautic\CampaignBundle\Entity\CampaignRepository;
 use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CampaignBundle\Event\CampaignEvent;
 use Mautic\CampaignBundle\Model\CampaignModel;
@@ -37,6 +38,7 @@ final class CampaignImportExportSubscriber implements EventSubscriberInterface
         private CampaignModel $campaignModel,
         private UserModel $userModel,
         private EntityManagerInterface $entityManager,
+        private CampaignRepository $campaignRepository,
         private EventDispatcherInterface $dispatcher,
         private LoggerInterface $logger,
         private AuditLogModel $auditLogModel,
@@ -181,7 +183,7 @@ final class CampaignImportExportSubscriber implements EventSubscriberInterface
         $allowedTags = ['p', 'b', 'strong', 'i', 'em', 'u', 'ul', 'ol', 'li', 'br', 'span', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'];
 
         foreach ($entityData[Campaign::ENTITY_NAME] as $campaignData) {
-            $object = $this->entityManager->getRepository(Campaign::class)->findOneBy(['uuid' => $campaignData['uuid']]);
+            $object = $this->campaignRepository->findOneBy(['uuid' => $campaignData['uuid']]);
             $isNew  = !$object;
 
             $object ??= new Campaign();
@@ -410,7 +412,7 @@ final class CampaignImportExportSubscriber implements EventSubscriberInterface
     private function persistUpdatedCanvasSettings(array &$data, array $campaignIdMap): void
     {
         foreach ($data[Campaign::ENTITY_NAME] as $campaignData) {
-            $campaign = $this->entityManager->getRepository(Campaign::class)->find($campaignIdMap[$campaignData['id']] ?? null);
+            $campaign = $this->campaignRepository->find($campaignIdMap[$campaignData['id']] ?? null);
 
             if ($campaign) {
                 $campaign->setCanvasSettings($campaignData['canvas_settings'] ?? '');
@@ -790,7 +792,7 @@ final class CampaignImportExportSubscriber implements EventSubscriberInterface
             return;
         }
         foreach ($summary['ids'] as $id) {
-            $entity = $this->entityManager->getRepository(Campaign::class)->find($id);
+            $entity = $this->campaignRepository->find($id);
 
             if ($entity) {
                 $this->entityManager->remove($entity);

--- a/app/bundles/CampaignBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/LeadSubscriber.php
@@ -2,11 +2,8 @@
 
 namespace Mautic\CampaignBundle\EventListener;
 
-use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CampaignBundle\Entity\EventRepository;
-use Mautic\CampaignBundle\Entity\Lead as CampaignLead;
-use Mautic\CampaignBundle\Entity\LeadEventLog;
 use Mautic\CampaignBundle\Entity\LeadEventLogRepository;
 use Mautic\CampaignBundle\Entity\LeadRepository;
 use Mautic\CampaignBundle\EventCollector\EventCollector;
@@ -23,9 +20,10 @@ final readonly class LeadSubscriber implements EventSubscriberInterface
     public function __construct(
         private EventCollector $eventCollector,
         private TranslatorInterface $translator,
-        private EntityManagerInterface $entityManager,
         private RouterInterface $router,
         private EventRepository $eventRepository,
+        private LeadEventLogRepository $leadEventLogRepository,
+        private LeadRepository $campaignLeadRepository,
     ) {
     }
 
@@ -51,14 +49,8 @@ final readonly class LeadSubscriber implements EventSubscriberInterface
      */
     public function onLeadMerge(LeadMergeEvent $event): void
     {
-        /** @var LeadEventLogRepository $leadEventLogRepository */
-        $leadEventLogRepository = $this->entityManager->getRepository(LeadEventLog::class);
-
-        /** @var LeadRepository $campaignLeadRepository */
-        $campaignLeadRepository = $this->entityManager->getRepository(CampaignLead::class);
-
-        $leadEventLogRepository->updateLead($event->getLoser()->getId(), $event->getVictor()->getId());
-        $campaignLeadRepository->updateLead($event->getLoser()->getId(), $event->getVictor()->getId());
+        $this->leadEventLogRepository->updateLead($event->getLoser()->getId(), $event->getVictor()->getId());
+        $this->campaignLeadRepository->updateLead($event->getLoser()->getId(), $event->getVictor()->getId());
     }
 
     private function addTimelineEvents(LeadTimelineEvent $event, string $eventTypeKey, string $eventTypeName): void
@@ -71,12 +63,9 @@ final readonly class LeadSubscriber implements EventSubscriberInterface
             return;
         }
 
-        /** @var LeadEventLogRepository $leadEventLogRepository */
-        $leadEventLogRepository = $this->entityManager->getRepository(LeadEventLog::class);
-
         $options                   = $event->getQueryOptions();
         $options['scheduledState'] = 'campaign.event' !== $eventTypeKey;
-        $logs                      = $leadEventLogRepository->getLeadLogs($event->getLeadId(), $options);
+        $logs                      = $this->leadEventLogRepository->getLeadLogs($event->getLeadId(), $options);
         $eventSettings             = $this->eventCollector->getEventsArray();
 
         // Add total number to counter

--- a/app/bundles/CoreBundle/EventListener/StatsSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/StatsSubscriber.php
@@ -3,18 +3,22 @@
 namespace Mautic\CoreBundle\EventListener;
 
 use Doctrine\ORM\EntityManager;
-use Mautic\CoreBundle\Entity\AuditLog;
-use Mautic\CoreBundle\Entity\IpAddress;
+use Mautic\CoreBundle\Entity\AuditLogRepository;
+use Mautic\CoreBundle\Entity\IpAddressRepository;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 
 final class StatsSubscriber extends CommonStatsSubscriber
 {
-    public function __construct(CorePermissions $security, EntityManager $entityManager)
-    {
+    public function __construct(
+        CorePermissions $security,
+        EntityManager $entityManager,
+        AuditLogRepository $auditLogRepository,
+        IpAddressRepository $ipAddressRepository,
+    ) {
         parent::__construct($security, $entityManager);
-        $this->repositories['MauticCoreBundle:AuditLog'] = $entityManager->getRepository(AuditLog::class);
+        $this->repositories['MauticCoreBundle:AuditLog'] = $auditLogRepository;
         $this->permissions['MauticCoreBundle:AuditLog']  = ['admin'];
 
-        $this->repositories['MauticCoreBundle:IpAddress'] = $entityManager->getRepository(IpAddress::class);
+        $this->repositories['MauticCoreBundle:IpAddress'] = $ipAddressRepository;
     }
 }

--- a/app/bundles/DynamicContentBundle/EventListener/DynamicContentImportExportSubscriber.php
+++ b/app/bundles/DynamicContentBundle/EventListener/DynamicContentImportExportSubscriber.php
@@ -13,6 +13,7 @@ use Mautic\CoreBundle\EventListener\ImportExportTrait;
 use Mautic\CoreBundle\Helper\IpLookupHelper;
 use Mautic\CoreBundle\Model\AuditLogModel;
 use Mautic\DynamicContentBundle\Entity\DynamicContent;
+use Mautic\DynamicContentBundle\Entity\DynamicContentRepository;
 use Mautic\DynamicContentBundle\Model\DynamicContentModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
@@ -24,6 +25,7 @@ final class DynamicContentImportExportSubscriber implements EventSubscriberInter
     public function __construct(
         private DynamicContentModel $dynamicContentModel,
         private EntityManagerInterface $entityManager,
+        private DynamicContentRepository $dynamicContentRepository,
         private AuditLogModel $auditLogModel,
         private IpLookupHelper $ipLookupHelper,
         private DenormalizerInterface $serializer,
@@ -87,7 +89,7 @@ final class DynamicContentImportExportSubscriber implements EventSubscriberInter
         ];
 
         foreach ($event->getEntityData() as $element) {
-            $object = $this->entityManager->getRepository(DynamicContent::class)->findOneBy(['uuid' => $element['uuid']]);
+            $object = $this->dynamicContentRepository->findOneBy(['uuid' => $element['uuid']]);
             $isNew  = !$object;
 
             $object ??= new DynamicContent();
@@ -129,7 +131,7 @@ final class DynamicContentImportExportSubscriber implements EventSubscriberInter
             return;
         }
         foreach ($summary['ids'] as $id) {
-            $entity = $this->entityManager->getRepository(DynamicContent::class)->find($id);
+            $entity = $this->dynamicContentRepository->find($id);
 
             if ($entity) {
                 $this->entityManager->remove($entity);

--- a/app/bundles/EmailBundle/EventListener/DetermineWinnerSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/DetermineWinnerSubscriber.php
@@ -2,19 +2,19 @@
 
 namespace Mautic\EmailBundle\EventListener;
 
-use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Event\DetermineWinnerEvent;
 use Mautic\EmailBundle\EmailEvents;
 use Mautic\EmailBundle\Entity\Email;
-use Mautic\EmailBundle\Entity\Stat;
-use Mautic\PageBundle\Entity\Hit;
+use Mautic\EmailBundle\Entity\StatRepository;
+use Mautic\PageBundle\Entity\HitRepository;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 final readonly class DetermineWinnerSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private EntityManagerInterface $em,
+        private StatRepository $statRepository,
+        private HitRepository $hitRepository,
         private TranslatorInterface $translator,
     ) {
     }
@@ -36,15 +36,13 @@ final readonly class DetermineWinnerSubscriber implements EventSubscriberInterfa
         $parent     = $parameters['parent'];
         $children   = $parameters['children'];
 
-        /** @var \Mautic\EmailBundle\Entity\StatRepository $repo */
-        $repo = $this->em->getRepository(Stat::class);
         /** @var Email $parent */
         $ids       = $parent->getRelatedEntityIds();
         $startDate = $parent->getVariantStartDate();
 
         if (null != $startDate && !empty($ids)) {
             // get their bounce rates
-            $counts = $repo->getOpenedRates($ids, $startDate, $parent->getVariantEndDate());
+            $counts = $this->statRepository->getOpenedRates($ids, $startDate, $parent->getVariantEndDate());
 
             if ($counts) {
                 $rates      = $support      = $data      = [];
@@ -128,18 +126,14 @@ final readonly class DetermineWinnerSubscriber implements EventSubscriberInterfa
         $parent     = $parameters['parent'];
         $children   = $parameters['children'];
 
-        /** @var \Mautic\PageBundle\Entity\HitRepository $pageRepo */
-        $pageRepo = $this->em->getRepository(Hit::class);
-        /** @var \Mautic\EmailBundle\Entity\StatRepository $emailRepo */
-        $emailRepo = $this->em->getRepository(Stat::class);
         /** @var Email $parent */
         $ids = $parent->getRelatedEntityIds();
 
         $startDate = $parent->getVariantStartDate();
         if (null != $startDate && !empty($ids)) {
             // get their bounce rates
-            $clickthroughCounts = $pageRepo->getEmailClickthroughHitCount($ids, $startDate, 200, $parent->getVariantEndDate());
-            $sentCounts         = $emailRepo->getSentCounts($ids, $startDate, $parent->getVariantEndDate());
+            $clickthroughCounts = $this->hitRepository->getEmailClickthroughHitCount($ids, $startDate, 200, $parent->getVariantEndDate());
+            $sentCounts         = $this->statRepository->getSentCounts($ids, $startDate, $parent->getVariantEndDate());
 
             if ($clickthroughCounts) {
                 $rates      = $support      = $data      = [];

--- a/app/bundles/EmailBundle/EventListener/EmailImportExportSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/EmailImportExportSubscriber.php
@@ -14,9 +14,12 @@ use Mautic\CoreBundle\EventListener\ImportExportTrait;
 use Mautic\CoreBundle\Helper\IpLookupHelper;
 use Mautic\CoreBundle\Model\AuditLogModel;
 use Mautic\EmailBundle\Entity\Email;
+use Mautic\EmailBundle\Entity\EmailRepository;
 use Mautic\EmailBundle\Model\EmailModel;
 use Mautic\FormBundle\Entity\Form;
+use Mautic\FormBundle\Entity\FormRepository;
 use Mautic\PageBundle\Entity\Page;
+use Mautic\PageBundle\Entity\PageRepository;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
@@ -28,6 +31,9 @@ final class EmailImportExportSubscriber implements EventSubscriberInterface
     public function __construct(
         private EmailModel $emailModel,
         private EntityManagerInterface $entityManager,
+        private EmailRepository $emailRepository,
+        private FormRepository $formRepository,
+        private PageRepository $pageRepository,
         private EventDispatcherInterface $dispatcher,
         private AuditLogModel $auditLogModel,
         private IpLookupHelper $ipLookupHelper,
@@ -136,16 +142,16 @@ final class EmailImportExportSubscriber implements EventSubscriberInterface
         ];
 
         foreach ($event->getEntityData() as $element) {
-            $email = $this->entityManager->getRepository(Email::class)->findOneBy(['uuid' => $element['uuid']]);
+            $email = $this->emailRepository->findOneBy(['uuid' => $element['uuid']]);
             $isNew = !$email;
 
             $email ??= new Email();
             $unsubscribeForm = !empty($element['unsubscribeform_id'])
-                ? $this->entityManager->getRepository(Form::class)->find($element['unsubscribeform_id'])
+                ? $this->formRepository->find($element['unsubscribeform_id'])
                 : null;
 
             $preferenceCenter = !empty($element['preference_center_id'])
-                ? $this->entityManager->getRepository(Page::class)->find($element['preference_center_id'])
+                ? $this->pageRepository->find($element['preference_center_id'])
                 : null;
 
             $email->setUnsubscribeForm($unsubscribeForm);
@@ -188,7 +194,7 @@ final class EmailImportExportSubscriber implements EventSubscriberInterface
             return;
         }
         foreach ($summary['ids'] as $id) {
-            $entity = $this->entityManager->getRepository(Email::class)->find($id);
+            $entity = $this->emailRepository->find($id);
 
             if ($entity) {
                 $this->entityManager->remove($entity);

--- a/app/bundles/EmailBundle/EventListener/StatsSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/StatsSubscriber.php
@@ -6,28 +6,26 @@ use Doctrine\ORM\EntityManager;
 use Mautic\CoreBundle\EventListener\CommonStatsSubscriber;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\EmailBundle\Entity\EmailReply;
-use Mautic\EmailBundle\Entity\Stat;
-use Mautic\EmailBundle\Entity\StatDevice;
 use Mautic\EmailBundle\Entity\StatDeviceRepository;
-use MauticPlugin\MauticFocusBundle\Entity\StatRepository;
+use Mautic\EmailBundle\Entity\StatRepository;
 
 final class StatsSubscriber extends CommonStatsSubscriber
 {
-    public function __construct(CorePermissions $security, EntityManager $entityManager)
-    {
+    public function __construct(
+        CorePermissions $security,
+        EntityManager $entityManager,
+        StatDeviceRepository $statDeviceRepository,
+        StatRepository $statRepository,
+    ) {
         parent::__construct($security, $entityManager);
 
-        /** @var StatDeviceRepository $repo */
-        $repo                                     = $entityManager->getRepository(StatDevice::class);
-        $this->repositories[]                     = $repo;
-        $this->permissions[$repo->getTableName()] = ['stat.lead' => 'lead:leads'];
+        $this->repositories[]                                     = $statDeviceRepository;
+        $this->permissions[$statDeviceRepository->getTableName()] = ['stat.lead' => 'lead:leads'];
 
         $this->addContactRestrictedRepositories([EmailReply::class]);
 
-        /** @var StatRepository $repo */
-        $repo                           = $entityManager->getRepository(Stat::class);
-        $this->repositories[]           = $repo;
-        $statsTable                     = $repo->getTableName();
+        $this->repositories[]           = $statRepository;
+        $statsTable                     = $statRepository->getTableName();
         $this->permissions[$statsTable] = ['lead' => 'lead:leads'];
         $this->selects[$statsTable]     = [
             'id',

--- a/app/bundles/EmailBundle/Tests/EventListener/DetermineWinnerSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/DetermineWinnerSubscriberTest.php
@@ -4,13 +4,10 @@ declare(strict_types=1);
 
 namespace Mautic\EmailBundle\Tests\EventListener;
 
-use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Event\DetermineWinnerEvent;
 use Mautic\EmailBundle\Entity\Email;
-use Mautic\EmailBundle\Entity\Stat;
 use Mautic\EmailBundle\Entity\StatRepository;
 use Mautic\EmailBundle\EventListener\DetermineWinnerSubscriber;
-use Mautic\PageBundle\Entity\Hit;
 use Mautic\PageBundle\Entity\HitRepository;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -18,9 +15,14 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 final class DetermineWinnerSubscriberTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var MockObject&EntityManagerInterface
+     * @var MockObject&StatRepository
      */
-    private MockObject $em;
+    private MockObject $statRepository;
+
+    /**
+     * @var MockObject&HitRepository
+     */
+    private MockObject $hitRepository;
 
     /**
      * @var MockObject&TranslatorInterface
@@ -33,16 +35,16 @@ final class DetermineWinnerSubscriberTest extends \PHPUnit\Framework\TestCase
     {
         parent::setUp();
 
-        $this->em         = $this->createMock(EntityManagerInterface::class);
-        $this->translator = $this->createMock(TranslatorInterface::class);
-        $this->subscriber = new DetermineWinnerSubscriber($this->em, $this->translator);
+        $this->statRepository = $this->createMock(StatRepository::class);
+        $this->hitRepository  = $this->createMock(HitRepository::class);
+        $this->translator     = $this->createMock(TranslatorInterface::class);
+        $this->subscriber     = new DetermineWinnerSubscriber($this->statRepository, $this->hitRepository, $this->translator);
     }
 
     public function testOnDetermineOpenRateWinner(): void
     {
         $parentMock = $this->createMock(Email::class);
         $children   = [2 => $this->createStub(Email::class)];
-        $repoMock   = $this->createMock(StatRepository::class);
         $ids        = [1, 2];
         $parameters = ['parent' => $parentMock, 'children' => $children];
         $event      = new DetermineWinnerEvent($parameters);
@@ -66,10 +68,6 @@ final class DetermineWinnerSubscriberTest extends \PHPUnit\Framework\TestCase
             ['mautic.email.abtest.label.sent', [], null, null, 'sent'],
         ]);
 
-        $this->em->expects($this->once())
-            ->method('getRepository')
-            ->willReturn($repoMock);
-
         $parentMock->expects($this->once())
             ->method('getRelatedEntityIds')
             ->willReturn($ids);
@@ -82,7 +80,7 @@ final class DetermineWinnerSubscriberTest extends \PHPUnit\Framework\TestCase
             ->method('getVariantStartDate')
             ->willReturn($startDate);
 
-        $repoMock->expects($this->once())
+        $this->statRepository->expects($this->once())
             ->method('getOpenedRates')
             ->with($ids, $startDate)
             ->willReturn($openedRates);
@@ -104,8 +102,6 @@ final class DetermineWinnerSubscriberTest extends \PHPUnit\Framework\TestCase
     {
         $parentMock    = $this->createMock(Email::class);
         $children      = [2 => $this->createStub(Email::class)];
-        $pageRepoMock  = $this->createMock(HitRepository::class);
-        $emailRepoMock = $this->createMock(StatRepository::class);
         $ids           = [1, 2];
         $parameters    = ['parent' => $parentMock, 'children' => $children];
         $event         = new DetermineWinnerEvent($parameters);
@@ -128,21 +124,6 @@ final class DetermineWinnerSubscriberTest extends \PHPUnit\Framework\TestCase
             ]
         );
 
-        $matcher = $this->exactly(2);
-
-        $this->em->expects($matcher)->method('getRepository')->willReturnCallback(function (...$parameters) use ($matcher, $pageRepoMock, $emailRepoMock) {
-            if (1 === $matcher->numberOfInvocations()) {
-                $this->assertSame(Hit::class, $parameters[0]);
-
-                return $pageRepoMock;
-            }
-            if (2 === $matcher->numberOfInvocations()) {
-                $this->assertSame(Stat::class, $parameters[0]);
-
-                return $emailRepoMock;
-            }
-        });
-
         $parentMock->expects($this->once())
             ->method('getRelatedEntityIds')
             ->willReturn($ids);
@@ -155,12 +136,12 @@ final class DetermineWinnerSubscriberTest extends \PHPUnit\Framework\TestCase
             ->method('getVariantStartDate')
             ->willReturn($startDate);
 
-        $pageRepoMock->expects($this->once())
+        $this->hitRepository->expects($this->once())
             ->method('getEmailClickthroughHitCount')
             ->with($ids, $startDate)
             ->willReturn($clickthroughCounts);
 
-        $emailRepoMock->expects($this->once())
+        $this->statRepository->expects($this->once())
             ->method('getSentCounts')
             ->with($ids, $startDate)
             ->willReturn($sentCounts);

--- a/app/bundles/FormBundle/EventListener/ActionImportExportSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/ActionImportExportSubscriber.php
@@ -15,7 +15,9 @@ use Mautic\CoreBundle\Helper\IpLookupHelper;
 use Mautic\CoreBundle\Helper\UuidHelper;
 use Mautic\CoreBundle\Model\AuditLogModel;
 use Mautic\FormBundle\Entity\Action;
+use Mautic\FormBundle\Entity\ActionRepository;
 use Mautic\FormBundle\Entity\Form;
+use Mautic\FormBundle\Entity\FormRepository;
 use Mautic\FormBundle\Model\ActionModel;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -27,6 +29,8 @@ final class ActionImportExportSubscriber implements EventSubscriberInterface
 
     public function __construct(
         private EntityManagerInterface $entityManager,
+        private ActionRepository $actionRepository,
+        private FormRepository $formRepository,
         private ActionModel $actionModel,
         private AuditLogModel $auditLogModel,
         private IpLookupHelper $ipLookupHelper,
@@ -105,12 +109,12 @@ final class ActionImportExportSubscriber implements EventSubscriberInterface
         ];
 
         foreach ($event->getEntityData() as $actionData) {
-            $action = $this->entityManager->getRepository(Action::class)->findOneBy(['uuid' => $actionData['uuid']]);
+            $action = $this->actionRepository->findOneBy(['uuid' => $actionData['uuid']]);
             $isNew  = !$action;
             $action ??= new Action();
 
             if (!empty($actionData['form'])) {
-                $form = $this->entityManager->getRepository(Form::class)->find($actionData['form']);
+                $form = $this->formRepository->find($actionData['form']);
                 if ($form instanceof Form) {
                     $action->setForm($form);
                     unset($actionData['form']);
@@ -160,7 +164,7 @@ final class ActionImportExportSubscriber implements EventSubscriberInterface
         }
 
         foreach ($summary['ids'] as $id) {
-            $action = $this->entityManager->getRepository(Action::class)->find($id);
+            $action = $this->actionRepository->find($id);
             if ($action) {
                 $this->entityManager->remove($action);
                 $this->logAction('undo_import', $id, ['deletedEntity' => Action::class], 'formAction');
@@ -188,7 +192,7 @@ final class ActionImportExportSubscriber implements EventSubscriberInterface
                 break;
             }
 
-            $existing = $this->entityManager->getRepository(Action::class)->findOneBy(['uuid' => $item['uuid']]);
+            $existing = $this->actionRepository->findOneBy(['uuid' => $item['uuid']]);
             if ($existing) {
                 $summary[EntityImportEvent::UPDATE]['names'][] = $existing->getName();
                 $summary[EntityImportEvent::UPDATE]['uuids'][] = $existing->getUuid();

--- a/app/bundles/FormBundle/EventListener/FieldImportExportSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/FieldImportExportSubscriber.php
@@ -14,7 +14,9 @@ use Mautic\CoreBundle\Helper\IpLookupHelper;
 use Mautic\CoreBundle\Helper\UuidHelper;
 use Mautic\CoreBundle\Model\AuditLogModel;
 use Mautic\FormBundle\Entity\Field;
+use Mautic\FormBundle\Entity\FieldRepository;
 use Mautic\FormBundle\Entity\Form;
+use Mautic\FormBundle\Entity\FormRepository;
 use Mautic\FormBundle\Model\FieldModel;
 use Mautic\LeadBundle\Entity\LeadField;
 use Mautic\LeadBundle\Model\FieldModel as LeadFieldModel;
@@ -28,6 +30,8 @@ final class FieldImportExportSubscriber implements EventSubscriberInterface
 
     public function __construct(
         private EntityManagerInterface $entityManager,
+        private FieldRepository $fieldRepository,
+        private FormRepository $formRepository,
         private AuditLogModel $auditLogModel,
         private IpLookupHelper $ipLookupHelper,
         private FieldModel $fieldModel,
@@ -127,7 +131,7 @@ final class FieldImportExportSubscriber implements EventSubscriberInterface
         ];
 
         foreach ($event->getEntityData() as $fieldData) {
-            $field = $this->entityManager->getRepository(Field::class)->findOneBy(['uuid' => $fieldData['uuid']]);
+            $field = $this->fieldRepository->findOneBy(['uuid' => $fieldData['uuid']]);
             $isNew = !$field;
             $field ??= new Field();
 
@@ -140,7 +144,7 @@ final class FieldImportExportSubscriber implements EventSubscriberInterface
 
             // Form mapping
             if (!empty($fieldData['form'])) {
-                $form = $this->entityManager->getRepository(Form::class)->find($fieldData['form']);
+                $form = $this->formRepository->find($fieldData['form']);
                 if ($form instanceof Form) {
                     $field->setForm($form);
                     unset($fieldData['form']);
@@ -185,7 +189,7 @@ final class FieldImportExportSubscriber implements EventSubscriberInterface
         }
 
         foreach ($summary['ids'] as $id) {
-            $field = $this->entityManager->getRepository(Field::class)->find($id);
+            $field = $this->fieldRepository->find($id);
 
             if ($field) {
                 $this->entityManager->remove($field);
@@ -214,7 +218,7 @@ final class FieldImportExportSubscriber implements EventSubscriberInterface
                 break;
             }
 
-            $existing = $this->entityManager->getRepository(Field::class)->findOneBy(['uuid' => $item['uuid']]);
+            $existing = $this->fieldRepository->findOneBy(['uuid' => $item['uuid']]);
             if ($existing) {
                 $summary[EntityImportEvent::UPDATE]['names'][] = $existing->getLabel() ?? $existing->getAlias();
                 $summary[EntityImportEvent::UPDATE]['uuids'][] = $existing->getUuid();

--- a/app/bundles/FormBundle/EventListener/FormImportExportSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/FormImportExportSubscriber.php
@@ -15,6 +15,7 @@ use Mautic\CoreBundle\Model\AuditLogModel;
 use Mautic\FormBundle\Entity\Action;
 use Mautic\FormBundle\Entity\Field;
 use Mautic\FormBundle\Entity\Form;
+use Mautic\FormBundle\Entity\FormRepository;
 use Mautic\FormBundle\Model\FormModel;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -26,6 +27,7 @@ final class FormImportExportSubscriber implements EventSubscriberInterface
 
     public function __construct(
         private EntityManagerInterface $entityManager,
+        private FormRepository $formRepository,
         private FormModel $formModel,
         private AuditLogModel $auditLogModel,
         private IpLookupHelper $ipLookupHelper,
@@ -119,7 +121,7 @@ final class FormImportExportSubscriber implements EventSubscriberInterface
         ];
 
         foreach ($event->getEntityData() as $formData) {
-            $form  = $this->entityManager->getRepository(Form::class)->findOneBy(['uuid' => $formData['uuid']]);
+            $form  = $this->formRepository->findOneBy(['uuid' => $formData['uuid']]);
             $isNew = !$form;
 
             $form ??= new Form();
@@ -159,7 +161,7 @@ final class FormImportExportSubscriber implements EventSubscriberInterface
             return;
         }
         foreach ($summary['ids'] as $id) {
-            $entity = $this->entityManager->getRepository(Form::class)->find($id);
+            $entity = $this->formRepository->find($id);
 
             if ($entity) {
                 $this->entityManager->remove($entity);

--- a/app/bundles/LeadBundle/EventListener/CustomFieldImportExportSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/CustomFieldImportExportSubscriber.php
@@ -13,6 +13,7 @@ use Mautic\CoreBundle\EventListener\ImportExportTrait;
 use Mautic\CoreBundle\Helper\IpLookupHelper;
 use Mautic\CoreBundle\Model\AuditLogModel;
 use Mautic\LeadBundle\Entity\LeadField;
+use Mautic\LeadBundle\Entity\LeadFieldRepository;
 use Mautic\LeadBundle\Model\FieldModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
@@ -24,6 +25,7 @@ final class CustomFieldImportExportSubscriber implements EventSubscriberInterfac
     public function __construct(
         private FieldModel $fieldModel,
         private EntityManagerInterface $entityManager,
+        private LeadFieldRepository $leadFieldRepository,
         private AuditLogModel $auditLogModel,
         private IpLookupHelper $ipLookupHelper,
         private DenormalizerInterface $serializer,
@@ -93,7 +95,7 @@ final class CustomFieldImportExportSubscriber implements EventSubscriberInterfac
         ];
 
         foreach ($event->getEntityData() as $element) {
-            $field = $this->entityManager->getRepository(LeadField::class)->findOneBy(['uuid' => $element['uuid']]);
+            $field = $this->leadFieldRepository->findOneBy(['uuid' => $element['uuid']]);
             $isNew = !$field;
 
             $field ??= new LeadField();
@@ -143,7 +145,7 @@ final class CustomFieldImportExportSubscriber implements EventSubscriberInterfac
             return;
         }
         foreach ($summary['ids'] as $id) {
-            $entity = $this->entityManager->getRepository(LeadField::class)->find($id);
+            $entity = $this->leadFieldRepository->find($id);
 
             if ($entity) {
                 $this->entityManager->remove($entity);

--- a/app/bundles/LeadBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/LeadSubscriber.php
@@ -3,23 +3,21 @@
 namespace Mautic\LeadBundle\EventListener;
 
 use Doctrine\DBAL\Exception;
-use Doctrine\ORM\EntityManager;
 use Mautic\CoreBundle\EventListener\ChannelTrait;
 use Mautic\CoreBundle\Factory\ModelFactory;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\IpLookupHelper;
 use Mautic\CoreBundle\Model\AuditLogModel;
 use Mautic\LeadBundle\Entity\CompanyLeadRepository;
-use Mautic\LeadBundle\Entity\DoNotContact;
+use Mautic\LeadBundle\Entity\DoNotContactRepository;
 use Mautic\LeadBundle\Entity\Lead;
-use Mautic\LeadBundle\Entity\LeadDevice;
-use Mautic\LeadBundle\Entity\LeadEventLog;
+use Mautic\LeadBundle\Entity\LeadDeviceRepository;
 use Mautic\LeadBundle\Entity\LeadEventLogRepository;
 use Mautic\LeadBundle\Entity\LeadListRepository;
-use Mautic\LeadBundle\Entity\LeadNote;
-use Mautic\LeadBundle\Entity\ListLead;
-use Mautic\LeadBundle\Entity\PointsChangeLog;
-use Mautic\LeadBundle\Entity\UtmTag;
+use Mautic\LeadBundle\Entity\LeadNoteRepository;
+use Mautic\LeadBundle\Entity\ListLeadRepository;
+use Mautic\LeadBundle\Entity\PointsChangeLogRepository;
+use Mautic\LeadBundle\Entity\UtmTagRepository;
 use Mautic\LeadBundle\Event as Events;
 use Mautic\LeadBundle\Event\LeadChangeCompanyEvent;
 use Mautic\LeadBundle\Event\LeadEvent;
@@ -52,13 +50,19 @@ final class LeadSubscriber implements EventSubscriberInterface
         private AuditLogModel $auditLogModel,
         private LeadChangeEventDispatcher $leadEventDispatcher,
         private DncReasonHelper $dncReasonHelper,
-        private EntityManager $entityManager,
         private TranslatorInterface $translator,
         private RouterInterface $router,
         private LeadListRepository $leadListRepository,
         private SegmentCountCacheHelper $segmentCountCacheHelper,
         private CoreParametersHelper $coreParametersHelper,
         private CompanyLeadRepository $companyLeadRepository,
+        private LeadEventLogRepository $leadEventLogRepository,
+        private PointsChangeLogRepository $pointsChangeLogRepository,
+        private ListLeadRepository $listLeadRepository,
+        private LeadNoteRepository $leadNoteRepository,
+        private LeadDeviceRepository $leadDeviceRepository,
+        private UtmTagRepository $utmTagRepository,
+        private DoNotContactRepository $doNotContactRepository,
         ModelFactory $modelFactory,
         private $isTest = false,
     ) {
@@ -266,7 +270,7 @@ final class LeadSubscriber implements EventSubscriberInterface
 
     public function preLeadMerge(Events\LeadMergeEvent $event): void
     {
-        $this->entityManager->getRepository(LeadEventLog::class)->updateLead(
+        $this->leadEventLogRepository->updateLead(
             $event->getLoser()->getId(),
             $event->getVictor()->getId()
         );
@@ -274,22 +278,22 @@ final class LeadSubscriber implements EventSubscriberInterface
 
     public function onLeadMerge(Events\LeadMergeEvent $event): void
     {
-        $this->entityManager->getRepository(PointsChangeLog::class)->updateLead(
+        $this->pointsChangeLogRepository->updateLead(
             $event->getLoser()->getId(),
             $event->getVictor()->getId()
         );
 
-        $this->entityManager->getRepository(ListLead::class)->updateLead(
+        $this->listLeadRepository->updateLead(
             $event->getLoser()->getId(),
             $event->getVictor()->getId()
         );
 
-        $this->entityManager->getRepository(LeadNote::class)->updateLead(
+        $this->leadNoteRepository->updateLead(
             $event->getLoser()->getId(),
             $event->getVictor()->getId()
         );
 
-        $this->entityManager->getRepository(LeadDevice::class)->updateLead(
+        $this->leadDeviceRepository->updateLead(
             $event->getLoser()->getId(),
             $event->getVictor()->getId()
         );
@@ -484,8 +488,7 @@ final class LeadSubscriber implements EventSubscriberInterface
 
     private function addTimelineUtmEntries(Events\LeadTimelineEvent $event, string $eventTypeKey, string $eventTypeName): void
     {
-        $utmRepo = $this->entityManager->getRepository(UtmTag::class);
-        $utmTags = $utmRepo->getUtmTagsByLead($event->getLead(), $event->getQueryOptions());
+        $utmTags = $this->utmTagRepository->getUtmTagsByLead($event->getLead(), $event->getQueryOptions());
         // Add to counter
         $event->addToCounter($eventTypeKey, $utmTags);
 
@@ -540,10 +543,7 @@ final class LeadSubscriber implements EventSubscriberInterface
 
     private function addTimelineDoNotContactEntries(Events\LeadTimelineEvent $event, string $eventTypeKey, string $eventTypeName): void
     {
-        /** @var \Mautic\LeadBundle\Entity\DoNotContactRepository $dncRepo */
-        $dncRepo = $this->entityManager->getRepository(DoNotContact::class);
-
-        $rows = $dncRepo->getTimelineStats($event->getLeadId(), $event->getQueryOptions());
+        $rows = $this->doNotContactRepository->getTimelineStats($event->getLeadId(), $event->getQueryOptions());
 
         // Add to counter
         $event->addToCounter($eventTypeKey, $rows);
@@ -606,9 +606,7 @@ final class LeadSubscriber implements EventSubscriberInterface
 
     private function addTimelineImportedEntries(Events\LeadTimelineEvent $event, string $eventTypeKey, string $eventTypeName): void
     {
-        /** @var LeadEventLogRepository $eventLogRepo */
-        $eventLogRepo = $this->entityManager->getRepository(LeadEventLog::class);
-        $imports      = $eventLogRepo->getEvents(
+        $imports = $this->leadEventLogRepository->getEvents(
             $event->getLead(),
             'lead',
             'import',
@@ -662,16 +660,14 @@ final class LeadSubscriber implements EventSubscriberInterface
 
     private function addTimelineApiCreatedEntries(Events\LeadTimelineEvent $event, string $eventTypeKey, string $eventTypeName): void
     {
-        /** @var LeadEventLogRepository $eventLogRepo */
-        $eventLogRepo    = $this->entityManager->getRepository(LeadEventLog::class);
-        $apiSingleEvents = $eventLogRepo->getEvents(
+        $apiSingleEvents = $this->leadEventLogRepository->getEvents(
             $event->getLead(),
             'lead',
             'api-single',
             null,
             $event->getQueryOptions()
         );
-        $apiBatchEvents = $eventLogRepo->getEvents(
+        $apiBatchEvents = $this->leadEventLogRepository->getEvents(
             $event->getLead(),
             'lead',
             'api-batch',

--- a/app/bundles/LeadBundle/EventListener/SegmentImportExportSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/SegmentImportExportSubscriber.php
@@ -14,6 +14,7 @@ use Mautic\CoreBundle\Helper\IpLookupHelper;
 use Mautic\CoreBundle\Model\AuditLogModel;
 use Mautic\LeadBundle\Entity\LeadField;
 use Mautic\LeadBundle\Entity\LeadList;
+use Mautic\LeadBundle\Entity\LeadListRepository;
 use Mautic\LeadBundle\Model\FieldModel;
 use Mautic\LeadBundle\Model\ListModel;
 use Mautic\PluginBundle\Model\PluginModel;
@@ -28,6 +29,7 @@ final class SegmentImportExportSubscriber implements EventSubscriberInterface
     public function __construct(
         private ListModel $leadListModel,
         private EntityManagerInterface $entityManager,
+        private LeadListRepository $leadListRepository,
         private AuditLogModel $auditLogModel,
         private PluginModel $pluginModel,
         private EventDispatcherInterface $dispatcher,
@@ -109,7 +111,7 @@ final class SegmentImportExportSubscriber implements EventSubscriberInterface
         ];
 
         foreach ($event->getEntityData() as $element) {
-            $segment = $this->entityManager->getRepository(LeadList::class)->findOneBy(['uuid' => $element['uuid']]);
+            $segment = $this->leadListRepository->findOneBy(['uuid' => $element['uuid']]);
             $isNew   = !$segment;
 
             $segment ??= new LeadList();
@@ -151,7 +153,7 @@ final class SegmentImportExportSubscriber implements EventSubscriberInterface
             return;
         }
         foreach ($summary['ids'] as $id) {
-            $entity = $this->entityManager->getRepository(LeadList::class)->find($id);
+            $entity = $this->leadListRepository->find($id);
 
             if ($entity) {
                 $this->entityManager->remove($entity);

--- a/app/bundles/LeadBundle/Tests/EventListener/LeadSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/LeadSubscriberTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\LeadBundle\Tests\EventListener;
 
-use Doctrine\ORM\EntityManager;
 use Mautic\CoreBundle\Factory\ModelFactory;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\IpLookupHelper;
@@ -12,10 +11,15 @@ use Mautic\CoreBundle\Model\AuditLogModel;
 use Mautic\CoreBundle\Tests\CommonMocks;
 use Mautic\LeadBundle\DataObject\LeadManipulator;
 use Mautic\LeadBundle\Entity\CompanyLeadRepository;
+use Mautic\LeadBundle\Entity\DoNotContactRepository;
 use Mautic\LeadBundle\Entity\Lead;
-use Mautic\LeadBundle\Entity\LeadEventLog;
+use Mautic\LeadBundle\Entity\LeadDeviceRepository;
 use Mautic\LeadBundle\Entity\LeadEventLogRepository;
 use Mautic\LeadBundle\Entity\LeadListRepository;
+use Mautic\LeadBundle\Entity\LeadNoteRepository;
+use Mautic\LeadBundle\Entity\ListLeadRepository;
+use Mautic\LeadBundle\Entity\PointsChangeLogRepository;
+use Mautic\LeadBundle\Entity\UtmTagRepository;
 use Mautic\LeadBundle\Event\LeadEvent;
 use Mautic\LeadBundle\Event\LeadTimelineEvent;
 use Mautic\LeadBundle\EventListener\LeadSubscriber;
@@ -38,9 +42,9 @@ final class LeadSubscriberTest extends CommonMocks
     private DncReasonHelper $dncReasonHelper;
 
     /**
-     * @var MockObject&EntityManager
+     * @var MockObject&LeadEventLogRepository
      */
-    private MockObject $entityManager;
+    private MockObject $leadEventLogRepository;
 
     /**
      * @var MockObject&TranslatorInterface
@@ -60,7 +64,7 @@ final class LeadSubscriberTest extends CommonMocks
         parent::setUp();
         $this->auditLogModel           = $this->createMock(AuditLogModel::class);
         $this->dncReasonHelper         = new DncReasonHelper($this->createStub(TranslatorInterface::class));
-        $this->entityManager           = $this->createMock(EntityManager::class);
+        $this->leadEventLogRepository  = $this->createMock(LeadEventLogRepository::class);
         $this->translator              = $this->createMock(TranslatorInterface::class);
         $this->leadListRepository      = $this->createStub(LeadListRepository::class);
         $this->segmentCountCacheHelper = $this->createStub(SegmentCountCacheHelper::class);
@@ -119,13 +123,19 @@ final class LeadSubscriberTest extends CommonMocks
             $this->auditLogModel,
             $this->createStub(LeadChangeEventDispatcher::class),
             $this->dncReasonHelper,
-            $this->entityManager,
             $this->translator,
             $this->createStub(RouterInterface::class),
             $this->leadListRepository,
             $this->segmentCountCacheHelper,
             $this->coreParametersHelper,
             $this->companyLeadRepository,
+            $this->leadEventLogRepository,
+            $this->createStub(PointsChangeLogRepository::class),
+            $this->createStub(ListLeadRepository::class),
+            $this->createStub(LeadNoteRepository::class),
+            $this->createStub(LeadDeviceRepository::class),
+            $this->createStub(UtmTagRepository::class),
+            $this->createStub(DoNotContactRepository::class),
             $this->createStub(ModelFactory::class),
         );
 
@@ -181,10 +191,9 @@ final class LeadSubscriberTest extends CommonMocks
         ];
 
         $leadEvent = new LeadTimelineEvent($lead);
-        $repo      = $this->createMock(LeadEventLogRepository::class);
         $matcher   = $this->exactly(2);
 
-        $repo->expects($matcher)
+        $this->leadEventLogRepository->expects($matcher)
             ->method('getEvents')->willReturnCallback(function (...$parameters) use ($matcher, $lead, $leadEvent, $logs) {
                 if (1 === $matcher->numberOfInvocations()) {
                     $this->assertSame($lead, $parameters[0]);
@@ -206,22 +215,24 @@ final class LeadSubscriberTest extends CommonMocks
                 }
             });
 
-        $this->entityManager->method('getRepository')
-            ->with(LeadEventLog::class)
-            ->willReturn($repo);
-
         $subscriber = new LeadSubscriber(
             $this->createStub(IpLookupHelper::class),
             $this->auditLogModel,
             $this->createStub(LeadChangeEventDispatcher::class),
             $this->dncReasonHelper,
-            $this->entityManager,
             $this->translator,
             $this->createStub(RouterInterface::class),
             $this->leadListRepository,
             $this->segmentCountCacheHelper,
             $this->coreParametersHelper,
             $this->companyLeadRepository,
+            $this->leadEventLogRepository,
+            $this->createStub(PointsChangeLogRepository::class),
+            $this->createStub(ListLeadRepository::class),
+            $this->createStub(LeadNoteRepository::class),
+            $this->createStub(LeadDeviceRepository::class),
+            $this->createStub(UtmTagRepository::class),
+            $this->createStub(DoNotContactRepository::class),
             $this->createStub(ModelFactory::class),
             true
         );
@@ -319,13 +330,19 @@ final class LeadSubscriberTest extends CommonMocks
             $this->auditLogModel,
             $this->createStub(LeadChangeEventDispatcher::class),
             $this->dncReasonHelper,
-            $this->entityManager,
             $this->translator,
             $this->createStub(RouterInterface::class),
             $this->leadListRepository,
             $this->segmentCountCacheHelper,
             $this->coreParametersHelper,
             $this->companyLeadRepository,
+            $this->leadEventLogRepository,
+            $this->createStub(PointsChangeLogRepository::class),
+            $this->createStub(ListLeadRepository::class),
+            $this->createStub(LeadNoteRepository::class),
+            $this->createStub(LeadDeviceRepository::class),
+            $this->createStub(UtmTagRepository::class),
+            $this->createStub(DoNotContactRepository::class),
             $this->createStub(ModelFactory::class),
             true
         );
@@ -382,13 +399,19 @@ final class LeadSubscriberTest extends CommonMocks
             $this->auditLogModel,
             $this->createStub(LeadChangeEventDispatcher::class),
             $this->dncReasonHelper,
-            $this->entityManager,
             $this->translator,
             $this->createStub(RouterInterface::class),
             $this->leadListRepository,
             $this->segmentCountCacheHelper,
             $this->coreParametersHelper,
             $this->companyLeadRepository,
+            $this->leadEventLogRepository,
+            $this->createStub(PointsChangeLogRepository::class),
+            $this->createStub(ListLeadRepository::class),
+            $this->createStub(LeadNoteRepository::class),
+            $this->createStub(LeadDeviceRepository::class),
+            $this->createStub(UtmTagRepository::class),
+            $this->createStub(DoNotContactRepository::class),
             $this->createStub(ModelFactory::class),
             true
         );

--- a/app/bundles/PageBundle/EventListener/PageImportExportSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/PageImportExportSubscriber.php
@@ -13,6 +13,7 @@ use Mautic\CoreBundle\EventListener\ImportExportTrait;
 use Mautic\CoreBundle\Helper\IpLookupHelper;
 use Mautic\CoreBundle\Model\AuditLogModel;
 use Mautic\PageBundle\Entity\Page;
+use Mautic\PageBundle\Entity\PageRepository;
 use Mautic\PageBundle\Model\PageModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
@@ -24,6 +25,7 @@ final class PageImportExportSubscriber implements EventSubscriberInterface
     public function __construct(
         private PageModel $pageModel,
         private EntityManagerInterface $entityManager,
+        private PageRepository $pageRepository,
         private AuditLogModel $auditLogModel,
         private IpLookupHelper $ipLookupHelper,
         private DenormalizerInterface $serializer,
@@ -94,7 +96,7 @@ final class PageImportExportSubscriber implements EventSubscriberInterface
         ];
 
         foreach ($event->getEntityData() as $element) {
-            $object = $this->entityManager->getRepository(Page::class)->findOneBy(['uuid' => $element['uuid']]);
+            $object = $this->pageRepository->findOneBy(['uuid' => $element['uuid']]);
             $isNew  = !$object;
 
             $object ??= new Page();
@@ -135,7 +137,7 @@ final class PageImportExportSubscriber implements EventSubscriberInterface
             return;
         }
         foreach ($summary['ids'] as $id) {
-            $entity = $this->entityManager->getRepository(Page::class)->find($id);
+            $entity = $this->pageRepository->find($id);
 
             if ($entity) {
                 $this->entityManager->remove($entity);

--- a/app/bundles/PageBundle/EventListener/StatsSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/StatsSubscriber.php
@@ -6,14 +6,18 @@ use Doctrine\ORM\EntityManager;
 use Mautic\CoreBundle\EventListener\CommonStatsSubscriber;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\PageBundle\Entity\Hit;
-use Mautic\PageBundle\Entity\Redirect;
-use Mautic\PageBundle\Entity\Trackable;
+use Mautic\PageBundle\Entity\RedirectRepository;
+use Mautic\PageBundle\Entity\TrackableRepository;
 use Mautic\PageBundle\Entity\VideoHit;
 
 final class StatsSubscriber extends CommonStatsSubscriber
 {
-    public function __construct(CorePermissions $security, EntityManager $entityManager)
-    {
+    public function __construct(
+        CorePermissions $security,
+        EntityManager $entityManager,
+        RedirectRepository $redirectRepository,
+        TrackableRepository $trackableRepository,
+    ) {
         parent::__construct($security, $entityManager);
         $this->addContactRestrictedRepositories(
             [
@@ -22,7 +26,7 @@ final class StatsSubscriber extends CommonStatsSubscriber
             ]
         );
 
-        $this->repositories[] = $entityManager->getRepository(Redirect::class);
-        $this->repositories[] = $entityManager->getRepository(Trackable::class);
+        $this->repositories[] = $redirectRepository;
+        $this->repositories[] = $trackableRepository;
     }
 }

--- a/app/bundles/PointBundle/EventListener/GroupImportExportSubscriber.php
+++ b/app/bundles/PointBundle/EventListener/GroupImportExportSubscriber.php
@@ -13,6 +13,7 @@ use Mautic\CoreBundle\EventListener\ImportExportTrait;
 use Mautic\CoreBundle\Helper\IpLookupHelper;
 use Mautic\CoreBundle\Model\AuditLogModel;
 use Mautic\PointBundle\Entity\Group;
+use Mautic\PointBundle\Entity\GroupRepository;
 use Mautic\PointBundle\Model\PointGroupModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
@@ -24,6 +25,7 @@ final class GroupImportExportSubscriber implements EventSubscriberInterface
     public function __construct(
         private PointGroupModel $pointGroupModel,
         private EntityManagerInterface $entityManager,
+        private GroupRepository $groupRepository,
         private AuditLogModel $auditLogModel,
         private IpLookupHelper $ipLookupHelper,
         private DenormalizerInterface $serializer,
@@ -76,7 +78,7 @@ final class GroupImportExportSubscriber implements EventSubscriberInterface
         ];
 
         foreach ($event->getEntityData() as $element) {
-            $group = $this->entityManager->getRepository(Group::class)->findOneBy(['uuid' => $element['uuid']]);
+            $group = $this->groupRepository->findOneBy(['uuid' => $element['uuid']]);
             $isNew = !$group;
 
             $group ??= new Group();
@@ -117,7 +119,7 @@ final class GroupImportExportSubscriber implements EventSubscriberInterface
             return;
         }
         foreach ($summary['ids'] as $id) {
-            $entity = $this->entityManager->getRepository(Group::class)->find($id);
+            $entity = $this->groupRepository->find($id);
 
             if ($entity) {
                 $this->entityManager->remove($entity);

--- a/app/bundles/SmsBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/SmsBundle/EventListener/LeadSubscriber.php
@@ -2,10 +2,9 @@
 
 namespace Mautic\SmsBundle\EventListener;
 
-use Doctrine\ORM\EntityManager;
 use Mautic\LeadBundle\Event\LeadTimelineEvent;
 use Mautic\LeadBundle\LeadEvents;
-use Mautic\SmsBundle\Entity\Stat;
+use Mautic\SmsBundle\Entity\StatRepository;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -15,7 +14,7 @@ final readonly class LeadSubscriber implements EventSubscriberInterface
     public function __construct(
         private TranslatorInterface $translator,
         private RouterInterface $router,
-        private EntityManager $em,
+        private StatRepository $statRepository,
     ) {
     }
 
@@ -48,11 +47,9 @@ final readonly class LeadSubscriber implements EventSubscriberInterface
             return;
         }
 
-        /** @var \Mautic\SmsBundle\Entity\StatRepository $statRepository */
-        $statRepository        = $this->em->getRepository(Stat::class);
         $queryOptions          = $event->getQueryOptions();
         $queryOptions['state'] = $state;
-        $stats                 = $statRepository->getLeadStats($event->getLeadId(), $queryOptions);
+        $stats                 = $this->statRepository->getLeadStats($event->getLeadId(), $queryOptions);
 
         // Add total to counter
         $event->addToCounter($eventTypeKey, $stats);

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -12914,3 +12914,501 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: plugins/MauticTagManagerBundle/Security/Permissions/TagManagerPermissions.php
+		-
+			message: '#^Entity manager must not fetch the "MauticPlugin\\MauticSocialBundle\\Entity\\Lead" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: plugins/MauticSocialBundle/Helper/TwitterCommandHelper.php
+
+		-
+			message: '#^Entity manager must not fetch the "MauticPlugin\\MauticSocialBundle\\Entity\\TweetStat" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: plugins/MauticSocialBundle/EventListener/StatsSubscriber.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\ApiBundle\\Entity\\oAuth2\\AccessToken" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/UserBundle/Security/Authentication/Token/Permissions/TokenPermissions.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\AssetBundle\\Entity\\Asset" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 2
+			path: app/bundles/AssetBundle/EventListener/AssetImportExportSubscriber.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\AssetBundle\\Entity\\Download" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/AssetBundle/EventListener/DetermineWinnerSubscriber.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\CampaignBundle\\Entity\\Campaign" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/CampaignBundle/Controller/CampaignController.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\CampaignBundle\\Entity\\Campaign" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 3
+			path: app/bundles/CampaignBundle/EventListener/CampaignImportExportSubscriber.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\CampaignBundle\\Entity\\Event" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 7
+			path: app/bundles/CampaignBundle/EventListener/CampaignEventImportExportSubscriber.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\CampaignBundle\\Entity\\Lead" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/CampaignBundle/EventListener/LeadSubscriber.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\CampaignBundle\\Entity\\LeadEventLog" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/CampaignBundle/Controller/CampaignController.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\CampaignBundle\\Entity\\LeadEventLog" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 2
+			path: app/bundles/CampaignBundle/EventListener/LeadSubscriber.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\CampaignBundle\\Entity\\Summary" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/CampaignBundle/Controller/CampaignController.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\CategoryBundle\\Entity\\Category" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/LeadBundle/DataFixtures/ORM/LoadCategorizedLeadListData.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\CategoryBundle\\Entity\\Category" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/LeadBundle/DataFixtures/ORM/LoadCategoryData.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\CoreBundle\\Entity\\AuditLog" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/CoreBundle/EventListener/StatsSubscriber.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\CoreBundle\\Entity\\AuditLog" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\CoreBundle\\Entity\\FormEntity" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/CoreBundle/Model/AbstractCommonModel.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\CoreBundle\\Entity\\IpAddress" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/CoreBundle/EventListener/StatsSubscriber.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\CoreBundle\\Entity\\IpAddress" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/CoreBundle/Helper/IpLookupHelper.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\DynamicContentBundle\\Entity\\DynamicContent" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 2
+			path: app/bundles/DynamicContentBundle/EventListener/DynamicContentImportExportSubscriber.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\EmailBundle\\Entity\\Copy" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/EmailBundle/Helper/MailHelper.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\EmailBundle\\Entity\\Email" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 2
+			path: app/bundles/EmailBundle/EventListener/EmailImportExportSubscriber.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\EmailBundle\\Entity\\Email" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/LeadBundle/Controller/LeadController.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\EmailBundle\\Entity\\Stat" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 2
+			path: app/bundles/EmailBundle/EventListener/DetermineWinnerSubscriber.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\EmailBundle\\Entity\\Stat" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/EmailBundle/EventListener/StatsSubscriber.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\EmailBundle\\Entity\\StatDevice" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/EmailBundle/EventListener/StatsSubscriber.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\FormBundle\\Entity\\Action" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 3
+			path: app/bundles/FormBundle/EventListener/ActionImportExportSubscriber.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\FormBundle\\Entity\\Field" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 3
+			path: app/bundles/FormBundle/EventListener/FieldImportExportSubscriber.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\FormBundle\\Entity\\Form" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/EmailBundle/EventListener/EmailImportExportSubscriber.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\FormBundle\\Entity\\Form" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/FormBundle/EventListener/ActionImportExportSubscriber.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\FormBundle\\Entity\\Form" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/FormBundle/EventListener/FieldImportExportSubscriber.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\FormBundle\\Entity\\Form" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 2
+			path: app/bundles/FormBundle/EventListener/FormImportExportSubscriber.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\FormBundle\\Entity\\Submission" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/FormBundle/Model/SubmissionResultLoader.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\Company" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\CompanyLead" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/LeadBundle/DataFixtures/ORM/LoadLeadData.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\DoNotContact" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/LeadBundle/Controller/AjaxController.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\DoNotContact" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 3
+			path: app/bundles/LeadBundle/Controller/LeadController.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\DoNotContact" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/LeadBundle/EventListener/LeadSubscriber.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\Lead" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/LeadBundle/Controller/LeadController.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\Lead" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/LeadBundle/DataFixtures/ORM/LoadLeadData.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\Lead" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/NotificationBundle/Controller/AppCallbackController.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\Lead" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/PluginBundle/Helper/EventHelper.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\Lead" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 2
+			path: app/bundles/PluginBundle/Helper/IntegrationHelper.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\Lead" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/PluginBundle/Integration/AbstractIntegration.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\Lead" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/SmsBundle/Helper/SmsHelper.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\Lead" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\LeadDevice" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/LeadBundle/EventListener/LeadSubscriber.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\LeadEventLog" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 3
+			path: app/bundles/LeadBundle/EventListener/LeadSubscriber.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\LeadField" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 2
+			path: app/bundles/LeadBundle/EventListener/CustomFieldImportExportSubscriber.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\LeadField" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/LeadBundle/Form/Type/FieldType.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\LeadList" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/LeadBundle/DataFixtures/ORM/LoadCategorizedLeadListData.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\LeadList" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 2
+			path: app/bundles/LeadBundle/EventListener/SegmentImportExportSubscriber.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\LeadList" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/LeadBundle/Segment/Query/ContactSegmentQueryBuilder.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\LeadNote" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/LeadBundle/EventListener/LeadSubscriber.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\ListLead" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/LeadBundle/EventListener/LeadSubscriber.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\PointsChangeLog" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/LeadBundle/EventListener/LeadSubscriber.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\UtmTag" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/LeadBundle/EventListener/LeadSubscriber.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\NotificationBundle\\Entity\\Notification" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/NotificationBundle/Controller/AppCallbackController.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\PageBundle\\Entity\\Hit" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/DashboardBundle/Controller/AjaxController.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\PageBundle\\Entity\\Hit" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/EmailBundle/EventListener/DetermineWinnerSubscriber.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\PageBundle\\Entity\\Hit" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/PageBundle/Helper/PointActionHelper.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\PageBundle\\Entity\\Page" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/EmailBundle/EventListener/EmailImportExportSubscriber.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\PageBundle\\Entity\\Page" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 2
+			path: app/bundles/PageBundle/EventListener/PageImportExportSubscriber.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\PageBundle\\Entity\\Redirect" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/PageBundle/EventListener/StatsSubscriber.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\PageBundle\\Entity\\Trackable" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/PageBundle/EventListener/StatsSubscriber.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\PluginBundle\\Entity\\Integration" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 3
+			path: app/bundles/PluginBundle/Helper/IntegrationHelper.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\PluginBundle\\Entity\\IntegrationEntity" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 2
+			path: app/bundles/PluginBundle/Integration/AbstractIntegration.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\PluginBundle\\Entity\\IntegrationEntity" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 4
+			path: plugins/MauticCrmBundle/Integration/ConnectwiseIntegration.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\PluginBundle\\Entity\\IntegrationEntity" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 3
+			path: plugins/MauticCrmBundle/Integration/DynamicsIntegration.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\PluginBundle\\Entity\\IntegrationEntity" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: plugins/MauticCrmBundle/Integration/HubspotIntegration.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\PluginBundle\\Entity\\IntegrationEntity" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 5
+			path: plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\PluginBundle\\Entity\\IntegrationEntity" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 7
+			path: plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\PluginBundle\\Entity\\IntegrationEntity" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 4
+			path: plugins/MauticCrmBundle/Integration/ZohoIntegration.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\PointBundle\\Entity\\Group" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 2
+			path: app/bundles/PointBundle/EventListener/GroupImportExportSubscriber.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\ReportBundle\\Entity\\Scheduler" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/ReportBundle/Scheduler/Model/SchedulerPlanner.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\SmsBundle\\Entity\\Stat" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/SmsBundle/EventListener/LeadSubscriber.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\StageBundle\\Entity\\Stage" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: plugins/MauticCrmBundle/Integration/HubspotIntegration.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\UserBundle\\Entity\\Role" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\UserBundle\\Entity\\User" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/ApiBundle/EventListener/PreAuthorizationEventListener.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\UserBundle\\Entity\\User" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/InstallBundle/Install/InstallService.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\UserBundle\\Entity\\User" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/PluginBundle/Integration/AbstractIntegration.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\UserBundle\\Entity\\User" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\UserBundle\\Entity\\User" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -385,6 +385,24 @@ parameters:
 			path: app/bundles/CampaignBundle/Controller/Api/CampaignApiController.php
 
 		-
+			message: '#^Entity manager must not fetch the "Mautic\\CampaignBundle\\Entity\\Campaign" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/CampaignBundle/Controller/CampaignController.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\CampaignBundle\\Entity\\LeadEventLog" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/CampaignBundle/Controller/CampaignController.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\CampaignBundle\\Entity\\Summary" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/CampaignBundle/Controller/CampaignController.php
+
+		-
 			message: '#^Method Mautic\\CampaignBundle\\Controller\\CampaignController\:\:getIndexItems\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -2560,6 +2578,12 @@ parameters:
 			path: app/bundles/CoreBundle/Helper/InputHelper.php
 
 		-
+			message: '#^Entity manager must not fetch the "Mautic\\CoreBundle\\Entity\\IpAddress" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/CoreBundle/Helper/IpLookupHelper.php
+
+		-
 			message: '#^Method Mautic\\CoreBundle\\Helper\\IpLookupHelper\:\:getClientIpFromProxyList\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -2884,6 +2908,12 @@ parameters:
 			path: app/bundles/CoreBundle/Menu/MenuHelper.php
 
 		-
+			message: '#^Entity manager must not fetch the "Mautic\\CoreBundle\\Entity\\FormEntity" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/CoreBundle/Model/AbstractCommonModel.php
+
+		-
 			message: '#^Method Mautic\\CoreBundle\\Model\\AbstractCommonModel\:\:decodeArrayFromUrl\(\) has parameter \$string with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -3092,6 +3122,12 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: app/bundles/CoreBundle/Validator/FileUploadValidator.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\PageBundle\\Entity\\Hit" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/DashboardBundle/Controller/AjaxController.php
 
 		-
 			message: '''
@@ -3740,6 +3776,12 @@ parameters:
 			identifier: missingType.parameter
 			count: 1
 			path: app/bundles/EmailBundle/Helper/EmailValidator.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\EmailBundle\\Entity\\Copy" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/EmailBundle/Helper/MailHelper.php
 
 		-
 			message: '#^Method Mautic\\EmailBundle\\Helper\\MailHelper\:\:addCustomHeader\(\) has parameter \$name with no type specified\.$#'
@@ -4957,6 +4999,12 @@ parameters:
 			path: app/bundles/FormBundle/Model/SubmissionModel.php
 
 		-
+			message: '#^Entity manager must not fetch the "Mautic\\FormBundle\\Entity\\Submission" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/FormBundle/Model/SubmissionResultLoader.php
+
+		-
 			message: '#^Parameter \#1 \$permissionNames of method Mautic\\CoreBundle\\Security\\Permissions\\AbstractPermissions\:\:addStandardPermissions\(\) expects array, string given\.$#'
 			identifier: argument.type
 			count: 1
@@ -5105,6 +5153,12 @@ parameters:
 			identifier: missingType.parameter
 			count: 1
 			path: app/bundles/InstallBundle/Helper/SchemaHelper.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\UserBundle\\Entity\\User" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/InstallBundle/Install/InstallService.php
 
 		-
 			message: '#^Method Mautic\\InstallBundle\\Install\\InstallService\:\:saveConfiguration\(\) has parameter \$clearCache with no type specified\.$#'
@@ -5389,6 +5443,12 @@ parameters:
 			path: app/bundles/IntegrationsBundle/Sync/ValueNormalizer/ValueNormalizerInterface.php
 
 		-
+			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\DoNotContact" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/LeadBundle/Controller/AjaxController.php
+
+		-
 			message: '#^Property Mautic\\LeadBundle\\Controller\\Api\\LeadApiController\:\:\$dncChannels has no type specified\.$#'
 			identifier: missingType.property
 			count: 1
@@ -5419,6 +5479,24 @@ parameters:
 			path: app/bundles/LeadBundle/Controller/LeadController.php
 
 		-
+			message: '#^Entity manager must not fetch the "Mautic\\EmailBundle\\Entity\\Email" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/LeadBundle/Controller/LeadController.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\DoNotContact" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 3
+			path: app/bundles/LeadBundle/Controller/LeadController.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\Lead" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/LeadBundle/Controller/LeadController.php
+
+		-
 			message: '#^Property Mautic\\LeadBundle\\Controller\\LeadController\:\:\$dncChannels has no type specified\.$#'
 			identifier: missingType.property
 			count: 1
@@ -5441,6 +5519,36 @@ parameters:
 			identifier: symplify.noJustPropertyAssign
 			count: 2
 			path: app/bundles/LeadBundle/Controller/NoteController.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\CategoryBundle\\Entity\\Category" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/LeadBundle/DataFixtures/ORM/LoadCategorizedLeadListData.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\LeadList" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/LeadBundle/DataFixtures/ORM/LoadCategorizedLeadListData.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\CategoryBundle\\Entity\\Category" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/LeadBundle/DataFixtures/ORM/LoadCategoryData.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\CompanyLead" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/LeadBundle/DataFixtures/ORM/LoadLeadData.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\Lead" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/LeadBundle/DataFixtures/ORM/LoadLeadData.php
 
 		-
 			message: '#^Property Mautic\\LeadBundle\\Deduplicate\\CompanyDeduper\:\:\$object has no type specified\.$#'
@@ -6715,6 +6823,12 @@ parameters:
 			path: app/bundles/LeadBundle/Form/Type/CompanyType.php
 
 		-
+			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\LeadField" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/LeadBundle/Form/Type/FieldType.php
+
+		-
 			message: '#^Method Mautic\\LeadBundle\\Form\\Type\\LeadType\:\:getFormFields\(\) has parameter \$object with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -7213,6 +7327,12 @@ parameters:
 			path: app/bundles/LeadBundle/Segment/Decorator/Date/DateOptionAbstract.php
 
 		-
+			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\LeadList" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/LeadBundle/Segment/Query/ContactSegmentQueryBuilder.php
+
+		-
 			message: '#^Parameter \#2 \$leadId of class Mautic\\LeadBundle\\Event\\LeadListFilteringEvent constructor expects int, null given\.$#'
 			identifier: argument.type
 			count: 1
@@ -7415,6 +7535,18 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: app/bundles/NotificationBundle/Api/AbstractNotificationApi.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\Lead" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/NotificationBundle/Controller/AppCallbackController.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\NotificationBundle\\Entity\\Notification" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/NotificationBundle/Controller/AppCallbackController.php
 
 		-
 			message: '#^Instead of assigning service property to a variable, use the property directly$#'
@@ -7937,6 +8069,12 @@ parameters:
 			identifier: isset.offset
 			count: 1
 			path: app/bundles/PageBundle/Form/Type/AbTestPropertiesType.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\PageBundle\\Entity\\Hit" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/PageBundle/Helper/PointActionHelper.php
 
 		-
 			message: '#^Method Mautic\\PageBundle\\Helper\\PointActionHelper\:\:validatePageHit\(\) has parameter \$eventDetails with no type specified\.$#'
@@ -8581,6 +8719,12 @@ parameters:
 			path: app/bundles/PluginBundle/Helper/Cleaner.php
 
 		-
+			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\Lead" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/PluginBundle/Helper/EventHelper.php
+
+		-
 			message: '#^Method Mautic\\PluginBundle\\Helper\\EventHelper\:\:pushIt\(\) has parameter \$errors with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -8602,6 +8746,18 @@ parameters:
 			message: '#^Call to an undefined method Mautic\\PluginBundle\\Integration\\UnifiedIntegrationInterface\:\:getIcon\(\)\.$#'
 			identifier: method.notFound
 			count: 1
+			path: app/bundles/PluginBundle/Helper/IntegrationHelper.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\Lead" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 2
+			path: app/bundles/PluginBundle/Helper/IntegrationHelper.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\PluginBundle\\Entity\\Integration" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 3
 			path: app/bundles/PluginBundle/Helper/IntegrationHelper.php
 
 		-
@@ -8717,6 +8873,24 @@ parameters:
 			identifier: missingType.property
 			count: 1
 			path: app/bundles/PluginBundle/Helper/oAuthHelper.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\Lead" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/PluginBundle/Integration/AbstractIntegration.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\PluginBundle\\Entity\\IntegrationEntity" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 2
+			path: app/bundles/PluginBundle/Integration/AbstractIntegration.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\UserBundle\\Entity\\User" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/PluginBundle/Integration/AbstractIntegration.php
 
 		-
 			message: '#^Method Mautic\\PluginBundle\\Integration\\AbstractIntegration\:\:buildIntegrationEntities\(\) has no return type specified\.$#'
@@ -9352,6 +9526,12 @@ parameters:
 			path: app/bundles/ReportBundle/Scheduler/BuilderInterface.php
 
 		-
+			message: '#^Entity manager must not fetch the "Mautic\\ReportBundle\\Entity\\Scheduler" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/ReportBundle/Scheduler/Model/SchedulerPlanner.php
+
+		-
 			message: '#^Method Mautic\\ReportBundle\\Scheduler\\Model\\SendSchedule\:\:send\(\) has parameter \$csvFilePath with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -9490,12 +9670,6 @@ parameters:
 			path: app/bundles/SmsBundle/Entity/StatRepository.php
 
 		-
-			message: '#^Method Mautic\\SmsBundle\\EventListener\\LeadSubscriber\:\:addSmsEvents\(\) has parameter \$state with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/bundles/SmsBundle/EventListener/LeadSubscriber.php
-
-		-
 			message: '#^Method Mautic\\SmsBundle\\EventListener\\ReplySubscriber\:\:addEvents\(\) has parameter \$action with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -9566,6 +9740,12 @@ parameters:
 			identifier: missingType.parameter
 			count: 1
 			path: app/bundles/SmsBundle/EventListener/ReplySubscriber.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\Lead" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/SmsBundle/Helper/SmsHelper.php
 
 		-
 			message: '#^Method Mautic\\SmsBundle\\Helper\\SmsHelper\:\:unsubscribe\(\) has no return type specified\.$#'
@@ -9944,6 +10124,12 @@ parameters:
 			identifier: missingType.parameter
 			count: 1
 			path: app/bundles/UserBundle/Model/UserModel.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\ApiBundle\\Entity\\oAuth2\\AccessToken" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: app/bundles/UserBundle/Security/Authentication/Token/Permissions/TokenPermissions.php
 
 		-
 			message: '#^Parameter \#1 \$permissionNames of method Mautic\\CoreBundle\\Security\\Permissions\\AbstractPermissions\:\:addStandardPermissions\(\) expects array, string given\.$#'
@@ -10630,6 +10816,12 @@ parameters:
 			path: plugins/MauticCrmBundle/EventListener/LeadListSubscriber.php
 
 		-
+			message: '#^Entity manager must not fetch the "Mautic\\PluginBundle\\Entity\\IntegrationEntity" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 4
+			path: plugins/MauticCrmBundle/Integration/ConnectwiseIntegration.php
+
+		-
 			message: '#^Method MauticPlugin\\MauticCrmBundle\\Integration\\ConnectwiseIntegration\:\:amendLeadDataBeforeMauticPopulate\(\) has parameter \$data with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -10772,6 +10964,18 @@ parameters:
 			identifier: missingType.parameter
 			count: 1
 			path: plugins/MauticCrmBundle/Integration/ConnectwiseIntegration.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\Lead" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\UserBundle\\Entity\\User" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
 
 		-
 			message: '#^Method MauticPlugin\\MauticCrmBundle\\Integration\\CrmAbstractIntegration\:\:amendLeadDataBeforeMauticPopulate\(\) has no return type specified\.$#'
@@ -11002,6 +11206,12 @@ parameters:
 			path: plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
 
 		-
+			message: '#^Entity manager must not fetch the "Mautic\\PluginBundle\\Entity\\IntegrationEntity" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 3
+			path: plugins/MauticCrmBundle/Integration/DynamicsIntegration.php
+
+		-
 			message: '#^Method MauticPlugin\\MauticCrmBundle\\Integration\\DynamicsIntegration\:\:getBearerToken\(\) should return string but returns false\.$#'
 			identifier: return.type
 			count: 1
@@ -11048,6 +11258,18 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: plugins/MauticCrmBundle/Integration/DynamicsIntegration.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\PluginBundle\\Entity\\IntegrationEntity" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: plugins/MauticCrmBundle/Integration/HubspotIntegration.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\StageBundle\\Entity\\Stage" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: plugins/MauticCrmBundle/Integration/HubspotIntegration.php
 
 		-
 			message: '#^Method MauticPlugin\\MauticCrmBundle\\Integration\\HubspotIntegration\:\:amendLeadDataBeforeMauticPopulate\(\) has parameter \$data with no type specified\.$#'
@@ -11162,6 +11384,30 @@ parameters:
 			identifier: missingType.parameter
 			count: 1
 			path: plugins/MauticCrmBundle/Integration/Salesforce/Object/Lead.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\CoreBundle\\Entity\\AuditLog" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\PluginBundle\\Entity\\IntegrationEntity" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 5
+			path: plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\UserBundle\\Entity\\Role" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\UserBundle\\Entity\\User" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
 
 		-
 			message: '#^Method MauticPlugin\\MauticCrmBundle\\Integration\\SalesforceIntegration\:\:amendLeadDataBeforeMauticPopulate\(\) has parameter \$data with no type specified\.$#'
@@ -11692,6 +11938,18 @@ parameters:
 			path: plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
 
 		-
+			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\Company" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\PluginBundle\\Entity\\IntegrationEntity" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 7
+			path: plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
+
+		-
 			message: '#^Method MauticPlugin\\MauticCrmBundle\\Integration\\SugarcrmIntegration\:\:authCallback\(\) should return array but returns bool\|string\.$#'
 			identifier: return.type
 			count: 1
@@ -11918,6 +12176,12 @@ parameters:
 			identifier: missingType.parameter
 			count: 1
 			path: plugins/MauticCrmBundle/Integration/VtigerIntegration.php
+
+		-
+			message: '#^Entity manager must not fetch the "Mautic\\PluginBundle\\Entity\\IntegrationEntity" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 4
+			path: plugins/MauticCrmBundle/Integration/ZohoIntegration.php
 
 		-
 			message: '#^Method MauticPlugin\\MauticCrmBundle\\Integration\\ZohoIntegration\:\:cleanPriorityFields\(\) has parameter \$fieldsToUpdate with no type specified\.$#'
@@ -12706,6 +12970,12 @@ parameters:
 			path: plugins/MauticSocialBundle/Form/Type/SocialLoginType.php
 
 		-
+			message: '#^Entity manager must not fetch the "MauticPlugin\\MauticSocialBundle\\Entity\\Lead" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
+			identifier: mautic.noEntityManagerGetRepository
+			count: 1
+			path: plugins/MauticSocialBundle/Helper/TwitterCommandHelper.php
+
+		-
 			message: '#^Method MauticPlugin\\MauticSocialBundle\\Integration\\FacebookIntegration\:\:getApiUrl\(\) has parameter \$endpoint with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -12914,501 +13184,4 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: plugins/MauticTagManagerBundle/Security/Permissions/TagManagerPermissions.php
-		-
-			message: '#^Entity manager must not fetch the "MauticPlugin\\MauticSocialBundle\\Entity\\Lead" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: plugins/MauticSocialBundle/Helper/TwitterCommandHelper.php
-
-		-
-			message: '#^Entity manager must not fetch the "MauticPlugin\\MauticSocialBundle\\Entity\\TweetStat" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: plugins/MauticSocialBundle/EventListener/StatsSubscriber.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\ApiBundle\\Entity\\oAuth2\\AccessToken" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/UserBundle/Security/Authentication/Token/Permissions/TokenPermissions.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\AssetBundle\\Entity\\Asset" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 2
-			path: app/bundles/AssetBundle/EventListener/AssetImportExportSubscriber.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\AssetBundle\\Entity\\Download" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/AssetBundle/EventListener/DetermineWinnerSubscriber.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\CampaignBundle\\Entity\\Campaign" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/CampaignBundle/Controller/CampaignController.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\CampaignBundle\\Entity\\Campaign" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 3
-			path: app/bundles/CampaignBundle/EventListener/CampaignImportExportSubscriber.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\CampaignBundle\\Entity\\Event" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 7
-			path: app/bundles/CampaignBundle/EventListener/CampaignEventImportExportSubscriber.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\CampaignBundle\\Entity\\Lead" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/CampaignBundle/EventListener/LeadSubscriber.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\CampaignBundle\\Entity\\LeadEventLog" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/CampaignBundle/Controller/CampaignController.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\CampaignBundle\\Entity\\LeadEventLog" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 2
-			path: app/bundles/CampaignBundle/EventListener/LeadSubscriber.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\CampaignBundle\\Entity\\Summary" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/CampaignBundle/Controller/CampaignController.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\CategoryBundle\\Entity\\Category" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/LeadBundle/DataFixtures/ORM/LoadCategorizedLeadListData.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\CategoryBundle\\Entity\\Category" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/LeadBundle/DataFixtures/ORM/LoadCategoryData.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\CoreBundle\\Entity\\AuditLog" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/CoreBundle/EventListener/StatsSubscriber.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\CoreBundle\\Entity\\AuditLog" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\CoreBundle\\Entity\\FormEntity" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/CoreBundle/Model/AbstractCommonModel.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\CoreBundle\\Entity\\IpAddress" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/CoreBundle/EventListener/StatsSubscriber.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\CoreBundle\\Entity\\IpAddress" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/CoreBundle/Helper/IpLookupHelper.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\DynamicContentBundle\\Entity\\DynamicContent" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 2
-			path: app/bundles/DynamicContentBundle/EventListener/DynamicContentImportExportSubscriber.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\EmailBundle\\Entity\\Copy" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/EmailBundle/Helper/MailHelper.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\EmailBundle\\Entity\\Email" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 2
-			path: app/bundles/EmailBundle/EventListener/EmailImportExportSubscriber.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\EmailBundle\\Entity\\Email" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/LeadBundle/Controller/LeadController.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\EmailBundle\\Entity\\Stat" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 2
-			path: app/bundles/EmailBundle/EventListener/DetermineWinnerSubscriber.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\EmailBundle\\Entity\\Stat" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/EmailBundle/EventListener/StatsSubscriber.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\EmailBundle\\Entity\\StatDevice" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/EmailBundle/EventListener/StatsSubscriber.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\FormBundle\\Entity\\Action" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 3
-			path: app/bundles/FormBundle/EventListener/ActionImportExportSubscriber.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\FormBundle\\Entity\\Field" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 3
-			path: app/bundles/FormBundle/EventListener/FieldImportExportSubscriber.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\FormBundle\\Entity\\Form" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/EmailBundle/EventListener/EmailImportExportSubscriber.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\FormBundle\\Entity\\Form" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/FormBundle/EventListener/ActionImportExportSubscriber.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\FormBundle\\Entity\\Form" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/FormBundle/EventListener/FieldImportExportSubscriber.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\FormBundle\\Entity\\Form" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 2
-			path: app/bundles/FormBundle/EventListener/FormImportExportSubscriber.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\FormBundle\\Entity\\Submission" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/FormBundle/Model/SubmissionResultLoader.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\Company" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\CompanyLead" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/LeadBundle/DataFixtures/ORM/LoadLeadData.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\DoNotContact" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/LeadBundle/Controller/AjaxController.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\DoNotContact" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 3
-			path: app/bundles/LeadBundle/Controller/LeadController.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\DoNotContact" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/LeadBundle/EventListener/LeadSubscriber.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\Lead" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/LeadBundle/Controller/LeadController.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\Lead" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/LeadBundle/DataFixtures/ORM/LoadLeadData.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\Lead" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/NotificationBundle/Controller/AppCallbackController.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\Lead" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/PluginBundle/Helper/EventHelper.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\Lead" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 2
-			path: app/bundles/PluginBundle/Helper/IntegrationHelper.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\Lead" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/PluginBundle/Integration/AbstractIntegration.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\Lead" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/SmsBundle/Helper/SmsHelper.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\Lead" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\LeadDevice" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/LeadBundle/EventListener/LeadSubscriber.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\LeadEventLog" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 3
-			path: app/bundles/LeadBundle/EventListener/LeadSubscriber.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\LeadField" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 2
-			path: app/bundles/LeadBundle/EventListener/CustomFieldImportExportSubscriber.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\LeadField" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/LeadBundle/Form/Type/FieldType.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\LeadList" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/LeadBundle/DataFixtures/ORM/LoadCategorizedLeadListData.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\LeadList" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 2
-			path: app/bundles/LeadBundle/EventListener/SegmentImportExportSubscriber.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\LeadList" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/LeadBundle/Segment/Query/ContactSegmentQueryBuilder.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\LeadNote" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/LeadBundle/EventListener/LeadSubscriber.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\ListLead" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/LeadBundle/EventListener/LeadSubscriber.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\PointsChangeLog" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/LeadBundle/EventListener/LeadSubscriber.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\LeadBundle\\Entity\\UtmTag" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/LeadBundle/EventListener/LeadSubscriber.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\NotificationBundle\\Entity\\Notification" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/NotificationBundle/Controller/AppCallbackController.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\PageBundle\\Entity\\Hit" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/DashboardBundle/Controller/AjaxController.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\PageBundle\\Entity\\Hit" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/EmailBundle/EventListener/DetermineWinnerSubscriber.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\PageBundle\\Entity\\Hit" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/PageBundle/Helper/PointActionHelper.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\PageBundle\\Entity\\Page" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/EmailBundle/EventListener/EmailImportExportSubscriber.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\PageBundle\\Entity\\Page" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 2
-			path: app/bundles/PageBundle/EventListener/PageImportExportSubscriber.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\PageBundle\\Entity\\Redirect" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/PageBundle/EventListener/StatsSubscriber.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\PageBundle\\Entity\\Trackable" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/PageBundle/EventListener/StatsSubscriber.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\PluginBundle\\Entity\\Integration" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 3
-			path: app/bundles/PluginBundle/Helper/IntegrationHelper.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\PluginBundle\\Entity\\IntegrationEntity" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 2
-			path: app/bundles/PluginBundle/Integration/AbstractIntegration.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\PluginBundle\\Entity\\IntegrationEntity" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 4
-			path: plugins/MauticCrmBundle/Integration/ConnectwiseIntegration.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\PluginBundle\\Entity\\IntegrationEntity" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 3
-			path: plugins/MauticCrmBundle/Integration/DynamicsIntegration.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\PluginBundle\\Entity\\IntegrationEntity" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: plugins/MauticCrmBundle/Integration/HubspotIntegration.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\PluginBundle\\Entity\\IntegrationEntity" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 5
-			path: plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\PluginBundle\\Entity\\IntegrationEntity" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 7
-			path: plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\PluginBundle\\Entity\\IntegrationEntity" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 4
-			path: plugins/MauticCrmBundle/Integration/ZohoIntegration.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\PointBundle\\Entity\\Group" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 2
-			path: app/bundles/PointBundle/EventListener/GroupImportExportSubscriber.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\ReportBundle\\Entity\\Scheduler" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/ReportBundle/Scheduler/Model/SchedulerPlanner.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\SmsBundle\\Entity\\Stat" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/SmsBundle/EventListener/LeadSubscriber.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\StageBundle\\Entity\\Stage" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: plugins/MauticCrmBundle/Integration/HubspotIntegration.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\UserBundle\\Entity\\Role" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\UserBundle\\Entity\\User" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/ApiBundle/EventListener/PreAuthorizationEventListener.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\UserBundle\\Entity\\User" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/InstallBundle/Install/InstallService.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\UserBundle\\Entity\\User" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: app/bundles/PluginBundle/Integration/AbstractIntegration.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\UserBundle\\Entity\\User" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
-
-		-
-			message: '#^Entity manager must not fetch the "Mautic\\UserBundle\\Entity\\User" repository by entity constant\. Inject the repository as a typed dependency instead, to make the dependency and its type explicit\.$#'
-			identifier: mautic.noEntityManagerGetRepository
-			count: 1
-			path: plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -225,8 +225,5 @@ rules:
 	- Utils\PHPStan\Rule\CommandMustHaveAsCommandAttributeRule
 	- Utils\PHPStan\Rule\NoNullableServiceInConstructorRule
 	- Utils\PHPStan\Rule\NoGetRepositoryWithEntityInRepositoryRule
-<<<<<<< HEAD
 	#- Utils\PHPStan\Rule\NoContainerGetRule
-=======
 	- Utils\PHPStan\Rule\NoEntityManagerGetRepositoryRule
->>>>>>> ae19446fe3 ([phpstan] add rule to forbid entity manager getRepository() with entity class constant)

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -225,4 +225,8 @@ rules:
 	- Utils\PHPStan\Rule\CommandMustHaveAsCommandAttributeRule
 	- Utils\PHPStan\Rule\NoNullableServiceInConstructorRule
 	- Utils\PHPStan\Rule\NoGetRepositoryWithEntityInRepositoryRule
+<<<<<<< HEAD
 	#- Utils\PHPStan\Rule\NoContainerGetRule
+=======
+	- Utils\PHPStan\Rule\NoEntityManagerGetRepositoryRule
+>>>>>>> ae19446fe3 ([phpstan] add rule to forbid entity manager getRepository() with entity class constant)

--- a/plugins/MauticSocialBundle/EventListener/StatsSubscriber.php
+++ b/plugins/MauticSocialBundle/EventListener/StatsSubscriber.php
@@ -5,19 +5,19 @@ namespace MauticPlugin\MauticSocialBundle\EventListener;
 use Doctrine\ORM\EntityManager;
 use Mautic\CoreBundle\EventListener\CommonStatsSubscriber;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
-use MauticPlugin\MauticSocialBundle\Entity\TweetStat;
 use MauticPlugin\MauticSocialBundle\Entity\TweetStatRepository;
 
 final class StatsSubscriber extends CommonStatsSubscriber
 {
-    public function __construct(CorePermissions $security, EntityManager $entityManager)
-    {
+    public function __construct(
+        CorePermissions $security,
+        EntityManager $entityManager,
+        TweetStatRepository $tweetStatRepository,
+    ) {
         parent::__construct($security, $entityManager);
 
-        /** @var TweetStatRepository $repo */
-        $repo                      = $entityManager->getRepository(TweetStat::class);
-        $table                     = $repo->getTableName();
-        $this->repositories[]      = $repo;
+        $table                     = $tweetStatRepository->getTableName();
+        $this->repositories[]      = $tweetStatRepository;
         $this->permissions[$table] = ['tweet' => 'mauticSocial:tweets'];
     }
 }

--- a/utils/phpstan/src/Rule/NoEntityManagerGetRepositoryRule.php
+++ b/utils/phpstan/src/Rule/NoEntityManagerGetRepositoryRule.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Rule;
+
+use Doctrine\Persistence\ObjectManager;
+use PhpParser\Node;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\ObjectType;
+
+/**
+ * An entity manager must not be asked for a repository by an entity class constant, e.g. getRepository(Lead::class).
+ *
+ * The returned repository has a generic type only, so the concrete repository methods are hidden from both the reader
+ * and static analysis. Inject the repository as a typed constructor dependency instead. The entity manager can be a
+ * property, a variable or any other expression - only its type matters.
+ *
+ * Tests are skipped, as fetching an entity by its repository is a legit shortcut there.
+ *
+ * @implements Rule<MethodCall>
+ */
+final class NoEntityManagerGetRepositoryRule implements Rule
+{
+    /**
+     * @var string
+     */
+    private const GET_REPOSITORY_METHOD = 'getRepository';
+
+    public function getNodeType(): string
+    {
+        return MethodCall::class;
+    }
+
+    /**
+     * @param MethodCall $node
+     *
+     * @return list<\PHPStan\Rules\IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        // inside a trait the scope file is the class using it, so the very same call would be reported
+        // once per using class, in a file that does not contain it
+        if ($scope->isInTrait()) {
+            return [];
+        }
+
+        if ($this->isTestFile($scope->getFile())) {
+            return [];
+        }
+
+        if (!$node->name instanceof Node\Identifier) {
+            return [];
+        }
+
+        if (self::GET_REPOSITORY_METHOD !== $node->name->toString()) {
+            return [];
+        }
+
+        $firstArg = $node->getArgs()[0] ?? null;
+        if (!$firstArg instanceof Node\Arg) {
+            return [];
+        }
+
+        // only an exact entity constant, e.g. Lead::class
+        if (!$firstArg->value instanceof ClassConstFetch) {
+            return [];
+        }
+
+        if (!$firstArg->value->class instanceof Name) {
+            return [];
+        }
+
+        if (!$firstArg->value->name instanceof Node\Identifier || 'class' !== $firstArg->value->name->toString()) {
+            return [];
+        }
+
+        // the caller must be an entity manager, a property, a variable or any other expression alike
+        $callerType = $scope->getType($node->var);
+        if (!(new ObjectType(ObjectManager::class))->isSuperTypeOf($callerType)->yes()) {
+            return [];
+        }
+
+        $ruleError = RuleErrorBuilder::message(sprintf(
+            'Entity manager must not fetch the "%s" repository by entity constant. Inject the repository as a typed dependency instead, to make the dependency and its type explicit.',
+            $firstArg->value->class->toString()
+        ))
+            ->identifier('mautic.noEntityManagerGetRepository')
+            ->build();
+
+        return [$ruleError];
+    }
+
+    private function isTestFile(string $filePath): bool
+    {
+        return str_contains($filePath, '/Tests/') || str_ends_with($filePath, 'Test.php') || str_ends_with($filePath, 'TestCase.php');
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/GetRepositoryOnEntityManagerService.php
+++ b/utils/phpstan/tests/Rule/Fixture/GetRepositoryOnEntityManagerService.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+use Doctrine\ORM\EntityManagerInterface;
+
+class GetRepositoryOnEntityManagerService
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function byProperty(): void
+    {
+        $this->entityManager->getRepository(\stdClass::class);
+    }
+
+    public function byVariable(EntityManagerInterface $entityManager): void
+    {
+        $entityManager->getRepository(\stdClass::class);
+    }
+
+    public function byString(): void
+    {
+        // a string name is not an entity constant, nothing to report
+        $this->entityManager->getRepository('MauticLeadBundle:Lead');
+    }
+
+    public function onAnotherService(SomeRepositoryHolder $someRepositoryHolder): void
+    {
+        // not an entity manager, nothing to report
+        $someRepositoryHolder->getRepository(\stdClass::class);
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/SomeRepositoryHolder.php
+++ b/utils/phpstan/tests/Rule/Fixture/SomeRepositoryHolder.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+class SomeRepositoryHolder
+{
+    /**
+     * @param class-string $entityClass
+     */
+    public function getRepository(string $entityClass): void
+    {
+    }
+}

--- a/utils/phpstan/tests/Rule/NoEntityManagerGetRepositoryRuleTest.php
+++ b/utils/phpstan/tests/Rule/NoEntityManagerGetRepositoryRuleTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use Utils\PHPStan\Rule\NoEntityManagerGetRepositoryRule;
+
+/**
+ * @extends RuleTestCase<NoEntityManagerGetRepositoryRule>
+ */
+final class NoEntityManagerGetRepositoryRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new NoEntityManagerGetRepositoryRule();
+    }
+
+    public function testRule(): void
+    {
+        $errorMessage = 'Entity manager must not fetch the "stdClass" repository by entity constant. Inject the repository as a typed dependency instead, to make the dependency and its type explicit.';
+
+        $this->analyse([__DIR__.'/Fixture/GetRepositoryOnEntityManagerService.php'], [
+            [$errorMessage, 18],
+            [$errorMessage, 23],
+        ]);
+    }
+}


### PR DESCRIPTION
Adds a PHPStan rule that forbids fetching a repository from the entity manager by an entity class constant. The entity manager can be a property, a variable or any other expression — only its type matters. Tests and traits are skipped.

The returned repository is generic, so its concrete methods are hidden from both the reader and static analysis. Injecting the repository makes the dependency and its type explicit.

```diff
-$stat = $this->entityManager->getRepository(Stat::class)->find($id);
+$stat = $this->statRepository->find($id);
```

Existing 131 violations are added to the baseline, to be fixed step by step.
