### PR TITLE
[solid] finalize exception classes

### DIFF
--- a/app/bundles/CampaignBundle/EventCollector/Accessor/Exception/EventNotFoundException.php
+++ b/app/bundles/CampaignBundle/EventCollector/Accessor/Exception/EventNotFoundException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\CampaignBundle\EventCollector\Accessor\Exception;
 
-class EventNotFoundException extends \InvalidArgumentException
+final class EventNotFoundException extends \InvalidArgumentException
 {
 }

--- a/app/bundles/CampaignBundle/EventCollector/Accessor/Exception/TypeNotFoundException.php
+++ b/app/bundles/CampaignBundle/EventCollector/Accessor/Exception/TypeNotFoundException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\CampaignBundle\EventCollector\Accessor\Exception;
 
-class TypeNotFoundException extends \InvalidArgumentException
+final class TypeNotFoundException extends \InvalidArgumentException
 {
 }

--- a/app/bundles/CampaignBundle/Executioner/Dispatcher/Exception/LogNotProcessedException.php
+++ b/app/bundles/CampaignBundle/Executioner/Dispatcher/Exception/LogNotProcessedException.php
@@ -4,7 +4,7 @@ namespace Mautic\CampaignBundle\Executioner\Dispatcher\Exception;
 
 use Mautic\CampaignBundle\Entity\LeadEventLog;
 
-class LogNotProcessedException extends \Exception
+final class LogNotProcessedException extends \Exception
 {
     public function __construct(LeadEventLog $log)
     {

--- a/app/bundles/CampaignBundle/Executioner/Dispatcher/Exception/LogPassedAndFailedException.php
+++ b/app/bundles/CampaignBundle/Executioner/Dispatcher/Exception/LogPassedAndFailedException.php
@@ -4,7 +4,7 @@ namespace Mautic\CampaignBundle\Executioner\Dispatcher\Exception;
 
 use Mautic\CampaignBundle\Entity\LeadEventLog;
 
-class LogPassedAndFailedException extends \Exception
+final class LogPassedAndFailedException extends \Exception
 {
     public function __construct(LeadEventLog $log)
     {

--- a/app/bundles/CampaignBundle/Executioner/Exception/CampaignNotExecutableException.php
+++ b/app/bundles/CampaignBundle/Executioner/Exception/CampaignNotExecutableException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\CampaignBundle\Executioner\Exception;
 
-class CampaignNotExecutableException extends \Exception
+final class CampaignNotExecutableException extends \Exception
 {
 }

--- a/app/bundles/CampaignBundle/Executioner/Exception/CannotProcessEventException.php
+++ b/app/bundles/CampaignBundle/Executioner/Exception/CannotProcessEventException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\CampaignBundle\Executioner\Exception;
 
-class CannotProcessEventException extends \Exception
+final class CannotProcessEventException extends \Exception
 {
 }

--- a/app/bundles/CampaignBundle/Executioner/Exception/ConditionFailedException.php
+++ b/app/bundles/CampaignBundle/Executioner/Exception/ConditionFailedException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\CampaignBundle\Executioner\Exception;
 
-class ConditionFailedException extends \Exception
+final class ConditionFailedException extends \Exception
 {
 }

--- a/app/bundles/CampaignBundle/Executioner/Exception/DecisionNotApplicableException.php
+++ b/app/bundles/CampaignBundle/Executioner/Exception/DecisionNotApplicableException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\CampaignBundle\Executioner\Exception;
 
-class DecisionNotApplicableException extends \Exception
+final class DecisionNotApplicableException extends \Exception
 {
 }

--- a/app/bundles/CampaignBundle/Executioner/Exception/IntervalNotConfiguredException.php
+++ b/app/bundles/CampaignBundle/Executioner/Exception/IntervalNotConfiguredException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\CampaignBundle\Executioner\Exception;
 
-class IntervalNotConfiguredException extends \Exception
+final class IntervalNotConfiguredException extends \Exception
 {
 }

--- a/app/bundles/CampaignBundle/Executioner/Exception/NoContactsFoundException.php
+++ b/app/bundles/CampaignBundle/Executioner/Exception/NoContactsFoundException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\CampaignBundle\Executioner\Exception;
 
-class NoContactsFoundException extends \Exception
+final class NoContactsFoundException extends \Exception
 {
 }

--- a/app/bundles/CampaignBundle/Executioner/Exception/NoEventsFoundException.php
+++ b/app/bundles/CampaignBundle/Executioner/Exception/NoEventsFoundException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\CampaignBundle\Executioner\Exception;
 
-class NoEventsFoundException extends \Exception
+final class NoEventsFoundException extends \Exception
 {
 }

--- a/app/bundles/CampaignBundle/Executioner/Scheduler/Exception/NotSchedulableException.php
+++ b/app/bundles/CampaignBundle/Executioner/Scheduler/Exception/NotSchedulableException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\CampaignBundle\Executioner\Scheduler\Exception;
 
-class NotSchedulableException extends \Exception
+final class NotSchedulableException extends \Exception
 {
 }

--- a/app/bundles/CampaignBundle/Membership/Exception/ContactAlreadyRemovedFromCampaignException.php
+++ b/app/bundles/CampaignBundle/Membership/Exception/ContactAlreadyRemovedFromCampaignException.php
@@ -4,6 +4,6 @@ namespace Mautic\CampaignBundle\Membership\Exception;
 
 use Mautic\CoreBundle\Exception\FlattenableException;
 
-class ContactAlreadyRemovedFromCampaignException extends FlattenableException
+final class ContactAlreadyRemovedFromCampaignException extends FlattenableException
 {
 }

--- a/app/bundles/CampaignBundle/Membership/Exception/ContactCannotBeAddedToCampaignException.php
+++ b/app/bundles/CampaignBundle/Membership/Exception/ContactCannotBeAddedToCampaignException.php
@@ -4,6 +4,6 @@ namespace Mautic\CampaignBundle\Membership\Exception;
 
 use Mautic\CoreBundle\Exception\FlattenableException;
 
-class ContactCannotBeAddedToCampaignException extends FlattenableException
+final class ContactCannotBeAddedToCampaignException extends FlattenableException
 {
 }

--- a/app/bundles/CampaignBundle/Membership/Exception/RunLimitReachedException.php
+++ b/app/bundles/CampaignBundle/Membership/Exception/RunLimitReachedException.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\CampaignBundle\Membership\Exception;
 
-class RunLimitReachedException extends \Exception
+final class RunLimitReachedException extends \Exception
 {
     private readonly int $contactsProcessed;
 

--- a/app/bundles/ConfigBundle/Exception/BadFormConfigException.php
+++ b/app/bundles/ConfigBundle/Exception/BadFormConfigException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\ConfigBundle\Exception;
 
-class BadFormConfigException extends \Exception
+final class BadFormConfigException extends \Exception
 {
 }

--- a/app/bundles/CoreBundle/Exception/BadConfigurationException.php
+++ b/app/bundles/CoreBundle/Exception/BadConfigurationException.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\CoreBundle\Exception;
 
-class BadConfigurationException extends \Exception
+final class BadConfigurationException extends \Exception
 {
     public function __construct($message = 'Configuration is bad.', $code = 0, ?\Exception $previous = null)
     {

--- a/app/bundles/CoreBundle/Exception/DatabaseConnectionException.php
+++ b/app/bundles/CoreBundle/Exception/DatabaseConnectionException.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\CoreBundle\Exception;
 
-class DatabaseConnectionException extends \Exception
+final class DatabaseConnectionException extends \Exception
 {
     public function __construct($message = 'Unable to connect to the database.', $code = 0, ?\Exception $previous = null)
     {

--- a/app/bundles/CoreBundle/Exception/FileExistsException.php
+++ b/app/bundles/CoreBundle/Exception/FileExistsException.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\CoreBundle\Exception;
 
-class FileExistsException extends \Exception
+final class FileExistsException extends \Exception
 {
     public function __construct($message = 'File exists.', $code = 0, ?\Exception $previous = null)
     {

--- a/app/bundles/CoreBundle/Exception/FileInvalidException.php
+++ b/app/bundles/CoreBundle/Exception/FileInvalidException.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\CoreBundle\Exception;
 
-class FileInvalidException extends \Exception
+final class FileInvalidException extends \Exception
 {
     private string $messageId = '';
 

--- a/app/bundles/CoreBundle/Exception/FileNotFoundException.php
+++ b/app/bundles/CoreBundle/Exception/FileNotFoundException.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\CoreBundle\Exception;
 
-class FileNotFoundException extends \Exception
+final class FileNotFoundException extends \Exception
 {
     public function __construct(string $message = 'File not found.', int $code = 0, ?\Exception $previous = null)
     {

--- a/app/bundles/CoreBundle/Exception/FilePathException.php
+++ b/app/bundles/CoreBundle/Exception/FilePathException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\CoreBundle\Exception;
 
-class FilePathException extends \Exception
+final class FilePathException extends \Exception
 {
 }

--- a/app/bundles/CoreBundle/Exception/FileUploadException.php
+++ b/app/bundles/CoreBundle/Exception/FileUploadException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\CoreBundle\Exception;
 
-class FileUploadException extends \Exception
+final class FileUploadException extends \Exception
 {
 }

--- a/app/bundles/CoreBundle/Exception/InvalidDecodedStringException.php
+++ b/app/bundles/CoreBundle/Exception/InvalidDecodedStringException.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\CoreBundle\Exception;
 
-class InvalidDecodedStringException extends \InvalidArgumentException
+final class InvalidDecodedStringException extends \InvalidArgumentException
 {
     public function __construct(string $string = '', int $code = 0, ?\Throwable $previous = null)
     {

--- a/app/bundles/CoreBundle/Exception/MessageOnlyErrorHandlerException.php
+++ b/app/bundles/CoreBundle/Exception/MessageOnlyErrorHandlerException.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\CoreBundle\Exception;
 
-class MessageOnlyErrorHandlerException extends ErrorHandlerException
+final class MessageOnlyErrorHandlerException extends ErrorHandlerException
 {
     public function __construct($message = '')
     {

--- a/app/bundles/CoreBundle/Exception/RecordCanNotUnpublishException.php
+++ b/app/bundles/CoreBundle/Exception/RecordCanNotUnpublishException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\Exception;
 
-class RecordCanNotUnpublishException extends \Exception
+final class RecordCanNotUnpublishException extends \Exception
 {
 }

--- a/app/bundles/CoreBundle/Exception/RecordNotFoundException.php
+++ b/app/bundles/CoreBundle/Exception/RecordNotFoundException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\CoreBundle\Exception;
 
-class RecordNotFoundException extends RecordException
+final class RecordNotFoundException extends RecordException
 {
 }

--- a/app/bundles/CoreBundle/Exception/RecordNotPublishedException.php
+++ b/app/bundles/CoreBundle/Exception/RecordNotPublishedException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\CoreBundle\Exception;
 
-class RecordNotPublishedException extends RecordException
+final class RecordNotPublishedException extends RecordException
 {
 }

--- a/app/bundles/CoreBundle/Exception/SchemaException.php
+++ b/app/bundles/CoreBundle/Exception/SchemaException.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\CoreBundle\Exception;
 
-class SchemaException extends \Exception
+final class SchemaException extends \Exception
 {
     public function __construct($message = 'Could not perform schema change.', $code = 0, ?\Exception $previous = null)
     {

--- a/app/bundles/CoreBundle/Exception/UpdateFailedException.php
+++ b/app/bundles/CoreBundle/Exception/UpdateFailedException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\CoreBundle\Exception;
 
-class UpdateFailedException extends \Exception
+final class UpdateFailedException extends \Exception
 {
 }

--- a/app/bundles/CoreBundle/Helper/ListParser/Exception/FormatNotSupportedException.php
+++ b/app/bundles/CoreBundle/Helper/ListParser/Exception/FormatNotSupportedException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\CoreBundle\Helper\ListParser\Exception;
 
-class FormatNotSupportedException extends \Exception
+final class FormatNotSupportedException extends \Exception
 {
 }

--- a/app/bundles/CoreBundle/Helper/Update/Exception/LatestVersionSupportedException.php
+++ b/app/bundles/CoreBundle/Helper/Update/Exception/LatestVersionSupportedException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\CoreBundle\Helper\Update\Exception;
 
-class LatestVersionSupportedException extends \Exception
+final class LatestVersionSupportedException extends \Exception
 {
 }

--- a/app/bundles/CoreBundle/Helper/Update/Exception/MetadataNotFoundException.php
+++ b/app/bundles/CoreBundle/Helper/Update/Exception/MetadataNotFoundException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\CoreBundle\Helper\Update\Exception;
 
-class MetadataNotFoundException extends \Exception
+final class MetadataNotFoundException extends \Exception
 {
 }

--- a/app/bundles/CoreBundle/Helper/Update/Exception/UpdateCacheDataNeedsToBeRefreshedException.php
+++ b/app/bundles/CoreBundle/Helper/Update/Exception/UpdateCacheDataNeedsToBeRefreshedException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\CoreBundle\Helper\Update\Exception;
 
-class UpdateCacheDataNeedsToBeRefreshedException extends \Exception
+final class UpdateCacheDataNeedsToBeRefreshedException extends \Exception
 {
 }

--- a/app/bundles/CoreBundle/Helper/Update/Exception/UpdatePackageNotFoundException.php
+++ b/app/bundles/CoreBundle/Helper/Update/Exception/UpdatePackageNotFoundException.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\CoreBundle\Helper\Update\Exception;
 
-class UpdatePackageNotFoundException extends CouldNotFetchLatestVersionException
+final class UpdatePackageNotFoundException extends CouldNotFetchLatestVersionException
 {
     protected $message = 'Update package could not be found';
 }

--- a/app/bundles/CoreBundle/ProcessSignal/Exception/InvalidStateException.php
+++ b/app/bundles/CoreBundle/ProcessSignal/Exception/InvalidStateException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\ProcessSignal\Exception;
 
-class InvalidStateException extends \InvalidArgumentException
+final class InvalidStateException extends \InvalidArgumentException
 {
     public function __construct(string $stateString, ?\Throwable $previous = null)
     {

--- a/app/bundles/CoreBundle/ProcessSignal/Exception/SignalCaughtException.php
+++ b/app/bundles/CoreBundle/ProcessSignal/Exception/SignalCaughtException.php
@@ -6,7 +6,7 @@ namespace Mautic\CoreBundle\ProcessSignal\Exception;
 
 use Mautic\CoreBundle\ProcessSignal\ProcessSignalState;
 
-class SignalCaughtException extends \Exception
+final class SignalCaughtException extends \Exception
 {
     public function __construct(
         int $signal,

--- a/app/bundles/CoreBundle/Security/Exception/Cryptography/Symmetric/InvalidDecryptionException.php
+++ b/app/bundles/CoreBundle/Security/Exception/Cryptography/Symmetric/InvalidDecryptionException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\CoreBundle\Security\Exception\Cryptography\Symmetric;
 
-class InvalidDecryptionException extends \Exception
+final class InvalidDecryptionException extends \Exception
 {
 }

--- a/app/bundles/CoreBundle/Security/Exception/PermissionBadFormatException.php
+++ b/app/bundles/CoreBundle/Security/Exception/PermissionBadFormatException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\CoreBundle\Security\Exception;
 
-class PermissionBadFormatException extends PermissionException
+final class PermissionBadFormatException extends PermissionException
 {
 }

--- a/app/bundles/CoreBundle/Security/Exception/PermissionNotFoundException.php
+++ b/app/bundles/CoreBundle/Security/Exception/PermissionNotFoundException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\CoreBundle\Security\Exception;
 
-class PermissionNotFoundException extends PermissionException
+final class PermissionNotFoundException extends PermissionException
 {
 }

--- a/app/bundles/DashboardBundle/Exception/CouldNotFormatDateTimeException.php
+++ b/app/bundles/DashboardBundle/Exception/CouldNotFormatDateTimeException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\DashboardBundle\Exception;
 
-class CouldNotFormatDateTimeException extends \Exception
+final class CouldNotFormatDateTimeException extends \Exception
 {
     public function __construct(
         string $message = 'Can\'t format date object to string',

--- a/app/bundles/EmailBundle/Exception/EmailCouldNotBeSentException.php
+++ b/app/bundles/EmailBundle/Exception/EmailCouldNotBeSentException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\EmailBundle\Exception;
 
-class EmailCouldNotBeSentException extends \Exception
+final class EmailCouldNotBeSentException extends \Exception
 {
 }

--- a/app/bundles/EmailBundle/Exception/FailedToSendToContactException.php
+++ b/app/bundles/EmailBundle/Exception/FailedToSendToContactException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\EmailBundle\Exception;
 
-class FailedToSendToContactException extends \Exception
+final class FailedToSendToContactException extends \Exception
 {
 }

--- a/app/bundles/EmailBundle/Exception/InvalidEmailException.php
+++ b/app/bundles/EmailBundle/Exception/InvalidEmailException.php
@@ -4,7 +4,7 @@ namespace Mautic\EmailBundle\Exception;
 
 use Mautic\CoreBundle\Exception\InvalidValueException;
 
-class InvalidEmailException extends InvalidValueException
+final class InvalidEmailException extends InvalidValueException
 {
     public function __construct(
         protected string $emailAddress,

--- a/app/bundles/EmailBundle/Exception/MailboxException.php
+++ b/app/bundles/EmailBundle/Exception/MailboxException.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\EmailBundle\Exception;
 
-class MailboxException extends \Exception
+final class MailboxException extends \Exception
 {
     public function __construct($message = null, $code = 0, ?\Exception $previous = null)
     {

--- a/app/bundles/EmailBundle/Helper/Exception/OwnerNotFoundException.php
+++ b/app/bundles/EmailBundle/Helper/Exception/OwnerNotFoundException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\EmailBundle\Helper\Exception;
 
-class OwnerNotFoundException extends \Exception
+final class OwnerNotFoundException extends \Exception
 {
 }

--- a/app/bundles/EmailBundle/Helper/Exception/TokenNotFoundOrEmptyException.php
+++ b/app/bundles/EmailBundle/Helper/Exception/TokenNotFoundOrEmptyException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\EmailBundle\Helper\Exception;
 
-class TokenNotFoundOrEmptyException extends \Exception
+final class TokenNotFoundOrEmptyException extends \Exception
 {
 }

--- a/app/bundles/EmailBundle/Mailer/Exception/BatchQueueMaxException.php
+++ b/app/bundles/EmailBundle/Mailer/Exception/BatchQueueMaxException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\EmailBundle\Mailer\Exception;
 
-class BatchQueueMaxException extends \Exception
+final class BatchQueueMaxException extends \Exception
 {
     public function __construct(string $message = 'Max number of emails have been queued. Run flushQueue() first then queue() again', int $code = 0, ?\Exception $previous = null)
     {

--- a/app/bundles/EmailBundle/MonitoredEmail/Exception/BounceNotFound.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Exception/BounceNotFound.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\EmailBundle\MonitoredEmail\Exception;
 
-class BounceNotFound extends \Exception
+final class BounceNotFound extends \Exception
 {
 }

--- a/app/bundles/EmailBundle/MonitoredEmail/Exception/CategoryNotFound.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Exception/CategoryNotFound.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\EmailBundle\MonitoredEmail\Exception;
 
-class CategoryNotFound extends \Exception
+final class CategoryNotFound extends \Exception
 {
 }

--- a/app/bundles/EmailBundle/MonitoredEmail/Exception/FeedbackLoopNotFound.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Exception/FeedbackLoopNotFound.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\EmailBundle\MonitoredEmail\Exception;
 
-class FeedbackLoopNotFound extends \Exception
+final class FeedbackLoopNotFound extends \Exception
 {
 }

--- a/app/bundles/EmailBundle/MonitoredEmail/Exception/NotConfiguredException.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Exception/NotConfiguredException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\EmailBundle\MonitoredEmail\Exception;
 
-class NotConfiguredException extends \Exception
+final class NotConfiguredException extends \Exception
 {
 }

--- a/app/bundles/EmailBundle/MonitoredEmail/Exception/ReplyNotFound.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Exception/ReplyNotFound.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\EmailBundle\MonitoredEmail\Exception;
 
-class ReplyNotFound extends \Exception
+final class ReplyNotFound extends \Exception
 {
 }

--- a/app/bundles/EmailBundle/MonitoredEmail/Exception/UnsubscriptionNotFound.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Exception/UnsubscriptionNotFound.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\EmailBundle\MonitoredEmail\Exception;
 
-class UnsubscriptionNotFound extends \Exception
+final class UnsubscriptionNotFound extends \Exception
 {
 }

--- a/app/bundles/EmailBundle/Stat/Exception/StatNotFoundException.php
+++ b/app/bundles/EmailBundle/Stat/Exception/StatNotFoundException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\EmailBundle\Stat\Exception;
 
-class StatNotFoundException extends \Exception
+final class StatNotFoundException extends \Exception
 {
 }

--- a/app/bundles/EmailBundle/Stats/Exception/InvalidStatHelperException.php
+++ b/app/bundles/EmailBundle/Stats/Exception/InvalidStatHelperException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\EmailBundle\Stats\Exception;
 
-class InvalidStatHelperException extends \Exception
+final class InvalidStatHelperException extends \Exception
 {
 }

--- a/app/bundles/FormBundle/Exception/FieldNotFoundException.php
+++ b/app/bundles/FormBundle/Exception/FieldNotFoundException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\FormBundle\Exception;
 
-class FieldNotFoundException extends \Exception
+final class FieldNotFoundException extends \Exception
 {
 }

--- a/app/bundles/FormBundle/Exception/FileValidationException.php
+++ b/app/bundles/FormBundle/Exception/FileValidationException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\FormBundle\Exception;
 
-class FileValidationException extends \Exception
+final class FileValidationException extends \Exception
 {
 }

--- a/app/bundles/FormBundle/Exception/NoFileGivenException.php
+++ b/app/bundles/FormBundle/Exception/NoFileGivenException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\FormBundle\Exception;
 
-class NoFileGivenException extends \Exception
+final class NoFileGivenException extends \Exception
 {
 }

--- a/app/bundles/FormBundle/Exception/ValidationException.php
+++ b/app/bundles/FormBundle/Exception/ValidationException.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\FormBundle\Exception;
 
-class ValidationException extends \Exception
+final class ValidationException extends \Exception
 {
     /**
      * @var mixed[]

--- a/app/bundles/InstallBundle/Exception/AlreadyInstalledException.php
+++ b/app/bundles/InstallBundle/Exception/AlreadyInstalledException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\InstallBundle\Exception;
 
-class AlreadyInstalledException extends \Exception
+final class AlreadyInstalledException extends \Exception
 {
     protected $message = 'Mautic is already installed.';
 }

--- a/app/bundles/InstallBundle/Exception/DatabaseVersionTooOldException.php
+++ b/app/bundles/InstallBundle/Exception/DatabaseVersionTooOldException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\InstallBundle\Exception;
 
-class DatabaseVersionTooOldException extends \Exception
+final class DatabaseVersionTooOldException extends \Exception
 {
     public function __construct(
         private readonly string $currentVersion,

--- a/app/bundles/IntegrationsBundle/Exception/IntegrationMappingException.php
+++ b/app/bundles/IntegrationsBundle/Exception/IntegrationMappingException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\IntegrationsBundle\Exception;
 
-class IntegrationMappingException extends \Exception
+final class IntegrationMappingException extends \Exception
 {
 }

--- a/app/bundles/IntegrationsBundle/Exception/IntegrationNotFoundException.php
+++ b/app/bundles/IntegrationsBundle/Exception/IntegrationNotFoundException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\IntegrationsBundle\Exception;
 
-class IntegrationNotFoundException extends \Exception
+final class IntegrationNotFoundException extends \Exception
 {
 }

--- a/app/bundles/IntegrationsBundle/Exception/IntegrationNotSetException.php
+++ b/app/bundles/IntegrationsBundle/Exception/IntegrationNotSetException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\IntegrationsBundle\Exception;
 
-class IntegrationNotSetException extends \Exception
+final class IntegrationNotSetException extends \Exception
 {
 }

--- a/app/bundles/IntegrationsBundle/Exception/InvalidCredentialsException.php
+++ b/app/bundles/IntegrationsBundle/Exception/InvalidCredentialsException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\IntegrationsBundle\Exception;
 
-class InvalidCredentialsException extends \Exception
+final class InvalidCredentialsException extends \Exception
 {
 }

--- a/app/bundles/IntegrationsBundle/Exception/InvalidFormOptionException.php
+++ b/app/bundles/IntegrationsBundle/Exception/InvalidFormOptionException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\IntegrationsBundle\Exception;
 
-class InvalidFormOptionException extends \Exception
+final class InvalidFormOptionException extends \Exception
 {
 }

--- a/app/bundles/IntegrationsBundle/Exception/InvalidProviderException.php
+++ b/app/bundles/IntegrationsBundle/Exception/InvalidProviderException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\IntegrationsBundle\Exception;
 
-class InvalidProviderException extends \Exception
+final class InvalidProviderException extends \Exception
 {
     public function __construct($provider, $code = 0, ?\Throwable $previous = null)
     {

--- a/app/bundles/IntegrationsBundle/Exception/PathNotFoundException.php
+++ b/app/bundles/IntegrationsBundle/Exception/PathNotFoundException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\IntegrationsBundle\Exception;
 
-class PathNotFoundException extends \Exception
+final class PathNotFoundException extends \Exception
 {
 }

--- a/app/bundles/IntegrationsBundle/Exception/PluginNotConfiguredException.php
+++ b/app/bundles/IntegrationsBundle/Exception/PluginNotConfiguredException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\IntegrationsBundle\Exception;
 
-class PluginNotConfiguredException extends \Exception
+final class PluginNotConfiguredException extends \Exception
 {
     protected $message = 'mautic.integration.not_configured';
 }

--- a/app/bundles/IntegrationsBundle/Exception/RequiredValueException.php
+++ b/app/bundles/IntegrationsBundle/Exception/RequiredValueException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\IntegrationsBundle\Exception;
 
-class RequiredValueException extends InvalidValueException
+final class RequiredValueException extends InvalidValueException
 {
 }

--- a/app/bundles/IntegrationsBundle/Exception/UnauthorizedException.php
+++ b/app/bundles/IntegrationsBundle/Exception/UnauthorizedException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\IntegrationsBundle\Exception;
 
-class UnauthorizedException extends \Exception
+final class UnauthorizedException extends \Exception
 {
 }

--- a/app/bundles/IntegrationsBundle/Exception/UnexpectedValueException.php
+++ b/app/bundles/IntegrationsBundle/Exception/UnexpectedValueException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\IntegrationsBundle\Exception;
 
-class UnexpectedValueException extends \Exception
+final class UnexpectedValueException extends \Exception
 {
 }

--- a/app/bundles/IntegrationsBundle/Sync/Exception/ConflictUnresolvedException.php
+++ b/app/bundles/IntegrationsBundle/Sync/Exception/ConflictUnresolvedException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\IntegrationsBundle\Sync\Exception;
 
-class ConflictUnresolvedException extends \Exception
+final class ConflictUnresolvedException extends \Exception
 {
 }

--- a/app/bundles/IntegrationsBundle/Sync/Exception/FieldNotFoundException.php
+++ b/app/bundles/IntegrationsBundle/Sync/Exception/FieldNotFoundException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\IntegrationsBundle\Sync\Exception;
 
-class FieldNotFoundException extends \Exception
+final class FieldNotFoundException extends \Exception
 {
     /**
      * @param int             $code

--- a/app/bundles/IntegrationsBundle/Sync/Exception/HandlerNotSupportedException.php
+++ b/app/bundles/IntegrationsBundle/Sync/Exception/HandlerNotSupportedException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\IntegrationsBundle\Sync\Exception;
 
-class HandlerNotSupportedException extends \Exception
+final class HandlerNotSupportedException extends \Exception
 {
 }

--- a/app/bundles/IntegrationsBundle/Sync/Exception/InternalIdNotFoundException.php
+++ b/app/bundles/IntegrationsBundle/Sync/Exception/InternalIdNotFoundException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\IntegrationsBundle\Sync\Exception;
 
-class InternalIdNotFoundException extends \Exception
+final class InternalIdNotFoundException extends \Exception
 {
     public function __construct(string $object)
     {

--- a/app/bundles/IntegrationsBundle/Sync/Exception/ObjectDeletedException.php
+++ b/app/bundles/IntegrationsBundle/Sync/Exception/ObjectDeletedException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\IntegrationsBundle\Sync\Exception;
 
-class ObjectDeletedException extends \Exception
+final class ObjectDeletedException extends \Exception
 {
 }

--- a/app/bundles/IntegrationsBundle/Sync/Exception/ObjectNotFoundException.php
+++ b/app/bundles/IntegrationsBundle/Sync/Exception/ObjectNotFoundException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\IntegrationsBundle\Sync\Exception;
 
-class ObjectNotFoundException extends \Exception
+final class ObjectNotFoundException extends \Exception
 {
     public function __construct(string $object)
     {

--- a/app/bundles/IntegrationsBundle/Sync/Exception/ObjectNotSupportedException.php
+++ b/app/bundles/IntegrationsBundle/Sync/Exception/ObjectNotSupportedException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\IntegrationsBundle\Sync\Exception;
 
-class ObjectNotSupportedException extends \Exception
+final class ObjectNotSupportedException extends \Exception
 {
     public function __construct(string $integration, string $object)
     {

--- a/app/bundles/IntegrationsBundle/Sync/Exception/ObjectSyncSkippedException.php
+++ b/app/bundles/IntegrationsBundle/Sync/Exception/ObjectSyncSkippedException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\IntegrationsBundle\Sync\Exception;
 
-class ObjectSyncSkippedException extends \Exception
+final class ObjectSyncSkippedException extends \Exception
 {
 }

--- a/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/Executioner/Exception/FieldSchemaNotFoundException.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/Executioner/Exception/FieldSchemaNotFoundException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\Executioner\Exception;
 
-class FieldSchemaNotFoundException extends \Exception
+final class FieldSchemaNotFoundException extends \Exception
 {
     public function __construct(string $object, string $alias)
     {

--- a/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/Executioner/Exception/ReferenceNotFoundException.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/Executioner/Exception/ReferenceNotFoundException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\Executioner\Exception;
 
-class ReferenceNotFoundException extends \Exception
+final class ReferenceNotFoundException extends \Exception
 {
 }

--- a/app/bundles/LeadBundle/Deduplicate/Exception/SameContactException.php
+++ b/app/bundles/LeadBundle/Deduplicate/Exception/SameContactException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\LeadBundle\Deduplicate\Exception;
 
-class SameContactException extends \Exception
+final class SameContactException extends \Exception
 {
 }

--- a/app/bundles/LeadBundle/Deduplicate/Exception/ValueNotMergeableException.php
+++ b/app/bundles/LeadBundle/Deduplicate/Exception/ValueNotMergeableException.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\LeadBundle\Deduplicate\Exception;
 
-class ValueNotMergeableException extends \Exception
+final class ValueNotMergeableException extends \Exception
 {
     /**
      * @param mixed $newerValue

--- a/app/bundles/LeadBundle/Exception/ChoicesNotFoundException.php
+++ b/app/bundles/LeadBundle/Exception/ChoicesNotFoundException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\LeadBundle\Exception;
 
-class ChoicesNotFoundException extends \Exception
+final class ChoicesNotFoundException extends \Exception
 {
 }

--- a/app/bundles/LeadBundle/Exception/ContactNotFoundException.php
+++ b/app/bundles/LeadBundle/Exception/ContactNotFoundException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\LeadBundle\Exception;
 
-class ContactNotFoundException extends \Exception
+final class ContactNotFoundException extends \Exception
 {
 }

--- a/app/bundles/LeadBundle/Exception/FieldNotFoundException.php
+++ b/app/bundles/LeadBundle/Exception/FieldNotFoundException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\LeadBundle\Exception;
 
-class FieldNotFoundException extends \Exception
+final class FieldNotFoundException extends \Exception
 {
 }

--- a/app/bundles/LeadBundle/Exception/FilterNotFoundException.php
+++ b/app/bundles/LeadBundle/Exception/FilterNotFoundException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\LeadBundle\Exception;
 
-class FilterNotFoundException extends \Exception
+final class FilterNotFoundException extends \Exception
 {
 }

--- a/app/bundles/LeadBundle/Exception/ImportDelayedException.php
+++ b/app/bundles/LeadBundle/Exception/ImportDelayedException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\LeadBundle\Exception;
 
-class ImportDelayedException extends \Exception
+final class ImportDelayedException extends \Exception
 {
 }

--- a/app/bundles/LeadBundle/Exception/ImportFailedException.php
+++ b/app/bundles/LeadBundle/Exception/ImportFailedException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\LeadBundle\Exception;
 
-class ImportFailedException extends \Exception
+final class ImportFailedException extends \Exception
 {
 }

--- a/app/bundles/LeadBundle/Exception/ImportRowFailedException.php
+++ b/app/bundles/LeadBundle/Exception/ImportRowFailedException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\LeadBundle\Exception;
 
-class ImportRowFailedException extends \Exception
+final class ImportRowFailedException extends \Exception
 {
 }

--- a/app/bundles/LeadBundle/Exception/InvalidContactFieldTokenException.php
+++ b/app/bundles/LeadBundle/Exception/InvalidContactFieldTokenException.php
@@ -6,6 +6,6 @@ namespace Mautic\LeadBundle\Exception;
 
 use Mautic\CoreBundle\Exception\InvalidValueException;
 
-class InvalidContactFieldTokenException extends InvalidValueException
+final class InvalidContactFieldTokenException extends InvalidValueException
 {
 }

--- a/app/bundles/LeadBundle/Exception/InvalidObjectTypeException.php
+++ b/app/bundles/LeadBundle/Exception/InvalidObjectTypeException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\LeadBundle\Exception;
 
-class InvalidObjectTypeException extends \Exception
+final class InvalidObjectTypeException extends \Exception
 {
 }

--- a/app/bundles/LeadBundle/Exception/NoListenerException.php
+++ b/app/bundles/LeadBundle/Exception/NoListenerException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\LeadBundle\Exception;
 
-class NoListenerException extends \Exception
+final class NoListenerException extends \Exception
 {
 }

--- a/app/bundles/LeadBundle/Exception/OperatorsNotFoundException.php
+++ b/app/bundles/LeadBundle/Exception/OperatorsNotFoundException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\LeadBundle\Exception;
 
-class OperatorsNotFoundException extends \Exception
+final class OperatorsNotFoundException extends \Exception
 {
 }

--- a/app/bundles/LeadBundle/Exception/PrimaryCompanyNotFoundException.php
+++ b/app/bundles/LeadBundle/Exception/PrimaryCompanyNotFoundException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\LeadBundle\Exception;
 
-class PrimaryCompanyNotFoundException extends \Exception
+final class PrimaryCompanyNotFoundException extends \Exception
 {
 }

--- a/app/bundles/LeadBundle/Exception/UniqueFieldNotFoundException.php
+++ b/app/bundles/LeadBundle/Exception/UniqueFieldNotFoundException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\LeadBundle\Exception;
 
-class UniqueFieldNotFoundException extends \Exception
+final class UniqueFieldNotFoundException extends \Exception
 {
 }

--- a/app/bundles/LeadBundle/Exception/UnknownDncReasonException.php
+++ b/app/bundles/LeadBundle/Exception/UnknownDncReasonException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\LeadBundle\Exception;
 
-class UnknownDncReasonException extends \Exception
+final class UnknownDncReasonException extends \Exception
 {
 }

--- a/app/bundles/LeadBundle/Field/Exception/AbortColumnCreateException.php
+++ b/app/bundles/LeadBundle/Field/Exception/AbortColumnCreateException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\LeadBundle\Field\Exception;
 
-class AbortColumnCreateException extends \Exception
+final class AbortColumnCreateException extends \Exception
 {
 }

--- a/app/bundles/LeadBundle/Field/Exception/AbortColumnUpdateException.php
+++ b/app/bundles/LeadBundle/Field/Exception/AbortColumnUpdateException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\LeadBundle\Field\Exception;
 
-class AbortColumnUpdateException extends \Exception
+final class AbortColumnUpdateException extends \Exception
 {
 }

--- a/app/bundles/LeadBundle/Field/Exception/ColumnAlreadyCreatedException.php
+++ b/app/bundles/LeadBundle/Field/Exception/ColumnAlreadyCreatedException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\LeadBundle\Field\Exception;
 
-class ColumnAlreadyCreatedException extends \Exception
+final class ColumnAlreadyCreatedException extends \Exception
 {
 }

--- a/app/bundles/LeadBundle/Field/Exception/CustomFieldLimitException.php
+++ b/app/bundles/LeadBundle/Field/Exception/CustomFieldLimitException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\LeadBundle\Field\Exception;
 
-class CustomFieldLimitException extends \Exception
+final class CustomFieldLimitException extends \Exception
 {
 }

--- a/app/bundles/LeadBundle/Field/Exception/LeadFieldWasNotFoundException.php
+++ b/app/bundles/LeadBundle/Field/Exception/LeadFieldWasNotFoundException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\LeadBundle\Field\Exception;
 
-class LeadFieldWasNotFoundException extends \Exception
+final class LeadFieldWasNotFoundException extends \Exception
 {
 }

--- a/app/bundles/LeadBundle/Field/Exception/NoUserException.php
+++ b/app/bundles/LeadBundle/Field/Exception/NoUserException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\LeadBundle\Field\Exception;
 
-class NoUserException extends \Exception
+final class NoUserException extends \Exception
 {
 }

--- a/app/bundles/LeadBundle/Segment/Exception/FieldNotFoundException.php
+++ b/app/bundles/LeadBundle/Segment/Exception/FieldNotFoundException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\LeadBundle\Segment\Exception;
 
-class FieldNotFoundException extends \Exception
+final class FieldNotFoundException extends \Exception
 {
 }

--- a/app/bundles/LeadBundle/Segment/Exception/InvalidUseException.php
+++ b/app/bundles/LeadBundle/Segment/Exception/InvalidUseException.php
@@ -5,6 +5,6 @@ namespace Mautic\LeadBundle\Segment\Exception;
 /**
  * This exception is risen if functionality requested does not belong to give FilterQueryBuilder.
  */
-class InvalidUseException extends SegmentQueryException
+final class InvalidUseException extends SegmentQueryException
 {
 }

--- a/app/bundles/LeadBundle/Segment/Exception/PluginHandledFilterException.php
+++ b/app/bundles/LeadBundle/Segment/Exception/PluginHandledFilterException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\LeadBundle\Segment\Exception;
 
-class PluginHandledFilterException extends \Exception
+final class PluginHandledFilterException extends \Exception
 {
 }

--- a/app/bundles/LeadBundle/Segment/Exception/SegmentNotFoundException.php
+++ b/app/bundles/LeadBundle/Segment/Exception/SegmentNotFoundException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\LeadBundle\Segment\Exception;
 
-class SegmentNotFoundException extends \Exception
+final class SegmentNotFoundException extends \Exception
 {
 }

--- a/app/bundles/LeadBundle/Segment/Exception/TableNotFoundException.php
+++ b/app/bundles/LeadBundle/Segment/Exception/TableNotFoundException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\LeadBundle\Segment\Exception;
 
-class TableNotFoundException extends SegmentQueryException
+final class TableNotFoundException extends SegmentQueryException
 {
 }

--- a/app/bundles/MarketplaceBundle/Exception/ApiException.php
+++ b/app/bundles/MarketplaceBundle/Exception/ApiException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\MarketplaceBundle\Exception;
 
-class ApiException extends \Exception
+final class ApiException extends \Exception
 {
 }

--- a/app/bundles/MarketplaceBundle/Exception/RecordNotFoundException.php
+++ b/app/bundles/MarketplaceBundle/Exception/RecordNotFoundException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\MarketplaceBundle\Exception;
 
-class RecordNotFoundException extends \Exception
+final class RecordNotFoundException extends \Exception
 {
 }

--- a/app/bundles/NotificationBundle/Exception/MissingApiKeyException.php
+++ b/app/bundles/NotificationBundle/Exception/MissingApiKeyException.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\NotificationBundle\Exception;
 
-class MissingApiKeyException extends \Exception
+final class MissingApiKeyException extends \Exception
 {
     protected $message = 'Missing Notification API Key';
 }

--- a/app/bundles/NotificationBundle/Exception/MissingAppIDException.php
+++ b/app/bundles/NotificationBundle/Exception/MissingAppIDException.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\NotificationBundle\Exception;
 
-class MissingAppIDException extends \Exception
+final class MissingAppIDException extends \Exception
 {
     protected $message = 'Missing Notification App ID';
 }

--- a/app/bundles/PageBundle/Exception/InvalidRenderedHtmlException.php
+++ b/app/bundles/PageBundle/Exception/InvalidRenderedHtmlException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\PageBundle\Exception;
 
-class InvalidRenderedHtmlException extends \Exception
+final class InvalidRenderedHtmlException extends \Exception
 {
 }

--- a/app/bundles/PluginBundle/Exception/ApiErrorException.php
+++ b/app/bundles/PluginBundle/Exception/ApiErrorException.php
@@ -4,7 +4,7 @@ namespace Mautic\PluginBundle\Exception;
 
 use Mautic\LeadBundle\Entity\Lead;
 
-class ApiErrorException extends \Exception
+final class ApiErrorException extends \Exception
 {
     private $contactId;
 

--- a/app/bundles/ReportBundle/Exception/FileIOException.php
+++ b/app/bundles/ReportBundle/Exception/FileIOException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\ReportBundle\Exception;
 
-class FileIOException extends \Exception
+final class FileIOException extends \Exception
 {
 }

--- a/app/bundles/ReportBundle/Exception/FileTooBigException.php
+++ b/app/bundles/ReportBundle/Exception/FileTooBigException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\ReportBundle\Exception;
 
-class FileTooBigException extends \Exception
+final class FileTooBigException extends \Exception
 {
 }

--- a/app/bundles/ReportBundle/Scheduler/Exception/InvalidSchedulerException.php
+++ b/app/bundles/ReportBundle/Scheduler/Exception/InvalidSchedulerException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\ReportBundle\Scheduler\Exception;
 
-class InvalidSchedulerException extends \Exception
+final class InvalidSchedulerException extends \Exception
 {
 }

--- a/app/bundles/ReportBundle/Scheduler/Exception/NoScheduleException.php
+++ b/app/bundles/ReportBundle/Scheduler/Exception/NoScheduleException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\ReportBundle\Scheduler\Exception;
 
-class NoScheduleException extends \Exception
+final class NoScheduleException extends \Exception
 {
 }

--- a/app/bundles/ReportBundle/Scheduler/Exception/NotSupportedScheduleTypeException.php
+++ b/app/bundles/ReportBundle/Scheduler/Exception/NotSupportedScheduleTypeException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\ReportBundle\Scheduler\Exception;
 
-class NotSupportedScheduleTypeException extends \Exception
+final class NotSupportedScheduleTypeException extends \Exception
 {
 }

--- a/app/bundles/ReportBundle/Scheduler/Exception/ScheduleNotValidException.php
+++ b/app/bundles/ReportBundle/Scheduler/Exception/ScheduleNotValidException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\ReportBundle\Scheduler\Exception;
 
-class ScheduleNotValidException extends \Exception
+final class ScheduleNotValidException extends \Exception
 {
 }

--- a/app/bundles/SmsBundle/Exception/CallbackHandlerNotFound.php
+++ b/app/bundles/SmsBundle/Exception/CallbackHandlerNotFound.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\SmsBundle\Exception;
 
-class CallbackHandlerNotFound extends \Exception
+final class CallbackHandlerNotFound extends \Exception
 {
 }

--- a/app/bundles/SmsBundle/Exception/NumberNotFoundException.php
+++ b/app/bundles/SmsBundle/Exception/NumberNotFoundException.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\SmsBundle\Exception;
 
-class NumberNotFoundException extends \Exception
+final class NumberNotFoundException extends \Exception
 {
     /**
      * @param string $number

--- a/app/bundles/SmsBundle/Exception/PrimaryTransportNotEnabledException.php
+++ b/app/bundles/SmsBundle/Exception/PrimaryTransportNotEnabledException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\SmsBundle\Exception;
 
-class PrimaryTransportNotEnabledException extends \Exception
+final class PrimaryTransportNotEnabledException extends \Exception
 {
 }

--- a/app/bundles/SmsBundle/Exception/RecipientNotFoundException.php
+++ b/app/bundles/SmsBundle/Exception/RecipientNotFoundException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\SmsBundle\Exception;
 
-class RecipientNotFoundException extends \Exception
+final class RecipientNotFoundException extends \Exception
 {
 }

--- a/app/bundles/UserBundle/Exception/WeakPasswordException.php
+++ b/app/bundles/UserBundle/Exception/WeakPasswordException.php
@@ -6,6 +6,6 @@ namespace Mautic\UserBundle\Exception;
 
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
-class WeakPasswordException extends AuthenticationException
+final class WeakPasswordException extends AuthenticationException
 {
 }

--- a/app/bundles/WebhookBundle/Exception/PrivateAddressException.php
+++ b/app/bundles/WebhookBundle/Exception/PrivateAddressException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\WebhookBundle\Exception;
 
-class PrivateAddressException extends \Exception
+final class PrivateAddressException extends \Exception
 {
     private const DEFAULT_MESSAGE = 'Access to private addresses is not allowed.';
 

--- a/plugins/MauticCloudStorageBundle/Exception/InvalidCredentialConfigurationException.php
+++ b/plugins/MauticCloudStorageBundle/Exception/InvalidCredentialConfigurationException.php
@@ -2,6 +2,6 @@
 
 namespace MauticPlugin\MauticCloudStorageBundle\Exception;
 
-class InvalidCredentialConfigurationException extends \RuntimeException
+final class InvalidCredentialConfigurationException extends \RuntimeException
 {
 }

--- a/plugins/MauticCloudStorageBundle/Exception/NoFormNeededException.php
+++ b/plugins/MauticCloudStorageBundle/Exception/NoFormNeededException.php
@@ -2,6 +2,6 @@
 
 namespace MauticPlugin\MauticCloudStorageBundle\Exception;
 
-class NoFormNeededException extends \Exception
+final class NoFormNeededException extends \Exception
 {
 }

--- a/plugins/MauticCrmBundle/Api/Salesforce/Exception/RetryRequestException.php
+++ b/plugins/MauticCrmBundle/Api/Salesforce/Exception/RetryRequestException.php
@@ -2,6 +2,6 @@
 
 namespace MauticPlugin\MauticCrmBundle\Api\Salesforce\Exception;
 
-class RetryRequestException extends \Exception
+final class RetryRequestException extends \Exception
 {
 }

--- a/plugins/MauticCrmBundle/Api/Zoho/Exception/MatchingKeyNotFoundException.php
+++ b/plugins/MauticCrmBundle/Api/Zoho/Exception/MatchingKeyNotFoundException.php
@@ -2,6 +2,6 @@
 
 namespace MauticPlugin\MauticCrmBundle\Api\Zoho\Exception;
 
-class MatchingKeyNotFoundException extends \Exception
+final class MatchingKeyNotFoundException extends \Exception
 {
 }

--- a/plugins/MauticCrmBundle/Integration/Salesforce/Exception/InvalidObjectException.php
+++ b/plugins/MauticCrmBundle/Integration/Salesforce/Exception/InvalidObjectException.php
@@ -2,6 +2,6 @@
 
 namespace MauticPlugin\MauticCrmBundle\Integration\Salesforce\Exception;
 
-class InvalidObjectException extends \InvalidArgumentException
+final class InvalidObjectException extends \InvalidArgumentException
 {
 }

--- a/plugins/MauticCrmBundle/Integration/Salesforce/Exception/NoObjectsToFetchException.php
+++ b/plugins/MauticCrmBundle/Integration/Salesforce/Exception/NoObjectsToFetchException.php
@@ -2,6 +2,6 @@
 
 namespace MauticPlugin\MauticCrmBundle\Integration\Salesforce\Exception;
 
-class NoObjectsToFetchException extends \Exception
+final class NoObjectsToFetchException extends \Exception
 {
 }

--- a/plugins/MauticFullContactBundle/Exception/ApiException.php
+++ b/plugins/MauticFullContactBundle/Exception/ApiException.php
@@ -2,6 +2,6 @@
 
 namespace MauticPlugin\MauticFullContactBundle\Exception;
 
-class ApiException extends BaseException
+final class ApiException extends BaseException
 {
 }

--- a/plugins/MauticFullContactBundle/Exception/NoCreditException.php
+++ b/plugins/MauticFullContactBundle/Exception/NoCreditException.php
@@ -2,6 +2,6 @@
 
 namespace MauticPlugin\MauticFullContactBundle\Exception;
 
-class NoCreditException extends BaseException
+final class NoCreditException extends BaseException
 {
 }

--- a/plugins/MauticFullContactBundle/Exception/NotImplementedException.php
+++ b/plugins/MauticFullContactBundle/Exception/NotImplementedException.php
@@ -2,6 +2,6 @@
 
 namespace MauticPlugin\MauticFullContactBundle\Exception;
 
-class NotImplementedException extends BaseException
+final class NotImplementedException extends BaseException
 {
 }

--- a/plugins/MauticSocialBundle/Exception/ExitMonitorException.php
+++ b/plugins/MauticSocialBundle/Exception/ExitMonitorException.php
@@ -2,7 +2,7 @@
 
 namespace MauticPlugin\MauticSocialBundle\Exception;
 
-class ExitMonitorException extends \Exception
+final class ExitMonitorException extends \Exception
 {
     public function __construct($message = 'Exit monitor requested', $code = 0, ?\Exception $previous = null)
     {


### PR DESCRIPTION
Makes exception classes `final`, as they are not meant to be extended.

Split out of #16738 for easier review.