### PR TITLE
[solid] finalize form type classes

### DIFF
--- a/app/bundles/ApiBundle/Form/Type/ClientType.php
+++ b/app/bundles/ApiBundle/Form/Type/ClientType.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @extends AbstractType<Client>
  */
-class ClientType extends AbstractType
+final class ClientType extends AbstractType
 {
     public function __construct(
         private readonly RequestStack $requestStack,

--- a/app/bundles/ApiBundle/Form/Type/ConfigType.php
+++ b/app/bundles/ApiBundle/Form/Type/ConfigType.php
@@ -11,7 +11,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 /**
  * @extends AbstractType<mixed>
  */
-class ConfigType extends AbstractType
+final class ConfigType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/ApiBundle/Form/Validator/Constraints/OAuthCallback.php
+++ b/app/bundles/ApiBundle/Form/Validator/Constraints/OAuthCallback.php
@@ -4,7 +4,7 @@ namespace Mautic\ApiBundle\Form\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
-class OAuthCallback extends Constraint
+final class OAuthCallback extends Constraint
 {
     public $message = 'The callback URL is invalid.';
 

--- a/app/bundles/ApiBundle/Form/Validator/Constraints/OAuthCallbackValidator.php
+++ b/app/bundles/ApiBundle/Form/Validator/Constraints/OAuthCallbackValidator.php
@@ -6,7 +6,7 @@ use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
-class OAuthCallbackValidator extends ConstraintValidator
+final class OAuthCallbackValidator extends ConstraintValidator
 {
     public const PATTERN = '~^[0-9a-z].*://(.*?)(:[0-9]+)?(/?|/\S+)$~ixu';
 

--- a/app/bundles/AssetBundle/Form/Type/AssetListType.php
+++ b/app/bundles/AssetBundle/Form/Type/AssetListType.php
@@ -12,7 +12,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class AssetListType extends AbstractType
+final class AssetListType extends AbstractType
 {
     public function __construct(
         private readonly CorePermissions $corePermissions,
@@ -32,7 +32,7 @@ class AssetListType extends AbstractType
         ]);
     }
 
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return ChoiceType::class;
     }

--- a/app/bundles/AssetBundle/Form/Type/AssetType.php
+++ b/app/bundles/AssetBundle/Form/Type/AssetType.php
@@ -26,7 +26,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @extends AbstractType<Asset>
  */
-class AssetType extends AbstractType
+final class AssetType extends AbstractType
 {
     public function __construct(
         private readonly TranslatorInterface $translator,

--- a/app/bundles/AssetBundle/Form/Type/CampaignEventAssetDownloadType.php
+++ b/app/bundles/AssetBundle/Form/Type/CampaignEventAssetDownloadType.php
@@ -8,7 +8,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class CampaignEventAssetDownloadType extends AbstractType
+final class CampaignEventAssetDownloadType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/AssetBundle/Form/Type/ConfigType.php
+++ b/app/bundles/AssetBundle/Form/Type/ConfigType.php
@@ -11,7 +11,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 /**
  * @extends AbstractType<mixed>
  */
-class ConfigType extends AbstractType
+final class ConfigType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/AssetBundle/Form/Type/FormSubmitActionDownloadFileType.php
+++ b/app/bundles/AssetBundle/Form/Type/FormSubmitActionDownloadFileType.php
@@ -9,7 +9,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class FormSubmitActionDownloadFileType extends AbstractType
+final class FormSubmitActionDownloadFileType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/AssetBundle/Form/Type/PointActionAssetDownloadType.php
+++ b/app/bundles/AssetBundle/Form/Type/PointActionAssetDownloadType.php
@@ -8,7 +8,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class PointActionAssetDownloadType extends AbstractType
+final class PointActionAssetDownloadType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/CampaignBundle/Form/Type/CampaignEventAddRemoveLeadType.php
+++ b/app/bundles/CampaignBundle/Form/Type/CampaignEventAddRemoveLeadType.php
@@ -10,7 +10,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class CampaignEventAddRemoveLeadType extends AbstractType
+final class CampaignEventAddRemoveLeadType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/CampaignBundle/Form/Type/CampaignEventJumpToEventType.php
+++ b/app/bundles/CampaignBundle/Form/Type/CampaignEventJumpToEventType.php
@@ -10,7 +10,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 /**
  * @extends AbstractType<mixed>
  */
-class CampaignEventJumpToEventType extends AbstractType
+final class CampaignEventJumpToEventType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/CampaignBundle/Form/Type/CampaignLeadSourceType.php
+++ b/app/bundles/CampaignBundle/Form/Type/CampaignLeadSourceType.php
@@ -13,7 +13,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 /**
  * @extends AbstractType<mixed>
  */
-class CampaignLeadSourceType extends AbstractType
+final class CampaignLeadSourceType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/CampaignBundle/Form/Type/CampaignListType.php
+++ b/app/bundles/CampaignBundle/Form/Type/CampaignListType.php
@@ -13,7 +13,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class CampaignListType extends AbstractType
+final class CampaignListType extends AbstractType
 {
     private readonly bool $canViewOther;
 
@@ -55,7 +55,7 @@ class CampaignListType extends AbstractType
         );
     }
 
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return ChoiceType::class;
     }

--- a/app/bundles/CampaignBundle/Form/Type/CampaignType.php
+++ b/app/bundles/CampaignBundle/Form/Type/CampaignType.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @extends AbstractType<Campaign>
  */
-class CampaignType extends AbstractType
+final class CampaignType extends AbstractType
 {
     public function __construct(
         private readonly CorePermissions $security,

--- a/app/bundles/CampaignBundle/Form/Type/ConfigType.php
+++ b/app/bundles/CampaignBundle/Form/Type/ConfigType.php
@@ -16,7 +16,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class ConfigType extends AbstractType
+final class ConfigType extends AbstractType
 {
     public function __construct(
         private readonly TranslatorInterface $translator,

--- a/app/bundles/CampaignBundle/Form/Type/EventCanvasSettingsType.php
+++ b/app/bundles/CampaignBundle/Form/Type/EventCanvasSettingsType.php
@@ -9,7 +9,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class EventCanvasSettingsType extends AbstractType
+final class EventCanvasSettingsType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/CampaignBundle/Form/Type/EventType.php
+++ b/app/bundles/CampaignBundle/Form/Type/EventType.php
@@ -21,7 +21,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class EventType extends AbstractType
+final class EventType extends AbstractType
 {
     use PropertiesTrait;
 

--- a/app/bundles/CategoryBundle/Form/Type/CategoryBundlesType.php
+++ b/app/bundles/CategoryBundle/Form/Type/CategoryBundlesType.php
@@ -13,7 +13,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class CategoryBundlesType extends AbstractType
+final class CategoryBundlesType extends AbstractType
 {
     public function __construct(
         private readonly EventDispatcherInterface $dispatcher,
@@ -44,7 +44,7 @@ class CategoryBundlesType extends AbstractType
         return 'category_bundles_form';
     }
 
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return ChoiceType::class;
     }

--- a/app/bundles/CategoryBundle/Form/Type/CategoryListType.php
+++ b/app/bundles/CategoryBundle/Form/Type/CategoryListType.php
@@ -17,7 +17,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class CategoryListType extends AbstractType
+final class CategoryListType extends AbstractType
 {
     public function __construct(
         private readonly EntityManager $em,
@@ -78,7 +78,7 @@ class CategoryListType extends AbstractType
         return 'category';
     }
 
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return ChoiceType::class;
     }

--- a/app/bundles/CategoryBundle/Form/Type/CategoryType.php
+++ b/app/bundles/CategoryBundle/Form/Type/CategoryType.php
@@ -18,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<Category>
  */
-class CategoryType extends AbstractType
+final class CategoryType extends AbstractType
 {
     public function __construct(
         private readonly RequestStack $requestStack,

--- a/app/bundles/ChannelBundle/Form/Type/ChannelType.php
+++ b/app/bundles/ChannelBundle/Form/Type/ChannelType.php
@@ -17,7 +17,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 /**
  * @extends AbstractType<Channel>
  */
-class ChannelType extends AbstractType
+final class ChannelType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/ChannelBundle/Form/Type/MessageListType.php
+++ b/app/bundles/ChannelBundle/Form/Type/MessageListType.php
@@ -10,7 +10,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class MessageListType extends AbstractType
+final class MessageListType extends AbstractType
 {
     public function configureOptions(OptionsResolver $resolver): void
     {
@@ -42,7 +42,7 @@ class MessageListType extends AbstractType
         );
     }
 
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return EntityLookupType::class;
     }

--- a/app/bundles/ChannelBundle/Form/Type/MessageSendType.php
+++ b/app/bundles/ChannelBundle/Form/Type/MessageSendType.php
@@ -13,7 +13,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 /**
  * @extends AbstractType<mixed>
  */
-class MessageSendType extends AbstractType
+final class MessageSendType extends AbstractType
 {
     public function __construct(
         protected RouterInterface $router,

--- a/app/bundles/ChannelBundle/Form/Type/MessageType.php
+++ b/app/bundles/ChannelBundle/Form/Type/MessageType.php
@@ -13,7 +13,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\Valid;
 
-class MessageType extends AbstractFormStandardType
+final class MessageType extends AbstractFormStandardType
 {
     public function __construct(
         protected MessageModel $model,

--- a/app/bundles/ConfigBundle/Form/Helper/RestrictionHelper.php
+++ b/app/bundles/ConfigBundle/Form/Helper/RestrictionHelper.php
@@ -6,7 +6,7 @@ use Mautic\ConfigBundle\Mapper\Helper\RestrictionHelper as FieldHelper;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class RestrictionHelper
+final readonly class RestrictionHelper
 {
     public const MODE_REMOVE = 'remove';
 
@@ -15,12 +15,12 @@ class RestrictionHelper
     /**
      * @var string[]
      */
-    private readonly array $restrictedFields;
+    private array $restrictedFields;
 
     public function __construct(
-        private readonly TranslatorInterface $translator,
+        private TranslatorInterface $translator,
         array $restrictedFields,
-        private readonly string $displayMode,
+        private string $displayMode,
     ) {
         $this->restrictedFields = FieldHelper::prepareRestrictions($restrictedFields);
     }

--- a/app/bundles/ConfigBundle/Form/Type/ConfigFileType.php
+++ b/app/bundles/ConfigBundle/Form/Type/ConfigFileType.php
@@ -8,9 +8,9 @@ use Symfony\Component\Form\Extension\Core\Type\FileType;
 /**
  * @extends AbstractType<mixed>
  */
-class ConfigFileType extends AbstractType
+final class ConfigFileType extends AbstractType
 {
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return FileType::class;
     }

--- a/app/bundles/ConfigBundle/Form/Type/ConfigType.php
+++ b/app/bundles/ConfigBundle/Form/Type/ConfigType.php
@@ -13,7 +13,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class ConfigType extends AbstractType
+final class ConfigType extends AbstractType
 {
     public function __construct(
         private readonly RestrictionHelper $restrictionHelper,

--- a/app/bundles/ConfigBundle/Form/Type/DsnType.php
+++ b/app/bundles/ConfigBundle/Form/Type/DsnType.php
@@ -20,7 +20,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<array>
  */
-class DsnType extends AbstractType
+final class DsnType extends AbstractType
 {
     public function __construct(
         private readonly DsnTransformerFactory $dsnTransformerFactory,

--- a/app/bundles/ConfigBundle/Form/Type/EscapeTransformer.php
+++ b/app/bundles/ConfigBundle/Form/Type/EscapeTransformer.php
@@ -9,12 +9,12 @@ use Symfony\Component\Form\DataTransformerInterface;
 /**
  * @implements DataTransformerInterface<array<string|int|float|array<string|int|float>>|string|int|float, array<string|int|float|array<string|int|float>>|string|int|float>
  */
-class EscapeTransformer implements DataTransformerInterface
+final readonly class EscapeTransformer implements DataTransformerInterface
 {
     /**
      * @var string[]
      */
-    private readonly array $allowedParameters;
+    private array $allowedParameters;
 
     public function __construct(array $allowedParameters)
     {

--- a/app/bundles/CoreBundle/Form/ChoiceLoader/EntityLookupChoiceLoader.php
+++ b/app/bundles/CoreBundle/Form/ChoiceLoader/EntityLookupChoiceLoader.php
@@ -15,27 +15,21 @@ use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class EntityLookupChoiceLoader implements ChoiceLoaderInterface
+final class EntityLookupChoiceLoader implements ChoiceLoaderInterface
 {
-    /**
-     * @var array
-     */
-    protected $selected = [];
+    private array $selected = [];
 
-    /**
-     * @var array
-     */
-    protected $choices = [];
+    private array $choices = [];
 
     /**
      * @param ModelFactory<object>               $modelFactory
      * @param Options<array<mixed>>|array<mixed> $options
      */
     public function __construct(
-        protected ModelFactory $modelFactory,
-        protected TranslatorInterface $translator,
-        protected Connection $connection,
-        protected $options = [],
+        private readonly ModelFactory $modelFactory,
+        private readonly TranslatorInterface $translator,
+        private readonly Connection $connection,
+        private $options = [],
     ) {
         if (is_array($options)) {
             $options = (new OptionsResolver())->setDefaults($options);
@@ -85,11 +79,10 @@ class EntityLookupChoiceLoader implements ChoiceLoaderInterface
 
     /**
      * @param array|null $data
-     * @param bool       $includeNew
      *
      * @return array
      */
-    protected function getChoices($data = null, $includeNew = false)
+    private function getChoices($data = null, bool $includeNew = false)
     {
         if (null === $data) {
             $data = $this->selected;
@@ -153,7 +146,7 @@ class EntityLookupChoiceLoader implements ChoiceLoaderInterface
     /**
      * @return array
      */
-    protected function prepareChoices($choices)
+    private function prepareChoices($choices)
     {
         $prepped   = $choices;
         $isGrouped = false;
@@ -189,7 +182,7 @@ class EntityLookupChoiceLoader implements ChoiceLoaderInterface
     /**
      * @return array|mixed
      */
-    protected function fetchChoices($modelName, $data = [])
+    private function fetchChoices($modelName, array $data = [])
     {
         $labelColumn = $this->options['entity_label_column'];
         $idColumn    = $this->options['entity_id_column'];
@@ -244,7 +237,7 @@ class EntityLookupChoiceLoader implements ChoiceLoaderInterface
         return $choices;
     }
 
-    protected function formatChoices(array &$choices): void
+    private function formatChoices(array &$choices): void
     {
         $firstKey = array_key_first($choices);
 

--- a/app/bundles/CoreBundle/Form/DataTransformer/ArrayLinebreakTransformer.php
+++ b/app/bundles/CoreBundle/Form/DataTransformer/ArrayLinebreakTransformer.php
@@ -7,7 +7,7 @@ use Symfony\Component\Form\DataTransformerInterface;
 /**
  * @implements DataTransformerInterface<array<string>|null, string|null>
  */
-class ArrayLinebreakTransformer implements DataTransformerInterface
+final class ArrayLinebreakTransformer implements DataTransformerInterface
 {
     /**
      * @param array<string>|null $array

--- a/app/bundles/CoreBundle/Form/DataTransformer/ArrayStringTransformer.php
+++ b/app/bundles/CoreBundle/Form/DataTransformer/ArrayStringTransformer.php
@@ -7,7 +7,7 @@ use Symfony\Component\Form\DataTransformerInterface;
 /**
  * @implements DataTransformerInterface<array<string>|string|null, string>
  */
-class ArrayStringTransformer implements DataTransformerInterface
+final class ArrayStringTransformer implements DataTransformerInterface
 {
     /**
      * @param array<string>|string|null $array

--- a/app/bundles/CoreBundle/Form/DataTransformer/BarStringTransformer.php
+++ b/app/bundles/CoreBundle/Form/DataTransformer/BarStringTransformer.php
@@ -12,7 +12,7 @@ use Symfony\Component\Form\DataTransformerInterface;
  *
  * @implements DataTransformerInterface<array<string>|null, string|null>
  */
-class BarStringTransformer implements DataTransformerInterface
+final class BarStringTransformer implements DataTransformerInterface
 {
     /**
      * @param array<string>|null $array

--- a/app/bundles/CoreBundle/Form/DataTransformer/IdToEntityModelTransformer.php
+++ b/app/bundles/CoreBundle/Form/DataTransformer/IdToEntityModelTransformer.php
@@ -10,7 +10,7 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
 /**
  * @implements DataTransformerInterface<array<mixed>|int|string, array<mixed>|int|string>
  */
-class IdToEntityModelTransformer implements DataTransformerInterface
+final class IdToEntityModelTransformer implements DataTransformerInterface
 {
     /**
      * @param class-string $repository

--- a/app/bundles/CoreBundle/Form/DataTransformer/SecondsConversionTransformer.php
+++ b/app/bundles/CoreBundle/Form/DataTransformer/SecondsConversionTransformer.php
@@ -7,7 +7,7 @@ use Symfony\Component\Form\DataTransformerInterface;
 /**
  * @implements DataTransformerInterface<string, string>
  */
-class SecondsConversionTransformer implements DataTransformerInterface
+final class SecondsConversionTransformer implements DataTransformerInterface
 {
     public function __construct(
         private $viewFormat = 'H',

--- a/app/bundles/CoreBundle/Form/DataTransformer/SortableListTransformer.php
+++ b/app/bundles/CoreBundle/Form/DataTransformer/SortableListTransformer.php
@@ -8,7 +8,7 @@ use Symfony\Component\Form\DataTransformerInterface;
 /**
  * @implements DataTransformerInterface<array<mixed>, array<mixed>>
  */
-class SortableListTransformer implements DataTransformerInterface
+final class SortableListTransformer implements DataTransformerInterface
 {
     /**
      * @param bool $withLabels

--- a/app/bundles/CoreBundle/Form/Extension/NormalizeFormExtension.php
+++ b/app/bundles/CoreBundle/Form/Extension/NormalizeFormExtension.php
@@ -11,7 +11,7 @@ use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class NormalizeFormExtension extends AbstractTypeExtension
+final class NormalizeFormExtension extends AbstractTypeExtension
 {
     /**
      * @param array<mixed> $options

--- a/app/bundles/CoreBundle/Form/Type/AlertType.php
+++ b/app/bundles/CoreBundle/Form/Type/AlertType.php
@@ -9,7 +9,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class AlertType extends AbstractType
+final class AlertType extends AbstractType
 {
     /**
      * @param FormInterface<FormInterface> $form

--- a/app/bundles/CoreBundle/Form/Type/BooleanType.php
+++ b/app/bundles/CoreBundle/Form/Type/BooleanType.php
@@ -8,7 +8,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class BooleanType extends AbstractType
+final class BooleanType extends AbstractType
 {
     public function configureOptions(OptionsResolver $resolver): void
     {
@@ -21,7 +21,7 @@ class BooleanType extends AbstractType
         ]);
     }
 
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return YesNoButtonGroupType::class;
     }

--- a/app/bundles/CoreBundle/Form/Type/ButtonGroupType.php
+++ b/app/bundles/CoreBundle/Form/Type/ButtonGroupType.php
@@ -11,9 +11,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class ButtonGroupType extends AbstractType
+final class ButtonGroupType extends AbstractType
 {
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return ChoiceType::class;
     }

--- a/app/bundles/CoreBundle/Form/Type/ConfigThemeType.php
+++ b/app/bundles/CoreBundle/Form/Type/ConfigThemeType.php
@@ -11,7 +11,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class ConfigThemeType extends AbstractType
+final class ConfigThemeType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/CoreBundle/Form/Type/ConfigType.php
+++ b/app/bundles/CoreBundle/Form/Type/ConfigType.php
@@ -35,7 +35,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class ConfigType extends AbstractType
+final class ConfigType extends AbstractType
 {
     public function __construct(
         private readonly TranslatorInterface $translator,

--- a/app/bundles/CoreBundle/Form/Type/ContentPreviewSettingsType.php
+++ b/app/bundles/CoreBundle/Form/Type/ContentPreviewSettingsType.php
@@ -18,7 +18,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * Preview settings form used for pages and emails in detail view page.
  */
-class ContentPreviewSettingsType extends AbstractType
+final class ContentPreviewSettingsType extends AbstractType
 {
     public const TYPE_EMAIL = 'email';
 

--- a/app/bundles/CoreBundle/Form/Type/CountryType.php
+++ b/app/bundles/CoreBundle/Form/Type/CountryType.php
@@ -10,7 +10,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class CountryType extends AbstractType
+final class CountryType extends AbstractType
 {
     public function configureOptions(OptionsResolver $resolver): void
     {
@@ -24,7 +24,7 @@ class CountryType extends AbstractType
         ]);
     }
 
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return ChoiceType::class;
     }

--- a/app/bundles/CoreBundle/Form/Type/DatePickerType.php
+++ b/app/bundles/CoreBundle/Form/Type/DatePickerType.php
@@ -11,7 +11,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class DatePickerType extends AbstractType
+final class DatePickerType extends AbstractType
 {
     public function configureOptions(OptionsResolver $resolver): void
     {

--- a/app/bundles/CoreBundle/Form/Type/DateRangeType.php
+++ b/app/bundles/CoreBundle/Form/Type/DateRangeType.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 /**
  * @extends AbstractType<mixed>
  */
-class DateRangeType extends AbstractType
+final class DateRangeType extends AbstractType
 {
     public function __construct(
         private readonly RequestStack $requestStack,

--- a/app/bundles/CoreBundle/Form/Type/DynamicContentFilterEntryFiltersType.php
+++ b/app/bundles/CoreBundle/Form/Type/DynamicContentFilterEntryFiltersType.php
@@ -16,7 +16,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class DynamicContentFilterEntryFiltersType extends AbstractType
+final class DynamicContentFilterEntryFiltersType extends AbstractType
 {
     use FilterTrait;
 

--- a/app/bundles/CoreBundle/Form/Type/DynamicContentFilterEntryType.php
+++ b/app/bundles/CoreBundle/Form/Type/DynamicContentFilterEntryType.php
@@ -18,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class DynamicContentFilterEntryType extends AbstractType
+final class DynamicContentFilterEntryType extends AbstractType
 {
     /**
      * @var mixed[]

--- a/app/bundles/CoreBundle/Form/Type/DynamicContentFilterType.php
+++ b/app/bundles/CoreBundle/Form/Type/DynamicContentFilterType.php
@@ -13,7 +13,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class DynamicContentFilterType extends AbstractType
+final class DynamicContentFilterType extends AbstractType
 {
     public function __construct(
         private readonly BuilderIntegrationsHelper $builderIntegrationsHelper,

--- a/app/bundles/CoreBundle/Form/Type/DynamicListType.php
+++ b/app/bundles/CoreBundle/Form/Type/DynamicListType.php
@@ -17,7 +17,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 /**
  * @extends AbstractType<mixed>
  */
-class DynamicListType extends AbstractType
+final class DynamicListType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
@@ -95,7 +95,7 @@ class DynamicListType extends AbstractType
         return 'dynamiclist';
     }
 
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return CollectionType::class;
     }

--- a/app/bundles/CoreBundle/Form/Type/EntityLookupType.php
+++ b/app/bundles/CoreBundle/Form/Type/EntityLookupType.php
@@ -20,7 +20,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class EntityLookupType extends AbstractType
+final class EntityLookupType extends AbstractType
 {
     /**
      * @var EntityLookupChoiceLoader[]
@@ -93,7 +93,7 @@ class EntityLookupType extends AbstractType
         );
     }
 
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return ChoiceType::class;
     }

--- a/app/bundles/CoreBundle/Form/Type/FormButtonsType.php
+++ b/app/bundles/CoreBundle/Form/Type/FormButtonsType.php
@@ -13,7 +13,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class FormButtonsType extends AbstractType
+final class FormButtonsType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/CoreBundle/Form/Type/IpLookupDownloadDataStoreButtonType.php
+++ b/app/bundles/CoreBundle/Form/Type/IpLookupDownloadDataStoreButtonType.php
@@ -15,7 +15,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class IpLookupDownloadDataStoreButtonType extends AbstractType
+final class IpLookupDownloadDataStoreButtonType extends AbstractType
 {
     public function __construct(
         private readonly DateHelper $dateHelper,

--- a/app/bundles/CoreBundle/Form/Type/LocaleType.php
+++ b/app/bundles/CoreBundle/Form/Type/LocaleType.php
@@ -10,7 +10,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class LocaleType extends AbstractType
+final class LocaleType extends AbstractType
 {
     public function configureOptions(OptionsResolver $resolver): void
     {
@@ -24,7 +24,7 @@ class LocaleType extends AbstractType
         ]);
     }
 
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return ChoiceType::class;
     }

--- a/app/bundles/CoreBundle/Form/Type/LookupType.php
+++ b/app/bundles/CoreBundle/Form/Type/LookupType.php
@@ -10,7 +10,7 @@ use Symfony\Component\Form\FormView;
 /**
  * @extends AbstractType<mixed>
  */
-class LookupType extends AbstractType
+final class LookupType extends AbstractType
 {
     public function buildView(FormView $view, FormInterface $form, array $options): void
     {

--- a/app/bundles/CoreBundle/Form/Type/MultiselectType.php
+++ b/app/bundles/CoreBundle/Form/Type/MultiselectType.php
@@ -10,7 +10,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class MultiselectType extends AbstractType
+final class MultiselectType extends AbstractType
 {
     public function configureOptions(OptionsResolver $resolver): void
     {
@@ -24,7 +24,7 @@ class MultiselectType extends AbstractType
         ]);
     }
 
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return ChoiceType::class;
     }

--- a/app/bundles/CoreBundle/Form/Type/PublishDownDateType.php
+++ b/app/bundles/CoreBundle/Form/Type/PublishDownDateType.php
@@ -10,7 +10,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class PublishDownDateType extends AbstractType
+final class PublishDownDateType extends AbstractType
 {
     public function configureOptions(OptionsResolver $resolver): void
     {

--- a/app/bundles/CoreBundle/Form/Type/PublishUpDateType.php
+++ b/app/bundles/CoreBundle/Form/Type/PublishUpDateType.php
@@ -10,7 +10,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class PublishUpDateType extends AbstractType
+final class PublishUpDateType extends AbstractType
 {
     public function configureOptions(OptionsResolver $resolver): void
     {

--- a/app/bundles/CoreBundle/Form/Type/RegionType.php
+++ b/app/bundles/CoreBundle/Form/Type/RegionType.php
@@ -10,7 +10,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class RegionType extends AbstractType
+final class RegionType extends AbstractType
 {
     public function configureOptions(OptionsResolver $resolver): void
     {
@@ -26,7 +26,7 @@ class RegionType extends AbstractType
         );
     }
 
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return ChoiceType::class;
     }

--- a/app/bundles/CoreBundle/Form/Type/SelectType.php
+++ b/app/bundles/CoreBundle/Form/Type/SelectType.php
@@ -9,7 +9,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class SelectType extends AbstractType
+final class SelectType extends AbstractType
 {
     public function configureOptions(OptionsResolver $resolver): void
     {
@@ -22,7 +22,7 @@ class SelectType extends AbstractType
         ]);
     }
 
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return ChoiceType::class;
     }

--- a/app/bundles/CoreBundle/Form/Type/SortableListType.php
+++ b/app/bundles/CoreBundle/Form/Type/SortableListType.php
@@ -17,7 +17,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 /**
  * @extends AbstractType<mixed>
  */
-class SortableListType extends AbstractType
+final class SortableListType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/CoreBundle/Form/Type/SortableValueLabelListType.php
+++ b/app/bundles/CoreBundle/Form/Type/SortableValueLabelListType.php
@@ -14,7 +14,7 @@ use Symfony\Component\Form\FormView;
 /**
  * @extends AbstractType<mixed>
  */
-class SortableValueLabelListType extends AbstractType
+final class SortableValueLabelListType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/CoreBundle/Form/Type/StandAloneButtonType.php
+++ b/app/bundles/CoreBundle/Form/Type/StandAloneButtonType.php
@@ -8,7 +8,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class StandAloneButtonType extends AbstractType
+final class StandAloneButtonType extends AbstractType
 {
     public function configureOptions(OptionsResolver $resolver): void
     {

--- a/app/bundles/CoreBundle/Form/Type/TelType.php
+++ b/app/bundles/CoreBundle/Form/Type/TelType.php
@@ -9,7 +9,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class TelType extends AbstractType
+final class TelType extends AbstractType
 {
     public function configureOptions(OptionsResolver $resolver): void
     {
@@ -18,7 +18,7 @@ class TelType extends AbstractType
         ]);
     }
 
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return TextType::class;
     }

--- a/app/bundles/CoreBundle/Form/Type/ThemeListType.php
+++ b/app/bundles/CoreBundle/Form/Type/ThemeListType.php
@@ -11,7 +11,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class ThemeListType extends AbstractType
+final class ThemeListType extends AbstractType
 {
     public function __construct(
         private readonly ThemeHelperInterface $themeHelper,
@@ -43,7 +43,7 @@ class ThemeListType extends AbstractType
         );
     }
 
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return ChoiceType::class;
     }

--- a/app/bundles/CoreBundle/Form/Type/ThemeUploadType.php
+++ b/app/bundles/CoreBundle/Form/Type/ThemeUploadType.php
@@ -10,7 +10,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class ThemeUploadType extends AbstractType
+final class ThemeUploadType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/CoreBundle/Form/Type/TimeFormatType.php
+++ b/app/bundles/CoreBundle/Form/Type/TimeFormatType.php
@@ -10,7 +10,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class TimeFormatType extends AbstractType
+final class TimeFormatType extends AbstractType
 {
     public function __construct(
         private readonly TranslatorInterface $translator,
@@ -33,7 +33,7 @@ class TimeFormatType extends AbstractType
         ]);
     }
 
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return ChoiceType::class;
     }

--- a/app/bundles/CoreBundle/Form/Type/TimezoneType.php
+++ b/app/bundles/CoreBundle/Form/Type/TimezoneType.php
@@ -10,7 +10,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class TimezoneType extends AbstractType
+final class TimezoneType extends AbstractType
 {
     public function configureOptions(OptionsResolver $resolver): void
     {
@@ -24,7 +24,7 @@ class TimezoneType extends AbstractType
         ]);
     }
 
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return ChoiceType::class;
     }

--- a/app/bundles/CoreBundle/Form/Type/YesNoButtonGroupType.php
+++ b/app/bundles/CoreBundle/Form/Type/YesNoButtonGroupType.php
@@ -9,9 +9,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class YesNoButtonGroupType extends AbstractType
+final class YesNoButtonGroupType extends AbstractType
 {
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return ButtonGroupType::class;
     }

--- a/app/bundles/CoreBundle/Form/Validator/Constraints/CircularDependency.php
+++ b/app/bundles/CoreBundle/Form/Validator/Constraints/CircularDependency.php
@@ -4,7 +4,7 @@ namespace Mautic\CoreBundle\Form\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
-class CircularDependency extends Constraint
+final class CircularDependency extends Constraint
 {
     public $message;
 

--- a/app/bundles/CoreBundle/Form/Validator/Constraints/CircularDependencyValidator.php
+++ b/app/bundles/CoreBundle/Form/Validator/Constraints/CircularDependencyValidator.php
@@ -12,7 +12,7 @@ use Symfony\Component\Validator\ConstraintValidator;
  * Throws an exception if the field alias is equal some segment filter keyword.
  * It would cause odd behavior with segment filters otherwise.
  */
-class CircularDependencyValidator extends ConstraintValidator
+final class CircularDependencyValidator extends ConstraintValidator
 {
     public function __construct(
         private readonly ListModel $model,

--- a/app/bundles/CoreBundle/Form/Validator/Constraints/FileEncoding.php
+++ b/app/bundles/CoreBundle/Form/Validator/Constraints/FileEncoding.php
@@ -4,7 +4,7 @@ namespace Mautic\CoreBundle\Form\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
-class FileEncoding extends Constraint
+final class FileEncoding extends Constraint
 {
     public $encodingFormatMessage = 'mautic.core.invalid_file_encoding';
 

--- a/app/bundles/CoreBundle/Form/Validator/Constraints/FileEncodingValidator.php
+++ b/app/bundles/CoreBundle/Form/Validator/Constraints/FileEncodingValidator.php
@@ -9,7 +9,7 @@ use Symfony\Component\Validator\ConstraintValidator;
  * Throws an exception if the field alias is equal some segment filter keyword.
  * It would cause odd behavior with segment filters otherwise.
  */
-class FileEncodingValidator extends ConstraintValidator
+final class FileEncodingValidator extends ConstraintValidator
 {
     public function validate(mixed $field, Constraint $constraint): void
     {

--- a/app/bundles/CoreBundle/Tests/Form/ToBcBccFieldsTraitTest.php
+++ b/app/bundles/CoreBundle/Tests/Form/ToBcBccFieldsTraitTest.php
@@ -103,7 +103,7 @@ final class ToBcBccFieldsTraitTest extends TypeTestCase
 /**
  * @extends AbstractType<mixed>
  */
-class ToBcBccStubFormType extends AbstractType
+final class ToBcBccStubFormType extends AbstractType
 {
     use ToBcBccFieldsTrait;
 

--- a/app/bundles/DashboardBundle/Form/Type/UploadType.php
+++ b/app/bundles/DashboardBundle/Form/Type/UploadType.php
@@ -10,7 +10,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class UploadType extends AbstractType
+final class UploadType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/DashboardBundle/Form/Type/WidgetType.php
+++ b/app/bundles/DashboardBundle/Form/Type/WidgetType.php
@@ -19,7 +19,7 @@ use Symfony\Component\Form\FormEvents;
 /**
  * @extends AbstractType<mixed>
  */
-class WidgetType extends AbstractType
+final class WidgetType extends AbstractType
 {
     public function __construct(
         protected EventDispatcherInterface $dispatcher,

--- a/app/bundles/DynamicContentBundle/Form/Type/DwcEntryFiltersType.php
+++ b/app/bundles/DynamicContentBundle/Form/Type/DwcEntryFiltersType.php
@@ -19,7 +19,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class DwcEntryFiltersType extends AbstractType
+final class DwcEntryFiltersType extends AbstractType
 {
     use FilterTrait;
 

--- a/app/bundles/DynamicContentBundle/Form/Type/DynamicContentDecisionType.php
+++ b/app/bundles/DynamicContentBundle/Form/Type/DynamicContentDecisionType.php
@@ -6,7 +6,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints\NotBlank;
 
-class DynamicContentDecisionType extends DynamicContentSendType
+final class DynamicContentDecisionType extends DynamicContentSendType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/DynamicContentBundle/Form/Type/DynamicContentListType.php
+++ b/app/bundles/DynamicContentBundle/Form/Type/DynamicContentListType.php
@@ -10,7 +10,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class DynamicContentListType extends AbstractType
+final class DynamicContentListType extends AbstractType
 {
     public function configureOptions(OptionsResolver $resolver): void
     {
@@ -54,7 +54,7 @@ class DynamicContentListType extends AbstractType
         return 'dwc_list';
     }
 
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return EntityLookupType::class;
     }

--- a/app/bundles/DynamicContentBundle/Form/Type/DynamicContentType.php
+++ b/app/bundles/DynamicContentBundle/Form/Type/DynamicContentType.php
@@ -40,7 +40,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @extends AbstractType<DynamicContent>
  */
-class DynamicContentType extends AbstractType
+final class DynamicContentType extends AbstractType
 {
     /**
      * @var mixed[]

--- a/app/bundles/EmailBundle/Form/Type/BatchCategoryType.php
+++ b/app/bundles/EmailBundle/Form/Type/BatchCategoryType.php
@@ -17,7 +17,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class BatchCategoryType extends AbstractType
+final class BatchCategoryType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/EmailBundle/Form/Type/BatchSendType.php
+++ b/app/bundles/EmailBundle/Form/Type/BatchSendType.php
@@ -8,7 +8,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class BatchSendType extends AbstractType
+final class BatchSendType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/EmailBundle/Form/Type/ConfigMonitoredEmailType.php
+++ b/app/bundles/EmailBundle/Form/Type/ConfigMonitoredEmailType.php
@@ -11,7 +11,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class ConfigMonitoredEmailType extends AbstractType
+final class ConfigMonitoredEmailType extends AbstractType
 {
     public function __construct(
         private readonly EventDispatcherInterface $dispatcher,

--- a/app/bundles/EmailBundle/Form/Type/ConfigMonitoredMailboxesType.php
+++ b/app/bundles/EmailBundle/Form/Type/ConfigMonitoredMailboxesType.php
@@ -18,7 +18,7 @@ use Symfony\Component\Validator\Constraints\Email;
 /**
  * @extends AbstractType<mixed>
  */
-class ConfigMonitoredMailboxesType extends AbstractType
+final class ConfigMonitoredMailboxesType extends AbstractType
 {
     public function __construct(
         private readonly Mailbox $imapHelper,

--- a/app/bundles/EmailBundle/Form/Type/ConfigType.php
+++ b/app/bundles/EmailBundle/Form/Type/ConfigType.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class ConfigType extends AbstractType
+final class ConfigType extends AbstractType
 {
     public const MINIFY_EMAIL_HTML = 'minify_email_html';
 

--- a/app/bundles/EmailBundle/Form/Type/DashboardBestHoursWidgetType.php
+++ b/app/bundles/EmailBundle/Form/Type/DashboardBestHoursWidgetType.php
@@ -12,7 +12,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class DashboardBestHoursWidgetType extends AbstractType
+final class DashboardBestHoursWidgetType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/EmailBundle/Form/Type/DashboardEmailsInTimeWidgetType.php
+++ b/app/bundles/EmailBundle/Form/Type/DashboardEmailsInTimeWidgetType.php
@@ -12,7 +12,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class DashboardEmailsInTimeWidgetType extends AbstractType
+final class DashboardEmailsInTimeWidgetType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/EmailBundle/Form/Type/DashboardMostHitEmailRedirectsWidgetType.php
+++ b/app/bundles/EmailBundle/Form/Type/DashboardMostHitEmailRedirectsWidgetType.php
@@ -11,7 +11,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class DashboardMostHitEmailRedirectsWidgetType extends AbstractType
+final class DashboardMostHitEmailRedirectsWidgetType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/EmailBundle/Form/Type/DashboardSentEmailToContactsWidgetType.php
+++ b/app/bundles/EmailBundle/Form/Type/DashboardSentEmailToContactsWidgetType.php
@@ -11,7 +11,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class DashboardSentEmailToContactsWidgetType extends AbstractType
+final class DashboardSentEmailToContactsWidgetType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/EmailBundle/Form/Type/EmailClickDecisionType.php
+++ b/app/bundles/EmailBundle/Form/Type/EmailClickDecisionType.php
@@ -9,7 +9,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class EmailClickDecisionType extends AbstractType
+final class EmailClickDecisionType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/EmailBundle/Form/Type/EmailListType.php
+++ b/app/bundles/EmailBundle/Form/Type/EmailListType.php
@@ -10,7 +10,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class EmailListType extends AbstractType
+final class EmailListType extends AbstractType
 {
     public function configureOptions(OptionsResolver $resolver): void
     {
@@ -56,7 +56,7 @@ class EmailListType extends AbstractType
         );
     }
 
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return EntityLookupType::class;
     }

--- a/app/bundles/EmailBundle/Form/Type/EmailOpenType.php
+++ b/app/bundles/EmailBundle/Form/Type/EmailOpenType.php
@@ -9,7 +9,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class EmailOpenType extends AbstractType
+final class EmailOpenType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/EmailBundle/Form/Type/EmailSendType.php
+++ b/app/bundles/EmailBundle/Form/Type/EmailSendType.php
@@ -17,7 +17,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 /**
  * @extends AbstractType<mixed>
  */
-class EmailSendType extends AbstractType
+final class EmailSendType extends AbstractType
 {
     public function __construct(
         private readonly RouterInterface $router,

--- a/app/bundles/EmailBundle/Form/Type/EmailToUserType.php
+++ b/app/bundles/EmailBundle/Form/Type/EmailToUserType.php
@@ -13,7 +13,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class EmailToUserType extends AbstractType
+final class EmailToUserType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/EmailBundle/Form/Type/EmailType.php
+++ b/app/bundles/EmailBundle/Form/Type/EmailType.php
@@ -49,7 +49,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @extends AbstractType<Email>
  */
-class EmailType extends AbstractType
+final class EmailType extends AbstractType
 {
     private readonly bool $isDraftEnabled;
 

--- a/app/bundles/EmailBundle/Form/Type/EmailUtmTagsType.php
+++ b/app/bundles/EmailBundle/Form/Type/EmailUtmTagsType.php
@@ -11,7 +11,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class EmailUtmTagsType extends AbstractType
+final class EmailUtmTagsType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/EmailBundle/Form/Type/ExampleSendType.php
+++ b/app/bundles/EmailBundle/Form/Type/ExampleSendType.php
@@ -16,7 +16,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class ExampleSendType extends AbstractType
+final class ExampleSendType extends AbstractType
 {
     public function __construct(
         private readonly TranslatorInterface $translator,

--- a/app/bundles/EmailBundle/Form/Type/FormSubmitActionUserEmailType.php
+++ b/app/bundles/EmailBundle/Form/Type/FormSubmitActionUserEmailType.php
@@ -11,7 +11,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 /**
  * @extends AbstractType<mixed>
  */
-class FormSubmitActionUserEmailType extends AbstractType
+final class FormSubmitActionUserEmailType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/EmailBundle/Form/Type/VariantType.php
+++ b/app/bundles/EmailBundle/Form/Type/VariantType.php
@@ -20,7 +20,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class VariantType extends AbstractType
+final class VariantType extends AbstractType
 {
     public const DEFAULT_WINNER_DELAY = 24;
 

--- a/app/bundles/FormBundle/Form/Type/ActionType.php
+++ b/app/bundles/FormBundle/Form/Type/ActionType.php
@@ -14,7 +14,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class ActionType extends AbstractType
+final class ActionType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/FormBundle/Form/Type/CampaignEventFormFieldValueType.php
+++ b/app/bundles/FormBundle/Form/Type/CampaignEventFormFieldValueType.php
@@ -14,7 +14,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 /**
  * @extends AbstractType<mixed>
  */
-class CampaignEventFormFieldValueType extends AbstractType
+final class CampaignEventFormFieldValueType extends AbstractType
 {
     public function __construct(
         private readonly FormModel $model,

--- a/app/bundles/FormBundle/Form/Type/CampaignEventFormSubmitType.php
+++ b/app/bundles/FormBundle/Form/Type/CampaignEventFormSubmitType.php
@@ -8,7 +8,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class CampaignEventFormSubmitType extends AbstractType
+final class CampaignEventFormSubmitType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/FormBundle/Form/Type/ConfigFormType.php
+++ b/app/bundles/FormBundle/Form/Type/ConfigFormType.php
@@ -12,7 +12,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class ConfigFormType extends AbstractType
+final class ConfigFormType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/FormBundle/Form/Type/FieldType.php
+++ b/app/bundles/FormBundle/Form/Type/FieldType.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class FieldType extends AbstractType
+final class FieldType extends AbstractType
 {
     use FormFieldTrait;
 

--- a/app/bundles/FormBundle/Form/Type/FormFieldCaptchaType.php
+++ b/app/bundles/FormBundle/Form/Type/FormFieldCaptchaType.php
@@ -9,7 +9,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class FormFieldCaptchaType extends AbstractType
+final class FormFieldCaptchaType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/FormBundle/Form/Type/FormFieldConditionType.php
+++ b/app/bundles/FormBundle/Form/Type/FormFieldConditionType.php
@@ -16,7 +16,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class FormFieldConditionType extends AbstractType
+final class FormFieldConditionType extends AbstractType
 {
     public function __construct(
         private readonly FieldModel $fieldModel,

--- a/app/bundles/FormBundle/Form/Type/FormFieldEmailType.php
+++ b/app/bundles/FormBundle/Form/Type/FormFieldEmailType.php
@@ -11,7 +11,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class FormFieldEmailType extends AbstractType
+final class FormFieldEmailType extends AbstractType
 {
     public function __construct(
         private readonly TranslatorInterface $translator,

--- a/app/bundles/FormBundle/Form/Type/FormFieldFileType.php
+++ b/app/bundles/FormBundle/Form/Type/FormFieldFileType.php
@@ -17,7 +17,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class FormFieldFileType extends AbstractType
+final class FormFieldFileType extends AbstractType
 {
     public const PROPERTY_ALLOWED_FILE_EXTENSIONS = 'allowed_file_extensions';
 

--- a/app/bundles/FormBundle/Form/Type/FormFieldGroupType.php
+++ b/app/bundles/FormBundle/Form/Type/FormFieldGroupType.php
@@ -9,7 +9,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class FormFieldGroupType extends AbstractType
+final class FormFieldGroupType extends AbstractType
 {
     use SortableListTrait;
 

--- a/app/bundles/FormBundle/Form/Type/FormFieldHTMLType.php
+++ b/app/bundles/FormBundle/Form/Type/FormFieldHTMLType.php
@@ -10,7 +10,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class FormFieldHTMLType extends AbstractType
+final class FormFieldHTMLType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/FormBundle/Form/Type/FormFieldNumberType.php
+++ b/app/bundles/FormBundle/Form/Type/FormFieldNumberType.php
@@ -12,7 +12,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<FormFieldNumberType>
  */
-class FormFieldNumberType extends AbstractType
+final class FormFieldNumberType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/FormBundle/Form/Type/FormFieldPageBreakType.php
+++ b/app/bundles/FormBundle/Form/Type/FormFieldPageBreakType.php
@@ -11,7 +11,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class FormFieldPageBreakType extends AbstractType
+final class FormFieldPageBreakType extends AbstractType
 {
     public function __construct(
         private readonly TranslatorInterface $translator,

--- a/app/bundles/FormBundle/Form/Type/FormFieldPlaceholderType.php
+++ b/app/bundles/FormBundle/Form/Type/FormFieldPlaceholderType.php
@@ -9,7 +9,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class FormFieldPlaceholderType extends AbstractType
+final class FormFieldPlaceholderType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/FormBundle/Form/Type/FormFieldSelectType.php
+++ b/app/bundles/FormBundle/Form/Type/FormFieldSelectType.php
@@ -11,7 +11,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class FormFieldSelectType extends AbstractType
+final class FormFieldSelectType extends AbstractType
 {
     use SortableListTrait;
 

--- a/app/bundles/FormBundle/Form/Type/FormFieldTelType.php
+++ b/app/bundles/FormBundle/Form/Type/FormFieldTelType.php
@@ -11,7 +11,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class FormFieldTelType extends AbstractType
+final class FormFieldTelType extends AbstractType
 {
     public function __construct(
         private readonly TranslatorInterface $translator,

--- a/app/bundles/FormBundle/Form/Type/FormFieldTextType.php
+++ b/app/bundles/FormBundle/Form/Type/FormFieldTextType.php
@@ -10,7 +10,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class FormFieldTextType extends AbstractType
+final class FormFieldTextType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/FormBundle/Form/Type/FormListType.php
+++ b/app/bundles/FormBundle/Form/Type/FormListType.php
@@ -13,7 +13,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class FormListType extends AbstractType
+final class FormListType extends AbstractType
 {
     private readonly bool $viewOther;
 
@@ -61,7 +61,7 @@ class FormListType extends AbstractType
         $resolver->setDefined(['form_type']);
     }
 
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return ChoiceType::class;
     }

--- a/app/bundles/FormBundle/Form/Type/FormType.php
+++ b/app/bundles/FormBundle/Form/Type/FormType.php
@@ -26,7 +26,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<Form>
  */
-class FormType extends AbstractType
+final class FormType extends AbstractType
 {
     public function __construct(
         private readonly CorePermissions $security,

--- a/app/bundles/FormBundle/Form/Type/PointActionFormSubmitType.php
+++ b/app/bundles/FormBundle/Form/Type/PointActionFormSubmitType.php
@@ -8,7 +8,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class PointActionFormSubmitType extends AbstractType
+final class PointActionFormSubmitType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/FormBundle/Form/Type/SubmitActionEmailType.php
+++ b/app/bundles/FormBundle/Form/Type/SubmitActionEmailType.php
@@ -18,7 +18,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class SubmitActionEmailType extends AbstractType
+final class SubmitActionEmailType extends AbstractType
 {
     use FormFieldTrait;
     use ToBcBccFieldsTrait;

--- a/app/bundles/FormBundle/Form/Type/SubmitActionRepostType.php
+++ b/app/bundles/FormBundle/Form/Type/SubmitActionRepostType.php
@@ -14,7 +14,7 @@ use Symfony\Component\Validator\Constraints\Url;
 /**
  * @extends AbstractType<mixed>
  */
-class SubmitActionRepostType extends AbstractType
+final class SubmitActionRepostType extends AbstractType
 {
     use FormFieldTrait;
 

--- a/app/bundles/InstallBundle/Configurator/Form/CheckStepType.php
+++ b/app/bundles/InstallBundle/Configurator/Form/CheckStepType.php
@@ -10,7 +10,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class CheckStepType extends AbstractType
+final class CheckStepType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/InstallBundle/Configurator/Form/DoctrineStepType.php
+++ b/app/bundles/InstallBundle/Configurator/Form/DoctrineStepType.php
@@ -21,7 +21,7 @@ use Symfony\Component\Validator\Constraints\Choice;
  *
  * @extends AbstractType<mixed>
  */
-class DoctrineStepType extends AbstractType
+final class DoctrineStepType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/InstallBundle/Configurator/Form/UserStepType.php
+++ b/app/bundles/InstallBundle/Configurator/Form/UserStepType.php
@@ -15,7 +15,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 /**
  * @extends AbstractType<mixed>
  */
-class UserStepType extends AbstractType
+final class UserStepType extends AbstractType
 {
     public function __construct(
         private readonly RequestStack $requestStack,

--- a/app/bundles/IntegrationsBundle/Form/Type/ActivityListType.php
+++ b/app/bundles/IntegrationsBundle/Form/Type/ActivityListType.php
@@ -12,7 +12,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class ActivityListType extends AbstractType
+final class ActivityListType extends AbstractType
 {
     public function __construct(
         private readonly LeadModel $leadModel,
@@ -35,7 +35,7 @@ class ActivityListType extends AbstractType
         );
     }
 
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return ChoiceType::class;
     }

--- a/app/bundles/IntegrationsBundle/Form/Type/IntegrationConfigType.php
+++ b/app/bundles/IntegrationsBundle/Form/Type/IntegrationConfigType.php
@@ -19,7 +19,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<Integration>
  */
-class IntegrationConfigType extends AbstractType
+final class IntegrationConfigType extends AbstractType
 {
     public function __construct(
         private readonly ConfigIntegrationsHelper $integrationsHelper,

--- a/app/bundles/IntegrationsBundle/Form/Type/IntegrationFeatureSettingsType.php
+++ b/app/bundles/IntegrationsBundle/Form/Type/IntegrationFeatureSettingsType.php
@@ -15,7 +15,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class IntegrationFeatureSettingsType extends AbstractType
+final class IntegrationFeatureSettingsType extends AbstractType
 {
     /**
      * @throws IntegrationNotFoundException

--- a/app/bundles/IntegrationsBundle/Form/Type/IntegrationSyncSettingsFieldMappingsType.php
+++ b/app/bundles/IntegrationsBundle/Form/Type/IntegrationSyncSettingsFieldMappingsType.php
@@ -19,7 +19,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class IntegrationSyncSettingsFieldMappingsType extends AbstractType
+final class IntegrationSyncSettingsFieldMappingsType extends AbstractType
 {
     public function __construct(
         private readonly LoggerInterface $logger,

--- a/app/bundles/IntegrationsBundle/Form/Type/IntegrationSyncSettingsObjectFieldMappingType.php
+++ b/app/bundles/IntegrationsBundle/Form/Type/IntegrationSyncSettingsObjectFieldMappingType.php
@@ -19,7 +19,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class IntegrationSyncSettingsObjectFieldMappingType extends AbstractType
+final class IntegrationSyncSettingsObjectFieldMappingType extends AbstractType
 {
     public function __construct(
         private readonly TranslatorInterface $translator,

--- a/app/bundles/IntegrationsBundle/Form/Type/IntegrationSyncSettingsObjectFieldType.php
+++ b/app/bundles/IntegrationsBundle/Form/Type/IntegrationSyncSettingsObjectFieldType.php
@@ -15,7 +15,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class IntegrationSyncSettingsObjectFieldType extends AbstractType
+final class IntegrationSyncSettingsObjectFieldType extends AbstractType
 {
     /**
      * @throws InvalidFormOptionException

--- a/app/bundles/IntegrationsBundle/Form/Type/IntegrationSyncSettingsType.php
+++ b/app/bundles/IntegrationsBundle/Form/Type/IntegrationSyncSettingsType.php
@@ -15,7 +15,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class IntegrationSyncSettingsType extends AbstractType
+final class IntegrationSyncSettingsType extends AbstractType
 {
     /**
      * @throws IntegrationNotFoundException

--- a/app/bundles/LeadBundle/Form/DataTransformer/FieldFilterTransformer.php
+++ b/app/bundles/LeadBundle/Form/DataTransformer/FieldFilterTransformer.php
@@ -13,7 +13,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @implements DataTransformerInterface<mixed, array<mixed>|mixed>
  */
-class FieldFilterTransformer implements DataTransformerInterface
+final class FieldFilterTransformer implements DataTransformerInterface
 {
     /**
      * @var string[]

--- a/app/bundles/LeadBundle/Form/DataTransformer/FieldToOrderTransformer.php
+++ b/app/bundles/LeadBundle/Form/DataTransformer/FieldToOrderTransformer.php
@@ -9,10 +9,10 @@ use Symfony\Component\Form\DataTransformerInterface;
 /**
  * @implements DataTransformerInterface<LeadField|null, int|null>
  */
-class FieldToOrderTransformer implements DataTransformerInterface
+final readonly class FieldToOrderTransformer implements DataTransformerInterface
 {
     public function __construct(
-        private readonly LeadFieldRepository $leadFieldRepository,
+        private LeadFieldRepository $leadFieldRepository,
     ) {
     }
 

--- a/app/bundles/LeadBundle/Form/DataTransformer/TagEntityModelTransformer.php
+++ b/app/bundles/LeadBundle/Form/DataTransformer/TagEntityModelTransformer.php
@@ -10,7 +10,7 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
 /**
  * @implements DataTransformerInterface<array<mixed>|int|null, array<mixed>|object|null>
  */
-class TagEntityModelTransformer implements DataTransformerInterface
+final class TagEntityModelTransformer implements DataTransformerInterface
 {
     /**
      * @param string $repository

--- a/app/bundles/LeadBundle/Form/Type/ActionAddUtmTagsType.php
+++ b/app/bundles/LeadBundle/Form/Type/ActionAddUtmTagsType.php
@@ -7,7 +7,7 @@ use Symfony\Component\Form\AbstractType;
 /**
  * @extends AbstractType<mixed>
  */
-class ActionAddUtmTagsType extends AbstractType
+final class ActionAddUtmTagsType extends AbstractType
 {
     public function getBlockPrefix(): string
     {

--- a/app/bundles/LeadBundle/Form/Type/ActionRemoveDoNotContact.php
+++ b/app/bundles/LeadBundle/Form/Type/ActionRemoveDoNotContact.php
@@ -7,7 +7,7 @@ use Symfony\Component\Form\AbstractType;
 /**
  * @extends AbstractType<mixed>
  */
-class ActionRemoveDoNotContact extends AbstractType
+final class ActionRemoveDoNotContact extends AbstractType
 {
     public function getBlockPrefix(): string
     {

--- a/app/bundles/LeadBundle/Form/Type/AddToCompanyActionType.php
+++ b/app/bundles/LeadBundle/Form/Type/AddToCompanyActionType.php
@@ -11,7 +11,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 /**
  * @extends AbstractType<mixed>
  */
-class AddToCompanyActionType extends AbstractType
+final class AddToCompanyActionType extends AbstractType
 {
     public function __construct(
         protected RouterInterface $router,

--- a/app/bundles/LeadBundle/Form/Type/BatchType.php
+++ b/app/bundles/LeadBundle/Form/Type/BatchType.php
@@ -12,7 +12,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class BatchType extends AbstractType
+final class BatchType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/LeadBundle/Form/Type/CampaignActionAddDNCType.php
+++ b/app/bundles/LeadBundle/Form/Type/CampaignActionAddDNCType.php
@@ -10,7 +10,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 /**
  * @extends AbstractType<mixed>
  */
-class CampaignActionAddDNCType extends AbstractType
+final class CampaignActionAddDNCType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/LeadBundle/Form/Type/CampaignActionRemoveDNCType.php
+++ b/app/bundles/LeadBundle/Form/Type/CampaignActionRemoveDNCType.php
@@ -9,7 +9,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 /**
  * @extends AbstractType<mixed>
  */
-class CampaignActionRemoveDNCType extends AbstractType
+final class CampaignActionRemoveDNCType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/LeadBundle/Form/Type/CampaignConditionLeadPageHitType.php
+++ b/app/bundles/LeadBundle/Form/Type/CampaignConditionLeadPageHitType.php
@@ -17,7 +17,7 @@ use Symfony\Component\Form\FormInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class CampaignConditionLeadPageHitType extends AbstractType
+final class CampaignConditionLeadPageHitType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/LeadBundle/Form/Type/CampaignEventLeadCampaignsType.php
+++ b/app/bundles/LeadBundle/Form/Type/CampaignEventLeadCampaignsType.php
@@ -13,7 +13,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class CampaignEventLeadCampaignsType extends AbstractType
+final class CampaignEventLeadCampaignsType extends AbstractType
 {
     public function __construct(
         protected ListModel $listModel,

--- a/app/bundles/LeadBundle/Form/Type/CampaignEventLeadDNCType.php
+++ b/app/bundles/LeadBundle/Form/Type/CampaignEventLeadDNCType.php
@@ -13,7 +13,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 /**
  * @extends AbstractType<mixed>
  */
-class CampaignEventLeadDNCType extends AbstractType
+final class CampaignEventLeadDNCType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/LeadBundle/Form/Type/CampaignEventLeadDeviceType.php
+++ b/app/bundles/LeadBundle/Form/Type/CampaignEventLeadDeviceType.php
@@ -11,7 +11,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class CampaignEventLeadDeviceType extends AbstractType
+final class CampaignEventLeadDeviceType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/LeadBundle/Form/Type/CampaignEventLeadFieldValueType.php
+++ b/app/bundles/LeadBundle/Form/Type/CampaignEventLeadFieldValueType.php
@@ -20,7 +20,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 /**
  * @extends AbstractType<mixed>
  */
-class CampaignEventLeadFieldValueType extends AbstractType
+final class CampaignEventLeadFieldValueType extends AbstractType
 {
     public function __construct(
         protected Translator $translator,

--- a/app/bundles/LeadBundle/Form/Type/CampaignEventLeadOwnerType.php
+++ b/app/bundles/LeadBundle/Form/Type/CampaignEventLeadOwnerType.php
@@ -9,7 +9,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class CampaignEventLeadOwnerType extends AbstractType
+final class CampaignEventLeadOwnerType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/LeadBundle/Form/Type/CampaignEventLeadSegmentsType.php
+++ b/app/bundles/LeadBundle/Form/Type/CampaignEventLeadSegmentsType.php
@@ -8,7 +8,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class CampaignEventLeadSegmentsType extends AbstractType
+final class CampaignEventLeadSegmentsType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/LeadBundle/Form/Type/CampaignEventLeadStagesType.php
+++ b/app/bundles/LeadBundle/Form/Type/CampaignEventLeadStagesType.php
@@ -11,7 +11,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class CampaignEventLeadStagesType extends AbstractType
+final class CampaignEventLeadStagesType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/LeadBundle/Form/Type/CampaignEventLeadTagsType.php
+++ b/app/bundles/LeadBundle/Form/Type/CampaignEventLeadTagsType.php
@@ -9,7 +9,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class CampaignEventLeadTagsType extends AbstractType
+final class CampaignEventLeadTagsType extends AbstractType
 {
     public function __construct(
         private readonly TranslatorInterface $translator,

--- a/app/bundles/LeadBundle/Form/Type/CampaignEventPointType.php
+++ b/app/bundles/LeadBundle/Form/Type/CampaignEventPointType.php
@@ -13,7 +13,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<CampaignEventPointType>
  */
-class CampaignEventPointType extends AbstractType
+final class CampaignEventPointType extends AbstractType
 {
     public function __construct(
         private readonly TypeOperatorProviderInterface $typeOperatorProvider,

--- a/app/bundles/LeadBundle/Form/Type/ChangeOwnerType.php
+++ b/app/bundles/LeadBundle/Form/Type/ChangeOwnerType.php
@@ -10,7 +10,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class ChangeOwnerType extends AbstractType
+final class ChangeOwnerType extends AbstractType
 {
     public function __construct(
         private readonly UserModel $userModel,

--- a/app/bundles/LeadBundle/Form/Type/CompanyChangeScoreActionType.php
+++ b/app/bundles/LeadBundle/Form/Type/CompanyChangeScoreActionType.php
@@ -10,7 +10,7 @@ use Symfony\Component\Validator\Constraints\NotEqualTo;
 /**
  * @extends AbstractType<mixed>
  */
-class CompanyChangeScoreActionType extends AbstractType
+final class CompanyChangeScoreActionType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/LeadBundle/Form/Type/CompanyListType.php
+++ b/app/bundles/LeadBundle/Form/Type/CompanyListType.php
@@ -14,7 +14,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class CompanyListType extends AbstractType
+final class CompanyListType extends AbstractType
 {
     public const DEFAULT_LIMIT = 100;
 
@@ -65,7 +65,7 @@ class CompanyListType extends AbstractType
         }
     }
 
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return EntityLookupType::class;
     }

--- a/app/bundles/LeadBundle/Form/Type/CompanyMergeType.php
+++ b/app/bundles/LeadBundle/Form/Type/CompanyMergeType.php
@@ -11,7 +11,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 /**
  * @extends AbstractType<mixed>
  */
-class CompanyMergeType extends AbstractType
+final class CompanyMergeType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/LeadBundle/Form/Type/CompanyType.php
+++ b/app/bundles/LeadBundle/Form/Type/CompanyType.php
@@ -21,7 +21,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @extends AbstractType<Company>
  */
-class CompanyType extends AbstractType
+final class CompanyType extends AbstractType
 {
     use EntityFieldsBuildFormTrait;
 

--- a/app/bundles/LeadBundle/Form/Type/ConfigCompanyType.php
+++ b/app/bundles/LeadBundle/Form/Type/ConfigCompanyType.php
@@ -13,7 +13,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 /**
  * @extends AbstractType<mixed>
  */
-class ConfigCompanyType extends AbstractType
+final class ConfigCompanyType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/LeadBundle/Form/Type/ConfigType.php
+++ b/app/bundles/LeadBundle/Form/Type/ConfigType.php
@@ -17,7 +17,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 /**
  * @extends AbstractType<mixed>
  */
-class ConfigType extends AbstractType
+final class ConfigType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/LeadBundle/Form/Type/ContactChannelsType.php
+++ b/app/bundles/LeadBundle/Form/Type/ContactChannelsType.php
@@ -16,7 +16,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class ContactChannelsType extends AbstractType
+final class ContactChannelsType extends AbstractType
 {
     public function __construct(
         private readonly CoreParametersHelper $coreParametersHelper,

--- a/app/bundles/LeadBundle/Form/Type/ContactColumnsType.php
+++ b/app/bundles/LeadBundle/Form/Type/ContactColumnsType.php
@@ -10,7 +10,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class ContactColumnsType extends AbstractType
+final class ContactColumnsType extends AbstractType
 {
     public function __construct(
         private readonly ContactColumnsDictionary $columnsDictionary,
@@ -34,7 +34,7 @@ class ContactColumnsType extends AbstractType
         );
     }
 
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return ChoiceType::class;
     }

--- a/app/bundles/LeadBundle/Form/Type/ContactFrequencyType.php
+++ b/app/bundles/LeadBundle/Form/Type/ContactFrequencyType.php
@@ -11,7 +11,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class ContactFrequencyType extends AbstractType
+final class ContactFrequencyType extends AbstractType
 {
     public function __construct(
         protected CoreParametersHelper $coreParametersHelper,

--- a/app/bundles/LeadBundle/Form/Type/ContactGroupPointsType.php
+++ b/app/bundles/LeadBundle/Form/Type/ContactGroupPointsType.php
@@ -12,7 +12,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class ContactGroupPointsType extends AbstractType
+final class ContactGroupPointsType extends AbstractType
 {
     private const SCORE_FIELD_PREFIX = 'score_group_';
 

--- a/app/bundles/LeadBundle/Form/Type/DashboardLeadsInTimeWidgetType.php
+++ b/app/bundles/LeadBundle/Form/Type/DashboardLeadsInTimeWidgetType.php
@@ -9,7 +9,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class DashboardLeadsInTimeWidgetType extends AbstractType
+final class DashboardLeadsInTimeWidgetType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/LeadBundle/Form/Type/DashboardLeadsLifetimeWidgetType.php
+++ b/app/bundles/LeadBundle/Form/Type/DashboardLeadsLifetimeWidgetType.php
@@ -11,7 +11,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class DashboardLeadsLifetimeWidgetType extends AbstractType
+final class DashboardLeadsLifetimeWidgetType extends AbstractType
 {
     public function __construct(
         private readonly ListModel $segmentModel,

--- a/app/bundles/LeadBundle/Form/Type/DashboardSegmentsBuildTime.php
+++ b/app/bundles/LeadBundle/Form/Type/DashboardSegmentsBuildTime.php
@@ -10,7 +10,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class DashboardSegmentsBuildTime extends AbstractType
+final class DashboardSegmentsBuildTime extends AbstractType
 {
     public function __construct(
         private readonly ListModel $segmentModel,

--- a/app/bundles/LeadBundle/Form/Type/DeviceType.php
+++ b/app/bundles/LeadBundle/Form/Type/DeviceType.php
@@ -12,7 +12,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<LeadDevice>
  */
-class DeviceType extends AbstractType
+final class DeviceType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/LeadBundle/Form/Type/DncType.php
+++ b/app/bundles/LeadBundle/Form/Type/DncType.php
@@ -11,7 +11,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class DncType extends AbstractType
+final class DncType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/LeadBundle/Form/Type/EmailType.php
+++ b/app/bundles/LeadBundle/Form/Type/EmailType.php
@@ -19,7 +19,7 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class EmailType extends AbstractType
+final class EmailType extends AbstractType
 {
     public const REPLY_TO_ADDRESS = 'replyToAddress';
 

--- a/app/bundles/LeadBundle/Form/Type/FieldType.php
+++ b/app/bundles/LeadBundle/Form/Type/FieldType.php
@@ -37,7 +37,7 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
 /**
  * @extends AbstractType<LeadField>
  */
-class FieldType extends AbstractType
+final class FieldType extends AbstractType
 {
     /**
      * @var string[]

--- a/app/bundles/LeadBundle/Form/Type/FilterPropertiesType.php
+++ b/app/bundles/LeadBundle/Form/Type/FilterPropertiesType.php
@@ -12,7 +12,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  *
  * @extends AbstractType<mixed>
  */
-class FilterPropertiesType extends AbstractType
+final class FilterPropertiesType extends AbstractType
 {
     public function configureOptions(OptionsResolver $resolver): void
     {

--- a/app/bundles/LeadBundle/Form/Type/FilterType.php
+++ b/app/bundles/LeadBundle/Form/Type/FilterType.php
@@ -18,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class FilterType extends AbstractType
+final class FilterType extends AbstractType
 {
     public function __construct(
         private readonly FormAdjustmentsProviderInterface $formAdjustmentsProvider,

--- a/app/bundles/LeadBundle/Form/Type/FormSubmitActionPointsChangeType.php
+++ b/app/bundles/LeadBundle/Form/Type/FormSubmitActionPointsChangeType.php
@@ -11,7 +11,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class FormSubmitActionPointsChangeType extends AbstractType
+final class FormSubmitActionPointsChangeType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/LeadBundle/Form/Type/HtmlType.php
+++ b/app/bundles/LeadBundle/Form/Type/HtmlType.php
@@ -5,7 +5,7 @@ namespace Mautic\LeadBundle\Form\Type;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 
-class HtmlType extends AbstractType
+final class HtmlType extends AbstractType
 {
     public function getParent(): string
     {

--- a/app/bundles/LeadBundle/Form/Type/LeadCategoryType.php
+++ b/app/bundles/LeadBundle/Form/Type/LeadCategoryType.php
@@ -13,7 +13,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class LeadCategoryType extends AbstractType
+final class LeadCategoryType extends AbstractType
 {
     public function __construct(
         private readonly CategoryModel $categoryModel,
@@ -38,7 +38,7 @@ class LeadCategoryType extends AbstractType
         ]);
     }
 
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return ChoiceType::class;
     }

--- a/app/bundles/LeadBundle/Form/Type/LeadFieldsType.php
+++ b/app/bundles/LeadBundle/Form/Type/LeadFieldsType.php
@@ -12,7 +12,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class LeadFieldsType extends AbstractType
+final class LeadFieldsType extends AbstractType
 {
     public function __construct(
         protected FieldModel $fieldModel,
@@ -48,7 +48,7 @@ class LeadFieldsType extends AbstractType
         ]);
     }
 
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return ChoiceType::class;
     }

--- a/app/bundles/LeadBundle/Form/Type/LeadImportFieldType.php
+++ b/app/bundles/LeadBundle/Form/Type/LeadImportFieldType.php
@@ -17,7 +17,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class LeadImportFieldType extends AbstractType
+final class LeadImportFieldType extends AbstractType
 {
     public function __construct(
         private readonly TranslatorInterface $translator,

--- a/app/bundles/LeadBundle/Form/Type/LeadImportType.php
+++ b/app/bundles/LeadBundle/Form/Type/LeadImportType.php
@@ -14,7 +14,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 /**
  * @extends AbstractType<mixed>
  */
-class LeadImportType extends AbstractType
+final class LeadImportType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/LeadBundle/Form/Type/LeadListType.php
+++ b/app/bundles/LeadBundle/Form/Type/LeadListType.php
@@ -11,7 +11,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class LeadListType extends AbstractType
+final class LeadListType extends AbstractType
 {
     public function __construct(
         private readonly ListModel $segmentModel,
@@ -42,7 +42,7 @@ class LeadListType extends AbstractType
         ]);
     }
 
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return ChoiceType::class;
     }

--- a/app/bundles/LeadBundle/Form/Type/LeadType.php
+++ b/app/bundles/LeadBundle/Form/Type/LeadType.php
@@ -25,7 +25,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @extends AbstractType<Lead>
  */
-class LeadType extends AbstractType
+final class LeadType extends AbstractType
 {
     use EntityFieldsBuildFormTrait;
 

--- a/app/bundles/LeadBundle/Form/Type/ListActionType.php
+++ b/app/bundles/LeadBundle/Form/Type/ListActionType.php
@@ -8,7 +8,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class ListActionType extends AbstractType
+final class ListActionType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/LeadBundle/Form/Type/ListType.php
+++ b/app/bundles/LeadBundle/Form/Type/ListType.php
@@ -27,7 +27,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @extends AbstractType<LeadList>
  */
-class ListType extends AbstractType
+final class ListType extends AbstractType
 {
     public function __construct(
         private readonly TranslatorInterface $translator,

--- a/app/bundles/LeadBundle/Form/Type/MergeType.php
+++ b/app/bundles/LeadBundle/Form/Type/MergeType.php
@@ -12,7 +12,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 /**
  * @extends AbstractType<mixed>
  */
-class MergeType extends AbstractType
+final class MergeType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/LeadBundle/Form/Type/ModifyLeadTagsType.php
+++ b/app/bundles/LeadBundle/Form/Type/ModifyLeadTagsType.php
@@ -9,7 +9,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class ModifyLeadTagsType extends AbstractType
+final class ModifyLeadTagsType extends AbstractType
 {
     public function __construct(
         private readonly TranslatorInterface $translator,

--- a/app/bundles/LeadBundle/Form/Type/NoteType.php
+++ b/app/bundles/LeadBundle/Form/Type/NoteType.php
@@ -17,7 +17,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<LeadNote>
  */
-class NoteType extends AbstractType
+final class NoteType extends AbstractType
 {
     private readonly DateTimeHelper $dateHelper;
 

--- a/app/bundles/LeadBundle/Form/Type/OwnerType.php
+++ b/app/bundles/LeadBundle/Form/Type/OwnerType.php
@@ -12,7 +12,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class OwnerType extends AbstractType
+final class OwnerType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/LeadBundle/Form/Type/PointActionType.php
+++ b/app/bundles/LeadBundle/Form/Type/PointActionType.php
@@ -11,7 +11,7 @@ use Symfony\Component\Validator\Constraints\NotEqualTo;
 /**
  * @extends AbstractType<mixed>
  */
-class PointActionType extends AbstractType
+final class PointActionType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/LeadBundle/Form/Type/PreferenceChannelsType.php
+++ b/app/bundles/LeadBundle/Form/Type/PreferenceChannelsType.php
@@ -11,7 +11,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class PreferenceChannelsType extends AbstractType
+final class PreferenceChannelsType extends AbstractType
 {
     public function __construct(
         private readonly LeadModel $leadModel,
@@ -35,7 +35,7 @@ class PreferenceChannelsType extends AbstractType
         );
     }
 
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return ChoiceType::class;
     }

--- a/app/bundles/LeadBundle/Form/Type/SegmentConfigType.php
+++ b/app/bundles/LeadBundle/Form/Type/SegmentConfigType.php
@@ -9,7 +9,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class SegmentConfigType extends AbstractType
+final class SegmentConfigType extends AbstractType
 {
     /**
      * @param FormBuilderInterface<FormBuilderInterface> $builder

--- a/app/bundles/LeadBundle/Form/Type/StageType.php
+++ b/app/bundles/LeadBundle/Form/Type/StageType.php
@@ -12,7 +12,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<mixed>
  */
-class StageType extends AbstractType
+final class StageType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/LeadBundle/Form/Type/TagEntityType.php
+++ b/app/bundles/LeadBundle/Form/Type/TagEntityType.php
@@ -9,7 +9,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class TagEntityType extends AbstractType
+final class TagEntityType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/LeadBundle/Form/Type/TagType.php
+++ b/app/bundles/LeadBundle/Form/Type/TagType.php
@@ -15,7 +15,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<Tag>
  */
-class TagType extends AbstractType
+final class TagType extends AbstractType
 {
     public function __construct(
         private readonly EntityManager $em,
@@ -56,7 +56,7 @@ class TagType extends AbstractType
         return 'lead_tag';
     }
 
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return EntityType::class;
     }

--- a/app/bundles/LeadBundle/Form/Type/UpdateCompanyActionType.php
+++ b/app/bundles/LeadBundle/Form/Type/UpdateCompanyActionType.php
@@ -11,7 +11,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class UpdateCompanyActionType extends AbstractType
+final class UpdateCompanyActionType extends AbstractType
 {
     use EntityFieldsBuildFormTrait;
 

--- a/app/bundles/LeadBundle/Form/Type/UpdateLeadActionType.php
+++ b/app/bundles/LeadBundle/Form/Type/UpdateLeadActionType.php
@@ -11,7 +11,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class UpdateLeadActionType extends AbstractType
+final class UpdateLeadActionType extends AbstractType
 {
     use EntityFieldsBuildFormTrait;
 

--- a/app/bundles/LeadBundle/Form/Validator/Constraints/EmailAddress.php
+++ b/app/bundles/LeadBundle/Form/Validator/Constraints/EmailAddress.php
@@ -5,10 +5,10 @@ namespace Mautic\LeadBundle\Form\Validator\Constraints;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
-class EmailAddress extends Constraint
+final class EmailAddress extends Constraint
 {
     public function validatedBy(): string
     {
-        return static::class.'Validator';
+        return self::class.'Validator';
     }
 }

--- a/app/bundles/LeadBundle/Form/Validator/Constraints/EmailAddressValidator.php
+++ b/app/bundles/LeadBundle/Form/Validator/Constraints/EmailAddressValidator.php
@@ -7,7 +7,7 @@ use Mautic\EmailBundle\Helper\EmailValidator;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
-class EmailAddressValidator extends ConstraintValidator
+final class EmailAddressValidator extends ConstraintValidator
 {
     public function __construct(
         private readonly EmailValidator $emailValidator,

--- a/app/bundles/LeadBundle/Form/Validator/Constraints/FieldAliasKeyword.php
+++ b/app/bundles/LeadBundle/Form/Validator/Constraints/FieldAliasKeyword.php
@@ -4,7 +4,7 @@ namespace Mautic\LeadBundle\Form\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
-class FieldAliasKeyword extends Constraint
+final class FieldAliasKeyword extends Constraint
 {
     public $message = 'mautic.lead.field.keyword.invalid';
 

--- a/app/bundles/LeadBundle/Form/Validator/Constraints/FieldAliasKeywordValidator.php
+++ b/app/bundles/LeadBundle/Form/Validator/Constraints/FieldAliasKeywordValidator.php
@@ -15,7 +15,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  * Throws an exception if the field alias is equal some segment filter keyword.
  * It would cause odd behavior with segment filters otherwise.
  */
-class FieldAliasKeywordValidator extends ConstraintValidator
+final class FieldAliasKeywordValidator extends ConstraintValidator
 {
     public const RESTRICTED_ALIASES = [
         'contact_id',

--- a/app/bundles/LeadBundle/Form/Validator/Constraints/LeadListAccess.php
+++ b/app/bundles/LeadBundle/Form/Validator/Constraints/LeadListAccess.php
@@ -5,7 +5,7 @@ namespace Mautic\LeadBundle\Form\Validator\Constraints;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
-class LeadListAccess extends Constraint
+final class LeadListAccess extends Constraint
 {
     public string $message  = 'mautic.lead.lists.failed';
 

--- a/app/bundles/LeadBundle/Form/Validator/Constraints/LeadListAccessValidator.php
+++ b/app/bundles/LeadBundle/Form/Validator/Constraints/LeadListAccessValidator.php
@@ -7,7 +7,7 @@ use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
-class LeadListAccessValidator extends ConstraintValidator
+final class LeadListAccessValidator extends ConstraintValidator
 {
     public function __construct(
         private readonly ListModel $segmentModel,

--- a/app/bundles/LeadBundle/Form/Validator/Constraints/SegmentInUse.php
+++ b/app/bundles/LeadBundle/Form/Validator/Constraints/SegmentInUse.php
@@ -6,7 +6,7 @@ namespace Mautic\LeadBundle\Form\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
-class SegmentInUse extends Constraint
+final class SegmentInUse extends Constraint
 {
     public $message = 'mautic.lead_list.is_in_use.unpublish';
 

--- a/app/bundles/LeadBundle/Form/Validator/Constraints/SegmentInUseValidator.php
+++ b/app/bundles/LeadBundle/Form/Validator/Constraints/SegmentInUseValidator.php
@@ -11,7 +11,7 @@ use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
-class SegmentInUseValidator extends ConstraintValidator
+final class SegmentInUseValidator extends ConstraintValidator
 {
     public function __construct(
         private readonly ListModel $listModel,

--- a/app/bundles/LeadBundle/Form/Validator/Constraints/UniqueCustomField.php
+++ b/app/bundles/LeadBundle/Form/Validator/Constraints/UniqueCustomField.php
@@ -6,13 +6,13 @@ namespace Mautic\LeadBundle\Form\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
-class UniqueCustomField extends Constraint
+final class UniqueCustomField extends Constraint
 {
     public string $message = 'mautic.lead.field.unique.is_used';
 
     public string $object;
 
-    public function getTargets(): string|array
+    public function getTargets(): string
     {
         return self::CLASS_CONSTRAINT;
     }

--- a/app/bundles/LeadBundle/Form/Validator/Constraints/UniqueCustomFieldValidator.php
+++ b/app/bundles/LeadBundle/Form/Validator/Constraints/UniqueCustomFieldValidator.php
@@ -14,7 +14,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
-class UniqueCustomFieldValidator extends ConstraintValidator
+final class UniqueCustomFieldValidator extends ConstraintValidator
 {
     public function __construct(
         private readonly LeadModel $leadModel,

--- a/app/bundles/LeadBundle/Form/Validator/Constraints/UniqueUserAlias.php
+++ b/app/bundles/LeadBundle/Form/Validator/Constraints/UniqueUserAlias.php
@@ -5,7 +5,7 @@ namespace Mautic\LeadBundle\Form\Validator\Constraints;
 use Symfony\Component\Validator\Constraint;
 
 #[\Attribute]
-class UniqueUserAlias extends Constraint
+final class UniqueUserAlias extends Constraint
 {
     public $message = 'This alias is already in use.';
 
@@ -16,7 +16,7 @@ class UniqueUserAlias extends Constraint
         return 'uniqueleadlist';
     }
 
-    public function getTargets(): string|array
+    public function getTargets(): string
     {
         return self::CLASS_CONSTRAINT;
     }
@@ -26,7 +26,7 @@ class UniqueUserAlias extends Constraint
         return ['field'];
     }
 
-    public function getDefaultOption(): ?string
+    public function getDefaultOption(): string
     {
         return 'field';
     }

--- a/app/bundles/LeadBundle/Form/Validator/Constraints/UniqueUserAliasValidator.php
+++ b/app/bundles/LeadBundle/Form/Validator/Constraints/UniqueUserAliasValidator.php
@@ -8,22 +8,12 @@ use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 
-class UniqueUserAliasValidator extends ConstraintValidator
+final class UniqueUserAliasValidator extends ConstraintValidator
 {
-    /**
-     * @var LeadListRepository
-     */
-    public $segmentRepository;
-
-    /**
-     * @var UserHelper
-     */
-    public $userHelper;
-
-    public function __construct(LeadListRepository $segmentRepository, UserHelper $userHelper)
-    {
-        $this->segmentRepository = $segmentRepository;
-        $this->userHelper        = $userHelper;
+    public function __construct(
+        public LeadListRepository $segmentRepository,
+        public UserHelper $userHelper,
+    ) {
     }
 
     public function validate(mixed $list, Constraint $constraint): void

--- a/app/bundles/MessengerBundle/Form/Type/ConfigType.php
+++ b/app/bundles/MessengerBundle/Form/Type/ConfigType.php
@@ -12,7 +12,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class ConfigType extends AbstractType
+final class ConfigType extends AbstractType
 {
     public function __construct(
         private readonly TranslatorInterface $translator,

--- a/app/bundles/NotificationBundle/Form/Type/MobileNotificationDetailsType.php
+++ b/app/bundles/NotificationBundle/Form/Type/MobileNotificationDetailsType.php
@@ -15,7 +15,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class MobileNotificationDetailsType extends AbstractType
+final class MobileNotificationDetailsType extends AbstractType
 {
     public function __construct(
         protected IntegrationHelper $integrationHelper,

--- a/app/bundles/NotificationBundle/Form/Type/MobileNotificationListType.php
+++ b/app/bundles/NotificationBundle/Form/Type/MobileNotificationListType.php
@@ -10,7 +10,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class MobileNotificationListType extends AbstractType
+final class MobileNotificationListType extends AbstractType
 {
     public function configureOptions(OptionsResolver $resolver): void
     {
@@ -55,7 +55,7 @@ class MobileNotificationListType extends AbstractType
         return 'mobilenotification_list';
     }
 
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return EntityLookupType::class;
     }

--- a/app/bundles/NotificationBundle/Form/Type/MobileNotificationSendType.php
+++ b/app/bundles/NotificationBundle/Form/Type/MobileNotificationSendType.php
@@ -12,7 +12,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class MobileNotificationSendType extends AbstractType
+final class MobileNotificationSendType extends AbstractType
 {
     public function __construct(
         protected RouterInterface $router,

--- a/app/bundles/NotificationBundle/Form/Type/MobileNotificationType.php
+++ b/app/bundles/NotificationBundle/Form/Type/MobileNotificationType.php
@@ -27,7 +27,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<Notification>
  */
-class MobileNotificationType extends AbstractType
+final class MobileNotificationType extends AbstractType
 {
     public function __construct(
         private readonly EntityManager $entityManager,

--- a/app/bundles/NotificationBundle/Form/Type/NotificationConfigType.php
+++ b/app/bundles/NotificationBundle/Form/Type/NotificationConfigType.php
@@ -16,7 +16,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class NotificationConfigType extends AbstractType
+final class NotificationConfigType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/NotificationBundle/Form/Type/NotificationListType.php
+++ b/app/bundles/NotificationBundle/Form/Type/NotificationListType.php
@@ -10,7 +10,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class NotificationListType extends AbstractType
+final class NotificationListType extends AbstractType
 {
     public function configureOptions(OptionsResolver $resolver): void
     {
@@ -44,7 +44,7 @@ class NotificationListType extends AbstractType
         );
     }
 
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return EntityLookupType::class;
     }

--- a/app/bundles/NotificationBundle/Form/Type/NotificationSendType.php
+++ b/app/bundles/NotificationBundle/Form/Type/NotificationSendType.php
@@ -12,7 +12,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class NotificationSendType extends AbstractType
+final class NotificationSendType extends AbstractType
 {
     public function __construct(
         protected RouterInterface $router,

--- a/app/bundles/NotificationBundle/Form/Type/NotificationType.php
+++ b/app/bundles/NotificationBundle/Form/Type/NotificationType.php
@@ -23,7 +23,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<Notification>
  */
-class NotificationType extends AbstractType
+final class NotificationType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/PageBundle/Form/Type/AbTestPropertiesType.php
+++ b/app/bundles/PageBundle/Form/Type/AbTestPropertiesType.php
@@ -9,7 +9,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class AbTestPropertiesType extends AbstractType
+final class AbTestPropertiesType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/PageBundle/Form/Type/CampaignEventPageHitType.php
+++ b/app/bundles/PageBundle/Form/Type/CampaignEventPageHitType.php
@@ -9,7 +9,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class CampaignEventPageHitType extends AbstractType
+final class CampaignEventPageHitType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/PageBundle/Form/Type/ConfigTrackingPageType.php
+++ b/app/bundles/PageBundle/Form/Type/ConfigTrackingPageType.php
@@ -10,7 +10,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class ConfigTrackingPageType extends AbstractType
+final class ConfigTrackingPageType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/PageBundle/Form/Type/ConfigType.php
+++ b/app/bundles/PageBundle/Form/Type/ConfigType.php
@@ -10,7 +10,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class ConfigType extends AbstractType
+final class ConfigType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/PageBundle/Form/Type/DashboardHitsInTimeWidgetType.php
+++ b/app/bundles/PageBundle/Form/Type/DashboardHitsInTimeWidgetType.php
@@ -9,7 +9,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class DashboardHitsInTimeWidgetType extends AbstractType
+final class DashboardHitsInTimeWidgetType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/PageBundle/Form/Type/PageListType.php
+++ b/app/bundles/PageBundle/Form/Type/PageListType.php
@@ -12,7 +12,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class PageListType extends AbstractType
+final class PageListType extends AbstractType
 {
     private readonly bool $canViewOther;
 
@@ -59,7 +59,7 @@ class PageListType extends AbstractType
         $resolver->setDefined(['top_level', 'ignore_ids', 'published_only']);
     }
 
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return ChoiceType::class;
     }

--- a/app/bundles/PageBundle/Form/Type/PageType.php
+++ b/app/bundles/PageBundle/Form/Type/PageType.php
@@ -35,7 +35,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<Page>
  */
-class PageType extends AbstractType
+final class PageType extends AbstractType
 {
     private readonly ?\Mautic\UserBundle\Entity\User $user;
 

--- a/app/bundles/PageBundle/Form/Type/PointActionPageHitType.php
+++ b/app/bundles/PageBundle/Form/Type/PointActionPageHitType.php
@@ -8,7 +8,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class PointActionPageHitType extends AbstractType
+final class PointActionPageHitType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/PageBundle/Form/Type/PointActionUrlHitType.php
+++ b/app/bundles/PageBundle/Form/Type/PointActionUrlHitType.php
@@ -15,7 +15,7 @@ use Symfony\Component\Form\FormInterface;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class PointActionUrlHitType extends AbstractType
+final class PointActionUrlHitType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/PageBundle/Form/Type/PreferenceCenterListType.php
+++ b/app/bundles/PageBundle/Form/Type/PreferenceCenterListType.php
@@ -9,7 +9,7 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class PreferenceCenterListType extends AbstractType
+final class PreferenceCenterListType extends AbstractType
 {
     private readonly bool $canViewOther;
 
@@ -57,7 +57,7 @@ class PreferenceCenterListType extends AbstractType
         $resolver->setDefined(['top_level', 'ignore_ids']);
     }
 
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return ChoiceType::class;
     }

--- a/app/bundles/PageBundle/Form/Type/RedirectListType.php
+++ b/app/bundles/PageBundle/Form/Type/RedirectListType.php
@@ -10,7 +10,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class RedirectListType extends AbstractType
+final class RedirectListType extends AbstractType
 {
     public function configureOptions(OptionsResolver $resolver): void
     {
@@ -37,7 +37,7 @@ class RedirectListType extends AbstractType
         $resolver->setDefined(['feature']);
     }
 
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return ChoiceType::class;
     }

--- a/app/bundles/PageBundle/Form/Type/TrackingPixelSendType.php
+++ b/app/bundles/PageBundle/Form/Type/TrackingPixelSendType.php
@@ -12,7 +12,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class TrackingPixelSendType extends AbstractType
+final class TrackingPixelSendType extends AbstractType
 {
     public function __construct(
         protected TrackingHelper $trackingHelper,

--- a/app/bundles/PageBundle/Form/Type/VariantType.php
+++ b/app/bundles/PageBundle/Form/Type/VariantType.php
@@ -14,7 +14,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 /**
  * @extends AbstractType<mixed>
  */
-class VariantType extends AbstractType
+final class VariantType extends AbstractType
 {
     public function __construct(
         private readonly PageModel $pageModel,

--- a/app/bundles/PluginBundle/Form/Constraint/CanPublish.php
+++ b/app/bundles/PluginBundle/Form/Constraint/CanPublish.php
@@ -6,7 +6,7 @@ namespace Mautic\PluginBundle\Form\Constraint;
 
 use Symfony\Component\Validator\Constraint;
 
-class CanPublish extends Constraint
+final class CanPublish extends Constraint
 {
     public string $message =  'mautic.lead_list.not_allowed_plugin_publish';
 

--- a/app/bundles/PluginBundle/Form/Constraint/CanPublishValidator.php
+++ b/app/bundles/PluginBundle/Form/Constraint/CanPublishValidator.php
@@ -11,7 +11,7 @@ use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
-class CanPublishValidator extends ConstraintValidator
+final class CanPublishValidator extends ConstraintValidator
 {
     public function __construct(
         private readonly EventDispatcherInterface $eventDispatcher,

--- a/app/bundles/PluginBundle/Form/Type/CompanyFieldsType.php
+++ b/app/bundles/PluginBundle/Form/Type/CompanyFieldsType.php
@@ -11,7 +11,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class CompanyFieldsType extends AbstractType
+final class CompanyFieldsType extends AbstractType
 {
     use FieldsTypeTrait;
 

--- a/app/bundles/PluginBundle/Form/Type/DetailsType.php
+++ b/app/bundles/PluginBundle/Form/Type/DetailsType.php
@@ -19,7 +19,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<Integration>
  */
-class DetailsType extends AbstractType
+final class DetailsType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/PluginBundle/Form/Type/FeatureSettingsType.php
+++ b/app/bundles/PluginBundle/Form/Type/FeatureSettingsType.php
@@ -16,7 +16,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class FeatureSettingsType extends AbstractType
+final class FeatureSettingsType extends AbstractType
 {
     public function __construct(
         protected RequestStack $requestStack,

--- a/app/bundles/PluginBundle/Form/Type/FieldsType.php
+++ b/app/bundles/PluginBundle/Form/Type/FieldsType.php
@@ -11,7 +11,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class FieldsType extends AbstractType
+final class FieldsType extends AbstractType
 {
     use FieldsTypeTrait;
 

--- a/app/bundles/PluginBundle/Form/Type/IntegrationCampaignsType.php
+++ b/app/bundles/PluginBundle/Form/Type/IntegrationCampaignsType.php
@@ -10,7 +10,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class IntegrationCampaignsType extends AbstractType
+final class IntegrationCampaignsType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/PluginBundle/Form/Type/IntegrationConfigType.php
+++ b/app/bundles/PluginBundle/Form/Type/IntegrationConfigType.php
@@ -10,7 +10,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<array<mixed>|mixed>
  */
-class IntegrationConfigType extends AbstractType
+final class IntegrationConfigType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/PluginBundle/Form/Type/IntegrationsListType.php
+++ b/app/bundles/PluginBundle/Form/Type/IntegrationsListType.php
@@ -14,7 +14,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 /**
  * @extends AbstractType<mixed>
  */
-class IntegrationsListType extends AbstractType
+final class IntegrationsListType extends AbstractType
 {
     public function __construct(
         private readonly IntegrationHelper $integrationHelper,

--- a/app/bundles/PluginBundle/Form/Type/KeysType.php
+++ b/app/bundles/PluginBundle/Form/Type/KeysType.php
@@ -13,7 +13,7 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class KeysType extends AbstractType
+final class KeysType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/PointBundle/Form/Type/GroupListType.php
+++ b/app/bundles/PointBundle/Form/Type/GroupListType.php
@@ -15,7 +15,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<GroupListType>
  */
-class GroupListType extends AbstractType
+final class GroupListType extends AbstractType
 {
     public function __construct(
         private readonly EntityManager $em,

--- a/app/bundles/PointBundle/Form/Type/GroupType.php
+++ b/app/bundles/PointBundle/Form/Type/GroupType.php
@@ -18,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<GroupType>
  */
-class GroupType extends AbstractType
+final class GroupType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/PointBundle/Form/Type/PointActionType.php
+++ b/app/bundles/PointBundle/Form/Type/PointActionType.php
@@ -10,7 +10,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class PointActionType extends AbstractType
+final class PointActionType extends AbstractType
 {
     /**
      * @param FormBuilderInterface<array<mixed>|null> $builder

--- a/app/bundles/PointBundle/Form/Type/PointType.php
+++ b/app/bundles/PointBundle/Form/Type/PointType.php
@@ -23,7 +23,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<Point>
  */
-class PointType extends AbstractType
+final class PointType extends AbstractType
 {
     public function __construct(
         private readonly CorePermissions $security,

--- a/app/bundles/PointBundle/Form/Type/TriggerEventType.php
+++ b/app/bundles/PointBundle/Form/Type/TriggerEventType.php
@@ -14,7 +14,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class TriggerEventType extends AbstractType
+final class TriggerEventType extends AbstractType
 {
     /**
      * @param FormBuilderInterface<array<mixed>|null> $builder

--- a/app/bundles/PointBundle/Form/Type/TriggerType.php
+++ b/app/bundles/PointBundle/Form/Type/TriggerType.php
@@ -23,7 +23,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<Trigger>
  */
-class TriggerType extends AbstractType
+final class TriggerType extends AbstractType
 {
     public function __construct(
         private readonly CorePermissions $security,

--- a/app/bundles/ReportBundle/Form/DataTransformer/ReportFilterDataTransformer.php
+++ b/app/bundles/ReportBundle/Form/DataTransformer/ReportFilterDataTransformer.php
@@ -11,7 +11,7 @@ use Symfony\Component\Form\Extension\Core\Type\TimeType;
 /**
  * @implements DataTransformerInterface<array<mixed>, array<mixed>>
  */
-class ReportFilterDataTransformer implements DataTransformerInterface
+final class ReportFilterDataTransformer implements DataTransformerInterface
 {
     /**
      * @param array $columns

--- a/app/bundles/ReportBundle/Form/Type/AggregatorType.php
+++ b/app/bundles/ReportBundle/Form/Type/AggregatorType.php
@@ -13,7 +13,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class AggregatorType extends AbstractType
+final class AggregatorType extends AbstractType
 {
     public function __construct(
         private readonly TranslatorInterface $translator,

--- a/app/bundles/ReportBundle/Form/Type/ConfigType.php
+++ b/app/bundles/ReportBundle/Form/Type/ConfigType.php
@@ -9,7 +9,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class ConfigType extends AbstractType
+final class ConfigType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/ReportBundle/Form/Type/DynamicFiltersType.php
+++ b/app/bundles/ReportBundle/Form/Type/DynamicFiltersType.php
@@ -17,7 +17,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class DynamicFiltersType extends AbstractType
+final class DynamicFiltersType extends AbstractType
 {
     public function __construct(
         private readonly TranslatorInterface $translator,

--- a/app/bundles/ReportBundle/Form/Type/FilterSelectorType.php
+++ b/app/bundles/ReportBundle/Form/Type/FilterSelectorType.php
@@ -17,7 +17,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class FilterSelectorType extends AbstractType
+final class FilterSelectorType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/ReportBundle/Form/Type/ReportFiltersType.php
+++ b/app/bundles/ReportBundle/Form/Type/ReportFiltersType.php
@@ -11,7 +11,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class ReportFiltersType extends AbstractType
+final class ReportFiltersType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
@@ -20,7 +20,7 @@ class ReportFiltersType extends AbstractType
         );
     }
 
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return CollectionType::class;
     }

--- a/app/bundles/ReportBundle/Form/Type/ReportSettingsType.php
+++ b/app/bundles/ReportBundle/Form/Type/ReportSettingsType.php
@@ -9,7 +9,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class ReportSettingsType extends AbstractType
+final class ReportSettingsType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/ReportBundle/Form/Type/ReportType.php
+++ b/app/bundles/ReportBundle/Form/Type/ReportType.php
@@ -24,7 +24,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<Report>
  */
-class ReportType extends AbstractType
+final class ReportType extends AbstractType
 {
     public function __construct(
         private readonly ReportModel $reportModel,

--- a/app/bundles/ReportBundle/Form/Type/ReportWidgetType.php
+++ b/app/bundles/ReportBundle/Form/Type/ReportWidgetType.php
@@ -11,7 +11,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class ReportWidgetType extends AbstractType
+final class ReportWidgetType extends AbstractType
 {
     public function __construct(
         protected ReportModel $model,

--- a/app/bundles/ReportBundle/Form/Type/TableOrderType.php
+++ b/app/bundles/ReportBundle/Form/Type/TableOrderType.php
@@ -13,7 +13,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class TableOrderType extends AbstractType
+final class TableOrderType extends AbstractType
 {
     public function __construct(
         private readonly TranslatorInterface $translator,

--- a/app/bundles/SmsBundle/Form/Type/CampaignReplyType.php
+++ b/app/bundles/SmsBundle/Form/Type/CampaignReplyType.php
@@ -9,7 +9,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class CampaignReplyType extends AbstractType
+final class CampaignReplyType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/SmsBundle/Form/Type/ConfigType.php
+++ b/app/bundles/SmsBundle/Form/Type/ConfigType.php
@@ -12,7 +12,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class ConfigType extends AbstractType
+final class ConfigType extends AbstractType
 {
     public const SMS_DISABLE_TRACKABLE_URLS = 'sms_disable_trackable_urls';
 

--- a/app/bundles/SmsBundle/Form/Type/SmsListType.php
+++ b/app/bundles/SmsBundle/Form/Type/SmsListType.php
@@ -10,7 +10,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class SmsListType extends AbstractType
+final class SmsListType extends AbstractType
 {
     public function configureOptions(OptionsResolver $resolver): void
     {
@@ -49,7 +49,7 @@ class SmsListType extends AbstractType
         );
     }
 
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return EntityLookupType::class;
     }

--- a/app/bundles/SmsBundle/Form/Type/SmsSendType.php
+++ b/app/bundles/SmsBundle/Form/Type/SmsSendType.php
@@ -12,7 +12,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class SmsSendType extends AbstractType
+final class SmsSendType extends AbstractType
 {
     public function __construct(
         protected RouterInterface $router,

--- a/app/bundles/SmsBundle/Form/Type/SmsType.php
+++ b/app/bundles/SmsBundle/Form/Type/SmsType.php
@@ -29,7 +29,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<Sms>
  */
-class SmsType extends AbstractType
+final class SmsType extends AbstractType
 {
     public function __construct(
         private readonly EntityManager $em,

--- a/app/bundles/StageBundle/Form/Type/GenericStageActionType.php
+++ b/app/bundles/StageBundle/Form/Type/GenericStageActionType.php
@@ -9,7 +9,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class GenericStageActionType extends AbstractType
+final class GenericStageActionType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/StageBundle/Form/Type/StageActionChangeType.php
+++ b/app/bundles/StageBundle/Form/Type/StageActionChangeType.php
@@ -10,7 +10,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class StageActionChangeType extends AbstractType
+final class StageActionChangeType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/StageBundle/Form/Type/StageActionListType.php
+++ b/app/bundles/StageBundle/Form/Type/StageActionListType.php
@@ -11,7 +11,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class StageActionListType extends AbstractType
+final class StageActionListType extends AbstractType
 {
     public function __construct(
         private readonly StageModel $model,
@@ -35,7 +35,7 @@ class StageActionListType extends AbstractType
         ]);
     }
 
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return ChoiceType::class;
     }

--- a/app/bundles/StageBundle/Form/Type/StageActionType.php
+++ b/app/bundles/StageBundle/Form/Type/StageActionType.php
@@ -10,7 +10,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class StageActionType extends AbstractType
+final class StageActionType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/StageBundle/Form/Type/StageListType.php
+++ b/app/bundles/StageBundle/Form/Type/StageListType.php
@@ -11,7 +11,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<Stage>
  */
-class StageListType extends AbstractType
+final class StageListType extends AbstractType
 {
     /**
      * @var array<string,int>
@@ -34,7 +34,7 @@ class StageListType extends AbstractType
         ]);
     }
 
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return ChoiceType::class;
     }

--- a/app/bundles/StageBundle/Form/Type/StageType.php
+++ b/app/bundles/StageBundle/Form/Type/StageType.php
@@ -22,7 +22,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<Stage>
  */
-class StageType extends AbstractType
+final class StageType extends AbstractType
 {
     public function __construct(
         private readonly CorePermissions $security,

--- a/app/bundles/UserBundle/Form/Type/ConfigType.php
+++ b/app/bundles/UserBundle/Form/Type/ConfigType.php
@@ -17,7 +17,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class ConfigType extends AbstractType
+final class ConfigType extends AbstractType
 {
     public function __construct(
         protected CoreParametersHelper $parameters,

--- a/app/bundles/UserBundle/Form/Type/ContactType.php
+++ b/app/bundles/UserBundle/Form/Type/ContactType.php
@@ -14,7 +14,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class ContactType extends AbstractType
+final class ContactType extends AbstractType
 {
     /**
      * @param FormBuilderInterface<array<mixed>|null> $builder

--- a/app/bundles/UserBundle/Form/Type/PasswordResetConfirmType.php
+++ b/app/bundles/UserBundle/Form/Type/PasswordResetConfirmType.php
@@ -15,7 +15,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class PasswordResetConfirmType extends AbstractType
+final class PasswordResetConfirmType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/UserBundle/Form/Type/PasswordResetType.php
+++ b/app/bundles/UserBundle/Form/Type/PasswordResetType.php
@@ -12,7 +12,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class PasswordResetType extends AbstractType
+final class PasswordResetType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/UserBundle/Form/Type/PermissionListType.php
+++ b/app/bundles/UserBundle/Form/Type/PermissionListType.php
@@ -10,7 +10,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class PermissionListType extends AbstractType
+final class PermissionListType extends AbstractType
 {
     public function configureOptions(OptionsResolver $resolver): void
     {
@@ -28,7 +28,7 @@ class PermissionListType extends AbstractType
         ]);
     }
 
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return ChoiceType::class;
     }

--- a/app/bundles/UserBundle/Form/Type/PermissionsType.php
+++ b/app/bundles/UserBundle/Form/Type/PermissionsType.php
@@ -11,7 +11,7 @@ use Symfony\Component\Validator\Constraints\Valid;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class PermissionsType extends AbstractType
+final class PermissionsType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/UserBundle/Form/Type/RoleListType.php
+++ b/app/bundles/UserBundle/Form/Type/RoleListType.php
@@ -10,7 +10,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class RoleListType extends AbstractType
+final class RoleListType extends AbstractType
 {
     public function __construct(
         private readonly RoleModel $roleModel,
@@ -30,7 +30,7 @@ class RoleListType extends AbstractType
         );
     }
 
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return ChoiceType::class;
     }

--- a/app/bundles/UserBundle/Form/Type/RoleType.php
+++ b/app/bundles/UserBundle/Form/Type/RoleType.php
@@ -17,7 +17,7 @@ use Symfony\Component\Validator\Constraints\Valid;
 /**
  * @extends AbstractType<RoleType>
  */
-class RoleType extends AbstractType
+final class RoleType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/UserBundle/Form/Type/UserListType.php
+++ b/app/bundles/UserBundle/Form/Type/UserListType.php
@@ -10,7 +10,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class UserListType extends AbstractType
+final class UserListType extends AbstractType
 {
     /**
      * @var array<string,int>
@@ -35,7 +35,7 @@ class UserListType extends AbstractType
         );
     }
 
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return ChoiceType::class;
     }

--- a/app/bundles/UserBundle/Form/Type/UserPreferencesType.php
+++ b/app/bundles/UserBundle/Form/Type/UserPreferencesType.php
@@ -9,7 +9,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<mixed>
  */
-class UserPreferencesType extends AbstractType
+final class UserPreferencesType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/UserBundle/Form/Type/UserType.php
+++ b/app/bundles/UserBundle/Form/Type/UserType.php
@@ -28,7 +28,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @extends AbstractType<User>
  */
-class UserType extends AbstractType
+final class UserType extends AbstractType
 {
     public function __construct(
         private readonly TranslatorInterface $translator,

--- a/app/bundles/WebhookBundle/Form/DataTransformer/EventsToArrayTransformer.php
+++ b/app/bundles/WebhookBundle/Form/DataTransformer/EventsToArrayTransformer.php
@@ -10,10 +10,10 @@ use Symfony\Component\Form\DataTransformerInterface;
 /**
  * @implements DataTransformerInterface<Collection<int, Event>, array<int, string>>
  */
-class EventsToArrayTransformer implements DataTransformerInterface
+final readonly class EventsToArrayTransformer implements DataTransformerInterface
 {
     public function __construct(
-        private readonly Webhook $webhook,
+        private Webhook $webhook,
     ) {
     }
 

--- a/app/bundles/WebhookBundle/Form/Type/CampaignEventSendWebhookType.php
+++ b/app/bundles/WebhookBundle/Form/Type/CampaignEventSendWebhookType.php
@@ -14,7 +14,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class CampaignEventSendWebhookType extends AbstractType
+final class CampaignEventSendWebhookType extends AbstractType
 {
     public function __construct(
         private readonly TranslatorInterface $translator,

--- a/app/bundles/WebhookBundle/Form/Type/ConfigType.php
+++ b/app/bundles/WebhookBundle/Form/Type/ConfigType.php
@@ -14,7 +14,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class ConfigType extends AbstractType
+final class ConfigType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/app/bundles/WebhookBundle/Form/Type/WebhookType.php
+++ b/app/bundles/WebhookBundle/Form/Type/WebhookType.php
@@ -22,7 +22,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<Webhook>
  */
-class WebhookType extends AbstractType
+final class WebhookType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/plugins/MauticClearbitBundle/Form/Type/BatchLookupType.php
+++ b/plugins/MauticClearbitBundle/Form/Type/BatchLookupType.php
@@ -11,7 +11,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class BatchLookupType extends AbstractType
+final class BatchLookupType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/plugins/MauticClearbitBundle/Form/Type/LookupType.php
+++ b/plugins/MauticClearbitBundle/Form/Type/LookupType.php
@@ -11,7 +11,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class LookupType extends AbstractType
+final class LookupType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/plugins/MauticCrmBundle/Form/Type/IntegrationCampaignsTaskType.php
+++ b/plugins/MauticCrmBundle/Form/Type/IntegrationCampaignsTaskType.php
@@ -13,7 +13,7 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class IntegrationCampaignsTaskType extends AbstractType
+final class IntegrationCampaignsTaskType extends AbstractType
 {
     public function __construct(
         private readonly ConnectwiseIntegration $connectwiseIntegration,

--- a/plugins/MauticEmailMarketingBundle/Form/Type/ConstantContactType.php
+++ b/plugins/MauticEmailMarketingBundle/Form/Type/ConstantContactType.php
@@ -19,7 +19,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class ConstantContactType extends AbstractType
+final class ConstantContactType extends AbstractType
 {
     public function __construct(
         private readonly IntegrationHelper $integrationHelper,

--- a/plugins/MauticEmailMarketingBundle/Form/Type/IcontactType.php
+++ b/plugins/MauticEmailMarketingBundle/Form/Type/IcontactType.php
@@ -18,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class IcontactType extends AbstractType
+final class IcontactType extends AbstractType
 {
     public function __construct(
         private readonly IntegrationHelper $integrationHelper,

--- a/plugins/MauticEmailMarketingBundle/Form/Type/MailchimpType.php
+++ b/plugins/MauticEmailMarketingBundle/Form/Type/MailchimpType.php
@@ -20,7 +20,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class MailchimpType extends AbstractType
+final class MailchimpType extends AbstractType
 {
     public function __construct(
         private readonly IntegrationHelper $integrationHelper,

--- a/plugins/MauticFocusBundle/Form/Type/ColorType.php
+++ b/plugins/MauticFocusBundle/Form/Type/ColorType.php
@@ -9,7 +9,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<array<string, mixed>>
  */
-class ColorType extends AbstractType
+final class ColorType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/plugins/MauticFocusBundle/Form/Type/ContentType.php
+++ b/plugins/MauticFocusBundle/Form/Type/ContentType.php
@@ -13,7 +13,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<array<string, mixed>>
  */
-class ContentType extends AbstractType
+final class ContentType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/plugins/MauticFocusBundle/Form/Type/FocusListType.php
+++ b/plugins/MauticFocusBundle/Form/Type/FocusListType.php
@@ -12,7 +12,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<array<string, mixed>|null>
  */
-class FocusListType extends AbstractType
+final class FocusListType extends AbstractType
 {
     private readonly FocusRepository $repo;
 
@@ -51,7 +51,7 @@ class FocusListType extends AbstractType
         );
     }
 
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return ChoiceType::class;
     }

--- a/plugins/MauticFocusBundle/Form/Type/FocusPropertiesType.php
+++ b/plugins/MauticFocusBundle/Form/Type/FocusPropertiesType.php
@@ -11,7 +11,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<array<string, mixed>>
  */
-class FocusPropertiesType extends AbstractType
+final class FocusPropertiesType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/plugins/MauticFocusBundle/Form/Type/FocusShowType.php
+++ b/plugins/MauticFocusBundle/Form/Type/FocusShowType.php
@@ -12,7 +12,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 /**
  * @extends AbstractType<array<string, mixed>>
  */
-class FocusShowType extends AbstractType
+final class FocusShowType extends AbstractType
 {
     public function __construct(
         protected RouterInterface $router,

--- a/plugins/MauticFocusBundle/Form/Type/FocusType.php
+++ b/plugins/MauticFocusBundle/Form/Type/FocusType.php
@@ -26,7 +26,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<Focus>
  */
-class FocusType extends AbstractType
+final class FocusType extends AbstractType
 {
     public function __construct(
         private readonly CorePermissions $security,

--- a/plugins/MauticFocusBundle/Form/Type/PropertiesType.php
+++ b/plugins/MauticFocusBundle/Form/Type/PropertiesType.php
@@ -12,7 +12,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<array<string, mixed>>
  */
-class PropertiesType extends AbstractType
+final class PropertiesType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/plugins/MauticFullContactBundle/Form/Type/BatchLookupType.php
+++ b/plugins/MauticFullContactBundle/Form/Type/BatchLookupType.php
@@ -11,7 +11,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<array<string, mixed>>
  */
-class BatchLookupType extends AbstractType
+final class BatchLookupType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/plugins/MauticFullContactBundle/Form/Type/LookupType.php
+++ b/plugins/MauticFullContactBundle/Form/Type/LookupType.php
@@ -11,7 +11,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<array<string, mixed>>
  */
-class LookupType extends AbstractType
+final class LookupType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/plugins/MauticSocialBundle/Form/Type/ConfigType.php
+++ b/plugins/MauticSocialBundle/Form/Type/ConfigType.php
@@ -10,7 +10,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class ConfigType extends AbstractType
+final class ConfigType extends AbstractType
 {
     public function __construct(
         private readonly FieldList $fieldList,

--- a/plugins/MauticSocialBundle/Form/Type/FacebookType.php
+++ b/plugins/MauticSocialBundle/Form/Type/FacebookType.php
@@ -10,7 +10,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class FacebookType extends AbstractType
+final class FacebookType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/plugins/MauticSocialBundle/Form/Type/MonitoringType.php
+++ b/plugins/MauticSocialBundle/Form/Type/MonitoringType.php
@@ -21,7 +21,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class MonitoringType extends AbstractType
+final class MonitoringType extends AbstractType
 {
     public function __construct(
         private readonly MonitoringModel $monitoringModel,

--- a/plugins/MauticSocialBundle/Form/Type/SocialLoginType.php
+++ b/plugins/MauticSocialBundle/Form/Type/SocialLoginType.php
@@ -12,7 +12,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class SocialLoginType extends AbstractType
+final class SocialLoginType extends AbstractType
 {
     public function __construct(
         private readonly IntegrationHelper $helper,

--- a/plugins/MauticSocialBundle/Form/Type/TweetListType.php
+++ b/plugins/MauticSocialBundle/Form/Type/TweetListType.php
@@ -10,7 +10,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class TweetListType extends AbstractType
+final class TweetListType extends AbstractType
 {
     public function configureOptions(OptionsResolver $resolver): void
     {
@@ -33,7 +33,7 @@ class TweetListType extends AbstractType
         );
     }
 
-    public function getParent(): ?string
+    public function getParent(): string
     {
         return EntityLookupType::class;
     }

--- a/plugins/MauticSocialBundle/Form/Type/TweetSendType.php
+++ b/plugins/MauticSocialBundle/Form/Type/TweetSendType.php
@@ -12,7 +12,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class TweetSendType extends AbstractType
+final class TweetSendType extends AbstractType
 {
     public function __construct(
         protected RouterInterface $router,

--- a/plugins/MauticSocialBundle/Form/Type/TweetType.php
+++ b/plugins/MauticSocialBundle/Form/Type/TweetType.php
@@ -23,7 +23,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 /**
  * @extends AbstractType<Tweet>
  */
-class TweetType extends AbstractType
+final class TweetType extends AbstractType
 {
     public function __construct(
         protected EntityManager $em,

--- a/plugins/MauticSocialBundle/Form/Type/TwitterHashtagType.php
+++ b/plugins/MauticSocialBundle/Form/Type/TwitterHashtagType.php
@@ -6,7 +6,7 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 
-class TwitterHashtagType extends TwitterAbstractType
+final class TwitterHashtagType extends TwitterAbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/plugins/MauticSocialBundle/Form/Type/TwitterMentionType.php
+++ b/plugins/MauticSocialBundle/Form/Type/TwitterMentionType.php
@@ -6,7 +6,7 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 
-class TwitterMentionType extends TwitterAbstractType
+final class TwitterMentionType extends TwitterAbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/plugins/MauticSocialBundle/Form/Type/TwitterType.php
+++ b/plugins/MauticSocialBundle/Form/Type/TwitterType.php
@@ -11,7 +11,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * @extends AbstractType<array<mixed>>
  */
-class TwitterType extends AbstractType
+final class TwitterType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/plugins/MauticTagManagerBundle/Form/Type/BatchTagType.php
+++ b/plugins/MauticTagManagerBundle/Form/Type/BatchTagType.php
@@ -9,7 +9,7 @@ use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints\NotBlank;
 
-class BatchTagType extends AbstractType
+final class BatchTagType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {

--- a/plugins/MauticTagManagerBundle/Form/Type/TagEntityType.php
+++ b/plugins/MauticTagManagerBundle/Form/Type/TagEntityType.php
@@ -14,7 +14,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 /**
  * @extends AbstractType<Tag>
  */
-class TagEntityType extends AbstractType
+final class TagEntityType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {


### PR DESCRIPTION
Makes form type, data transformer and validator classes `final`, as they are not meant to be extended.

Split out of #16738 for easier review.