### PR TITLE
[solid] finalize bundle and compiler pass classes

### DIFF
--- a/app/bundles/ApiBundle/DependencyInjection/Compiler/SerializerPass.php
+++ b/app/bundles/ApiBundle/DependencyInjection/Compiler/SerializerPass.php
@@ -9,7 +9,7 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-class SerializerPass implements CompilerPassInterface
+final class SerializerPass implements CompilerPassInterface
 {
     /**
      * Replaces the available metadata drivers (yaml, xml, and annotation)

--- a/app/bundles/ApiBundle/MauticApiBundle.php
+++ b/app/bundles/ApiBundle/MauticApiBundle.php
@@ -7,7 +7,7 @@ use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class MauticApiBundle extends Bundle
+final class MauticApiBundle extends Bundle
 {
     public function build(ContainerBuilder $container): void
     {

--- a/app/bundles/AssetBundle/MauticAssetBundle.php
+++ b/app/bundles/AssetBundle/MauticAssetBundle.php
@@ -4,6 +4,6 @@ namespace Mautic\AssetBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class MauticAssetBundle extends Bundle
+final class MauticAssetBundle extends Bundle
 {
 }

--- a/app/bundles/CacheBundle/MauticCacheBundle.php
+++ b/app/bundles/CacheBundle/MauticCacheBundle.php
@@ -6,6 +6,6 @@ namespace Mautic\CacheBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class MauticCacheBundle extends Bundle
+final class MauticCacheBundle extends Bundle
 {
 }

--- a/app/bundles/CampaignBundle/MauticCampaignBundle.php
+++ b/app/bundles/CampaignBundle/MauticCampaignBundle.php
@@ -5,7 +5,7 @@ namespace Mautic\CampaignBundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class MauticCampaignBundle extends Bundle
+final class MauticCampaignBundle extends Bundle
 {
     public function build(ContainerBuilder $container): void
     {

--- a/app/bundles/CategoryBundle/MauticCategoryBundle.php
+++ b/app/bundles/CategoryBundle/MauticCategoryBundle.php
@@ -4,6 +4,6 @@ namespace Mautic\CategoryBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class MauticCategoryBundle extends Bundle
+final class MauticCategoryBundle extends Bundle
 {
 }

--- a/app/bundles/ChannelBundle/MauticChannelBundle.php
+++ b/app/bundles/ChannelBundle/MauticChannelBundle.php
@@ -4,6 +4,6 @@ namespace Mautic\ChannelBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class MauticChannelBundle extends Bundle
+final class MauticChannelBundle extends Bundle
 {
 }

--- a/app/bundles/ConfigBundle/MauticConfigBundle.php
+++ b/app/bundles/ConfigBundle/MauticConfigBundle.php
@@ -4,6 +4,6 @@ namespace Mautic\ConfigBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class MauticConfigBundle extends Bundle
+final class MauticConfigBundle extends Bundle
 {
 }

--- a/app/bundles/CoreBundle/DependencyInjection/Compiler/ConfiguratorPass.php
+++ b/app/bundles/CoreBundle/DependencyInjection/Compiler/ConfiguratorPass.php
@@ -6,7 +6,7 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-class ConfiguratorPass implements CompilerPassInterface
+final class ConfiguratorPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {

--- a/app/bundles/CoreBundle/DependencyInjection/Compiler/DbalPass.php
+++ b/app/bundles/CoreBundle/DependencyInjection/Compiler/DbalPass.php
@@ -8,7 +8,7 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-class DbalPass implements CompilerPassInterface
+final class DbalPass implements CompilerPassInterface
 {
     /**
      * Allows result caching with DBAL using the same configuration as the orm if provided and enabled.

--- a/app/bundles/CoreBundle/DependencyInjection/Compiler/ModelPass.php
+++ b/app/bundles/CoreBundle/DependencyInjection/Compiler/ModelPass.php
@@ -8,7 +8,7 @@ use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-class ModelPass implements CompilerPassInterface
+final class ModelPass implements CompilerPassInterface
 {
     public const TAG = 'mautic.model';
 

--- a/app/bundles/CoreBundle/DependencyInjection/Compiler/ORMPurgerPass.php
+++ b/app/bundles/CoreBundle/DependencyInjection/Compiler/ORMPurgerPass.php
@@ -9,7 +9,7 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-class ORMPurgerPass implements CompilerPassInterface
+final class ORMPurgerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {

--- a/app/bundles/CoreBundle/DependencyInjection/Compiler/PermissionsPass.php
+++ b/app/bundles/CoreBundle/DependencyInjection/Compiler/PermissionsPass.php
@@ -7,7 +7,7 @@ namespace Mautic\CoreBundle\DependencyInjection\Compiler;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class PermissionsPass implements CompilerPassInterface
+final class PermissionsPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {

--- a/app/bundles/CoreBundle/DependencyInjection/Compiler/PreUpdateCheckPass.php
+++ b/app/bundles/CoreBundle/DependencyInjection/Compiler/PreUpdateCheckPass.php
@@ -8,7 +8,7 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-class PreUpdateCheckPass implements CompilerPassInterface
+final class PreUpdateCheckPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {

--- a/app/bundles/CoreBundle/DependencyInjection/Compiler/RequirementsPass.php
+++ b/app/bundles/CoreBundle/DependencyInjection/Compiler/RequirementsPass.php
@@ -6,7 +6,7 @@ use Mautic\CoreBundle\Exception\MessageOnlyErrorHandlerException;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class RequirementsPass implements CompilerPassInterface
+final class RequirementsPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {

--- a/app/bundles/CoreBundle/DependencyInjection/Compiler/ShortenerServicePass.php
+++ b/app/bundles/CoreBundle/DependencyInjection/Compiler/ShortenerServicePass.php
@@ -7,7 +7,7 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-class ShortenerServicePass implements CompilerPassInterface
+final class ShortenerServicePass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {

--- a/app/bundles/CoreBundle/DependencyInjection/Compiler/SystemThemeTemplatePathPass.php
+++ b/app/bundles/CoreBundle/DependencyInjection/Compiler/SystemThemeTemplatePathPass.php
@@ -8,7 +8,7 @@ use Symfony\Component\Config\Resource\FileExistenceResource;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class SystemThemeTemplatePathPass implements CompilerPassInterface
+final class SystemThemeTemplatePathPass implements CompilerPassInterface
 {
     /**
      * Processes the container to update Twig template paths.

--- a/app/bundles/CoreBundle/DependencyInjection/Compiler/TranslationLoaderPass.php
+++ b/app/bundles/CoreBundle/DependencyInjection/Compiler/TranslationLoaderPass.php
@@ -6,7 +6,7 @@ use Mautic\CoreBundle\Translation\TranslatorLoader;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class TranslationLoaderPass implements CompilerPassInterface
+final class TranslationLoaderPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {

--- a/app/bundles/CoreBundle/DependencyInjection/Compiler/TranslationsPass.php
+++ b/app/bundles/CoreBundle/DependencyInjection/Compiler/TranslationsPass.php
@@ -7,7 +7,7 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-class TranslationsPass implements CompilerPassInterface
+final class TranslationsPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {

--- a/app/bundles/CoreBundle/DependencyInjection/Compiler/TwigPass.php
+++ b/app/bundles/CoreBundle/DependencyInjection/Compiler/TwigPass.php
@@ -7,7 +7,7 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-class TwigPass implements CompilerPassInterface
+final class TwigPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {

--- a/app/bundles/CoreBundle/DependencyInjection/Compiler/UpdateStepPass.php
+++ b/app/bundles/CoreBundle/DependencyInjection/Compiler/UpdateStepPass.php
@@ -6,7 +6,7 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-class UpdateStepPass implements CompilerPassInterface
+final class UpdateStepPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {

--- a/app/bundles/CoreBundle/MauticCoreBundle.php
+++ b/app/bundles/CoreBundle/MauticCoreBundle.php
@@ -7,7 +7,7 @@ use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class MauticCoreBundle extends Bundle
+final class MauticCoreBundle extends Bundle
 {
     public function build(ContainerBuilder $container): void
     {

--- a/app/bundles/DashboardBundle/MauticDashboardBundle.php
+++ b/app/bundles/DashboardBundle/MauticDashboardBundle.php
@@ -4,6 +4,6 @@ namespace Mautic\DashboardBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class MauticDashboardBundle extends Bundle
+final class MauticDashboardBundle extends Bundle
 {
 }

--- a/app/bundles/DynamicContentBundle/MauticDynamicContentBundle.php
+++ b/app/bundles/DynamicContentBundle/MauticDynamicContentBundle.php
@@ -4,6 +4,6 @@ namespace Mautic\DynamicContentBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class MauticDynamicContentBundle extends Bundle
+final class MauticDynamicContentBundle extends Bundle
 {
 }

--- a/app/bundles/EmailBundle/DependencyInjection/Compiler/StatHelperPass.php
+++ b/app/bundles/EmailBundle/DependencyInjection/Compiler/StatHelperPass.php
@@ -6,7 +6,7 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-class StatHelperPass implements CompilerPassInterface
+final class StatHelperPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {

--- a/app/bundles/EmailBundle/MauticEmailBundle.php
+++ b/app/bundles/EmailBundle/MauticEmailBundle.php
@@ -9,7 +9,7 @@ use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class MauticEmailBundle extends Bundle
+final class MauticEmailBundle extends Bundle
 {
     public function build(ContainerBuilder $container): void
     {

--- a/app/bundles/FormBundle/MauticFormBundle.php
+++ b/app/bundles/FormBundle/MauticFormBundle.php
@@ -4,6 +4,6 @@ namespace Mautic\FormBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class MauticFormBundle extends Bundle
+final class MauticFormBundle extends Bundle
 {
 }

--- a/app/bundles/InstallBundle/DependencyInjection/Compiler/InstallCommandPass.php
+++ b/app/bundles/InstallBundle/DependencyInjection/Compiler/InstallCommandPass.php
@@ -9,7 +9,7 @@ use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class InstallCommandPass implements CompilerPassInterface
+final class InstallCommandPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {

--- a/app/bundles/InstallBundle/MauticInstallBundle.php
+++ b/app/bundles/InstallBundle/MauticInstallBundle.php
@@ -9,7 +9,7 @@ use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class MauticInstallBundle extends Bundle
+final class MauticInstallBundle extends Bundle
 {
     public function build(ContainerBuilder $container): void
     {

--- a/app/bundles/IntegrationsBundle/DependencyInjection/Compiler/AuthenticationIntegrationPass.php
+++ b/app/bundles/IntegrationsBundle/DependencyInjection/Compiler/AuthenticationIntegrationPass.php
@@ -8,7 +8,7 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-class AuthenticationIntegrationPass implements CompilerPassInterface
+final class AuthenticationIntegrationPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {

--- a/app/bundles/IntegrationsBundle/DependencyInjection/Compiler/BuilderIntegrationPass.php
+++ b/app/bundles/IntegrationsBundle/DependencyInjection/Compiler/BuilderIntegrationPass.php
@@ -8,7 +8,7 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-class BuilderIntegrationPass implements CompilerPassInterface
+final class BuilderIntegrationPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {

--- a/app/bundles/IntegrationsBundle/DependencyInjection/Compiler/ConfigIntegrationPass.php
+++ b/app/bundles/IntegrationsBundle/DependencyInjection/Compiler/ConfigIntegrationPass.php
@@ -8,7 +8,7 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-class ConfigIntegrationPass implements CompilerPassInterface
+final class ConfigIntegrationPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {

--- a/app/bundles/IntegrationsBundle/DependencyInjection/Compiler/IntegrationsPass.php
+++ b/app/bundles/IntegrationsBundle/DependencyInjection/Compiler/IntegrationsPass.php
@@ -8,7 +8,7 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-class IntegrationsPass implements CompilerPassInterface
+final class IntegrationsPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {

--- a/app/bundles/IntegrationsBundle/DependencyInjection/Compiler/SyncIntegrationsPass.php
+++ b/app/bundles/IntegrationsBundle/DependencyInjection/Compiler/SyncIntegrationsPass.php
@@ -8,7 +8,7 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-class SyncIntegrationsPass implements CompilerPassInterface
+final class SyncIntegrationsPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {

--- a/app/bundles/IntegrationsBundle/DependencyInjection/Compiler/TestPass.php
+++ b/app/bundles/IntegrationsBundle/DependencyInjection/Compiler/TestPass.php
@@ -9,7 +9,7 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-class TestPass implements CompilerPassInterface
+final class TestPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {

--- a/app/bundles/IntegrationsBundle/IntegrationsBundle.php
+++ b/app/bundles/IntegrationsBundle/IntegrationsBundle.php
@@ -14,7 +14,7 @@ use Mautic\IntegrationsBundle\DependencyInjection\Compiler\TestPass;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class IntegrationsBundle extends AbstractPluginBundle
+final class IntegrationsBundle extends AbstractPluginBundle
 {
     public function build(ContainerBuilder $container): void
     {

--- a/app/bundles/LeadBundle/MauticLeadBundle.php
+++ b/app/bundles/LeadBundle/MauticLeadBundle.php
@@ -4,6 +4,6 @@ namespace Mautic\LeadBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class MauticLeadBundle extends Bundle
+final class MauticLeadBundle extends Bundle
 {
 }

--- a/app/bundles/MarketplaceBundle/MarketplaceBundle.php
+++ b/app/bundles/MarketplaceBundle/MarketplaceBundle.php
@@ -6,6 +6,6 @@ namespace Mautic\MarketplaceBundle;
 
 use Mautic\PluginBundle\Bundle\PluginBundleBase;
 
-class MarketplaceBundle extends PluginBundleBase
+final class MarketplaceBundle extends PluginBundleBase
 {
 }

--- a/app/bundles/MessengerBundle/MauticMessengerBundle.php
+++ b/app/bundles/MessengerBundle/MauticMessengerBundle.php
@@ -6,6 +6,6 @@ namespace Mautic\MessengerBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class MauticMessengerBundle extends Bundle
+final class MauticMessengerBundle extends Bundle
 {
 }

--- a/app/bundles/NotificationBundle/MauticNotificationBundle.php
+++ b/app/bundles/NotificationBundle/MauticNotificationBundle.php
@@ -4,6 +4,6 @@ namespace Mautic\NotificationBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class MauticNotificationBundle extends Bundle
+final class MauticNotificationBundle extends Bundle
 {
 }

--- a/app/bundles/PageBundle/MauticPageBundle.php
+++ b/app/bundles/PageBundle/MauticPageBundle.php
@@ -4,6 +4,6 @@ namespace Mautic\PageBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class MauticPageBundle extends Bundle
+final class MauticPageBundle extends Bundle
 {
 }

--- a/app/bundles/PluginBundle/MauticPluginBundle.php
+++ b/app/bundles/PluginBundle/MauticPluginBundle.php
@@ -8,7 +8,7 @@ use Mautic\PluginBundle\Tests\DependencyInjection\Compiler\TestPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class MauticPluginBundle extends Bundle
+final class MauticPluginBundle extends Bundle
 {
     public function build(ContainerBuilder $container): void
     {

--- a/app/bundles/PluginBundle/Tests/DependencyInjection/Compiler/TestPass.php
+++ b/app/bundles/PluginBundle/Tests/DependencyInjection/Compiler/TestPass.php
@@ -10,7 +10,7 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-class TestPass implements CompilerPassInterface
+final class TestPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {

--- a/app/bundles/PointBundle/MauticPointBundle.php
+++ b/app/bundles/PointBundle/MauticPointBundle.php
@@ -4,6 +4,6 @@ namespace Mautic\PointBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class MauticPointBundle extends Bundle
+final class MauticPointBundle extends Bundle
 {
 }

--- a/app/bundles/ProjectBundle/MauticProjectBundle.php
+++ b/app/bundles/ProjectBundle/MauticProjectBundle.php
@@ -6,6 +6,6 @@ namespace Mautic\ProjectBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class MauticProjectBundle extends Bundle
+final class MauticProjectBundle extends Bundle
 {
 }

--- a/app/bundles/ReportBundle/MauticReportBundle.php
+++ b/app/bundles/ReportBundle/MauticReportBundle.php
@@ -4,6 +4,6 @@ namespace Mautic\ReportBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class MauticReportBundle extends Bundle
+final class MauticReportBundle extends Bundle
 {
 }

--- a/app/bundles/SmsBundle/DependencyInjection/Compiler/SmsTransportPass.php
+++ b/app/bundles/SmsBundle/DependencyInjection/Compiler/SmsTransportPass.php
@@ -6,7 +6,7 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-class SmsTransportPass implements CompilerPassInterface
+final class SmsTransportPass implements CompilerPassInterface
 {
     private ?ContainerBuilder $container = null;
 

--- a/app/bundles/SmsBundle/MauticSmsBundle.php
+++ b/app/bundles/SmsBundle/MauticSmsBundle.php
@@ -7,7 +7,7 @@ use Mautic\SmsBundle\DependencyInjection\Compiler\SmsTransportPass;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class MauticSmsBundle extends PluginBundleBase
+final class MauticSmsBundle extends PluginBundleBase
 {
     public function build(ContainerBuilder $container): void
     {

--- a/app/bundles/StageBundle/MauticStageBundle.php
+++ b/app/bundles/StageBundle/MauticStageBundle.php
@@ -4,6 +4,6 @@ namespace Mautic\StageBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class MauticStageBundle extends Bundle
+final class MauticStageBundle extends Bundle
 {
 }

--- a/app/bundles/StatsBundle/MauticStatsBundle.php
+++ b/app/bundles/StatsBundle/MauticStatsBundle.php
@@ -4,6 +4,6 @@ namespace Mautic\StatsBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class MauticStatsBundle extends Bundle
+final class MauticStatsBundle extends Bundle
 {
 }

--- a/app/bundles/UserBundle/DependencyInjection/Compiler/FormLoginAuthenticatorOptionsPass.php
+++ b/app/bundles/UserBundle/DependencyInjection/Compiler/FormLoginAuthenticatorOptionsPass.php
@@ -7,7 +7,7 @@ namespace Mautic\UserBundle\DependencyInjection\Compiler;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class FormLoginAuthenticatorOptionsPass implements CompilerPassInterface
+final class FormLoginAuthenticatorOptionsPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {

--- a/app/bundles/UserBundle/DependencyInjection/Compiler/OAuthReplacePass.php
+++ b/app/bundles/UserBundle/DependencyInjection/Compiler/OAuthReplacePass.php
@@ -8,7 +8,7 @@ use Mautic\UserBundle\Security\Authenticator\Oauth2Authenticator;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class OAuthReplacePass implements CompilerPassInterface
+final class OAuthReplacePass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {

--- a/app/bundles/UserBundle/DependencyInjection/Compiler/SsoAuthenticatorPass.php
+++ b/app/bundles/UserBundle/DependencyInjection/Compiler/SsoAuthenticatorPass.php
@@ -13,7 +13,7 @@ use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
  * This will replace $options in the
  * \Mautic\UserBundle\DependencyInjection\Firewall\Factory\MauticSsoFactory::createAuthenticator.
  */
-class SsoAuthenticatorPass implements CompilerPassInterface
+final class SsoAuthenticatorPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {

--- a/app/bundles/UserBundle/MauticUserBundle.php
+++ b/app/bundles/UserBundle/MauticUserBundle.php
@@ -12,7 +12,7 @@ use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class MauticUserBundle extends Bundle
+final class MauticUserBundle extends Bundle
 {
     public function build(ContainerBuilder $container): void
     {

--- a/app/bundles/WebhookBundle/MauticWebhookBundle.php
+++ b/app/bundles/WebhookBundle/MauticWebhookBundle.php
@@ -4,6 +4,6 @@ namespace Mautic\WebhookBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class MauticWebhookBundle extends Bundle
+final class MauticWebhookBundle extends Bundle
 {
 }

--- a/plugins/GrapesJsBuilderBundle/GrapesJsBuilderBundle.php
+++ b/plugins/GrapesJsBuilderBundle/GrapesJsBuilderBundle.php
@@ -6,6 +6,6 @@ namespace MauticPlugin\GrapesJsBuilderBundle;
 
 use Mautic\IntegrationsBundle\Bundle\AbstractPluginBundle;
 
-class GrapesJsBuilderBundle extends AbstractPluginBundle
+final class GrapesJsBuilderBundle extends AbstractPluginBundle
 {
 }

--- a/plugins/MauticClearbitBundle/MauticClearbitBundle.php
+++ b/plugins/MauticClearbitBundle/MauticClearbitBundle.php
@@ -4,6 +4,6 @@ namespace MauticPlugin\MauticClearbitBundle;
 
 use Mautic\PluginBundle\Bundle\PluginBundleBase;
 
-class MauticClearbitBundle extends PluginBundleBase
+final class MauticClearbitBundle extends PluginBundleBase
 {
 }

--- a/plugins/MauticCloudStorageBundle/MauticCloudStorageBundle.php
+++ b/plugins/MauticCloudStorageBundle/MauticCloudStorageBundle.php
@@ -4,6 +4,6 @@ namespace MauticPlugin\MauticCloudStorageBundle;
 
 use Mautic\PluginBundle\Bundle\PluginBundleBase;
 
-class MauticCloudStorageBundle extends PluginBundleBase
+final class MauticCloudStorageBundle extends PluginBundleBase
 {
 }

--- a/plugins/MauticCrmBundle/MauticCrmBundle.php
+++ b/plugins/MauticCrmBundle/MauticCrmBundle.php
@@ -4,6 +4,6 @@ namespace MauticPlugin\MauticCrmBundle;
 
 use Mautic\PluginBundle\Bundle\PluginBundleBase;
 
-class MauticCrmBundle extends PluginBundleBase
+final class MauticCrmBundle extends PluginBundleBase
 {
 }

--- a/plugins/MauticEmailMarketingBundle/MauticEmailMarketingBundle.php
+++ b/plugins/MauticEmailMarketingBundle/MauticEmailMarketingBundle.php
@@ -4,6 +4,6 @@ namespace MauticPlugin\MauticEmailMarketingBundle;
 
 use Mautic\PluginBundle\Bundle\PluginBundleBase;
 
-class MauticEmailMarketingBundle extends PluginBundleBase
+final class MauticEmailMarketingBundle extends PluginBundleBase
 {
 }

--- a/plugins/MauticFocusBundle/MauticFocusBundle.php
+++ b/plugins/MauticFocusBundle/MauticFocusBundle.php
@@ -4,6 +4,6 @@ namespace MauticPlugin\MauticFocusBundle;
 
 use Mautic\PluginBundle\Bundle\PluginBundleBase;
 
-class MauticFocusBundle extends PluginBundleBase
+final class MauticFocusBundle extends PluginBundleBase
 {
 }

--- a/plugins/MauticFullContactBundle/MauticFullContactBundle.php
+++ b/plugins/MauticFullContactBundle/MauticFullContactBundle.php
@@ -4,6 +4,6 @@ namespace MauticPlugin\MauticFullContactBundle;
 
 use Mautic\PluginBundle\Bundle\PluginBundleBase;
 
-class MauticFullContactBundle extends PluginBundleBase
+final class MauticFullContactBundle extends PluginBundleBase
 {
 }

--- a/plugins/MauticGmailBundle/MauticGmailBundle.php
+++ b/plugins/MauticGmailBundle/MauticGmailBundle.php
@@ -4,6 +4,6 @@ namespace MauticPlugin\MauticGmailBundle;
 
 use Mautic\PluginBundle\Bundle\PluginBundleBase;
 
-class MauticGmailBundle extends PluginBundleBase
+final class MauticGmailBundle extends PluginBundleBase
 {
 }

--- a/plugins/MauticOutlookBundle/MauticOutlookBundle.php
+++ b/plugins/MauticOutlookBundle/MauticOutlookBundle.php
@@ -4,6 +4,6 @@ namespace MauticPlugin\MauticOutlookBundle;
 
 use Mautic\PluginBundle\Bundle\PluginBundleBase;
 
-class MauticOutlookBundle extends PluginBundleBase
+final class MauticOutlookBundle extends PluginBundleBase
 {
 }

--- a/plugins/MauticSocialBundle/MauticSocialBundle.php
+++ b/plugins/MauticSocialBundle/MauticSocialBundle.php
@@ -4,6 +4,6 @@ namespace MauticPlugin\MauticSocialBundle;
 
 use Mautic\PluginBundle\Bundle\PluginBundleBase;
 
-class MauticSocialBundle extends PluginBundleBase
+final class MauticSocialBundle extends PluginBundleBase
 {
 }

--- a/plugins/MauticTagManagerBundle/MauticTagManagerBundle.php
+++ b/plugins/MauticTagManagerBundle/MauticTagManagerBundle.php
@@ -4,6 +4,6 @@ namespace MauticPlugin\MauticTagManagerBundle;
 
 use Mautic\PluginBundle\Bundle\PluginBundleBase;
 
-class MauticTagManagerBundle extends PluginBundleBase
+final class MauticTagManagerBundle extends PluginBundleBase
 {
 }

--- a/plugins/MauticZapierBundle/MauticZapierBundle.php
+++ b/plugins/MauticZapierBundle/MauticZapierBundle.php
@@ -4,6 +4,6 @@ namespace MauticPlugin\MauticZapierBundle;
 
 use Mautic\PluginBundle\Bundle\PluginBundleBase;
 
-class MauticZapierBundle extends PluginBundleBase
+final class MauticZapierBundle extends PluginBundleBase
 {
 }


### PR DESCRIPTION
Makes bundle and compiler pass classes `final`, as they are not meant to be extended.

Split out of #16738 for easier review.