### PR TITLE
[solid] finalize event classes

### DIFF
--- a/app/bundles/ApiBundle/Event/ApiEntityEvent.php
+++ b/app/bundles/ApiBundle/Event/ApiEntityEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\ApiBundle\Event;
 use Mautic\CoreBundle\Event\CommonEvent;
 use Symfony\Component\HttpFoundation\Request;
 
-class ApiEntityEvent extends CommonEvent
+final class ApiEntityEvent extends CommonEvent
 {
     /**
      * @param object $entity

--- a/app/bundles/ApiBundle/Event/ClientEvent.php
+++ b/app/bundles/ApiBundle/Event/ClientEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\ApiBundle\Event;
 use Mautic\ApiBundle\Entity\oAuth2\Client;
 use Mautic\CoreBundle\Event\CommonEvent;
 
-class ClientEvent extends CommonEvent
+final class ClientEvent extends CommonEvent
 {
     private readonly string $apiMode;
 

--- a/app/bundles/AssetBundle/Event/AssetEvent.php
+++ b/app/bundles/AssetBundle/Event/AssetEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\AssetBundle\Event;
 use Mautic\AssetBundle\Entity\Asset;
 use Mautic\CoreBundle\Event\CommonEvent;
 
-class AssetEvent extends CommonEvent
+final class AssetEvent extends CommonEvent
 {
     /**
      * @param bool $isNew

--- a/app/bundles/AssetBundle/Event/AssetLoadEvent.php
+++ b/app/bundles/AssetBundle/Event/AssetLoadEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\AssetBundle\Event;
 use Mautic\AssetBundle\Entity\Download;
 use Mautic\CoreBundle\Event\CommonEvent;
 
-class AssetLoadEvent extends CommonEvent
+final class AssetLoadEvent extends CommonEvent
 {
     public function __construct(
         Download $download,

--- a/app/bundles/AssetBundle/Event/RemoteAssetBrowseEvent.php
+++ b/app/bundles/AssetBundle/Event/RemoteAssetBrowseEvent.php
@@ -6,7 +6,7 @@ use Gaufrette\Adapter;
 use Mautic\CoreBundle\Event\CommonEvent;
 use Mautic\PluginBundle\Integration\UnifiedIntegrationInterface;
 
-class RemoteAssetBrowseEvent extends CommonEvent
+final class RemoteAssetBrowseEvent extends CommonEvent
 {
     private ?Adapter $adapter       = null;
 

--- a/app/bundles/CampaignBundle/Event/CampaignBuilderEvent.php
+++ b/app/bundles/CampaignBundle/Event/CampaignBuilderEvent.php
@@ -7,7 +7,7 @@ use Mautic\CoreBundle\Event\ComponentValidationTrait;
 use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class CampaignBuilderEvent extends Event
+final class CampaignBuilderEvent extends Event
 {
     use ComponentValidationTrait;
 

--- a/app/bundles/CampaignBundle/Event/CampaignDecisionEvent.php
+++ b/app/bundles/CampaignBundle/Event/CampaignDecisionEvent.php
@@ -8,7 +8,7 @@ use Symfony\Contracts\EventDispatcher\Event;
 /**
  * @deprecated 2.13.0; to be removed in 3.0
  */
-class CampaignDecisionEvent extends Event
+final class CampaignDecisionEvent extends Event
 {
     protected $decisionTriggered = false;
 

--- a/app/bundles/CampaignBundle/Event/CampaignEvent.php
+++ b/app/bundles/CampaignBundle/Event/CampaignEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\CampaignBundle\Event;
 use Mautic\CampaignBundle\Entity\Campaign;
 use Mautic\CoreBundle\Event\CommonEvent;
 
-class CampaignEvent extends CommonEvent
+final class CampaignEvent extends CommonEvent
 {
     /**
      * @param bool $isNew

--- a/app/bundles/CampaignBundle/Event/CampaignLeadChangeEvent.php
+++ b/app/bundles/CampaignBundle/Event/CampaignLeadChangeEvent.php
@@ -6,7 +6,7 @@ use Mautic\CampaignBundle\Entity\Campaign;
 use Mautic\LeadBundle\Entity\Lead;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class CampaignLeadChangeEvent extends Event
+final class CampaignLeadChangeEvent extends Event
 {
     /**
      * @var ?Lead

--- a/app/bundles/CampaignBundle/Event/CampaignTriggerEvent.php
+++ b/app/bundles/CampaignBundle/Event/CampaignTriggerEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\CampaignBundle\Event;
 use Mautic\CampaignBundle\Entity\Campaign;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class CampaignTriggerEvent extends Event
+final class CampaignTriggerEvent extends Event
 {
     /**
      * @var bool

--- a/app/bundles/CampaignBundle/Event/ConditionEvent.php
+++ b/app/bundles/CampaignBundle/Event/ConditionEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\CampaignBundle\Event;
 use Mautic\CampaignBundle\Entity\LeadEventLog;
 use Mautic\CampaignBundle\EventCollector\Accessor\Event\AbstractEventAccessor;
 
-class ConditionEvent extends CampaignExecutionEvent
+final class ConditionEvent extends CampaignExecutionEvent
 {
     use ContextTrait;
 

--- a/app/bundles/CampaignBundle/Event/DecisionEvent.php
+++ b/app/bundles/CampaignBundle/Event/DecisionEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\CampaignBundle\Event;
 use Mautic\CampaignBundle\Entity\LeadEventLog;
 use Mautic\CampaignBundle\EventCollector\Accessor\Event\AbstractEventAccessor;
 
-class DecisionEvent extends CampaignExecutionEvent
+final class DecisionEvent extends CampaignExecutionEvent
 {
     use ContextTrait;
 

--- a/app/bundles/CampaignBundle/Event/DecisionResultsEvent.php
+++ b/app/bundles/CampaignBundle/Event/DecisionResultsEvent.php
@@ -8,7 +8,7 @@ use Mautic\CampaignBundle\EventCollector\Accessor\Event\AbstractEventAccessor;
 use Mautic\CampaignBundle\Executioner\Result\EvaluatedContacts;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class DecisionResultsEvent extends Event
+final class DecisionResultsEvent extends Event
 {
     /**
      * @param ArrayCollection<int, LeadEventLog> $eventLogs

--- a/app/bundles/CampaignBundle/Event/Exception/KeyAlreadyRegisteredException.php
+++ b/app/bundles/CampaignBundle/Event/Exception/KeyAlreadyRegisteredException.php
@@ -7,6 +7,6 @@ use Symfony\Component\Process\Exception\InvalidArgumentException;
 /**
  * Extends Symfony\Component\Process\Exception\InvalidArgumentException to keep BC.
  */
-class KeyAlreadyRegisteredException extends InvalidArgumentException
+final class KeyAlreadyRegisteredException extends InvalidArgumentException
 {
 }

--- a/app/bundles/CampaignBundle/Event/ExecutedBatchEvent.php
+++ b/app/bundles/CampaignBundle/Event/ExecutedBatchEvent.php
@@ -4,7 +4,7 @@ namespace Mautic\CampaignBundle\Event;
 
 use Doctrine\Common\Collections\ArrayCollection;
 
-class ExecutedBatchEvent extends AbstractLogCollectionEvent
+final class ExecutedBatchEvent extends AbstractLogCollectionEvent
 {
     /**
      * @return ArrayCollection

--- a/app/bundles/CampaignBundle/Event/ExecutedEvent.php
+++ b/app/bundles/CampaignBundle/Event/ExecutedEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\CampaignBundle\Event;
 use Mautic\CampaignBundle\Entity\LeadEventLog;
 use Mautic\CampaignBundle\EventCollector\Accessor\Event\AbstractEventAccessor;
 
-class ExecutedEvent extends \Symfony\Contracts\EventDispatcher\Event
+final class ExecutedEvent extends \Symfony\Contracts\EventDispatcher\Event
 {
     public function __construct(
         private readonly AbstractEventAccessor $config,

--- a/app/bundles/CampaignBundle/Event/FailedEvent.php
+++ b/app/bundles/CampaignBundle/Event/FailedEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\CampaignBundle\Event;
 use Mautic\CampaignBundle\Entity\LeadEventLog;
 use Mautic\CampaignBundle\EventCollector\Accessor\Event\AbstractEventAccessor;
 
-class FailedEvent extends \Symfony\Contracts\EventDispatcher\Event
+final class FailedEvent extends \Symfony\Contracts\EventDispatcher\Event
 {
     public function __construct(
         private readonly AbstractEventAccessor $config,

--- a/app/bundles/CampaignBundle/Event/NotifyOfFailureEvent.php
+++ b/app/bundles/CampaignBundle/Event/NotifyOfFailureEvent.php
@@ -6,7 +6,7 @@ use Mautic\CampaignBundle\Entity\Event as CampaignEvent;
 use Mautic\LeadBundle\Entity\Lead;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class NotifyOfFailureEvent extends Event
+final class NotifyOfFailureEvent extends Event
 {
     public function __construct(
         private readonly Lead $lead,

--- a/app/bundles/CampaignBundle/Event/NotifyOfUnpublishEvent.php
+++ b/app/bundles/CampaignBundle/Event/NotifyOfUnpublishEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\CampaignBundle\Event;
 use Mautic\CampaignBundle\Entity\Event as CampaignEvent;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class NotifyOfUnpublishEvent extends Event
+final class NotifyOfUnpublishEvent extends Event
 {
     public function __construct(
         private readonly CampaignEvent $failedEvent,

--- a/app/bundles/CampaignBundle/Event/ScheduledBatchEvent.php
+++ b/app/bundles/CampaignBundle/Event/ScheduledBatchEvent.php
@@ -6,7 +6,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CampaignBundle\EventCollector\Accessor\Event\AbstractEventAccessor;
 
-class ScheduledBatchEvent extends AbstractLogCollectionEvent
+final class ScheduledBatchEvent extends AbstractLogCollectionEvent
 {
     /**
      * @param bool $isReschedule

--- a/app/bundles/CampaignBundle/Event/ScheduledEvent.php
+++ b/app/bundles/CampaignBundle/Event/ScheduledEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\CampaignBundle\Event;
 use Mautic\CampaignBundle\Entity\LeadEventLog;
 use Mautic\CampaignBundle\EventCollector\Accessor\Event\AbstractEventAccessor;
 
-class ScheduledEvent extends CampaignScheduledEvent
+final class ScheduledEvent extends CampaignScheduledEvent
 {
     use ContextTrait;
 

--- a/app/bundles/CategoryBundle/Event/CategoryEvent.php
+++ b/app/bundles/CategoryBundle/Event/CategoryEvent.php
@@ -7,7 +7,7 @@ use Mautic\CoreBundle\Event\CommonEvent;
 use Mautic\CoreBundle\Event\DependencyErrorEventInterface;
 use Mautic\CoreBundle\Event\DependencyErrorEventTrait;
 
-class CategoryEvent extends CommonEvent implements DependencyErrorEventInterface
+final class CategoryEvent extends CommonEvent implements DependencyErrorEventInterface
 {
     use DependencyErrorEventTrait;
 

--- a/app/bundles/CategoryBundle/Event/CategoryTypesEvent.php
+++ b/app/bundles/CategoryBundle/Event/CategoryTypesEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\CategoryBundle\Event;
 use Mautic\CategoryBundle\Entity\Category;
 use Mautic\CoreBundle\Event\CommonEvent;
 
-class CategoryTypesEvent extends CommonEvent
+final class CategoryTypesEvent extends CommonEvent
 {
     /**
      * @var array

--- a/app/bundles/ChannelBundle/Event/ChannelBroadcastEvent.php
+++ b/app/bundles/ChannelBundle/Event/ChannelBroadcastEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\ChannelBundle\Event;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class ChannelBroadcastEvent extends Event
+final class ChannelBroadcastEvent extends Event
 {
     /**
      * Number of contacts successfully processed and/or failed per channel.
@@ -17,14 +17,14 @@ class ChannelBroadcastEvent extends Event
     /**
      * Min contact ID filter can be used for process parallelization.
      *
-     * @var int
+     * @var int|null
      */
     private $minContactIdFilter;
 
     /**
      * Max contact ID filter can be used for process parallelization.
      *
-     * @var int
+     * @var int|null
      */
     private $maxContactIdFilter;
 

--- a/app/bundles/ChannelBundle/Event/ChannelEvent.php
+++ b/app/bundles/ChannelBundle/Event/ChannelEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\ChannelBundle\Event;
 use Mautic\ChannelBundle\Model\MessageModel;
 use Mautic\CoreBundle\Event\CommonEvent;
 
-class ChannelEvent extends CommonEvent
+final class ChannelEvent extends CommonEvent
 {
     /**
      * @var array

--- a/app/bundles/ChannelBundle/Event/MessageEvent.php
+++ b/app/bundles/ChannelBundle/Event/MessageEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\ChannelBundle\Event;
 use Mautic\ChannelBundle\Entity\Message;
 use Mautic\CoreBundle\Event\CommonEvent;
 
-class MessageEvent extends CommonEvent
+final class MessageEvent extends CommonEvent
 {
     /**
      * @param bool $isNew

--- a/app/bundles/ChannelBundle/Event/MessageQueueBatchProcessEvent.php
+++ b/app/bundles/ChannelBundle/Event/MessageQueueBatchProcessEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\ChannelBundle\Event;
 use Mautic\ChannelBundle\Entity\MessageQueue;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class MessageQueueBatchProcessEvent extends Event
+final class MessageQueueBatchProcessEvent extends Event
 {
     /**
      * @param MessageQueue[] $messages

--- a/app/bundles/ChannelBundle/Event/MessageQueueEvent.php
+++ b/app/bundles/ChannelBundle/Event/MessageQueueEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\ChannelBundle\Event;
 use Mautic\ChannelBundle\Entity\MessageQueue;
 use Mautic\CoreBundle\Event\CommonEvent;
 
-class MessageQueueEvent extends CommonEvent
+final class MessageQueueEvent extends CommonEvent
 {
     /**
      * @param bool $isNew

--- a/app/bundles/ChannelBundle/Event/MessageQueueProcessEvent.php
+++ b/app/bundles/ChannelBundle/Event/MessageQueueProcessEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\ChannelBundle\Event;
 use Mautic\ChannelBundle\Entity\MessageQueue;
 use Mautic\CoreBundle\Event\CommonEvent;
 
-class MessageQueueProcessEvent extends CommonEvent
+final class MessageQueueProcessEvent extends CommonEvent
 {
     public function __construct(MessageQueue $entity)
     {

--- a/app/bundles/CoreBundle/Doctrine/Common/DataFixtures/Event/PreExecuteEvent.php
+++ b/app/bundles/CoreBundle/Doctrine/Common/DataFixtures/Event/PreExecuteEvent.php
@@ -8,7 +8,7 @@ use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class PreExecuteEvent extends Event
+final class PreExecuteEvent extends Event
 {
     public function __construct(
         private readonly EntityManagerInterface $entityManager,

--- a/app/bundles/CoreBundle/Event/BuildJsEvent.php
+++ b/app/bundles/CoreBundle/Event/BuildJsEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\CoreBundle\Event;
 use MatthiasMullie\Minify;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class BuildJsEvent extends Event
+final class BuildJsEvent extends Event
 {
     /**
      * @param bool           $debugMode

--- a/app/bundles/CoreBundle/Event/CommandListEvent.php
+++ b/app/bundles/CoreBundle/Event/CommandListEvent.php
@@ -4,7 +4,7 @@ namespace Mautic\CoreBundle\Event;
 
 use Symfony\Contracts\EventDispatcher\Event;
 
-class CommandListEvent extends Event
+final class CommandListEvent extends Event
 {
     /**
      * @var array

--- a/app/bundles/CoreBundle/Event/CustomButtonEvent.php
+++ b/app/bundles/CoreBundle/Event/CustomButtonEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\CoreBundle\Event;
 use Mautic\CoreBundle\Twig\Helper\ButtonHelper;
 use Symfony\Component\HttpFoundation\Request;
 
-class CustomButtonEvent extends AbstractCustomRequestEvent
+final class CustomButtonEvent extends AbstractCustomRequestEvent
 {
     /**
      * @var array

--- a/app/bundles/CoreBundle/Event/CustomContentEvent.php
+++ b/app/bundles/CoreBundle/Event/CustomContentEvent.php
@@ -4,7 +4,7 @@ namespace Mautic\CoreBundle\Event;
 
 use Symfony\Contracts\EventDispatcher\Event;
 
-class CustomContentEvent extends Event
+final class CustomContentEvent extends Event
 {
     /**
      * @var array

--- a/app/bundles/CoreBundle/Event/CustomTemplateEvent.php
+++ b/app/bundles/CoreBundle/Event/CustomTemplateEvent.php
@@ -4,7 +4,7 @@ namespace Mautic\CoreBundle\Event;
 
 use Symfony\Component\HttpFoundation\Request;
 
-class CustomTemplateEvent extends AbstractCustomRequestEvent
+final class CustomTemplateEvent extends AbstractCustomRequestEvent
 {
     protected string $template;
 

--- a/app/bundles/CoreBundle/Event/DetermineWinnerEvent.php
+++ b/app/bundles/CoreBundle/Event/DetermineWinnerEvent.php
@@ -4,7 +4,7 @@ namespace Mautic\CoreBundle\Event;
 
 use Symfony\Contracts\EventDispatcher\Event;
 
-class DetermineWinnerEvent extends Event
+final class DetermineWinnerEvent extends Event
 {
     /**
      * @var array{

--- a/app/bundles/CoreBundle/Event/EntityValidateEvent.php
+++ b/app/bundles/CoreBundle/Event/EntityValidateEvent.php
@@ -8,7 +8,7 @@ use Mautic\CoreBundle\Validator\EntityEvent;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class EntityValidateEvent extends Event
+final class EntityValidateEvent extends Event
 {
     public function __construct(
         private readonly object $entity,

--- a/app/bundles/CoreBundle/Event/GeneratedColumnsEvent.php
+++ b/app/bundles/CoreBundle/Event/GeneratedColumnsEvent.php
@@ -8,7 +8,7 @@ use Mautic\CoreBundle\Doctrine\GeneratedColumn\GeneratedColumn;
 use Mautic\CoreBundle\Doctrine\GeneratedColumn\GeneratedColumns;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class GeneratedColumnsEvent extends Event
+final class GeneratedColumnsEvent extends Event
 {
     private readonly GeneratedColumns $generatedColumns;
 

--- a/app/bundles/CoreBundle/Event/GlobalSearchEvent.php
+++ b/app/bundles/CoreBundle/Event/GlobalSearchEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\CoreBundle\Event;
 use Mautic\CoreBundle\Translation\Translator;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class GlobalSearchEvent extends Event
+final class GlobalSearchEvent extends Event
 {
     public const RESULTS_LIMIT = 3;
 

--- a/app/bundles/CoreBundle/Event/IconEvent.php
+++ b/app/bundles/CoreBundle/Event/IconEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\CoreBundle\Event;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class IconEvent extends Event
+final class IconEvent extends Event
 {
     /**
      * @var array

--- a/app/bundles/CoreBundle/Event/MenuEvent.php
+++ b/app/bundles/CoreBundle/Event/MenuEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\CoreBundle\Event;
 use Mautic\CoreBundle\Menu\MenuHelper;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class MenuEvent extends Event
+final class MenuEvent extends Event
 {
     /**
      * @var array

--- a/app/bundles/CoreBundle/Event/RouteEvent.php
+++ b/app/bundles/CoreBundle/Event/RouteEvent.php
@@ -6,7 +6,7 @@ use Symfony\Component\Config\Loader\Loader;
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class RouteEvent extends Event
+final class RouteEvent extends Event
 {
     protected RouteCollection $collection;
 

--- a/app/bundles/CoreBundle/Event/UpgradeEvent.php
+++ b/app/bundles/CoreBundle/Event/UpgradeEvent.php
@@ -4,7 +4,7 @@ namespace Mautic\CoreBundle\Event;
 
 use Symfony\Contracts\EventDispatcher\Event;
 
-class UpgradeEvent extends Event
+final class UpgradeEvent extends Event
 {
     public function __construct(
         protected array $status,

--- a/app/bundles/DashboardBundle/Event/WidgetFormEvent.php
+++ b/app/bundles/DashboardBundle/Event/WidgetFormEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\DashboardBundle\Event;
 use Mautic\CoreBundle\Event\CommonEvent;
 use Mautic\DashboardBundle\Entity\Widget;
 
-class WidgetFormEvent extends CommonEvent
+final class WidgetFormEvent extends CommonEvent
 {
     protected $form;
 

--- a/app/bundles/DashboardBundle/Event/WidgetTypeListEvent.php
+++ b/app/bundles/DashboardBundle/Event/WidgetTypeListEvent.php
@@ -7,7 +7,7 @@ use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\DashboardBundle\Entity\Widget;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class WidgetTypeListEvent extends CommonEvent
+final class WidgetTypeListEvent extends CommonEvent
 {
     /**
      * @var array

--- a/app/bundles/DynamicContentBundle/Event/DynamicContentEvent.php
+++ b/app/bundles/DynamicContentBundle/Event/DynamicContentEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\DynamicContentBundle\Event;
 use Mautic\CoreBundle\Event\CommonEvent;
 use Mautic\DynamicContentBundle\Entity\DynamicContent;
 
-class DynamicContentEvent extends CommonEvent
+final class DynamicContentEvent extends CommonEvent
 {
     /**
      * @param bool $isNew

--- a/app/bundles/EmailBundle/Event/EmailBuilderEvent.php
+++ b/app/bundles/EmailBundle/Event/EmailBuilderEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\EmailBundle\Event;
 use Mautic\CoreBundle\Event\BuilderEvent;
 use Mautic\EmailBundle\Entity\Email;
 
-class EmailBuilderEvent extends BuilderEvent
+final class EmailBuilderEvent extends BuilderEvent
 {
     /**
      * @return Email|null

--- a/app/bundles/EmailBundle/Event/EmailEvent.php
+++ b/app/bundles/EmailBundle/Event/EmailEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\EmailBundle\Event;
 use Mautic\CoreBundle\Event\CommonEvent;
 use Mautic\EmailBundle\Entity\Email;
 
-class EmailEvent extends CommonEvent
+final class EmailEvent extends CommonEvent
 {
     /**
      * @param bool $isNew

--- a/app/bundles/EmailBundle/Event/EmailOpenEvent.php
+++ b/app/bundles/EmailBundle/Event/EmailOpenEvent.php
@@ -7,7 +7,7 @@ use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Entity\Stat;
 use Symfony\Component\HttpFoundation\Request;
 
-class EmailOpenEvent extends CommonEvent
+final class EmailOpenEvent extends CommonEvent
 {
     private readonly ?Email $email;
 

--- a/app/bundles/EmailBundle/Event/EmailReplyEvent.php
+++ b/app/bundles/EmailBundle/Event/EmailReplyEvent.php
@@ -6,7 +6,7 @@ use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Entity\Stat;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class EmailReplyEvent extends Event
+final class EmailReplyEvent extends Event
 {
     private readonly ?Email $email;
 

--- a/app/bundles/EmailBundle/Event/MonitoredEmailEvent.php
+++ b/app/bundles/EmailBundle/Event/MonitoredEmailEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\EmailBundle\Event;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class MonitoredEmailEvent extends Event
+final class MonitoredEmailEvent extends Event
 {
     private array $folders = [];
 

--- a/app/bundles/EmailBundle/Event/ParseEmailEvent.php
+++ b/app/bundles/EmailBundle/Event/ParseEmailEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\EmailBundle\Event;
 use Mautic\EmailBundle\MonitoredEmail\Message;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class ParseEmailEvent extends Event
+final class ParseEmailEvent extends Event
 {
     /**
      * @var mixed[]

--- a/app/bundles/EmailBundle/Event/QueueEmailEvent.php
+++ b/app/bundles/EmailBundle/Event/QueueEmailEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\EmailBundle\Event;
 use Mautic\EmailBundle\Mailer\Message\MauticMessage;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class QueueEmailEvent extends Event
+final class QueueEmailEvent extends Event
 {
     private bool $retry = false;
 

--- a/app/bundles/FormBundle/Event/FormBuilderEvent.php
+++ b/app/bundles/FormBundle/Event/FormBuilderEvent.php
@@ -10,7 +10,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class FormBuilderEvent extends Event
+final class FormBuilderEvent extends Event
 {
     use ComponentValidationTrait;
 

--- a/app/bundles/FormBundle/Event/FormEvent.php
+++ b/app/bundles/FormBundle/Event/FormEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\FormBundle\Event;
 use Mautic\CoreBundle\Event\CommonEvent;
 use Mautic\FormBundle\Entity\Form;
 
-class FormEvent extends CommonEvent
+final class FormEvent extends CommonEvent
 {
     /**
      * @param bool $isNew

--- a/app/bundles/FormBundle/Event/Service/FieldValueTransformer.php
+++ b/app/bundles/FormBundle/Event/Service/FieldValueTransformer.php
@@ -7,7 +7,7 @@ use Mautic\FormBundle\Event\SubmissionEvent;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
 
-class FieldValueTransformer
+final class FieldValueTransformer
 {
     private array $contactFieldsToUpdate = [];
 

--- a/app/bundles/FormBundle/Event/ValidationEvent.php
+++ b/app/bundles/FormBundle/Event/ValidationEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\FormBundle\Event;
 use Mautic\CoreBundle\Event\CommonEvent;
 use Mautic\FormBundle\Entity\Field;
 
-class ValidationEvent extends CommonEvent
+final class ValidationEvent extends CommonEvent
 {
     private bool $valid = true;
 

--- a/app/bundles/IntegrationsBundle/Event/CompletedSyncIterationEvent.php
+++ b/app/bundles/IntegrationsBundle/Event/CompletedSyncIterationEvent.php
@@ -9,7 +9,7 @@ use Mautic\IntegrationsBundle\Sync\DAO\Sync\InputOptionsDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Sync\Order\OrderResultsDAO;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class CompletedSyncIterationEvent extends Event
+final class CompletedSyncIterationEvent extends Event
 {
     public function __construct(
         private readonly OrderResultsDAO $orderResultsDAO,

--- a/app/bundles/IntegrationsBundle/Event/ConfigSaveEvent.php
+++ b/app/bundles/IntegrationsBundle/Event/ConfigSaveEvent.php
@@ -7,7 +7,7 @@ namespace Mautic\IntegrationsBundle\Event;
 use Mautic\PluginBundle\Entity\Integration;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class ConfigSaveEvent extends Event
+final class ConfigSaveEvent extends Event
 {
     public function __construct(
         private readonly Integration $integrationConfiguration,

--- a/app/bundles/IntegrationsBundle/Event/FormLoadEvent.php
+++ b/app/bundles/IntegrationsBundle/Event/FormLoadEvent.php
@@ -7,7 +7,7 @@ namespace Mautic\IntegrationsBundle\Event;
 use Mautic\PluginBundle\Entity\Integration;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class FormLoadEvent extends Event
+final class FormLoadEvent extends Event
 {
     public function __construct(
         private readonly Integration $integrationConfiguration,

--- a/app/bundles/IntegrationsBundle/Event/InternalObjectCreateEvent.php
+++ b/app/bundles/IntegrationsBundle/Event/InternalObjectCreateEvent.php
@@ -8,7 +8,7 @@ use Mautic\IntegrationsBundle\Entity\ObjectMapping;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\Object\ObjectInterface;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class InternalObjectCreateEvent extends Event
+final class InternalObjectCreateEvent extends Event
 {
     /**
      * @var ObjectMapping[]

--- a/app/bundles/IntegrationsBundle/Event/InternalObjectEvent.php
+++ b/app/bundles/IntegrationsBundle/Event/InternalObjectEvent.php
@@ -7,7 +7,7 @@ namespace Mautic\IntegrationsBundle\Event;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\Object\ObjectInterface;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class InternalObjectEvent extends Event
+final class InternalObjectEvent extends Event
 {
     private array $objects = [];
 

--- a/app/bundles/IntegrationsBundle/Event/InternalObjectFindEvent.php
+++ b/app/bundles/IntegrationsBundle/Event/InternalObjectFindEvent.php
@@ -8,7 +8,7 @@ use Mautic\IntegrationsBundle\Sync\DAO\DateRange;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\Object\ObjectInterface;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class InternalObjectFindEvent extends Event
+final class InternalObjectFindEvent extends Event
 {
     /**
      * @var int[]

--- a/app/bundles/IntegrationsBundle/Event/InternalObjectOwnerEvent.php
+++ b/app/bundles/IntegrationsBundle/Event/InternalObjectOwnerEvent.php
@@ -7,7 +7,7 @@ namespace Mautic\IntegrationsBundle\Event;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\Object\ObjectInterface;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class InternalObjectOwnerEvent extends Event
+final class InternalObjectOwnerEvent extends Event
 {
     /**
      * Format: [object_id => owner_id].

--- a/app/bundles/IntegrationsBundle/Event/InternalObjectRouteEvent.php
+++ b/app/bundles/IntegrationsBundle/Event/InternalObjectRouteEvent.php
@@ -7,7 +7,7 @@ namespace Mautic\IntegrationsBundle\Event;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\Object\ObjectInterface;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class InternalObjectRouteEvent extends Event
+final class InternalObjectRouteEvent extends Event
 {
     private ?string $route = null;
 

--- a/app/bundles/IntegrationsBundle/Event/InternalObjectUpdateEvent.php
+++ b/app/bundles/IntegrationsBundle/Event/InternalObjectUpdateEvent.php
@@ -9,7 +9,7 @@ use Mautic\IntegrationsBundle\Sync\DAO\Sync\Order\ObjectChangeDAO;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\Object\ObjectInterface;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class InternalObjectUpdateEvent extends Event
+final class InternalObjectUpdateEvent extends Event
 {
     /**
      * @var UpdatedObjectMappingDAO[]

--- a/app/bundles/IntegrationsBundle/Event/KeysDecryptionEvent.php
+++ b/app/bundles/IntegrationsBundle/Event/KeysDecryptionEvent.php
@@ -7,7 +7,7 @@ namespace Mautic\IntegrationsBundle\Event;
 use Mautic\PluginBundle\Entity\Integration;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class KeysDecryptionEvent extends Event
+final class KeysDecryptionEvent extends Event
 {
     public function __construct(
         private readonly Integration $integrationConfiguration,

--- a/app/bundles/IntegrationsBundle/Event/KeysEncryptionEvent.php
+++ b/app/bundles/IntegrationsBundle/Event/KeysEncryptionEvent.php
@@ -7,7 +7,7 @@ namespace Mautic\IntegrationsBundle\Event;
 use Mautic\PluginBundle\Entity\Integration;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class KeysEncryptionEvent extends Event
+final class KeysEncryptionEvent extends Event
 {
     public function __construct(
         private readonly Integration $integrationConfiguration,

--- a/app/bundles/IntegrationsBundle/Event/MappedIntegrationObjectTokenEvent.php
+++ b/app/bundles/IntegrationsBundle/Event/MappedIntegrationObjectTokenEvent.php
@@ -10,7 +10,7 @@ use Mautic\CoreBundle\Event\CommonEvent;
  * This event is dispatched to allow plugins to provide tokens which create links
  * to any synced integration objects they may provide.
  */
-class MappedIntegrationObjectTokenEvent extends CommonEvent
+final class MappedIntegrationObjectTokenEvent extends CommonEvent
 {
     private array $tokens = [];
 

--- a/app/bundles/IntegrationsBundle/Event/SyncEvent.php
+++ b/app/bundles/IntegrationsBundle/Event/SyncEvent.php
@@ -7,7 +7,7 @@ namespace Mautic\IntegrationsBundle\Event;
 use Mautic\IntegrationsBundle\Sync\DAO\Sync\InputOptionsDAO;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class SyncEvent extends Event
+final class SyncEvent extends Event
 {
     public function __construct(
         private readonly InputOptionsDAO $inputOptionsDAO,

--- a/app/bundles/LeadBundle/Event/CategoryChangeEvent.php
+++ b/app/bundles/LeadBundle/Event/CategoryChangeEvent.php
@@ -6,7 +6,7 @@ use Mautic\CategoryBundle\Entity\Category;
 use Mautic\LeadBundle\Entity\Lead;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class CategoryChangeEvent extends Event
+final class CategoryChangeEvent extends Event
 {
     private ?Lead $lead = null;
 

--- a/app/bundles/LeadBundle/Event/ChannelSubscriptionChange.php
+++ b/app/bundles/LeadBundle/Event/ChannelSubscriptionChange.php
@@ -6,7 +6,7 @@ use Mautic\LeadBundle\Entity\DoNotContact;
 use Mautic\LeadBundle\Entity\Lead;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class ChannelSubscriptionChange extends Event
+final class ChannelSubscriptionChange extends Event
 {
     /**
      * @param string $channel

--- a/app/bundles/LeadBundle/Event/CompanyBuildSearchEvent.php
+++ b/app/bundles/LeadBundle/Event/CompanyBuildSearchEvent.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\LeadBundle\Event;
 
-class CompanyBuildSearchEvent extends LeadBuildSearchEvent
+final class CompanyBuildSearchEvent extends LeadBuildSearchEvent
 {
 }

--- a/app/bundles/LeadBundle/Event/ContactExportEvent.php
+++ b/app/bundles/LeadBundle/Event/ContactExportEvent.php
@@ -6,7 +6,7 @@ namespace Mautic\LeadBundle\Event;
 
 use Symfony\Contracts\EventDispatcher\Event;
 
-class ContactExportEvent extends Event
+final class ContactExportEvent extends Event
 {
     /**
      * @param array<string|int, int|string|array<string, mixed>> $args

--- a/app/bundles/LeadBundle/Event/ContactExportSchedulerEvent.php
+++ b/app/bundles/LeadBundle/Event/ContactExportSchedulerEvent.php
@@ -7,7 +7,7 @@ namespace Mautic\LeadBundle\Event;
 use Mautic\LeadBundle\Entity\ContactExportScheduler;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class ContactExportSchedulerEvent extends Event
+final class ContactExportSchedulerEvent extends Event
 {
     private string $filePath;
 

--- a/app/bundles/LeadBundle/Event/ContactIdentificationEvent.php
+++ b/app/bundles/LeadBundle/Event/ContactIdentificationEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\LeadBundle\Event;
 use Mautic\LeadBundle\Entity\Lead;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class ContactIdentificationEvent extends Event
+final class ContactIdentificationEvent extends Event
 {
     private ?Lead $identifiedContact = null;
 

--- a/app/bundles/LeadBundle/Event/ImportEvent.php
+++ b/app/bundles/LeadBundle/Event/ImportEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\LeadBundle\Event;
 use Mautic\CoreBundle\Event\CommonEvent;
 use Mautic\LeadBundle\Entity\Import;
 
-class ImportEvent extends CommonEvent
+final class ImportEvent extends CommonEvent
 {
     /**
      * @param bool $isNew

--- a/app/bundles/LeadBundle/Event/LeadChangeCompanyEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadChangeCompanyEvent.php
@@ -6,7 +6,7 @@ use Mautic\LeadBundle\Entity\Company;
 use Mautic\LeadBundle\Entity\Lead;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class LeadChangeCompanyEvent extends Event
+final class LeadChangeCompanyEvent extends Event
 {
     private ?Lead $lead = null;
 

--- a/app/bundles/LeadBundle/Event/LeadChangeEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadChangeEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\LeadBundle\Event;
 use Mautic\LeadBundle\Entity\Lead;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class LeadChangeEvent extends Event
+final class LeadChangeEvent extends Event
 {
     public function __construct(
         private readonly Lead $oldLead,

--- a/app/bundles/LeadBundle/Event/LeadDeviceEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadDeviceEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\LeadBundle\Event;
 use Mautic\CoreBundle\Event\CommonEvent;
 use Mautic\LeadBundle\Entity\LeadDevice;
 
-class LeadDeviceEvent extends CommonEvent
+final class LeadDeviceEvent extends CommonEvent
 {
     /**
      * @param bool $isNew

--- a/app/bundles/LeadBundle/Event/LeadListFilteringEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadListFilteringEvent.php
@@ -10,7 +10,7 @@ use Mautic\LeadBundle\Segment\Query\QueryBuilder;
 /**
  * Please refer to LeadListRepository.php, inside getListFilterExprCombined method, for examples.
  */
-class LeadListFilteringEvent extends CommonEvent
+final class LeadListFilteringEvent extends CommonEvent
 {
     protected bool $isFilteringDone;
 

--- a/app/bundles/LeadBundle/Event/LeadListFiltersChoicesEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadListFiltersChoicesEvent.php
@@ -8,7 +8,7 @@ use Mautic\CoreBundle\Event\AbstractCustomRequestEvent;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class LeadListFiltersChoicesEvent extends AbstractCustomRequestEvent
+final class LeadListFiltersChoicesEvent extends AbstractCustomRequestEvent
 {
     /**
      * @param mixed[] $choices

--- a/app/bundles/LeadBundle/Event/LeadListFiltersOperatorsEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadListFiltersOperatorsEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\LeadBundle\Event;
 use Mautic\CoreBundle\Event\CommonEvent;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class LeadListFiltersOperatorsEvent extends CommonEvent
+final class LeadListFiltersOperatorsEvent extends CommonEvent
 {
     /**
      * @deprecated to be removed in Mautic 3

--- a/app/bundles/LeadBundle/Event/LeadListMergeFiltersEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadListMergeFiltersEvent.php
@@ -4,7 +4,7 @@ namespace Mautic\LeadBundle\Event;
 
 use Mautic\CoreBundle\Event\CommonEvent;
 
-class LeadListMergeFiltersEvent extends CommonEvent
+final class LeadListMergeFiltersEvent extends CommonEvent
 {
     /**
      * @param mixed[] $filters

--- a/app/bundles/LeadBundle/Event/LeadListQueryBuilderGeneratedEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadListQueryBuilderGeneratedEvent.php
@@ -6,7 +6,7 @@ use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Segment\Query\QueryBuilder;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class LeadListQueryBuilderGeneratedEvent extends Event
+final class LeadListQueryBuilderGeneratedEvent extends Event
 {
     public function __construct(
         private readonly LeadList $segment,

--- a/app/bundles/LeadBundle/Event/LeadMergeEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadMergeEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\LeadBundle\Event;
 use Mautic\LeadBundle\Entity\Lead;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class LeadMergeEvent extends Event
+final class LeadMergeEvent extends Event
 {
     public function __construct(
         private readonly Lead $victor,

--- a/app/bundles/LeadBundle/Event/LeadNoteEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadNoteEvent.php
@@ -6,7 +6,7 @@ use Mautic\CoreBundle\Event\CommonEvent;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadNote;
 
-class LeadNoteEvent extends CommonEvent
+final class LeadNoteEvent extends CommonEvent
 {
     /**
      * @param bool $isNew

--- a/app/bundles/LeadBundle/Event/LeadTimelineEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadTimelineEvent.php
@@ -7,7 +7,7 @@ use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\LeadBundle\Entity\Lead;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class LeadTimelineEvent extends Event
+final class LeadTimelineEvent extends Event
 {
     /**
      * Container with all filtered events.

--- a/app/bundles/LeadBundle/Event/LeadUtmTagsEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadUtmTagsEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\LeadBundle\Event;
 use Mautic\CoreBundle\Event\CommonEvent;
 use Mautic\LeadBundle\Entity\Lead;
 
-class LeadUtmTagsEvent extends CommonEvent
+final class LeadUtmTagsEvent extends CommonEvent
 {
     /**
      * @param mixed[] $utmtags

--- a/app/bundles/LeadBundle/Event/ListPreProcessListEvent.php
+++ b/app/bundles/LeadBundle/Event/ListPreProcessListEvent.php
@@ -4,7 +4,7 @@ namespace Mautic\LeadBundle\Event;
 
 use Mautic\CoreBundle\Event\CommonEvent;
 
-class ListPreProcessListEvent extends CommonEvent
+final class ListPreProcessListEvent extends CommonEvent
 {
     protected $result;
 

--- a/app/bundles/LeadBundle/Event/PointsChangeEvent.php
+++ b/app/bundles/LeadBundle/Event/PointsChangeEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\LeadBundle\Event;
 use Mautic\CoreBundle\Event\CommonEvent;
 use Mautic\LeadBundle\Entity\Lead;
 
-class PointsChangeEvent extends CommonEvent
+final class PointsChangeEvent extends CommonEvent
 {
     protected int $old;
 

--- a/app/bundles/LeadBundle/Event/SegmentDictionaryGenerationEvent.php
+++ b/app/bundles/LeadBundle/Event/SegmentDictionaryGenerationEvent.php
@@ -12,7 +12,7 @@ use Mautic\CoreBundle\Event\CommonEvent;
  *
  * This is not related to language translations at all
  */
-class SegmentDictionaryGenerationEvent extends CommonEvent
+final class SegmentDictionaryGenerationEvent extends CommonEvent
 {
     /**
      * @param array<string,mixed[]> $translations

--- a/app/bundles/LeadBundle/Event/TagEvent.php
+++ b/app/bundles/LeadBundle/Event/TagEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\LeadBundle\Event;
 use Mautic\CoreBundle\Event\CommonEvent;
 use Mautic\LeadBundle\Entity\Tag;
 
-class TagEvent extends CommonEvent
+final class TagEvent extends CommonEvent
 {
     /**
      * @param bool $isNew

--- a/app/bundles/NotificationBundle/Event/NotificationEvent.php
+++ b/app/bundles/NotificationBundle/Event/NotificationEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\NotificationBundle\Event;
 use Mautic\CoreBundle\Event\CommonEvent;
 use Mautic\NotificationBundle\Entity\Notification;
 
-class NotificationEvent extends CommonEvent
+final class NotificationEvent extends CommonEvent
 {
     /**
      * @param bool $isNew

--- a/app/bundles/NotificationBundle/Event/NotificationSendEvent.php
+++ b/app/bundles/NotificationBundle/Event/NotificationSendEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\NotificationBundle\Event;
 use Mautic\CoreBundle\Event\CommonEvent;
 use Mautic\LeadBundle\Entity\Lead;
 
-class NotificationSendEvent extends CommonEvent
+final class NotificationSendEvent extends CommonEvent
 {
     /**
      * @param string $message

--- a/app/bundles/PageBundle/Event/PageBuilderEvent.php
+++ b/app/bundles/PageBundle/Event/PageBuilderEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\PageBundle\Event;
 use Mautic\CoreBundle\Event\BuilderEvent;
 use Mautic\PageBundle\Entity\Page;
 
-class PageBuilderEvent extends BuilderEvent
+final class PageBuilderEvent extends BuilderEvent
 {
     /**
      * @return Page|null

--- a/app/bundles/PageBundle/Event/PageEvent.php
+++ b/app/bundles/PageBundle/Event/PageEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\PageBundle\Event;
 use Mautic\CoreBundle\Event\CommonEvent;
 use Mautic\PageBundle\Entity\Page;
 
-class PageEvent extends CommonEvent
+final class PageEvent extends CommonEvent
 {
     /**
      * @param bool $isNew

--- a/app/bundles/PageBundle/Event/RedirectGenerationEvent.php
+++ b/app/bundles/PageBundle/Event/RedirectGenerationEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\PageBundle\Event;
 use Mautic\CoreBundle\Event\CommonEvent;
 use Mautic\PageBundle\Entity\Redirect;
 
-class RedirectGenerationEvent extends CommonEvent
+final class RedirectGenerationEvent extends CommonEvent
 {
     public function __construct(
         private readonly Redirect $redirect,

--- a/app/bundles/PageBundle/Event/TrackingEvent.php
+++ b/app/bundles/PageBundle/Event/TrackingEvent.php
@@ -9,7 +9,7 @@ use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class TrackingEvent extends Event
+final class TrackingEvent extends Event
 {
     private readonly ParameterBag $response;
 

--- a/app/bundles/PageBundle/Event/UntrackableUrlsEvent.php
+++ b/app/bundles/PageBundle/Event/UntrackableUrlsEvent.php
@@ -4,7 +4,7 @@ namespace Mautic\PageBundle\Event;
 
 use Symfony\Contracts\EventDispatcher\Event;
 
-class UntrackableUrlsEvent extends Event
+final class UntrackableUrlsEvent extends Event
 {
     /**
      * @var string[]

--- a/app/bundles/PageBundle/Event/VideoHitEvent.php
+++ b/app/bundles/PageBundle/Event/VideoHitEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\PageBundle\Event;
 use Mautic\CoreBundle\Event\CommonEvent;
 use Mautic\PageBundle\Entity\VideoHit;
 
-class VideoHitEvent extends CommonEvent
+final class VideoHitEvent extends CommonEvent
 {
     public function __construct(
         VideoHit $hit,

--- a/app/bundles/PluginBundle/Event/PluginInstallEvent.php
+++ b/app/bundles/PluginBundle/Event/PluginInstallEvent.php
@@ -8,7 +8,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Mautic\PluginBundle\Entity\Plugin;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class PluginInstallEvent extends Event
+final class PluginInstallEvent extends Event
 {
     /**
      * @param array<class-string, ClassMetadata>|null $metadata

--- a/app/bundles/PluginBundle/Event/PluginIntegrationAuthCallbackUrlEvent.php
+++ b/app/bundles/PluginBundle/Event/PluginIntegrationAuthCallbackUrlEvent.php
@@ -4,7 +4,7 @@ namespace Mautic\PluginBundle\Event;
 
 use Mautic\PluginBundle\Integration\UnifiedIntegrationInterface;
 
-class PluginIntegrationAuthCallbackUrlEvent extends AbstractPluginIntegrationEvent
+final class PluginIntegrationAuthCallbackUrlEvent extends AbstractPluginIntegrationEvent
 {
     /**
      * @param string $callbackUrl

--- a/app/bundles/PluginBundle/Event/PluginIntegrationAuthRedirectEvent.php
+++ b/app/bundles/PluginBundle/Event/PluginIntegrationAuthRedirectEvent.php
@@ -4,7 +4,7 @@ namespace Mautic\PluginBundle\Event;
 
 use Mautic\PluginBundle\Integration\UnifiedIntegrationInterface;
 
-class PluginIntegrationAuthRedirectEvent extends AbstractPluginIntegrationEvent
+final class PluginIntegrationAuthRedirectEvent extends AbstractPluginIntegrationEvent
 {
     /**
      * @param string $authUrl

--- a/app/bundles/PluginBundle/Event/PluginIntegrationEvent.php
+++ b/app/bundles/PluginBundle/Event/PluginIntegrationEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\PluginBundle\Event;
 use Mautic\PluginBundle\Entity\Integration;
 use Mautic\PluginBundle\Integration\UnifiedIntegrationInterface;
 
-class PluginIntegrationEvent extends AbstractPluginIntegrationEvent
+final class PluginIntegrationEvent extends AbstractPluginIntegrationEvent
 {
     public function __construct(UnifiedIntegrationInterface $integration)
     {

--- a/app/bundles/PluginBundle/Event/PluginIntegrationFormBuildEvent.php
+++ b/app/bundles/PluginBundle/Event/PluginIntegrationFormBuildEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\PluginBundle\Event;
 use Mautic\PluginBundle\Integration\UnifiedIntegrationInterface;
 use Symfony\Component\Form\FormBuilderInterface;
 
-class PluginIntegrationFormBuildEvent extends AbstractPluginIntegrationEvent
+final class PluginIntegrationFormBuildEvent extends AbstractPluginIntegrationEvent
 {
     public function __construct(
         UnifiedIntegrationInterface $integration,

--- a/app/bundles/PluginBundle/Event/PluginIntegrationFormDisplayEvent.php
+++ b/app/bundles/PluginBundle/Event/PluginIntegrationFormDisplayEvent.php
@@ -4,7 +4,7 @@ namespace Mautic\PluginBundle\Event;
 
 use Mautic\PluginBundle\Integration\UnifiedIntegrationInterface;
 
-class PluginIntegrationFormDisplayEvent extends AbstractPluginIntegrationEvent
+final class PluginIntegrationFormDisplayEvent extends AbstractPluginIntegrationEvent
 {
     /**
      * @param array<string, mixed> $settings

--- a/app/bundles/PluginBundle/Event/PluginUpdateEvent.php
+++ b/app/bundles/PluginBundle/Event/PluginUpdateEvent.php
@@ -9,7 +9,7 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Mautic\PluginBundle\Entity\Plugin;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class PluginUpdateEvent extends Event
+final class PluginUpdateEvent extends Event
 {
     /**
      * @param array<class-string, ClassMetadata>|null $metadata null value is when the plugin does not have Entities (an Entity directory)

--- a/app/bundles/PointBundle/Event/PointActionEvent.php
+++ b/app/bundles/PointBundle/Event/PointActionEvent.php
@@ -6,7 +6,7 @@ use Mautic\CoreBundle\Event\CommonEvent;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\PointBundle\Entity\Point;
 
-class PointActionEvent extends CommonEvent
+final class PointActionEvent extends CommonEvent
 {
     public function __construct(
         protected Point $point,

--- a/app/bundles/PointBundle/Event/PointEvent.php
+++ b/app/bundles/PointBundle/Event/PointEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\PointBundle\Event;
 use Mautic\CoreBundle\Event\CommonEvent;
 use Mautic\PointBundle\Entity\Point;
 
-class PointEvent extends CommonEvent
+final class PointEvent extends CommonEvent
 {
     /**
      * @param bool $isNew

--- a/app/bundles/PointBundle/Event/TriggerBuilderEvent.php
+++ b/app/bundles/PointBundle/Event/TriggerBuilderEvent.php
@@ -6,7 +6,7 @@ use Symfony\Component\Process\Exception\InvalidArgumentException;
 use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class TriggerBuilderEvent extends Event
+final class TriggerBuilderEvent extends Event
 {
     private array $events = [];
 

--- a/app/bundles/PointBundle/Event/TriggerEvent.php
+++ b/app/bundles/PointBundle/Event/TriggerEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\PointBundle\Event;
 use Mautic\CoreBundle\Event\CommonEvent;
 use Mautic\PointBundle\Entity\Trigger;
 
-class TriggerEvent extends CommonEvent
+final class TriggerEvent extends CommonEvent
 {
     /**
      * @var Trigger

--- a/app/bundles/ReportBundle/Event/PermanentReportFileCreatedEvent.php
+++ b/app/bundles/ReportBundle/Event/PermanentReportFileCreatedEvent.php
@@ -4,7 +4,7 @@ namespace Mautic\ReportBundle\Event;
 
 use Mautic\ReportBundle\Entity\Report;
 
-class PermanentReportFileCreatedEvent extends AbstractReportEvent
+final class PermanentReportFileCreatedEvent extends AbstractReportEvent
 {
     public function __construct(Report $report)
     {

--- a/app/bundles/ReportBundle/Event/ReportEvent.php
+++ b/app/bundles/ReportBundle/Event/ReportEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\ReportBundle\Event;
 use Mautic\CoreBundle\Event\CommonEvent;
 use Mautic\ReportBundle\Entity\Report;
 
-class ReportEvent extends CommonEvent
+final class ReportEvent extends CommonEvent
 {
     /**
      * @param bool $isNew

--- a/app/bundles/ReportBundle/Event/ReportQueryEvent.php
+++ b/app/bundles/ReportBundle/Event/ReportQueryEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\ReportBundle\Event;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Mautic\ReportBundle\Entity\Report;
 
-class ReportQueryEvent extends AbstractReportEvent
+final class ReportQueryEvent extends AbstractReportEvent
 {
     private readonly int $totalResults;
 

--- a/app/bundles/ReportBundle/Event/ReportScheduleSendEvent.php
+++ b/app/bundles/ReportBundle/Event/ReportScheduleSendEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\ReportBundle\Event;
 use Mautic\ReportBundle\Entity\Scheduler;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class ReportScheduleSendEvent extends Event
+final class ReportScheduleSendEvent extends Event
 {
     /**
      * @param string $file

--- a/app/bundles/SmsBundle/Event/ReplyEvent.php
+++ b/app/bundles/SmsBundle/Event/ReplyEvent.php
@@ -6,7 +6,7 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadEventLog;
 use Symfony\Component\HttpFoundation\Response;
 
-class ReplyEvent extends \Symfony\Contracts\EventDispatcher\Event
+final class ReplyEvent extends \Symfony\Contracts\EventDispatcher\Event
 {
     private ?Response $response = null;
 

--- a/app/bundles/SmsBundle/Event/SmsEvent.php
+++ b/app/bundles/SmsBundle/Event/SmsEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\SmsBundle\Event;
 use Mautic\CoreBundle\Event\CommonEvent;
 use Mautic\SmsBundle\Entity\Sms;
 
-class SmsEvent extends CommonEvent
+final class SmsEvent extends CommonEvent
 {
     /**
      * @param bool $isNew

--- a/app/bundles/SmsBundle/Event/TokensBuildEvent.php
+++ b/app/bundles/SmsBundle/Event/TokensBuildEvent.php
@@ -4,7 +4,7 @@ namespace Mautic\SmsBundle\Event;
 
 use Symfony\Contracts\EventDispatcher\Event;
 
-class TokensBuildEvent extends Event
+final class TokensBuildEvent extends Event
 {
     /**
      * @param array<string, string> $tokens

--- a/app/bundles/StageBundle/Event/StageBuilderEvent.php
+++ b/app/bundles/StageBundle/Event/StageBuilderEvent.php
@@ -6,7 +6,7 @@ use Symfony\Component\Process\Exception\InvalidArgumentException;
 use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class StageBuilderEvent extends Event
+final class StageBuilderEvent extends Event
 {
     private array $actions = [];
 

--- a/app/bundles/StageBundle/Event/StageEvent.php
+++ b/app/bundles/StageBundle/Event/StageEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\StageBundle\Event;
 use Mautic\CoreBundle\Event\CommonEvent;
 use Mautic\StageBundle\Entity\Stage;
 
-class StageEvent extends CommonEvent
+final class StageEvent extends CommonEvent
 {
     /**
      * @param bool $isNew

--- a/app/bundles/StatsBundle/Event/AggregateStatRequestEvent.php
+++ b/app/bundles/StatsBundle/Event/AggregateStatRequestEvent.php
@@ -6,7 +6,7 @@ use Mautic\StatsBundle\Aggregate\Collection\StatCollection;
 use Mautic\StatsBundle\Event\Options\FetchOptions;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class AggregateStatRequestEvent extends Event
+final class AggregateStatRequestEvent extends Event
 {
     private readonly StatCollection $statCollection;
 

--- a/app/bundles/UserBundle/Event/AuthenticationContentEvent.php
+++ b/app/bundles/UserBundle/Event/AuthenticationContentEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\UserBundle\Event;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class AuthenticationContentEvent extends Event
+final class AuthenticationContentEvent extends Event
 {
     /**
      * @var array

--- a/app/bundles/UserBundle/Event/LogoutEvent.php
+++ b/app/bundles/UserBundle/Event/LogoutEvent.php
@@ -6,7 +6,7 @@ use Mautic\UserBundle\Entity\User;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class LogoutEvent extends Event
+final class LogoutEvent extends Event
 {
     private array $session = [];
 

--- a/app/bundles/UserBundle/Event/RoleEvent.php
+++ b/app/bundles/UserBundle/Event/RoleEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\UserBundle\Event;
 use Mautic\CoreBundle\Event\CommonEvent;
 use Mautic\UserBundle\Entity\Role;
 
-class RoleEvent extends CommonEvent
+final class RoleEvent extends CommonEvent
 {
     /**
      * @param bool $isNew

--- a/app/bundles/UserBundle/Event/UserEvent.php
+++ b/app/bundles/UserBundle/Event/UserEvent.php
@@ -5,7 +5,7 @@ namespace Mautic\UserBundle\Event;
 use Mautic\CoreBundle\Event\CommonEvent;
 use Mautic\UserBundle\Entity\User;
 
-class UserEvent extends CommonEvent
+final class UserEvent extends CommonEvent
 {
     /**
      * @param bool $isNew

--- a/app/bundles/WebhookBundle/Event/WebhookQueueEvent.php
+++ b/app/bundles/WebhookBundle/Event/WebhookQueueEvent.php
@@ -6,7 +6,7 @@ use Mautic\CoreBundle\Event\CommonEvent;
 use Mautic\WebhookBundle\Entity\Webhook;
 use Mautic\WebhookBundle\Entity\WebhookQueue;
 
-class WebhookQueueEvent extends CommonEvent
+final class WebhookQueueEvent extends CommonEvent
 {
     /**
      * @param bool $isNew

--- a/app/bundles/WebhookBundle/Event/WebhookRequestEvent.php
+++ b/app/bundles/WebhookBundle/Event/WebhookRequestEvent.php
@@ -7,7 +7,7 @@ namespace Mautic\WebhookBundle\Event;
 use Mautic\LeadBundle\Entity\Lead;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class WebhookRequestEvent extends Event
+final class WebhookRequestEvent extends Event
 {
     public function __construct(
         private readonly Lead $contact,

--- a/plugins/MauticFocusBundle/Event/FocusEvent.php
+++ b/plugins/MauticFocusBundle/Event/FocusEvent.php
@@ -5,7 +5,7 @@ namespace MauticPlugin\MauticFocusBundle\Event;
 use Mautic\CoreBundle\Event\CommonEvent;
 use MauticPlugin\MauticFocusBundle\Entity\Focus;
 
-class FocusEvent extends CommonEvent
+final class FocusEvent extends CommonEvent
 {
     /**
      * @param bool|false $isNew

--- a/plugins/MauticFocusBundle/Event/FocusViewEvent.php
+++ b/plugins/MauticFocusBundle/Event/FocusViewEvent.php
@@ -5,7 +5,7 @@ namespace MauticPlugin\MauticFocusBundle\Event;
 use MauticPlugin\MauticFocusBundle\Entity\Stat;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class FocusViewEvent extends Event
+final class FocusViewEvent extends Event
 {
     public function __construct(
         private readonly Stat $stat,

--- a/plugins/MauticSocialBundle/Event/SocialEvent.php
+++ b/plugins/MauticSocialBundle/Event/SocialEvent.php
@@ -5,7 +5,7 @@ namespace MauticPlugin\MauticSocialBundle\Event;
 use Mautic\CoreBundle\Event\CommonEvent;
 use MauticPlugin\MauticSocialBundle\Entity\Monitoring;
 
-class SocialEvent extends CommonEvent
+final class SocialEvent extends CommonEvent
 {
     /**
      * @param bool $isNew

--- a/plugins/MauticSocialBundle/Event/SocialMonitorEvent.php
+++ b/plugins/MauticSocialBundle/Event/SocialMonitorEvent.php
@@ -5,7 +5,7 @@ namespace MauticPlugin\MauticSocialBundle\Event;
 use Mautic\CoreBundle\Event\CommonEvent;
 use MauticPlugin\MauticSocialBundle\Entity\Monitoring;
 
-class SocialMonitorEvent extends CommonEvent
+final class SocialMonitorEvent extends CommonEvent
 {
     protected int $newLeadCount;
 


### PR DESCRIPTION
Makes event classes `final`, as they are not meant to be extended.

Split out of #16738 for easier review.