### PR TITLE
[ApiBundle] flip config.php service to autowired service

### DIFF
--- a/app/bundles/ApiBundle/Config/config.php
+++ b/app/bundles/ApiBundle/Config/config.php
@@ -58,11 +58,7 @@ return [
     ],
 
     'services' => [
-        'helpers' => [
-            'mautic.api.helper.entity_result' => [
-                'class' => Mautic\ApiBundle\Helper\EntityResultHelper::class,
-            ],
-        ],
+        'helpers' => [],
         'other' => [
             'mautic.api.oauth.event_listener' => [
                 'class'     => Mautic\ApiBundle\EventListener\PreAuthorizationEventListener::class,

--- a/app/bundles/ApiBundle/Config/services.php
+++ b/app/bundles/ApiBundle/Config/services.php
@@ -24,6 +24,7 @@ return function (ContainerConfigurator $configurator): void {
         ->exclude('../{'.implode(',', array_merge(MauticCoreExtension::DEFAULT_EXCLUDES, $excludes)).'}');
 
     $services->load('Mautic\\ApiBundle\\Entity\\oAuth2\\', '../Entity/oAuth2/*Repository.php');
+    $services->set('mautic.api.helper.entity_result', Mautic\ApiBundle\Helper\EntityResultHelper::class);
 
     $services->alias(AuthorizeFormHandler::class, 'fos_oauth_server.authorize.form.handler.default');
 


### PR DESCRIPTION
Part of the split of the "config service to autowired service" conversion - one bundle per PR.

The service definition moves from the `Config/config.php` array to `Config/services.php`, where Symfony autowiring fills the constructor arguments. **The service id stays the same**, so any code or config referencing it by id keeps working.

Generated by [`ConfigServiceToAutowiredServiceRector`](https://github.com/mautic/mautic/pull/16761).

## Change shape

```diff
 // Config/config.php
-    'mautic.some.helper' => [
-        'class'     => Mautic\SomeBundle\Helper\SomeHelper::class,
-        'arguments' => [
-            'translator',
-        ],
-    ],
```

```diff
 // Config/services.php
+    $services->set('mautic.some.helper', Mautic\SomeBundle\Helper\SomeHelper::class);
```
