### PR TITLE
[rector] add ConfigServiceToAutowiredServiceRector rule

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -27,6 +27,7 @@ parameters:
 		- plugins/*/node_modules/*
 		- plugins/*/vendor/*
 		- */Fixture/*
+		- */Source/*
 		# @todo handle once the other PRs are merged
 		- app/bundles/CoreBundle/Controller/AbstractStandardFormController.php
 	dynamicConstantNames:

--- a/utils/rector/src/ConfigServiceToAutowiredServiceRector.php
+++ b/utils/rector/src/ConfigServiceToAutowiredServiceRector.php
@@ -1,0 +1,444 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\Rector;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ArrayItem;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Name;
+use PhpParser\Node\Param;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\Return_;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Type\Type;
+use Rector\PhpParser\Node\BetterNodeFinder;
+use Rector\PhpParser\Parser\SimplePhpParser;
+use Rector\Rector\AbstractRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+/**
+ * Moves plain service definitions from bundle Config/config.php to the autowired Config/services.php next to it.
+ *
+ * Only "class" and "arguments" definitions are moved, as autowiring covers both:
+ *
+ *   'mautic.some.service' => ['class' => SomeService::class]  ->  $services->set('mautic.some.service', SomeService::class);
+ *
+ * The manual "arguments" are dropped, but only for a class whose constructor autowiring can fill on its own -
+ * a single scalar or array argument, e.g. a "%mautic.some_config%" parameter, keeps the whole definition in config.php.
+ *
+ * Definitions with "tag", "alias", "parent", "factory", ... are left in place,
+ * as moving them would silently drop their configuration.
+ *
+ * The move takes 2 runs on purpose - the 1st one registers the service in services.php,
+ * the 2nd one drops it from config.php. That way a service can never end up removed
+ * from config.php without being registered in services.php first.
+ */
+final class ConfigServiceToAutowiredServiceRector extends AbstractRector
+{
+    /**
+     * @var string
+     */
+    private const SERVICES_VARIABLE_NAME = 'services';
+
+    public function __construct(
+        private readonly SimplePhpParser $simplePhpParser,
+        private readonly BetterNodeFinder $betterNodeFinder,
+        private readonly ReflectionProvider $reflectionProvider,
+    ) {
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Return_::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        if (!$node instanceof Return_) {
+            return null;
+        }
+
+        if ($node->expr instanceof Array_) {
+            return $this->refactorConfigFile($node, $node->expr);
+        }
+
+        if ($node->expr instanceof Closure) {
+            return $this->refactorServicesFile($node, $node->expr);
+        }
+
+        return null;
+    }
+
+    private function refactorConfigFile(Return_ $return, Array_ $configArray): ?Return_
+    {
+        // the service is only dropped here once services.php registers it, never in the same run;
+        // Rector prints file by file, so services.php might not be updated yet
+        $registeredServiceNames = $this->resolveRegisteredServiceNames(
+            dirname($this->getFile()->getFilePath()).'/services.php'
+        );
+
+        if ([] === $registeredServiceNames) {
+            return null;
+        }
+
+        $servicesArray = $this->matchArrayValueByKey($configArray, 'services');
+        if (!$servicesArray instanceof Array_) {
+            return null;
+        }
+
+        $hasChanged = false;
+
+        foreach ($servicesArray->items as $groupArrayItem) {
+            $groupArray = $groupArrayItem->value;
+            if (!$groupArray instanceof Array_) {
+                continue;
+            }
+
+            $hasGroupChanged = false;
+
+            foreach ($groupArray->items as $key => $serviceArrayItem) {
+                if (!$this->matchServiceClass($serviceArrayItem) instanceof String_) {
+                    continue;
+                }
+
+                $serviceName = $serviceArrayItem->key;
+                if (!$serviceName instanceof String_ || !in_array($serviceName->value, $registeredServiceNames, true)) {
+                    continue;
+                }
+
+                unset($groupArray->items[$key]);
+                $hasGroupChanged = true;
+            }
+
+            if ($hasGroupChanged) {
+                $groupArray->items = array_values($groupArray->items);
+                $hasChanged = true;
+            }
+        }
+
+        if (!$hasChanged) {
+            return null;
+        }
+
+        return $return;
+    }
+
+    private function refactorServicesFile(Return_ $return, Closure $closure): ?Return_
+    {
+        if (!$this->isContainerConfiguratorClosure($closure)) {
+            return null;
+        }
+
+        $configFilePath = dirname($this->getFile()->getFilePath()).'/config.php';
+        if (!file_exists($configFilePath)) {
+            return null;
+        }
+
+        $serviceClassesByName = $this->resolveMovableServices($configFilePath);
+        if ([] === $serviceClassesByName) {
+            return null;
+        }
+
+        if (!$this->hasServicesVariable($closure)) {
+            return null;
+        }
+
+        $setStmts = [];
+
+        foreach ($serviceClassesByName as $serviceName => $className) {
+            if ($this->hasServiceSet($closure, $serviceName)) {
+                continue;
+            }
+
+            $setStmts[] = $this->createServiceSetStmt($serviceName, $className);
+        }
+
+        if ([] === $setStmts) {
+            return null;
+        }
+
+        $insertPosition = $this->resolveInsertPosition($closure);
+        array_splice($closure->stmts, $insertPosition, 0, $setStmts);
+
+        return $return;
+    }
+
+    /**
+     * @return string[] service names already registered in services.php
+     */
+    private function resolveRegisteredServiceNames(string $servicesFilePath): array
+    {
+        if (!file_exists($servicesFilePath)) {
+            return [];
+        }
+
+        $stmts = $this->simplePhpParser->parseFile($servicesFilePath);
+
+        $setMethodCalls = $this->betterNodeFinder->find(
+            $stmts,
+            fn (Node $node): bool => $node instanceof MethodCall && $this->isName($node->name, 'set')
+        );
+
+        $serviceNames = [];
+
+        foreach ($setMethodCalls as $setMethodCall) {
+            if (!$setMethodCall instanceof MethodCall) {
+                continue;
+            }
+
+            $firstArg = $setMethodCall->getArgs()[0] ?? null;
+            if (!$firstArg instanceof Arg || !$firstArg->value instanceof String_) {
+                continue;
+            }
+
+            $serviceNames[] = $firstArg->value->value;
+        }
+
+        return $serviceNames;
+    }
+
+    /**
+     * @return array<string, string> service name to class name
+     */
+    private function resolveMovableServices(string $configFilePath): array
+    {
+        $stmts = $this->simplePhpParser->parseFile($configFilePath);
+
+        $return = $this->betterNodeFinder->findFirstInstanceOf($stmts, Return_::class);
+        if (!$return instanceof Return_ || !$return->expr instanceof Array_) {
+            return [];
+        }
+
+        $servicesArray = $this->matchArrayValueByKey($return->expr, 'services');
+        if (!$servicesArray instanceof Array_) {
+            return [];
+        }
+
+        $serviceClassesByName = [];
+
+        foreach ($servicesArray->items as $groupArrayItem) {
+            $groupArray = $groupArrayItem->value;
+            if (!$groupArray instanceof Array_) {
+                continue;
+            }
+
+            foreach ($groupArray->items as $serviceArrayItem) {
+                $className = $this->matchServiceClass($serviceArrayItem);
+                if (!$className instanceof String_) {
+                    continue;
+                }
+
+                $serviceName = $serviceArrayItem->key;
+                if (!$serviceName instanceof String_) {
+                    continue;
+                }
+
+                $serviceClassesByName[$serviceName->value] = $className->value;
+            }
+        }
+
+        return $serviceClassesByName;
+    }
+
+    /**
+     * Matches a service definition made of a "class" key and optional "arguments",
+     * e.g. ['class' => SomeService::class] or ['class' => SomeService::class, 'arguments' => ['translator']].
+     */
+    private function matchServiceClass(ArrayItem $arrayItem): ?String_
+    {
+        if (!$arrayItem->key instanceof String_) {
+            return null;
+        }
+
+        // 3rd party class overrides, e.g. "oneup_uploader.controller.dropzone.class"; those are not autowirable
+        if (str_ends_with($arrayItem->key->value, '.class')) {
+            return null;
+        }
+
+        $definitionArray = $arrayItem->value;
+        if (!$definitionArray instanceof Array_) {
+            return null;
+        }
+
+        $definitionKeys = [];
+        foreach ($definitionArray->items as $definitionArrayItem) {
+            if (!$definitionArrayItem->key instanceof String_) {
+                return null;
+            }
+
+            $definitionKeys[] = $definitionArrayItem->key->value;
+        }
+
+        // "tag", "alias", "parent", "factory", ... would be silently dropped on the way
+        if ([] !== array_diff($definitionKeys, ['class', 'arguments'])) {
+            return null;
+        }
+
+        $classValue = $this->matchArrayValueByKey($definitionArray, 'class');
+        $className   = $this->matchClassName($classValue);
+        if (!$className instanceof String_) {
+            return null;
+        }
+
+        // manual arguments are only dropped when autowiring can fill every constructor argument on its own
+        if (in_array('arguments', $definitionKeys, true) && !$this->isAutowirableClass($className->value)) {
+            return null;
+        }
+
+        return $className;
+    }
+
+    private function matchClassName(?Node $classValue): ?String_
+    {
+        if ($classValue instanceof String_) {
+            return $classValue;
+        }
+
+        if (!$classValue instanceof ClassConstFetch || !$classValue->class instanceof Name) {
+            return null;
+        }
+
+        if (!$this->isName($classValue->name, 'class')) {
+            return null;
+        }
+
+        return new String_($classValue->class->toString());
+    }
+
+    private function isAutowirableClass(string $className): bool
+    {
+        if (!$this->reflectionProvider->hasClass($className)) {
+            return false;
+        }
+
+        $classReflection = $this->reflectionProvider->getClass($className);
+        if (!$classReflection->hasConstructor()) {
+            return true;
+        }
+
+        $parametersAcceptor = $classReflection->getConstructor()->getVariants()[0] ?? null;
+        if (null === $parametersAcceptor) {
+            return false;
+        }
+
+        foreach ($parametersAcceptor->getParameters() as $parameterReflection) {
+            if ($parameterReflection->getDefaultValue() instanceof Type) {
+                continue;
+            }
+
+            // scalars, arrays and parameters like "%mautic.some_config%" have to stay wired by hand
+            if (!$parameterReflection->getType()->isObject()->yes()) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function matchArrayValueByKey(Array_ $array, string $keyName): ?Node
+    {
+        foreach ($array->items as $arrayItem) {
+            if (!$arrayItem->key instanceof String_) {
+                continue;
+            }
+
+            if ($arrayItem->key->value !== $keyName) {
+                continue;
+            }
+
+            return $arrayItem->value;
+        }
+
+        return null;
+    }
+
+    private function isContainerConfiguratorClosure(Closure $closure): bool
+    {
+        $firstParam = $closure->params[0] ?? null;
+        if (!$firstParam instanceof Param) {
+            return false;
+        }
+
+        if (!$firstParam->type instanceof Name) {
+            return false;
+        }
+
+        return $this->isName($firstParam->type, ContainerConfigurator::class);
+    }
+
+    private function hasServicesVariable(Closure $closure): bool
+    {
+        $variable = $this->betterNodeFinder->findFirst(
+            $closure->stmts,
+            fn (Node $node): bool => $node instanceof Variable && $this->isName($node, self::SERVICES_VARIABLE_NAME)
+        );
+
+        return $variable instanceof Variable;
+    }
+
+    private function hasServiceSet(Closure $closure, string $serviceName): bool
+    {
+        $methodCall = $this->betterNodeFinder->findFirst(
+            $closure->stmts,
+            function (Node $node) use ($serviceName): bool {
+                if (!$node instanceof MethodCall || !$this->isName($node->name, 'set')) {
+                    return false;
+                }
+
+                $firstArg = $node->getArgs()[0] ?? null;
+
+                return $firstArg instanceof Arg
+                    && $firstArg->value instanceof String_
+                    && $firstArg->value->value === $serviceName;
+            }
+        );
+
+        return $methodCall instanceof MethodCall;
+    }
+
+    private function createServiceSetStmt(string $serviceName, string $className): Expression
+    {
+        $methodCall = new MethodCall(new Variable(self::SERVICES_VARIABLE_NAME), 'set', [
+            new Arg(new String_($serviceName)),
+            new Arg(new ClassConstFetch(new Name($className), 'class')),
+        ]);
+
+        return new Expression($methodCall);
+    }
+
+    /**
+     * Puts the new services right after the last $services->load(...) call, to keep them above aliases.
+     */
+    private function resolveInsertPosition(Closure $closure): int
+    {
+        $insertPosition = count($closure->stmts);
+
+        foreach ($closure->stmts as $key => $stmt) {
+            if (!$stmt instanceof Expression) {
+                continue;
+            }
+
+            $loadMethodCall = $this->betterNodeFinder->findFirst(
+                $stmt->expr,
+                fn (Node $node): bool => $node instanceof MethodCall && $this->isName($node->name, 'load')
+            );
+
+            if ($loadMethodCall instanceof MethodCall) {
+                $insertPosition = $key + 1;
+            }
+        }
+
+        return $insertPosition;
+    }
+}

--- a/utils/rector/src/ModelGetRepositoryToRepositoryServiceRector.php
+++ b/utils/rector/src/ModelGetRepositoryToRepositoryServiceRector.php
@@ -27,8 +27,6 @@ use Rector\NodeManipulator\ClassDependencyManipulator;
 use Rector\PhpParser\AstResolver;
 use Rector\PostRector\ValueObject\PropertyMetadata;
 use Rector\Rector\AbstractRector;
-use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
-use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
  * Replaces the argument-less $model->getRepository() service locator with the concrete repository service.
@@ -74,23 +72,6 @@ final class ModelGetRepositoryToRepositoryServiceRector extends AbstractRector
         private readonly ClassDependencyManipulator $classDependencyManipulator,
         private readonly NodeFinder $nodeFinder,
     ) {
-    }
-
-    public function getRuleDefinition(): RuleDefinition
-    {
-        return new RuleDefinition(
-            'Replace argument-less $model->getRepository() with the concrete repository service',
-            [
-                new CodeSample(
-                    <<<'CODE_SAMPLE'
-$form = $this->formModel->getRepository()->findOneById($id);
-CODE_SAMPLE,
-                    <<<'CODE_SAMPLE'
-$form = $this->formRepository->findOneById($id);
-CODE_SAMPLE
-                ),
-            ]
-        );
     }
 
     /**

--- a/utils/rector/src/UnserializeToSerializerDecodeRector.php
+++ b/utils/rector/src/UnserializeToSerializerDecodeRector.php
@@ -15,8 +15,6 @@ use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Scalar\String_;
 use Rector\Rector\AbstractRector;
-use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
-use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
  * Replaces raw unserialize() calls with the secure Serializer::decode() helper,
@@ -31,23 +29,6 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  */
 final class UnserializeToSerializerDecodeRector extends AbstractRector
 {
-    public function getRuleDefinition(): RuleDefinition
-    {
-        return new RuleDefinition(
-            'Replace unserialize() with Serializer::decode() to prevent PHP Object Injection',
-            [
-                new CodeSample(
-                    'unserialize($data);',
-                    '\\Mautic\\CoreBundle\\Helper\\Serializer::decode($data);',
-                ),
-                new CodeSample(
-                    "unserialize(\$data, ['allowed_classes' => false]);",
-                    '\\Mautic\\CoreBundle\\Helper\\Serializer::decode($data);',
-                ),
-            ]
-        );
-    }
-
     /**
      * @return array<class-string<Node>>
      */

--- a/utils/rector/tests/ConfigServiceToAutowiredServiceRector/ConfigServiceToAutowiredServiceRectorTest.php
+++ b/utils/rector/tests/ConfigServiceToAutowiredServiceRector/ConfigServiceToAutowiredServiceRectorTest.php
@@ -1,0 +1,337 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\Rector\Tests\ConfigServiceToAutowiredServiceRector;
+
+use PhpParser\Node\Stmt\Return_;
+use Rector\Application\Provider\CurrentFileProvider;
+use Rector\PhpParser\Node\BetterNodeFinder;
+use Rector\PhpParser\Parser\SimplePhpParser;
+use Rector\PhpParser\Printer\BetterStandardPrinter;
+use Rector\Testing\PHPUnit\AbstractLazyTestCase;
+use Rector\ValueObject\Application\File;
+use Utils\Rector\ConfigServiceToAutowiredServiceRector;
+
+/**
+ * The rule moves code between config.php and services.php of the very same directory,
+ * so it needs both files on disk - that is beyond what plain *.php.inc fixtures can express.
+ */
+final class ConfigServiceToAutowiredServiceRectorTest extends AbstractLazyTestCase
+{
+    private const CONFIG_WITH_CLASS_ONLY_SERVICE = <<<'CODE_SAMPLE'
+<?php
+
+return [
+    'services' => [
+        'others' => [
+            'mautic.some.helper' => [
+                'class' => SomeNamespace\SomeHelper::class,
+            ],
+            'mautic.some.wired_helper' => [
+                'class'     => SomeNamespace\SomeWiredHelper::class,
+                'arguments' => [
+                    'translator',
+                ],
+            ],
+        ],
+    ],
+];
+CODE_SAMPLE;
+
+    private const SERVICES_FILE = <<<'CODE_SAMPLE'
+<?php
+
+return function (\Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator $configurator): void {
+    $services = $configurator->services();
+
+    $services->load('SomeNamespace\\', '../');
+
+    $services->alias('mautic.some.model', SomeNamespace\SomeModel::class);
+};
+CODE_SAMPLE;
+
+    private const SERVICES_FILE_WITH_REGISTERED_SERVICE = <<<'CODE_SAMPLE'
+<?php
+
+return function (\Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator $configurator): void {
+    $services = $configurator->services();
+
+    $services->load('SomeNamespace\\', '../');
+
+    $services->set('mautic.some.helper', SomeNamespace\SomeHelper::class);
+
+    $services->alias('mautic.some.model', SomeNamespace\SomeModel::class);
+};
+CODE_SAMPLE;
+
+    private string $temporaryDirectory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // the container is shared between test cases, drop it to get a rule with a fresh file provider
+        self::$rectorConfig = null;
+
+        $this->temporaryDirectory = sys_get_temp_dir().'/rector_config_service_test_'.uniqid();
+        mkdir($this->temporaryDirectory, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->temporaryDirectory.'/*.php') ?: [] as $filePath) {
+            unlink($filePath);
+        }
+
+        rmdir($this->temporaryDirectory);
+
+        parent::tearDown();
+    }
+
+    public function testAddsClassOnlyServiceBelowLoad(): void
+    {
+        $this->createFile('config.php', self::CONFIG_WITH_CLASS_ONLY_SERVICE);
+
+        $printedFileContent = $this->refactorFile('services.php', self::SERVICES_FILE);
+        $this->assertIsString($printedFileContent);
+
+        $this->assertStringContainsString(
+            "\$services->set('mautic.some.helper', SomeNamespace\SomeHelper::class);",
+            $printedFileContent
+        );
+
+        // the manually wired service stays in config.php
+        $this->assertStringNotContainsString('mautic.some.wired_helper', $printedFileContent);
+
+        // the new service lands below loads and above aliases
+        $loadPosition  = strpos($printedFileContent, '$services->load');
+        $setPosition   = strpos($printedFileContent, '$services->set');
+        $aliasPosition = strpos($printedFileContent, '$services->alias');
+
+        $this->assertGreaterThan($loadPosition, $setPosition);
+        $this->assertGreaterThan($setPosition, $aliasPosition);
+    }
+
+    public function testAddsServiceWithAutowirableArguments(): void
+    {
+        $configFileContent = <<<'CODE_SAMPLE'
+<?php
+
+return [
+    'services' => [
+        'others' => [
+            'mautic.some.autowirable_helper' => [
+                'class'     => Utils\Rector\Tests\ConfigServiceToAutowiredServiceRector\Source\AutowirableHelper::class,
+                'arguments' => [
+                    'translator',
+                ],
+            ],
+        ],
+    ],
+];
+CODE_SAMPLE;
+
+        $this->createFile('config.php', $configFileContent);
+
+        $printedFileContent = $this->refactorFile('services.php', self::SERVICES_FILE);
+        $this->assertIsString($printedFileContent);
+
+        $this->assertStringContainsString(
+            "\$services->set('mautic.some.autowirable_helper', Utils\Rector\Tests\ConfigServiceToAutowiredServiceRector\Source\AutowirableHelper::class);",
+            $printedFileContent
+        );
+    }
+
+    public function testSkipServiceWithScalarConstructorArgument(): void
+    {
+        $configFileContent = <<<'CODE_SAMPLE'
+<?php
+
+return [
+    'services' => [
+        'others' => [
+            'mautic.some.parameter_aware_helper' => [
+                'class'     => Utils\Rector\Tests\ConfigServiceToAutowiredServiceRector\Source\ParameterAwareHelper::class,
+                'arguments' => [
+                    'translator',
+                    '%mautic.some_secret%',
+                ],
+            ],
+        ],
+    ],
+];
+CODE_SAMPLE;
+
+        $this->createFile('config.php', $configFileContent);
+
+        $this->assertNull($this->refactorFile('services.php', self::SERVICES_FILE));
+    }
+
+    public function testSkipServiceWithUnknownClass(): void
+    {
+        $configFileContent = <<<'CODE_SAMPLE'
+<?php
+
+return [
+    'services' => [
+        'others' => [
+            'mautic.some.wired_helper' => [
+                'class'     => SomeNamespace\SomeWiredHelper::class,
+                'arguments' => [
+                    'translator',
+                ],
+            ],
+        ],
+    ],
+];
+CODE_SAMPLE;
+
+        $this->createFile('config.php', $configFileContent);
+
+        $this->assertNull($this->refactorFile('services.php', self::SERVICES_FILE));
+    }
+
+    public function testRemovesAlreadyRegisteredServiceFromConfig(): void
+    {
+        $this->createFile('services.php', self::SERVICES_FILE_WITH_REGISTERED_SERVICE);
+
+        $printedFileContent = $this->refactorFile('config.php', self::CONFIG_WITH_CLASS_ONLY_SERVICE);
+        $this->assertIsString($printedFileContent);
+
+        $this->assertStringNotContainsString('mautic.some.helper', $printedFileContent);
+        $this->assertStringContainsString('mautic.some.wired_helper', $printedFileContent);
+    }
+
+    public function testSkipServiceNotRegisteredInServicesFileYet(): void
+    {
+        $this->createFile('services.php', self::SERVICES_FILE);
+
+        $this->assertNull($this->refactorFile('config.php', self::CONFIG_WITH_CLASS_ONLY_SERVICE));
+    }
+
+    public function testSkipConfigWithoutServicesFile(): void
+    {
+        $this->assertNull($this->refactorFile('config.php', self::CONFIG_WITH_CLASS_ONLY_SERVICE));
+    }
+
+    public function testSkipServiceWithTag(): void
+    {
+        $this->createFile('services.php', self::SERVICES_FILE_WITH_REGISTERED_SERVICE);
+
+        $configFileContent = <<<'CODE_SAMPLE'
+<?php
+
+return [
+    'services' => [
+        'events' => [
+            'mautic.some.helper' => [
+                'class' => SomeNamespace\SomeHelper::class,
+                'tag'   => 'kernel.event_subscriber',
+            ],
+        ],
+    ],
+];
+CODE_SAMPLE;
+
+        $this->assertNull($this->refactorFile('config.php', $configFileContent));
+    }
+
+    public function testSkipConfigWithoutServices(): void
+    {
+        $this->createFile('services.php', self::SERVICES_FILE_WITH_REGISTERED_SERVICE);
+
+        $configFileContent = <<<'CODE_SAMPLE'
+<?php
+
+return [
+    'routes' => [
+        'main' => [
+            'mautic_some_index' => [
+                'path' => '/some/{page}',
+            ],
+        ],
+    ],
+];
+CODE_SAMPLE;
+
+        $this->assertNull($this->refactorFile('config.php', $configFileContent));
+    }
+
+    public function testSkipThirdPartyClassOverride(): void
+    {
+        $configFileContent = <<<'CODE_SAMPLE'
+<?php
+
+return [
+    'services' => [
+        'others' => [
+            'oneup_uploader.controller.dropzone.class' => [
+                'class' => SomeNamespace\UploadController::class,
+            ],
+        ],
+    ],
+];
+CODE_SAMPLE;
+
+        $this->createFile('config.php', $configFileContent);
+
+        $this->assertNull($this->refactorFile('services.php', self::SERVICES_FILE));
+    }
+
+    public function testSkipAlreadyRegisteredService(): void
+    {
+        $this->createFile('config.php', self::CONFIG_WITH_CLASS_ONLY_SERVICE);
+
+        $servicesFileContent = <<<'CODE_SAMPLE'
+<?php
+
+return function (\Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator $configurator): void {
+    $services = $configurator->services();
+
+    $services->set('mautic.some.helper', SomeNamespace\SomeHelper::class);
+};
+CODE_SAMPLE;
+
+        $this->assertNull($this->refactorFile('services.php', $servicesFileContent));
+    }
+
+    private function createFile(string $fileName, string $fileContent): string
+    {
+        $filePath = $this->temporaryDirectory.'/'.$fileName;
+        file_put_contents($filePath, $fileContent);
+
+        return $filePath;
+    }
+
+    /**
+     * @return string|null printed file contents, null when the rule made no change
+     */
+    private function refactorFile(string $fileName, string $fileContent): ?string
+    {
+        $filePath = $this->createFile($fileName, $fileContent);
+
+        $currentFileProvider = new CurrentFileProvider();
+        $currentFileProvider->setFile(new File($filePath, $fileContent));
+
+        // must be shared, so the rule under test picks the very same file
+        self::getContainer()->instance(CurrentFileProvider::class, $currentFileProvider);
+
+        $simplePhpParser = $this->make(SimplePhpParser::class);
+        $stmts           = $simplePhpParser->parseString($fileContent);
+
+        $betterNodeFinder = $this->make(BetterNodeFinder::class);
+        $return           = $betterNodeFinder->findFirstInstanceOf($stmts, Return_::class);
+        $this->assertInstanceOf(Return_::class, $return);
+
+        $rector = $this->make(ConfigServiceToAutowiredServiceRector::class);
+
+        if (!$rector->refactor($return) instanceof Return_) {
+            return null;
+        }
+
+        $betterStandardPrinter = $this->make(BetterStandardPrinter::class);
+
+        return $betterStandardPrinter->print($stmts);
+    }
+}

--- a/utils/rector/tests/ConfigServiceToAutowiredServiceRector/Source/AutowirableHelper.php
+++ b/utils/rector/tests/ConfigServiceToAutowiredServiceRector/Source/AutowirableHelper.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\Rector\Tests\ConfigServiceToAutowiredServiceRector\Source;
+
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class AutowirableHelper
+{
+    public function __construct(private TranslatorInterface $translator)
+    {
+    }
+}

--- a/utils/rector/tests/ConfigServiceToAutowiredServiceRector/Source/ParameterAwareHelper.php
+++ b/utils/rector/tests/ConfigServiceToAutowiredServiceRector/Source/ParameterAwareHelper.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\Rector\Tests\ConfigServiceToAutowiredServiceRector\Source;
+
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class ParameterAwareHelper
+{
+    public function __construct(private TranslatorInterface $translator, private string $secret)
+    {
+    }
+}


### PR DESCRIPTION
Adds a Rector rule that moves plain service definitions out of bundle `Config/config.php` arrays into `Config/services.php`, where Symfony autowiring takes care of the constructor arguments.

The service id stays the same, so nothing that references the service by id has to change.

## What the rule does

```diff
 // app/bundles/StatsBundle/Config/config.php
 return [
     'services' => [
-        'other' => [
-            'mautic.stats.aggregate.collector' => [
-                'class'     => Mautic\StatsBundle\Aggregate\Collector::class,
-                'arguments' => [
-                    'event_dispatcher',
-                ],
-            ],
-        ],
+        'other' => [],
     ],
 ];
```

```diff
 // app/bundles/StatsBundle/Config/services.php
     $services->load('Mautic\\StatsBundle\\', '../')
         ->exclude('../{'.implode(',', array_merge(MauticCoreExtension::DEFAULT_EXCLUDES, $excludes)).'}');
+    $services->set('mautic.stats.aggregate.collector', Mautic\StatsBundle\Aggregate\Collector::class);
 };
```

The rule only converts definitions it can prove are safe to autowire - it skips services with tags, factories, calls, decorations, parameter arguments (`%mautic.something%`) or constructor arguments that cannot be resolved to an autowirable type.

## Notes

* The rule is **not** registered in `rector.php` yet. It is enabled in a follow-up PR, once the per-bundle conversion PRs are merged - otherwise the Rector CI check would fail on every not-yet-converted bundle.
* `getRuleDefinition()` was dropped from the two existing custom rules; `symplify/rule-doc-generator` is not a dependency of this repo, so those classes were not loadable.
* `phpstan.neon` excludes `*/Source/*` so the rule test fixtures are not analysed.
