### PR TITLE
[config] use more generic types to enable autowiring

### DIFF
--- a/app/bundles/ApiBundle/EventListener/PreAuthorizationEventListener.php
+++ b/app/bundles/ApiBundle/EventListener/PreAuthorizationEventListener.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\ApiBundle\EventListener;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use FOS\OAuthServerBundle\Event\OAuthEvent;
 use Mautic\ApiBundle\Entity\oAuth2\Client;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
@@ -13,7 +13,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class PreAuthorizationEventListener
 {
     public function __construct(
-        private readonly EntityManager $em,
+        private readonly EntityManagerInterface $em,
         private readonly UserRepository $userRepository,
         private readonly CorePermissions $mauticSecurity,
         private readonly TranslatorInterface $translator,

--- a/app/bundles/ApiBundle/Model/ClientModel.php
+++ b/app/bundles/ApiBundle/Model/ClientModel.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\ApiBundle\Model;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\ApiBundle\ApiEvents;
 use Mautic\ApiBundle\Entity\oAuth2\Client;
 use Mautic\ApiBundle\Entity\oAuth2\ClientRepository;
@@ -40,7 +40,7 @@ class ClientModel extends FormModel implements GlobalSearchInterface
 
     public function __construct(
         private readonly RequestStack $requestStack,
-        EntityManager $em,
+        EntityManagerInterface $em,
         CorePermissions $security,
         EventDispatcherInterface $dispatcher,
         UrlGeneratorInterface $router,

--- a/app/bundles/AssetBundle/EventListener/StatsSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/StatsSubscriber.php
@@ -2,14 +2,14 @@
 
 namespace Mautic\AssetBundle\EventListener;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\AssetBundle\Entity\Download;
 use Mautic\CoreBundle\EventListener\CommonStatsSubscriber;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 
 final class StatsSubscriber extends CommonStatsSubscriber
 {
-    public function __construct(CorePermissions $security, EntityManager $entityManager)
+    public function __construct(CorePermissions $security, EntityManagerInterface $entityManager)
     {
         parent::__construct($security, $entityManager);
         $this->addContactRestrictedRepositories([Download::class]);

--- a/app/bundles/AssetBundle/Model/AssetModel.php
+++ b/app/bundles/AssetBundle/Model/AssetModel.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\AssetBundle\Model;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\PersistentCollection;
 use Mautic\AssetBundle\AssetEvents;
 use Mautic\AssetBundle\Entity\Asset;
@@ -61,7 +61,7 @@ class AssetModel extends FormModel implements GlobalSearchInterface
         private readonly DeviceDetectorFactoryInterface $deviceDetectorFactory,
         private readonly DeviceTrackingServiceInterface $deviceTrackingService,
         private readonly ContactTracker $contactTracker,
-        EntityManager $em,
+        EntityManagerInterface $em,
         CorePermissions $security,
         EventDispatcherInterface $dispatcher,
         UrlGeneratorInterface $router,

--- a/app/bundles/CampaignBundle/Controller/CampaignController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignController.php
@@ -3,7 +3,7 @@
 namespace Mautic\CampaignBundle\Controller;
 
 use Doctrine\DBAL\Cache\CacheException;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
 use Mautic\AssetBundle\Event\AssetExportListEvent;
 use Mautic\CampaignBundle\Entity\Campaign;
@@ -112,7 +112,7 @@ class CampaignController extends AbstractStandardFormController
         private LoggerInterface $logger,
         private RequestStack $requestStack,
         CorePermissions $security,
-        private EntityManager $em,
+        private EntityManagerInterface $em,
         private PublishStateService $publishStateService,
         private CampaignModel $campaignModel,
         private EventModel $eventModel,

--- a/app/bundles/CampaignBundle/EventListener/StatsSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/StatsSubscriber.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\CampaignBundle\EventListener;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CampaignBundle\Entity\Lead;
 use Mautic\CampaignBundle\Entity\LeadEventLog;
 use Mautic\CoreBundle\EventListener\CommonStatsSubscriber;
@@ -10,7 +10,7 @@ use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 
 final class StatsSubscriber extends CommonStatsSubscriber
 {
-    public function __construct(CorePermissions $security, EntityManager $entityManager)
+    public function __construct(CorePermissions $security, EntityManagerInterface $entityManager)
     {
         parent::__construct($security, $entityManager);
         $this->addContactRestrictedRepositories(

--- a/app/bundles/CampaignBundle/Model/CampaignModel.php
+++ b/app/bundles/CampaignBundle/Model/CampaignModel.php
@@ -3,7 +3,7 @@
 namespace Mautic\CampaignBundle\Model;
 
 use Doctrine\DBAL\Exception;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\PersistentCollection;
 use Mautic\CampaignBundle\CampaignEvents;
 use Mautic\CampaignBundle\Entity\Campaign;
@@ -57,7 +57,7 @@ class CampaignModel extends CommonFormModel implements GlobalSearchInterface
         private readonly MembershipBuilder $membershipBuilder,
         private readonly ContactTracker $contactTracker,
         private readonly GeneratedColumnsProviderInterface $generatedColumnsProvider,
-        EntityManager $em,
+        EntityManagerInterface $em,
         CorePermissions $security,
         EventDispatcherInterface $dispatcher,
         UrlGeneratorInterface $router,

--- a/app/bundles/CampaignBundle/Model/EventLogModel.php
+++ b/app/bundles/CampaignBundle/Model/EventLogModel.php
@@ -3,7 +3,7 @@
 namespace Mautic\CampaignBundle\Model;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CampaignBundle\Entity\LeadEventLog;
 use Mautic\CampaignBundle\Entity\LeadEventLogRepository;
@@ -30,7 +30,7 @@ class EventLogModel extends AbstractCommonModel
         protected CampaignModel $campaignModel,
         protected IpLookupHelper $ipLookupHelper,
         protected EventScheduler $eventScheduler,
-        EntityManager $em,
+        EntityManagerInterface $em,
         CorePermissions $security,
         EventDispatcherInterface $dispatcher,
         UrlGeneratorInterface $router,

--- a/app/bundles/CategoryBundle/Form/Type/CategoryListType.php
+++ b/app/bundles/CategoryBundle/Form/Type/CategoryListType.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\CategoryBundle\Form\Type;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CategoryBundle\Entity\Category;
 use Mautic\CategoryBundle\Model\CategoryModel;
 use Mautic\CoreBundle\Form\DataTransformer\IdToEntityModelTransformer;
@@ -20,7 +20,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 final class CategoryListType extends AbstractType
 {
     public function __construct(
-        private readonly EntityManager $em,
+        private readonly EntityManagerInterface $em,
         private readonly TranslatorInterface $translator,
         private readonly CategoryModel $model,
         private readonly RouterInterface $router,

--- a/app/bundles/CategoryBundle/Model/CategoryModel.php
+++ b/app/bundles/CategoryBundle/Model/CategoryModel.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\CategoryBundle\Model;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CategoryBundle\CategoryEvents;
 use Mautic\CategoryBundle\Entity\Category;
 use Mautic\CategoryBundle\Entity\CategoryRepository;
@@ -36,7 +36,7 @@ class CategoryModel extends FormModel implements AjaxLookupModelInterface
 
     public function __construct(
         protected RequestStack $requestStack,
-        EntityManager $em,
+        EntityManagerInterface $em,
         CorePermissions $security,
         EventDispatcherInterface $dispatcher,
         UrlGeneratorInterface $router,

--- a/app/bundles/ChannelBundle/Model/MessageModel.php
+++ b/app/bundles/ChannelBundle/Model/MessageModel.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\ChannelBundle\Model;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CampaignBundle\Model\CampaignModel;
 use Mautic\ChannelBundle\ChannelEvents;
 use Mautic\ChannelBundle\Entity\Message;
@@ -39,7 +39,7 @@ class MessageModel extends FormModel implements AjaxLookupModelInterface, Global
     public function __construct(
         protected ChannelListHelper $channelListHelper,
         protected CampaignModel $campaignModel,
-        EntityManager $em,
+        EntityManagerInterface $em,
         CorePermissions $security,
         EventDispatcherInterface $dispatcher,
         UrlGeneratorInterface $router,

--- a/app/bundles/CoreBundle/Command/MaxMindDoNotSellPurgeCommand.php
+++ b/app/bundles/CoreBundle/Command/MaxMindDoNotSellPurgeCommand.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\CoreBundle\Command;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\IpLookup\DoNotSellList\MaxMindDoNotSellList;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadRepository;
@@ -35,7 +35,7 @@ TXT
 class MaxMindDoNotSellPurgeCommand extends Command
 {
     public function __construct(
-        private readonly EntityManager $em,
+        private readonly EntityManagerInterface $em,
         private readonly LeadRepository $leadRepository,
         private readonly MaxMindDoNotSellList $doNotSellList,
     ) {

--- a/app/bundles/CoreBundle/EventListener/CommonStatsSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/CommonStatsSubscriber.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\CoreBundle\EventListener;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Entity\CommonRepository;
 use Mautic\CoreBundle\Event\StatsEvent;
@@ -29,7 +29,7 @@ abstract class CommonStatsSubscriber implements EventSubscriberInterface
 
     public function __construct(
         protected CorePermissions $security,
-        protected EntityManager $entityManager,
+        protected EntityManagerInterface $entityManager,
     ) {
     }
 

--- a/app/bundles/CoreBundle/EventListener/ExceptionListener.php
+++ b/app/bundles/CoreBundle/EventListener/ExceptionListener.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpKernel\EventListener\ErrorListener;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
-use Symfony\Component\Routing\Router;
+use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\LazyResponseException;
@@ -29,7 +29,7 @@ class ExceptionListener extends ErrorListener
      * @param string|object|mixed[]|null $controller
      */
     public function __construct(
-        protected Router $router,
+        protected RouterInterface $router,
         string|object|array|null $controller,
         LoggerInterface $logger,
     ) {

--- a/app/bundles/CoreBundle/EventListener/StatsSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/StatsSubscriber.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\CoreBundle\EventListener;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Entity\AuditLogRepository;
 use Mautic\CoreBundle\Entity\IpAddressRepository;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
@@ -11,7 +11,7 @@ final class StatsSubscriber extends CommonStatsSubscriber
 {
     public function __construct(
         CorePermissions $security,
-        EntityManager $entityManager,
+        EntityManagerInterface $entityManager,
         AuditLogRepository $auditLogRepository,
         IpAddressRepository $ipAddressRepository,
     ) {

--- a/app/bundles/CoreBundle/Helper/IpLookupHelper.php
+++ b/app/bundles/CoreBundle/Helper/IpLookupHelper.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\CoreBundle\Helper;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Entity\IpAddress;
 use Mautic\CoreBundle\Entity\IpAddressRepository;
 use Mautic\CoreBundle\IpLookup\AbstractLookup;
@@ -46,7 +46,7 @@ class IpLookupHelper
 
     public function __construct(
         protected RequestStack $requestStack,
-        protected EntityManager $em,
+        protected EntityManagerInterface $em,
         CoreParametersHelper $coreParametersHelper,
         private readonly DeviceDetectorFactoryInterface $deviceDetectorFactory,
         protected ?AbstractLookup $ipLookup = null,

--- a/app/bundles/CoreBundle/Helper/Update/PreUpdateChecks/CheckDatabaseDriverAndVersion.php
+++ b/app/bundles/CoreBundle/Helper/Update/PreUpdateChecks/CheckDatabaseDriverAndVersion.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\Helper\Update\PreUpdateChecks;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\InstallBundle\Configurator\Step\DoctrineStep;
 
 class CheckDatabaseDriverAndVersion extends AbstractPreUpdateCheck
 {
     public function __construct(
-        private readonly EntityManager $em,
+        private readonly EntityManagerInterface $em,
     ) {
     }
 

--- a/app/bundles/CoreBundle/Model/NotificationModel.php
+++ b/app/bundles/CoreBundle/Model/NotificationModel.php
@@ -17,7 +17,7 @@ use Mautic\UserBundle\Entity\User;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
@@ -47,12 +47,9 @@ class NotificationModel extends FormModel
         parent::__construct($em, $security, $dispatcher, $router, $translator, $userHelper, $mauticLogger, $coreParametersHelper);
     }
 
-    private function getSession(): Session
+    private function getSession(): SessionInterface
     {
-        $session = $this->requestStack->getSession();
-        \assert($session instanceof Session);
-
-        return $session;
+        return $this->requestStack->getSession();
     }
 
     /**

--- a/app/bundles/CoreBundle/Model/NotificationModel.php
+++ b/app/bundles/CoreBundle/Model/NotificationModel.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\CoreBundle\Model;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Entity\Notification;
 use Mautic\CoreBundle\Entity\NotificationRepository;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
@@ -34,7 +34,7 @@ class NotificationModel extends FormModel
         protected PathsHelper $pathsHelper,
         protected UpdateHelper $updateHelper,
         CoreParametersHelper $coreParametersHelper,
-        EntityManager $em,
+        EntityManagerInterface $em,
         CorePermissions $security,
         EventDispatcherInterface $dispatcher,
         UrlGeneratorInterface $router,

--- a/app/bundles/CoreBundle/Test/AbstractMauticTestCase.php
+++ b/app/bundles/CoreBundle/Test/AbstractMauticTestCase.php
@@ -6,7 +6,7 @@ namespace Mautic\CoreBundle\Test;
 
 use Doctrine\Common\DataFixtures\Executor\AbstractExecutor;
 use Doctrine\DBAL\Connection;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Liip\TestFixturesBundle\Services\DatabaseToolCollection;
 use Liip\TestFixturesBundle\Services\DatabaseTools\AbstractDatabaseTool;
@@ -26,7 +26,7 @@ use Symfony\Component\Routing\Router;
 
 abstract class AbstractMauticTestCase extends WebTestCase
 {
-    protected EntityManager $em;
+    protected EntityManagerInterface $em;
 
     protected Connection $connection;
 

--- a/app/bundles/CoreBundle/Test/AbstractMauticTestCase.php
+++ b/app/bundles/CoreBundle/Test/AbstractMauticTestCase.php
@@ -6,6 +6,7 @@ namespace Mautic\CoreBundle\Test;
 
 use Doctrine\Common\DataFixtures\Executor\AbstractExecutor;
 use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Liip\TestFixturesBundle\Services\DatabaseToolCollection;
 use Liip\TestFixturesBundle\Services\DatabaseTools\AbstractDatabaseTool;
@@ -25,7 +26,7 @@ use Symfony\Component\Routing\Router;
 
 abstract class AbstractMauticTestCase extends WebTestCase
 {
-    protected EntityManagerInterface $em;
+    protected EntityManager $em;
 
     protected Connection $connection;
 

--- a/app/bundles/CoreBundle/Test/AbstractMauticTestCase.php
+++ b/app/bundles/CoreBundle/Test/AbstractMauticTestCase.php
@@ -7,7 +7,6 @@ namespace Mautic\CoreBundle\Test;
 use Doctrine\Common\DataFixtures\Executor\AbstractExecutor;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\EntityManagerInterface;
 use Liip\TestFixturesBundle\Services\DatabaseToolCollection;
 use Liip\TestFixturesBundle\Services\DatabaseTools\AbstractDatabaseTool;
 use Mautic\EmailBundle\Mailer\Message\MauticMessage;

--- a/app/bundles/DynamicContentBundle/EventListener/StatsSubscriber.php
+++ b/app/bundles/DynamicContentBundle/EventListener/StatsSubscriber.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\DynamicContentBundle\EventListener;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\EventListener\CommonStatsSubscriber;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\DynamicContentBundle\Entity\DynamicContentLeadData;
@@ -10,7 +10,7 @@ use Mautic\DynamicContentBundle\Entity\Stat;
 
 final class StatsSubscriber extends CommonStatsSubscriber
 {
-    public function __construct(CorePermissions $security, EntityManager $entityManager)
+    public function __construct(CorePermissions $security, EntityManagerInterface $entityManager)
     {
         parent::__construct($security, $entityManager);
         $this->addContactRestrictedRepositories(

--- a/app/bundles/DynamicContentBundle/Form/Type/DynamicContentType.php
+++ b/app/bundles/DynamicContentBundle/Form/Type/DynamicContentType.php
@@ -4,7 +4,7 @@ namespace Mautic\DynamicContentBundle\Form\Type;
 
 use DeviceDetector\Parser\Device\AbstractDeviceParser as DeviceParser;
 use DeviceDetector\Parser\OperatingSystem;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CategoryBundle\Form\Type\CategoryListType;
 use Mautic\CoreBundle\Form\DataTransformer\IdToEntityModelTransformer;
 use Mautic\CoreBundle\Form\EventListener\CleanFormSubscriber;
@@ -85,7 +85,7 @@ final class DynamicContentType extends AbstractType
      * @throws \InvalidArgumentException
      */
     public function __construct(
-        private readonly EntityManager $em,
+        private readonly EntityManagerInterface $em,
         ListModel $listModel,
         private readonly TranslatorInterface $translator,
         private readonly LeadModel $leadModel,

--- a/app/bundles/EmailBundle/EventListener/BroadcastSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/BroadcastSubscriber.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\EmailBundle\EventListener;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\ChannelBundle\ChannelEvents;
 use Mautic\ChannelBundle\Event\ChannelBroadcastEvent;
 use Mautic\CoreBundle\Helper\DateTimeHelper;
@@ -15,7 +15,7 @@ final readonly class BroadcastSubscriber implements EventSubscriberInterface
 {
     public function __construct(
         private EmailModel $model,
-        private EntityManager $em,
+        private EntityManagerInterface $em,
         private TranslatorInterface $translator,
     ) {
     }

--- a/app/bundles/EmailBundle/EventListener/PointSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/PointSubscriber.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\EmailBundle\EventListener;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityNotFoundException;
 use Mautic\EmailBundle\EmailEvents;
 use Mautic\EmailBundle\Event\EmailOpenEvent;
@@ -22,7 +22,7 @@ final readonly class PointSubscriber implements EventSubscriberInterface
 {
     public function __construct(
         private PointModel $pointModel,
-        private EntityManager $entityManager,
+        private EntityManagerInterface $entityManager,
         private PointEventHelper $pointEventHelper,
     ) {
     }

--- a/app/bundles/EmailBundle/EventListener/StatsSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/StatsSubscriber.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\EmailBundle\EventListener;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\EventListener\CommonStatsSubscriber;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\EmailBundle\Entity\EmailReply;
@@ -13,7 +13,7 @@ final class StatsSubscriber extends CommonStatsSubscriber
 {
     public function __construct(
         CorePermissions $security,
-        EntityManager $entityManager,
+        EntityManagerInterface $entityManager,
         StatDeviceRepository $statDeviceRepository,
         StatRepository $statRepository,
     ) {

--- a/app/bundles/EmailBundle/Tests/Controller/AjaxControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/AjaxControllerFunctionalTest.php
@@ -271,7 +271,7 @@ final class AjaxControllerFunctionalTest extends MauticMysqlTestCase
         $email->setSubject('Email Subject');
         $email->setEmailType('template');
         $this->em->persist($email);
-        $this->em->flush($email);
+        $this->em->flush();
 
         $payload = [
             'action'     => 'email:getLookupChoiceList',

--- a/app/bundles/EmailBundle/Tests/Controller/EmailControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailControllerFunctionalTest.php
@@ -1255,7 +1255,7 @@ final class EmailControllerFunctionalTest extends MauticMysqlTestCase
 
         $email = $this->createEmail('Email A', self::SUBJECT_A, 'list', 'blank', 'Ahoy <i>{contactfield=email}</i><a href="https://mautic.org">Mautic</a>', $segment);
         $this->em->persist($email);
-        $this->em->flush($email);
+        $this->em->flush();
 
         // Schedule the email to be sent
         $crawler       = $this->client->request(Request::METHOD_GET, "/s/emails/scheduleSend/{$email->getId()}");
@@ -1302,7 +1302,7 @@ final class EmailControllerFunctionalTest extends MauticMysqlTestCase
 
         $email = $this->createEmail('Email A', self::SUBJECT_A, 'list', 'blank', 'Ahoy <i>{contactfield=email}</i><a href="https://mautic.org">Mautic</a>', $segment);
         $this->em->persist($email);
-        $this->em->flush($email);
+        $this->em->flush();
 
         // Schedule the email to be sent
         $crawler = $this->client->request(Request::METHOD_GET, "/s/emails/scheduleSend/{$email->getId()}");

--- a/app/bundles/EmailBundle/Tests/Controller/PublicControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/PublicControllerFunctionalTest.php
@@ -115,7 +115,7 @@ final class PublicControllerFunctionalTest extends MauticMysqlTestCase
 
         $this->client->request('GET', '/email/unsubscribe/'.$stat->getTrackingHash());
 
-        $this->em->clear(Page::class);
+        $this->em->clear();
 
         $entity = self::getContainer()->get(PageRepository::class)->getEntity($stat->getEmail()->getPreferenceCenter()->getId());
         $this->assertSame(1, $entity->getHits(), $this->client->getResponse()->getContent());

--- a/app/bundles/FormBundle/Command/DeleteOrphanFormResultsTableCommand.php
+++ b/app/bundles/FormBundle/Command/DeleteOrphanFormResultsTableCommand.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Mautic\FormBundle\Command;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Helper\ExitCode;
 use Mautic\FormBundle\Entity\FormRepository;
 use Psr\Log\LoggerInterface;
@@ -26,7 +26,7 @@ class DeleteOrphanFormResultsTableCommand extends Command
     private readonly Connection $conn;
 
     public function __construct(
-        private readonly EntityManager $entityManager,
+        private readonly EntityManagerInterface $entityManager,
         private readonly LoggerInterface $logger,
         private readonly TranslatorInterface $translator,
         private readonly FormRepository $formRepository,

--- a/app/bundles/FormBundle/EventListener/StatsSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/StatsSubscriber.php
@@ -2,14 +2,14 @@
 
 namespace Mautic\FormBundle\EventListener;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\EventListener\CommonStatsSubscriber;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\FormBundle\Entity\Submission;
 
 final class StatsSubscriber extends CommonStatsSubscriber
 {
-    public function __construct(CorePermissions $security, EntityManager $entityManager)
+    public function __construct(CorePermissions $security, EntityManagerInterface $entityManager)
     {
         parent::__construct($security, $entityManager);
         $this->addContactRestrictedRepositories([Submission::class]);

--- a/app/bundles/FormBundle/Model/FieldModel.php
+++ b/app/bundles/FormBundle/Model/FieldModel.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\FormBundle\Model;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Doctrine\Helper\ColumnSchemaHelper;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\UserHelper;
@@ -32,7 +32,7 @@ class FieldModel extends CommonFormModel
 {
     public function __construct(
         protected LeadFieldModel $leadFieldModel,
-        EntityManager $em,
+        EntityManagerInterface $em,
         CorePermissions $security,
         EventDispatcherInterface $dispatcher,
         UrlGeneratorInterface $router,

--- a/app/bundles/FormBundle/Model/SubmissionModel.php
+++ b/app/bundles/FormBundle/Model/SubmissionModel.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\FormBundle\Model;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\ORMException;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use Mautic\CampaignBundle\Entity\Campaign;
@@ -92,7 +92,7 @@ class SubmissionModel extends CommonFormModel
         private readonly ContactTracker $contactTracker,
         private readonly ContactMerger $contactMerger,
         private readonly FieldsWithUniqueIdentifier $fieldsWithUniqueIdentifier,
-        EntityManager $em,
+        EntityManagerInterface $em,
         CorePermissions $security,
         EventDispatcherInterface $dispatcher,
         UrlGeneratorInterface $router,

--- a/app/bundles/FormBundle/Model/SubmissionResultLoader.php
+++ b/app/bundles/FormBundle/Model/SubmissionResultLoader.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\FormBundle\Model;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Model\MauticModelInterface;
 use Mautic\FormBundle\Entity\Submission;
 use Mautic\FormBundle\Entity\SubmissionRepository;
@@ -10,7 +10,7 @@ use Mautic\FormBundle\Entity\SubmissionRepository;
 class SubmissionResultLoader implements MauticModelInterface
 {
     public function __construct(
-        private readonly EntityManager $entityManager,
+        private readonly EntityManagerInterface $entityManager,
     ) {
     }
 

--- a/app/bundles/InstallBundle/Helper/SchemaHelper.php
+++ b/app/bundles/InstallBundle/Helper/SchemaHelper.php
@@ -9,7 +9,7 @@ use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\ForeignKeyConstraint;
 use Doctrine\DBAL\Schema\Index;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\ORMException;
 use Doctrine\ORM\Tools\SchemaTool;
 use Mautic\CoreBundle\Release\ThisRelease;
@@ -20,7 +20,7 @@ class SchemaHelper
     protected Connection $db;
 
     /**
-     * @var EntityManager
+     * @var EntityManagerInterface
      */
     protected $em;
 
@@ -62,7 +62,7 @@ class SchemaHelper
         $this->dbParams = $dbParams;
     }
 
-    public function setEntityManager(EntityManager $em): void
+    public function setEntityManager(EntityManagerInterface $em): void
     {
         $this->em = $em;
     }

--- a/app/bundles/InstallBundle/Install/InstallService.php
+++ b/app/bundles/InstallBundle/Install/InstallService.php
@@ -6,7 +6,7 @@ namespace Mautic\InstallBundle\Install;
 
 use Doctrine\Common\DataFixtures\Executor\ORMExecutor;
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Configurator\Configurator;
 use Mautic\CoreBundle\Configurator\Step\StepInterface;
 use Mautic\CoreBundle\Doctrine\Loader\FixturesLoaderInterface;
@@ -45,7 +45,7 @@ class InstallService
         private readonly Configurator $configurator,
         private readonly CacheHelper $cacheHelper,
         protected PathsHelper $pathsHelper,
-        private readonly EntityManager $entityManager,
+        private readonly EntityManagerInterface $entityManager,
         private readonly TranslatorInterface $translator,
         private readonly KernelInterface $kernel,
         private readonly ValidatorInterface $validator,

--- a/app/bundles/InstallBundle/Install/InstallService.php
+++ b/app/bundles/InstallBundle/Install/InstallService.php
@@ -26,7 +26,7 @@ use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\HttpKernel\KernelInterface;
-use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasher;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -49,7 +49,7 @@ class InstallService
         private readonly TranslatorInterface $translator,
         private readonly KernelInterface $kernel,
         private readonly ValidatorInterface $validator,
-        private readonly UserPasswordHasher $hasher,
+        private readonly UserPasswordHasherInterface $hasher,
         private readonly FixturesLoaderInterface $fixturesLoader,
     ) {
     }

--- a/app/bundles/IntegrationsBundle/Controller/ConfigController.php
+++ b/app/bundles/IntegrationsBundle/Controller/ConfigController.php
@@ -32,7 +32,6 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\Session\Session;
 
 final class ConfigController extends AbstractFormController
 {
@@ -78,7 +77,6 @@ final class ConfigController extends AbstractFormController
         }
 
         // Clear the session of previously stored fields in case it got stuck
-        /** @var Session $session */
         $session = $request->getSession();
         $session->remove("{$integration}-fields");
 

--- a/app/bundles/IntegrationsBundle/Migration/AbstractMigration.php
+++ b/app/bundles/IntegrationsBundle/Migration/AbstractMigration.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Mautic\IntegrationsBundle\Migration;
 
 use Doctrine\DBAL\Schema\Schema;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 
 abstract class AbstractMigration implements MigrationInterface
 {
@@ -15,7 +15,7 @@ abstract class AbstractMigration implements MigrationInterface
     private array $queries = [];
 
     public function __construct(
-        protected EntityManager $entityManager,
+        protected EntityManagerInterface $entityManager,
         protected string $tablePrefix,
     ) {
     }

--- a/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ReportBuilder/FieldBuilder.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ReportBuilder/FieldBuilder.php
@@ -12,7 +12,7 @@ use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Helper\FieldHelper;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\ObjectHelper\ContactObjectHelper;
 use Mautic\IntegrationsBundle\Sync\ValueNormalizer\ValueNormalizer;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Symfony\Component\Routing\Router;
+use Symfony\Component\Routing\RouterInterface;
 
 class FieldBuilder
 {
@@ -23,7 +23,7 @@ class FieldBuilder
     private ?RequestObjectDAO $requestObject = null;
 
     public function __construct(
-        private readonly Router $router,
+        private readonly RouterInterface $router,
         private readonly FieldHelper $fieldHelper,
         private readonly ContactObjectHelper $contactObjectHelper,
     ) {

--- a/app/bundles/LeadBundle/Event/LeadListFilteringEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadListFilteringEvent.php
@@ -3,7 +3,6 @@
 namespace Mautic\LeadBundle\Event;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Event\CommonEvent;
 use Mautic\LeadBundle\Segment\Query\QueryBuilder;
 

--- a/app/bundles/LeadBundle/Event/LeadListFilteringEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadListFilteringEvent.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\LeadBundle\Event;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Event\CommonEvent;
 use Mautic\LeadBundle\Segment\Query\QueryBuilder;
@@ -31,7 +31,7 @@ final class LeadListFilteringEvent extends CommonEvent
         protected $alias,
         protected $func,
         protected $queryBuilder,
-        EntityManager $entityManager,
+        EntityManagerInterface $entityManager,
     ) {
         $this->em              = $entityManager;
         $this->isFilteringDone = false;

--- a/app/bundles/LeadBundle/EventListener/CompanySubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/CompanySubscriber.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\LeadBundle\EventListener;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\IpLookupHelper;
 use Mautic\CoreBundle\Model\AuditLogModel;
@@ -17,7 +17,7 @@ final readonly class CompanySubscriber implements EventSubscriberInterface
     public function __construct(
         private IpLookupHelper $ipLookupHelper,
         private AuditLogModel $auditLogModel,
-        private EntityManager $entityManager,
+        private EntityManagerInterface $entityManager,
         private CoreParametersHelper $coreParametersHelper,
         private CompanyLeadRepository $companyLeadRepository,
         private CompanyModel $companyModel,

--- a/app/bundles/LeadBundle/EventListener/StatsSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/StatsSubscriber.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\LeadBundle\EventListener;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\EventListener\CommonStatsSubscriber;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\LeadBundle\Entity\CompanyChangeLog;
@@ -19,7 +19,7 @@ use Mautic\LeadBundle\Entity\UtmTag;
 
 final class StatsSubscriber extends CommonStatsSubscriber
 {
-    public function __construct(CorePermissions $security, EntityManager $entityManager)
+    public function __construct(CorePermissions $security, EntityManagerInterface $entityManager)
     {
         parent::__construct($security, $entityManager);
         $this->addContactRestrictedRepositories(

--- a/app/bundles/LeadBundle/Field/Dispatcher/FieldDeleteDispatcher.php
+++ b/app/bundles/LeadBundle/Field/Dispatcher/FieldDeleteDispatcher.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\LeadBundle\Field\Dispatcher;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\LeadBundle\Entity\LeadField;
 use Mautic\LeadBundle\Event\LeadFieldEvent;
 use Mautic\LeadBundle\Exception\NoListenerException;
@@ -17,7 +17,7 @@ class FieldDeleteDispatcher
 {
     public function __construct(
         private readonly EventDispatcherInterface $dispatcher,
-        private readonly EntityManager $entityManager,
+        private readonly EntityManagerInterface $entityManager,
         private readonly BackgroundSettings $backgroundSettings,
     ) {
     }

--- a/app/bundles/LeadBundle/Field/Dispatcher/FieldSaveDispatcher.php
+++ b/app/bundles/LeadBundle/Field/Dispatcher/FieldSaveDispatcher.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\LeadBundle\Field\Dispatcher;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\LeadBundle\Entity\LeadField;
 use Mautic\LeadBundle\Event\LeadFieldEvent;
 use Mautic\LeadBundle\Exception\NoListenerException;
@@ -15,7 +15,7 @@ class FieldSaveDispatcher
 {
     public function __construct(
         private readonly EventDispatcherInterface $dispatcher,
-        private readonly EntityManager $entityManager,
+        private readonly EntityManagerInterface $entityManager,
     ) {
     }
 

--- a/app/bundles/LeadBundle/Field/Helper/IndexHelper.php
+++ b/app/bundles/LeadBundle/Field/Helper/IndexHelper.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Mautic\LeadBundle\Field\Helper;
 
 use Doctrine\DBAL\Exception as DBALException;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\LeadBundle\Entity\Lead;
 
 /**
@@ -28,7 +28,7 @@ class IndexHelper
     private int $indexCount = 0;
 
     public function __construct(
-        private readonly EntityManager $entityManager,
+        private readonly EntityManagerInterface $entityManager,
     ) {
     }
 

--- a/app/bundles/LeadBundle/Form/DataTransformer/TagEntityModelTransformer.php
+++ b/app/bundles/LeadBundle/Form/DataTransformer/TagEntityModelTransformer.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\LeadBundle\Form\DataTransformer;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\PersistentCollection;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Exception\TransformationFailedException;
@@ -17,7 +17,7 @@ final class TagEntityModelTransformer implements DataTransformerInterface
      * @param bool   $isArray
      */
     public function __construct(
-        private readonly EntityManager $em,
+        private readonly EntityManagerInterface $em,
         private $repository = '',
         private $isArray = false,
     ) {

--- a/app/bundles/LeadBundle/Form/Type/CompanyType.php
+++ b/app/bundles/LeadBundle/Form/Type/CompanyType.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\LeadBundle\Form\Type;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Form\DataTransformer\IdToEntityModelTransformer;
 use Mautic\CoreBundle\Form\EventListener\CleanFormSubscriber;
 use Mautic\CoreBundle\Form\Type\FormButtonsType;
@@ -26,7 +26,7 @@ final class CompanyType extends AbstractType
     use EntityFieldsBuildFormTrait;
 
     public function __construct(
-        private EntityManager $em,
+        private EntityManagerInterface $em,
         protected RouterInterface $router,
         protected TranslatorInterface $translator,
     ) {

--- a/app/bundles/LeadBundle/Form/Type/LeadImportFieldType.php
+++ b/app/bundles/LeadBundle/Form/Type/LeadImportFieldType.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\LeadBundle\Form\Type;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Form\DataTransformer\IdToEntityModelTransformer;
 use Mautic\CoreBundle\Form\Type\FormButtonsType;
 use Mautic\CoreBundle\Form\Type\YesNoButtonGroupType;
@@ -21,7 +21,7 @@ final class LeadImportFieldType extends AbstractType
 {
     public function __construct(
         private readonly TranslatorInterface $translator,
-        private readonly EntityManager $entityManager,
+        private readonly EntityManagerInterface $entityManager,
     ) {
     }
 

--- a/app/bundles/LeadBundle/Form/Type/LeadType.php
+++ b/app/bundles/LeadBundle/Form/Type/LeadType.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\LeadBundle\Form\Type;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Form\DataTransformer\IdToEntityModelTransformer;
 use Mautic\CoreBundle\Form\EventListener\CleanFormSubscriber;
 use Mautic\CoreBundle\Form\EventListener\FormExitSubscriber;
@@ -32,7 +32,7 @@ final class LeadType extends AbstractType
     public function __construct(
         private TranslatorInterface $translator,
         private CompanyModel $companyModel,
-        private EntityManager $entityManager,
+        private EntityManagerInterface $entityManager,
         private CoreParametersHelper $coreParametersHelper,
     ) {
     }

--- a/app/bundles/LeadBundle/Form/Type/TagType.php
+++ b/app/bundles/LeadBundle/Form/Type/TagType.php
@@ -3,7 +3,7 @@
 namespace Mautic\LeadBundle\Form\Type;
 
 use Doctrine\Common\Collections\Order;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Mautic\LeadBundle\Entity\Tag;
 use Mautic\LeadBundle\Form\DataTransformer\TagEntityModelTransformer;
@@ -18,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 final class TagType extends AbstractType
 {
     public function __construct(
-        private readonly EntityManager $em,
+        private readonly EntityManagerInterface $em,
     ) {
     }
 

--- a/app/bundles/LeadBundle/Form/Validator/Constraints/FieldAliasKeywordValidator.php
+++ b/app/bundles/LeadBundle/Form/Validator/Constraints/FieldAliasKeywordValidator.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\LeadBundle\Form\Validator\Constraints;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\LeadBundle\Entity\LeadField;
 use Mautic\LeadBundle\Helper\FieldAliasHelper;
 use Mautic\LeadBundle\Model\ListModel;
@@ -35,7 +35,7 @@ final class FieldAliasKeywordValidator extends ConstraintValidator
     public function __construct(
         private readonly ListModel $listModel,
         private readonly FieldAliasHelper $aliasHelper,
-        private readonly EntityManager $em,
+        private readonly EntityManagerInterface $em,
         private readonly TranslatorInterface $translator,
         private readonly ContactSegmentFilterDictionary $contactSegmentFilterDictionary,
     ) {

--- a/app/bundles/LeadBundle/Model/CompanyModel.php
+++ b/app/bundles/LeadBundle/Model/CompanyModel.php
@@ -3,7 +3,7 @@
 namespace Mautic\LeadBundle\Model;
 
 use Doctrine\DBAL\Query\Expression\ExpressionBuilder;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Cache\ResultCacheOptions;
 use Mautic\CoreBundle\Form\RequestTrait;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
@@ -66,7 +66,7 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
         protected FieldModel $leadFieldModel,
         protected EmailValidator $emailValidator,
         protected CompanyDeduper $companyDeduper,
-        EntityManager $em,
+        EntityManagerInterface $em,
         CorePermissions $security,
         EventDispatcherInterface $dispatcher,
         UrlGeneratorInterface $router,

--- a/app/bundles/LeadBundle/Model/ContactExportSchedulerModel.php
+++ b/app/bundles/LeadBundle/Model/ContactExportSchedulerModel.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\LeadBundle\Model;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\ExportHelper;
 use Mautic\CoreBundle\Helper\UserHelper;
@@ -37,7 +37,7 @@ class ContactExportSchedulerModel extends AbstractCommonModel
         private readonly LeadModel $leadModel,
         private readonly ExportHelper $exportHelper,
         private readonly MailHelper $mailHelper,
-        EntityManager $em,
+        EntityManagerInterface $em,
         CorePermissions $security,
         EventDispatcherInterface $dispatcher,
         UrlGeneratorInterface $router,

--- a/app/bundles/LeadBundle/Model/DeviceModel.php
+++ b/app/bundles/LeadBundle/Model/DeviceModel.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\LeadBundle\Model;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\CoreBundle\Model\FormModel;
@@ -28,7 +28,7 @@ class DeviceModel extends FormModel
 {
     public function __construct(
         private readonly LeadDeviceRepository $leadDeviceRepository,
-        EntityManager $em,
+        EntityManagerInterface $em,
         CorePermissions $security,
         EventDispatcherInterface $dispatcher,
         UrlGeneratorInterface $router,

--- a/app/bundles/LeadBundle/Model/IpAddressModel.php
+++ b/app/bundles/LeadBundle/Model/IpAddressModel.php
@@ -4,7 +4,7 @@ namespace Mautic\LeadBundle\Model;
 
 use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Entity\IpAddress;
 use Mautic\CoreBundle\Entity\IpAddressRepository;
 use Mautic\LeadBundle\Entity\Lead;
@@ -15,7 +15,7 @@ class IpAddressModel
     private const DELETE_SIZE = 10000;
 
     public function __construct(
-        protected EntityManager $entityManager,
+        protected EntityManagerInterface $entityManager,
         protected LoggerInterface $logger,
         private readonly IpAddressRepository $ipAddressRepository,
     ) {

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Mautic\LeadBundle\Model;
 
 use Doctrine\DBAL\Exception as DBALException;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use Illuminate\Support\Collection;
@@ -140,7 +140,7 @@ class LeadModel extends FormModel
         private ContactTracker $contactTracker,
         private DeviceTracker $deviceTracker,
         private IpAddressModel $ipAddressModel,
-        EntityManager $em,
+        EntityManagerInterface $em,
         CorePermissions $security,
         EventDispatcherInterface $dispatcher,
         UrlGeneratorInterface $router,

--- a/app/bundles/LeadBundle/Segment/ContactSegmentFilterFactory.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentFilterFactory.php
@@ -8,7 +8,7 @@ use Mautic\LeadBundle\LeadEvents;
 use Mautic\LeadBundle\Segment\Decorator\DecoratorFactory;
 use Mautic\LeadBundle\Segment\Decorator\FilterDecoratorInterface;
 use Mautic\LeadBundle\Segment\Query\Filter\FilterQueryBuilderInterface;
-use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class ContactSegmentFilterFactory
@@ -22,7 +22,7 @@ class ContactSegmentFilterFactory
 
     public function __construct(
         private readonly TableSchemaColumnsCache $schemaCache,
-        private readonly Container $container,
+        private readonly ContainerInterface $container,
         private readonly DecoratorFactory $decoratorFactory,
         private readonly EventDispatcherInterface $eventDispatcher,
     ) {

--- a/app/bundles/LeadBundle/Segment/Query/ContactSegmentQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/ContactSegmentQueryBuilder.php
@@ -3,7 +3,7 @@
 namespace Mautic\LeadBundle\Segment\Query;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Event\LeadListFilteringEvent;
@@ -29,7 +29,7 @@ class ContactSegmentQueryBuilder
     private array $dependencyMap = [];
 
     public function __construct(
-        private EntityManager $entityManager,
+        private EntityManagerInterface $entityManager,
         private RandomParameterName $randomParameterName,
         private EventDispatcherInterface $dispatcher,
     ) {

--- a/app/bundles/LeadBundle/Segment/Stat/SegmentCampaignShare.php
+++ b/app/bundles/LeadBundle/Segment/Stat/SegmentCampaignShare.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\LeadBundle\Segment\Stat;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CampaignBundle\Model\CampaignModel;
 use Mautic\CoreBundle\Helper\CacheStorageHelper;
 
@@ -11,7 +11,7 @@ class SegmentCampaignShare
     public function __construct(
         private readonly CampaignModel $campaignModel,
         private readonly CacheStorageHelper $cacheStorageHelper,
-        private readonly EntityManager $entityManager,
+        private readonly EntityManagerInterface $entityManager,
     ) {
     }
 

--- a/app/bundles/LeadBundle/Segment/TableSchemaColumnsCache.php
+++ b/app/bundles/LeadBundle/Segment/TableSchemaColumnsCache.php
@@ -2,14 +2,14 @@
 
 namespace Mautic\LeadBundle\Segment;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 
 class TableSchemaColumnsCache
 {
     private array $cache;
 
     public function __construct(
-        private readonly EntityManager $entityManager,
+        private readonly EntityManagerInterface $entityManager,
     ) {
         $this->cache         = [];
     }

--- a/app/bundles/NotificationBundle/EventListener/StatsSubscriber.php
+++ b/app/bundles/NotificationBundle/EventListener/StatsSubscriber.php
@@ -2,14 +2,14 @@
 
 namespace Mautic\NotificationBundle\EventListener;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\EventListener\CommonStatsSubscriber;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\NotificationBundle\Entity\Stat;
 
 final class StatsSubscriber extends CommonStatsSubscriber
 {
-    public function __construct(CorePermissions $security, EntityManager $entityManager)
+    public function __construct(CorePermissions $security, EntityManagerInterface $entityManager)
     {
         parent::__construct($security, $entityManager);
         $this->addContactRestrictedRepositories([Stat::class]);

--- a/app/bundles/NotificationBundle/Form/Type/MobileNotificationType.php
+++ b/app/bundles/NotificationBundle/Form/Type/MobileNotificationType.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\NotificationBundle\Form\Type;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CategoryBundle\Form\Type\CategoryListType;
 use Mautic\CoreBundle\Form\DataTransformer\IdToEntityModelTransformer;
 use Mautic\CoreBundle\Form\EventListener\CleanFormSubscriber;
@@ -30,7 +30,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 final class MobileNotificationType extends AbstractType
 {
     public function __construct(
-        private readonly EntityManager $entityManager,
+        private readonly EntityManagerInterface $entityManager,
     ) {
     }
 

--- a/app/bundles/NotificationBundle/Model/NotificationModel.php
+++ b/app/bundles/NotificationBundle/Model/NotificationModel.php
@@ -3,7 +3,7 @@
 namespace Mautic\NotificationBundle\Model;
 
 use Doctrine\DBAL\Query\QueryBuilder;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Helper\Chart\ChartQuery;
 use Mautic\CoreBundle\Helper\Chart\LineChart;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
@@ -43,7 +43,7 @@ class NotificationModel extends FormModel implements AjaxLookupModelInterface, G
 
     public function __construct(
         protected TrackableModel $pageTrackableModel,
-        EntityManager $em,
+        EntityManagerInterface $em,
         CorePermissions $security,
         EventDispatcherInterface $dispatcher,
         UrlGeneratorInterface $router,

--- a/app/bundles/PageBundle/EventListener/StatsSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/StatsSubscriber.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\PageBundle\EventListener;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\EventListener\CommonStatsSubscriber;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\PageBundle\Entity\Hit;
@@ -14,7 +14,7 @@ final class StatsSubscriber extends CommonStatsSubscriber
 {
     public function __construct(
         CorePermissions $security,
-        EntityManager $entityManager,
+        EntityManagerInterface $entityManager,
         RedirectRepository $redirectRepository,
         TrackableRepository $trackableRepository,
     ) {

--- a/app/bundles/PageBundle/Form/Type/PageType.php
+++ b/app/bundles/PageBundle/Form/Type/PageType.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\PageBundle\Form\Type;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CategoryBundle\Form\Type\CategoryListType;
 use Mautic\CoreBundle\Form\DataTransformer\IdToEntityModelTransformer;
 use Mautic\CoreBundle\Form\EventListener\CleanFormSubscriber;
@@ -42,7 +42,7 @@ final class PageType extends AbstractType
     private readonly bool $canViewOther;
 
     public function __construct(
-        private readonly EntityManager $em,
+        private readonly EntityManagerInterface $em,
         private readonly PageModel $model,
         CorePermissions $corePermissions,
         UserHelper $userHelper,

--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -3,7 +3,7 @@
 namespace Mautic\PageBundle\Model;
 
 use Doctrine\DBAL\Query\QueryBuilder;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use GuzzleHttp\Psr7\Query;
 use Mautic\CoreBundle\Entity\VariantEntityInterface;
 use Mautic\CoreBundle\Helper\Chart\ChartQuery;
@@ -105,7 +105,7 @@ class PageModel extends FormModel implements GlobalSearchInterface
         CoreParametersHelper $coreParametersHelper,
         private ContactRequestHelper $contactRequestHelper,
         private VariantConverterService $variantConverterService,
-        EntityManager $em,
+        EntityManagerInterface $em,
         CorePermissions $security,
         EventDispatcherInterface $dispatcher,
         UrlGeneratorInterface $router,

--- a/app/bundles/PageBundle/Model/VideoModel.php
+++ b/app/bundles/PageBundle/Model/VideoModel.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\PageBundle\Model;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\IpLookupHelper;
 use Mautic\CoreBundle\Helper\UserHelper;
@@ -28,7 +28,7 @@ class VideoModel extends FormModel
     public function __construct(
         protected IpLookupHelper $ipLookupHelper,
         protected ContactTracker $contactTracker,
-        EntityManager $em,
+        EntityManagerInterface $em,
         CorePermissions $security,
         EventDispatcherInterface $dispatcher,
         UrlGeneratorInterface $router,

--- a/app/bundles/PluginBundle/Helper/IntegrationHelper.php
+++ b/app/bundles/PluginBundle/Helper/IntegrationHelper.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\PluginBundle\Helper;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Cache\ResultCacheOptions;
 use Mautic\CoreBundle\Helper\BundleHelper;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
@@ -42,7 +42,7 @@ class IntegrationHelper
 
     public function __construct(
         private readonly ContainerInterface $container,
-        protected EntityManager $em,
+        protected EntityManagerInterface $em,
         protected PathsHelper $pathsHelper,
         protected BundleHelper $bundleHelper,
         protected CoreParametersHelper $coreParametersHelper,

--- a/app/bundles/PluginBundle/Integration/AbstractIntegration.php
+++ b/app/bundles/PluginBundle/Integration/AbstractIntegration.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\PluginBundle\Integration;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\CurlHandler;
 use GuzzleHttp\HandlerStack;
@@ -99,7 +99,7 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
     public function __construct(
         protected EventDispatcherInterface $dispatcher,
         CacheStorageHelper $cacheStorageHelper,
-        protected EntityManager $em,
+        protected EntityManagerInterface $em,
         protected RequestStack $requestStack,
         protected RouterInterface $router,
         protected TranslatorInterface $translator,

--- a/app/bundles/PluginBundle/Model/PluginModel.php
+++ b/app/bundles/PluginBundle/Model/PluginModel.php
@@ -4,7 +4,7 @@ namespace Mautic\PluginBundle\Model;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Mautic\CoreBundle\Helper\BundleHelper;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
@@ -32,7 +32,7 @@ class PluginModel extends FormModel
         private readonly FieldList $fieldList,
         CoreParametersHelper $coreParametersHelper,
         private readonly BundleHelper $bundleHelper,
-        EntityManager $em,
+        EntityManagerInterface $em,
         CorePermissions $security,
         EventDispatcherInterface $dispatcher,
         UrlGeneratorInterface $router,

--- a/app/bundles/PointBundle/EventListener/StatsSubscriber.php
+++ b/app/bundles/PointBundle/EventListener/StatsSubscriber.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\PointBundle\EventListener;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\EventListener\CommonStatsSubscriber;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\PointBundle\Entity\LeadPointLog;
@@ -10,7 +10,7 @@ use Mautic\PointBundle\Entity\LeadTriggerLog;
 
 final class StatsSubscriber extends CommonStatsSubscriber
 {
-    public function __construct(CorePermissions $security, EntityManager $entityManager)
+    public function __construct(CorePermissions $security, EntityManagerInterface $entityManager)
     {
         parent::__construct($security, $entityManager);
         $this->addContactRestrictedRepositories(

--- a/app/bundles/PointBundle/Form/Type/GroupListType.php
+++ b/app/bundles/PointBundle/Form/Type/GroupListType.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\PointBundle\Form\Type;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Form\DataTransformer\IdToEntityModelTransformer;
 use Mautic\PointBundle\Entity\Group;
 use Mautic\PointBundle\Entity\GroupRepository;
@@ -18,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 final class GroupListType extends AbstractType
 {
     public function __construct(
-        private readonly EntityManager $em,
+        private readonly EntityManagerInterface $em,
         private readonly GroupRepository $repo,
     ) {
     }

--- a/app/bundles/PointBundle/Model/PointGroupModel.php
+++ b/app/bundles/PointBundle/Model/PointGroupModel.php
@@ -13,7 +13,7 @@ use Mautic\PointBundle\Entity\GroupRepository;
 use Mautic\PointBundle\Event as Events;
 use Mautic\PointBundle\Form\Type\GroupType;
 use Mautic\PointBundle\PointGroupEvents;
-use Symfony\Component\Form\FormFactory;
+use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Contracts\EventDispatcher\Event;
@@ -44,7 +44,7 @@ class PointGroupModel extends CommonFormModel implements GlobalSearchInterface
 
     /**
      * @param object               $entity
-     * @param FormFactory          $formFactory
+     * @param FormFactoryInterface $formFactory
      * @param string|null          $action
      * @param array<string,string> $options
      *

--- a/app/bundles/PointBundle/Model/PointModel.php
+++ b/app/bundles/PointBundle/Model/PointModel.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\PointBundle\Model;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Helper\Chart\ChartQuery;
 use Mautic\CoreBundle\Helper\Chart\LineChart;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
@@ -48,7 +48,7 @@ class PointModel extends CommonFormModel implements GlobalSearchInterface, Reset
         protected IpLookupHelper $ipLookupHelper,
         protected LeadModel $leadModel,
         private readonly ContactTracker $contactTracker,
-        EntityManager $em,
+        EntityManagerInterface $em,
         CorePermissions $security,
         EventDispatcherInterface $dispatcher,
         UrlGeneratorInterface $router,

--- a/app/bundles/PointBundle/Tests/Functional/PointActionFunctionalTest.php
+++ b/app/bundles/PointBundle/Tests/Functional/PointActionFunctionalTest.php
@@ -51,7 +51,7 @@ final class PointActionFunctionalTest extends MauticMysqlTestCase
         $this->createEmailStat($lead, $email, $trackingHash);
         $pointAction = $this->createReadEmailAction(5, $group);
         $this->client->request('GET', '/email/'.$trackingHash.'.gif');
-        $this->em->clear(Lead::class);
+        $this->em->clear();
         $lead        = $leadModel->getEntity($lead->getId());
         $this->assertInstanceOf(Lead::class, $lead);
         $groupScore  = $lead->getGroupScores()->first();

--- a/app/bundles/PointBundle/Tests/Functional/PointTriggerFunctionalTest.php
+++ b/app/bundles/PointBundle/Tests/Functional/PointTriggerFunctionalTest.php
@@ -31,7 +31,7 @@ final class PointTriggerFunctionalTest extends MauticMysqlTestCase
         $model->setFieldValues($lead, $data, false, true, true);
         $model->saveEntity($lead);
 
-        $this->em->clear();
+        $this->em->getUnitOfWork()->clear(Lead::class);
 
         $lead = $model->getEntity($lead->getId());
         $this->assertInstanceOf(Lead::class, $lead);
@@ -62,7 +62,7 @@ final class PointTriggerFunctionalTest extends MauticMysqlTestCase
         $model->setFieldValues($lead, $data, false, true, true);
         $model->saveEntity($lead);
 
-        $this->em->clear();
+        $this->em->getUnitOfWork()->clear(Lead::class);
 
         $lead = $model->getEntity($lead->getId());
         $this->assertInstanceOf(Lead::class, $lead);
@@ -88,7 +88,7 @@ final class PointTriggerFunctionalTest extends MauticMysqlTestCase
         $leadModel->setFieldValues($lead, $data, false, true, true);
         $leadModel->saveEntity($lead);
 
-        $this->em->clear();
+        $this->em->getUnitOfWork()->clear(Lead::class);
 
         $triggerA      = $this->createTrigger('Group A Trigger (should trigger)', 5, null, true);
         $triggerEventA = $this->createAddTagEvent('tagA', $triggerA);

--- a/app/bundles/PointBundle/Tests/Functional/PointTriggerFunctionalTest.php
+++ b/app/bundles/PointBundle/Tests/Functional/PointTriggerFunctionalTest.php
@@ -31,7 +31,8 @@ final class PointTriggerFunctionalTest extends MauticMysqlTestCase
         $model->setFieldValues($lead, $data, false, true, true);
         $model->saveEntity($lead);
 
-        $this->em->clear(Lead::class);
+        $this->em->clear();
+
         $lead = $model->getEntity($lead->getId());
         $this->assertInstanceOf(Lead::class, $lead);
         $this->assertFalse($lead->getTags()->isEmpty());
@@ -61,7 +62,8 @@ final class PointTriggerFunctionalTest extends MauticMysqlTestCase
         $model->setFieldValues($lead, $data, false, true, true);
         $model->saveEntity($lead);
 
-        $this->em->clear(Lead::class);
+        $this->em->clear();
+
         $lead = $model->getEntity($lead->getId());
         $this->assertInstanceOf(Lead::class, $lead);
         $pointGroupModel->adjustPoints($lead, $groupA, 5);
@@ -86,7 +88,7 @@ final class PointTriggerFunctionalTest extends MauticMysqlTestCase
         $leadModel->setFieldValues($lead, $data, false, true, true);
         $leadModel->saveEntity($lead);
 
-        $this->em->clear(Lead::class);
+        $this->em->clear();
 
         $triggerA      = $this->createTrigger('Group A Trigger (should trigger)', 5, null, true);
         $triggerEventA = $this->createAddTagEvent('tagA', $triggerA);

--- a/app/bundles/ReportBundle/Model/ScheduleModel.php
+++ b/app/bundles/ReportBundle/Model/ScheduleModel.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\ReportBundle\Model;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\ReportBundle\Entity\Report;
 use Mautic\ReportBundle\Entity\Scheduler;
 use Mautic\ReportBundle\Entity\SchedulerRepository;
@@ -12,7 +12,7 @@ use Mautic\ReportBundle\Scheduler\Option\ExportOption;
 class ScheduleModel
 {
     public function __construct(
-        private readonly EntityManager $entityManager,
+        private readonly EntityManagerInterface $entityManager,
         private readonly SchedulerPlanner $schedulerPlanner,
         private readonly SchedulerRepository $schedulerRepository,
     ) {

--- a/app/bundles/ReportBundle/Scheduler/Model/SchedulerPlanner.php
+++ b/app/bundles/ReportBundle/Scheduler/Model/SchedulerPlanner.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\ReportBundle\Scheduler\Model;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\ReportBundle\Entity\Report;
 use Mautic\ReportBundle\Entity\Scheduler;
 use Mautic\ReportBundle\Entity\SchedulerRepository;
@@ -18,7 +18,7 @@ class SchedulerPlanner
 
     public function __construct(
         private readonly DateBuilder $dateBuilder,
-        private readonly EntityManager $entityManager,
+        private readonly EntityManagerInterface $entityManager,
     ) {
         $this->schedulerRepository = $entityManager->getRepository(Scheduler::class);
     }

--- a/app/bundles/SmsBundle/Broadcast/BroadcastQuery.php
+++ b/app/bundles/SmsBundle/Broadcast/BroadcastQuery.php
@@ -3,7 +3,7 @@
 namespace Mautic\SmsBundle\Broadcast;
 
 use Doctrine\DBAL\Query\QueryBuilder;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CampaignBundle\Entity\ContactLimiterTrait;
 use Mautic\CampaignBundle\Executioner\ContactFinder\Limiter\ContactLimiter;
 use Mautic\ChannelBundle\Entity\MessageQueue;
@@ -17,7 +17,7 @@ class BroadcastQuery
     private QueryBuilder $query;
 
     public function __construct(
-        private EntityManager $entityManager,
+        private EntityManagerInterface $entityManager,
         private SmsModel $smsModel,
     ) {
     }

--- a/app/bundles/SmsBundle/EventListener/StatsSubscriber.php
+++ b/app/bundles/SmsBundle/EventListener/StatsSubscriber.php
@@ -2,14 +2,14 @@
 
 namespace Mautic\SmsBundle\EventListener;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\EventListener\CommonStatsSubscriber;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\SmsBundle\Entity\Stat;
 
 final class StatsSubscriber extends CommonStatsSubscriber
 {
-    public function __construct(CorePermissions $security, EntityManager $entityManager)
+    public function __construct(CorePermissions $security, EntityManagerInterface $entityManager)
     {
         parent::__construct($security, $entityManager);
         $this->addContactRestrictedRepositories([Stat::class]);

--- a/app/bundles/SmsBundle/Form/Type/SmsType.php
+++ b/app/bundles/SmsBundle/Form/Type/SmsType.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\SmsBundle\Form\Type;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CategoryBundle\Form\Type\CategoryListType;
 use Mautic\CoreBundle\Form\DataTransformer\IdToEntityModelTransformer;
 use Mautic\CoreBundle\Form\EventListener\CleanFormSubscriber;
@@ -32,7 +32,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 final class SmsType extends AbstractType
 {
     public function __construct(
-        private readonly EntityManager $em,
+        private readonly EntityManagerInterface $em,
     ) {
     }
 

--- a/app/bundles/SmsBundle/Helper/SmsHelper.php
+++ b/app/bundles/SmsBundle/Helper/SmsHelper.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\SmsBundle\Helper;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use libphonenumber\PhoneNumberFormat;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\PhoneNumberHelper;
@@ -18,7 +18,7 @@ use Mautic\SmsBundle\Model\SmsModel;
 class SmsHelper
 {
     public function __construct(
-        protected EntityManager $em,
+        protected EntityManagerInterface $em,
         protected LeadModel $leadModel,
         protected PhoneNumberHelper $phoneNumberHelper,
         protected SmsModel $smsModel,

--- a/app/bundles/StageBundle/EventListener/StatsSubscriber.php
+++ b/app/bundles/StageBundle/EventListener/StatsSubscriber.php
@@ -2,14 +2,14 @@
 
 namespace Mautic\StageBundle\EventListener;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\EventListener\CommonStatsSubscriber;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\StageBundle\Entity\LeadStageLog;
 
 final class StatsSubscriber extends CommonStatsSubscriber
 {
-    public function __construct(CorePermissions $security, EntityManager $entityManager)
+    public function __construct(CorePermissions $security, EntityManagerInterface $entityManager)
     {
         parent::__construct($security, $entityManager);
         $this->addContactRestrictedRepositories([LeadStageLog::class]);

--- a/app/bundles/StageBundle/Model/StageModel.php
+++ b/app/bundles/StageBundle/Model/StageModel.php
@@ -3,7 +3,7 @@
 namespace Mautic\StageBundle\Model;
 
 use Doctrine\DBAL\ParameterType;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Helper\Chart\ChartQuery;
 use Mautic\CoreBundle\Helper\Chart\LineChart;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
@@ -37,7 +37,7 @@ class StageModel extends CommonFormModel implements GlobalSearchInterface
     public function __construct(
         protected LeadModel $leadModel,
         UserHelper $userHelper,
-        EntityManager $em,
+        EntityManagerInterface $em,
         CorePermissions $security,
         EventDispatcherInterface $dispatcher,
         UrlGeneratorInterface $router,

--- a/app/bundles/UserBundle/DataFixtures/ORM/LoadUserData.php
+++ b/app/bundles/UserBundle/DataFixtures/ORM/LoadUserData.php
@@ -7,7 +7,7 @@ use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Mautic\UserBundle\Entity\User;
-use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasher;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
 class LoadUserData extends AbstractFixture implements OrderedFixtureInterface, FixtureGroupInterface
 {
@@ -17,7 +17,7 @@ class LoadUserData extends AbstractFixture implements OrderedFixtureInterface, F
     }
 
     public function __construct(
-        private readonly UserPasswordHasher $hasher,
+        private readonly UserPasswordHasherInterface $hasher,
     ) {
     }
 

--- a/app/bundles/UserBundle/Model/UserModel.php
+++ b/app/bundles/UserBundle/Model/UserModel.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\UserBundle\Model;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\CoreBundle\Model\FormModel;
@@ -46,7 +46,7 @@ class UserModel extends FormModel implements GlobalSearchInterface
     public function __construct(
         protected MailHelper $mailHelper,
         private readonly UserTokenServiceInterface $userTokenService,
-        EntityManager $em,
+        EntityManagerInterface $em,
         CorePermissions $security,
         EventDispatcherInterface $dispatcher,
         UrlGeneratorInterface $router,

--- a/app/bundles/UserBundle/Security/SAML/User/UserCreator.php
+++ b/app/bundles/UserBundle/Security/SAML/User/UserCreator.php
@@ -9,7 +9,7 @@ use Mautic\CoreBundle\Helper\EncryptionHelper;
 use Mautic\UserBundle\Entity\Role;
 use Mautic\UserBundle\Entity\User;
 use Mautic\UserBundle\Model\UserModel;
-use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasher;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 
 class UserCreator implements UserCreatorInterface
@@ -27,7 +27,7 @@ class UserCreator implements UserCreatorInterface
         private readonly EntityManagerInterface $entityManager,
         private readonly UserMapper $userMapper,
         private readonly UserModel $userModel,
-        private readonly UserPasswordHasher $hasher,
+        private readonly UserPasswordHasherInterface $hasher,
         $defaultRole,
     ) {
         $this->defaultRole   = (int) $defaultRole;

--- a/app/bundles/WebhookBundle/EventListener/StatsSubscriber.php
+++ b/app/bundles/WebhookBundle/EventListener/StatsSubscriber.php
@@ -2,14 +2,14 @@
 
 namespace Mautic\WebhookBundle\EventListener;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\EventListener\CommonStatsSubscriber;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\WebhookBundle\Entity\Log;
 
 final class StatsSubscriber extends CommonStatsSubscriber
 {
-    public function __construct(CorePermissions $security, EntityManager $entityManager)
+    public function __construct(CorePermissions $security, EntityManagerInterface $entityManager)
     {
         parent::__construct($security, $entityManager);
         $this->addRestrictedRepostories([Log::class], ['webhook' => 'webhook:webhooks']);

--- a/app/bundles/WebhookBundle/Http/Client.php
+++ b/app/bundles/WebhookBundle/Http/Client.php
@@ -2,7 +2,6 @@
 
 namespace Mautic\WebhookBundle\Http;
 
-use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Psr7\Request;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\PrivateAddressChecker;
@@ -13,7 +12,7 @@ class Client
 {
     public function __construct(
         private readonly CoreParametersHelper $coreParametersHelper,
-        private readonly GuzzleClient $httpClient,
+        private readonly \GuzzleHttp\Client $httpClient,
         private readonly PrivateAddressChecker $privateAddressChecker,
     ) {
     }

--- a/app/bundles/WebhookBundle/Model/WebhookModel.php
+++ b/app/bundles/WebhookBundle/Model/WebhookModel.php
@@ -3,7 +3,7 @@
 namespace Mautic\WebhookBundle\Model;
 
 use Doctrine\Common\Collections\Order;
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use JMS\Serializer\SerializationContext;
 use JMS\Serializer\SerializerInterface;
 use Mautic\ApiBundle\Serializer\Exclusion\PublishDetailsExclusionStrategy;
@@ -130,7 +130,7 @@ class WebhookModel extends FormModel
         CoreParametersHelper $coreParametersHelper,
         protected SerializerInterface $serializer,
         private readonly Client $httpClient,
-        EntityManager $em,
+        EntityManagerInterface $em,
         CorePermissions $security,
         EventDispatcherInterface $dispatcher,
         UrlGeneratorInterface $router,

--- a/app/bundles/WebhookBundle/Notificator/WebhookNotificationSender.php
+++ b/app/bundles/WebhookBundle/Notificator/WebhookNotificationSender.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\WebhookBundle\Notificator;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Exception\MissingIdentifierField;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Model\NotificationModel;
@@ -21,7 +21,7 @@ class WebhookNotificationSender
     public function __construct(
         private readonly Environment $twig,
         private readonly NotificationModel $notificationModel,
-        private readonly EntityManager $entityManager,
+        private readonly EntityManagerInterface $entityManager,
         private readonly MailHelper $mailer,
         private readonly CoreParametersHelper $coreParametersHelper,
         private readonly UserRepository $userRepository,

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -188,11 +188,22 @@ parameters:
 			identifier: mautic.noTablePrefixDefinitionInTests
 			path: app/bundles/CoreBundle/Test/EventListener/MaintenanceSubscriberTest.php
 
+		# the concrete Form is created by the form factory, not autowired
+		-
+			identifier: mautic.preferInterfaceInConstructor
+			path: app/bundles/ApiBundle/Controller/oAuth2/AuthorizeController.php
+
 		# not useful, rather pedantic from phsptan-* extensions
 		-
 			identifier: argument.templateType
 			path: app/bundles/CoreBundle/Helper/CookieHelper.php
 			count: 1
+		# repository is resolved from a dynamic entity class name
+		-
+			identifier: argument.templateType
+			paths:
+				- app/bundles/CoreBundle/EventListener/CommonStatsSubscriber.php
+				- app/bundles/LeadBundle/Form/DataTransformer/TagEntityModelTransformer.php
 		-
 			message: '#Method PHPUnit\\Framework\\MockObject\\Builder\\InvocationMocker::willReturnOnConsecutiveCalls\(\) invoked with unpacked array with possibly string key#'
 			path: app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/Executioner/ReferenceResolverTest.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -227,3 +227,4 @@ rules:
 	- Utils\PHPStan\Rule\NoGetRepositoryWithEntityInRepositoryRule
 	#- Utils\PHPStan\Rule\NoContainerGetRule
 	- Utils\PHPStan\Rule\NoEntityManagerGetRepositoryRule
+	- Utils\PHPStan\Rule\PreferInterfaceInConstructorRule

--- a/plugins/GrapesJsBuilderBundle/Model/GrapesJsBuilderModel.php
+++ b/plugins/GrapesJsBuilderBundle/Model/GrapesJsBuilderModel.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace MauticPlugin\GrapesJsBuilderBundle\Model;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\CoreBundle\Model\AbstractCommonModel;
@@ -29,7 +29,7 @@ class GrapesJsBuilderModel extends AbstractCommonModel
     public function __construct(
         private readonly RequestStack $requestStack,
         private readonly EmailModel $emailModel,
-        EntityManager $em,
+        EntityManagerInterface $em,
         CorePermissions $security,
         EventDispatcherInterface $dispatcher,
         UrlGeneratorInterface $router,

--- a/plugins/MauticCrmBundle/Integration/DynamicsIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/DynamicsIntegration.php
@@ -342,7 +342,7 @@ class DynamicsIntegration extends CrmAbstractIntegration
                     $integrationEntity->setInternalEntityId($lead->getId());
                     $integrationEntity->setLastSyncDate(new \DateTime());
                     $this->em->persist($integrationEntity);
-                    $this->em->flush($integrationEntity);
+                    $this->em->flush();
 
                     return $id;
                 }

--- a/plugins/MauticCrmBundle/Integration/HubspotIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/HubspotIntegration.php
@@ -2,7 +2,7 @@
 
 namespace MauticPlugin\MauticCrmBundle\Integration;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Helper\ArrayHelper;
 use Mautic\CoreBundle\Helper\CacheStorageHelper;
 use Mautic\CoreBundle\Helper\EncryptionHelper;
@@ -43,7 +43,7 @@ class HubspotIntegration extends CrmAbstractIntegration
     public function __construct(
         EventDispatcherInterface $eventDispatcher,
         CacheStorageHelper $cacheStorageHelper,
-        EntityManager $entityManager,
+        EntityManagerInterface $entityManager,
         RequestStack $requestStack,
         RouterInterface $router,
         TranslatorInterface $translator,

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -2,7 +2,7 @@
 
 namespace MauticPlugin\MauticCrmBundle\Integration;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\ORMException;
 use Exception;
 use Mautic\CoreBundle\Entity\AuditLog;
@@ -3081,7 +3081,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
         return $matchedFields;
     }
 
-    public function getEntityManager(): EntityManager
+    public function getEntityManager(): EntityManagerInterface
     {
         return $this->em;
     }

--- a/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
@@ -1117,7 +1117,7 @@ class SugarcrmIntegration extends CrmAbstractIntegration
                     }
                     $integrationEntity->setLastSyncDate(new \DateTime());
                     $this->em->persist($integrationEntity);
-                    $this->em->flush($integrationEntity);
+                    $this->em->flush();
                 }
 
                 return true;

--- a/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
@@ -2,7 +2,7 @@
 
 namespace MauticPlugin\MauticCrmBundle\Integration;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Form\Type\ButtonGroupType;
 use Mautic\CoreBundle\Helper\CacheStorageHelper;
 use Mautic\CoreBundle\Helper\EncryptionHelper;
@@ -56,7 +56,7 @@ class SugarcrmIntegration extends CrmAbstractIntegration
     public function __construct(
         EventDispatcherInterface $eventDispatcher,
         CacheStorageHelper $cacheStorageHelper,
-        EntityManager $entityManager,
+        EntityManagerInterface $entityManager,
         RequestStack $requestStack,
         RouterInterface $router,
         TranslatorInterface $translator,

--- a/plugins/MauticFocusBundle/EventListener/StatsSubscriber.php
+++ b/plugins/MauticFocusBundle/EventListener/StatsSubscriber.php
@@ -2,14 +2,14 @@
 
 namespace MauticPlugin\MauticFocusBundle\EventListener;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\EventListener\CommonStatsSubscriber;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use MauticPlugin\MauticFocusBundle\Entity\Stat;
 
 final class StatsSubscriber extends CommonStatsSubscriber
 {
-    public function __construct(CorePermissions $security, EntityManager $entityManager)
+    public function __construct(CorePermissions $security, EntityManagerInterface $entityManager)
     {
         parent::__construct($security, $entityManager);
         $this->addContactRestrictedRepositories([Stat::class]);

--- a/plugins/MauticSocialBundle/EventListener/StatsSubscriber.php
+++ b/plugins/MauticSocialBundle/EventListener/StatsSubscriber.php
@@ -2,7 +2,7 @@
 
 namespace MauticPlugin\MauticSocialBundle\EventListener;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\EventListener\CommonStatsSubscriber;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use MauticPlugin\MauticSocialBundle\Entity\TweetStatRepository;
@@ -11,7 +11,7 @@ final class StatsSubscriber extends CommonStatsSubscriber
 {
     public function __construct(
         CorePermissions $security,
-        EntityManager $entityManager,
+        EntityManagerInterface $entityManager,
         TweetStatRepository $tweetStatRepository,
     ) {
         parent::__construct($security, $entityManager);

--- a/plugins/MauticSocialBundle/Form/Type/TweetType.php
+++ b/plugins/MauticSocialBundle/Form/Type/TweetType.php
@@ -2,7 +2,7 @@
 
 namespace MauticPlugin\MauticSocialBundle\Form\Type;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\AssetBundle\Entity\Asset;
 use Mautic\AssetBundle\Form\Type\AssetListType;
 use Mautic\CategoryBundle\Form\Type\CategoryListType;
@@ -26,7 +26,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 final class TweetType extends AbstractType
 {
     public function __construct(
-        protected EntityManager $em,
+        protected EntityManagerInterface $em,
     ) {
     }
 

--- a/plugins/MauticSocialBundle/Integration/SocialIntegration.php
+++ b/plugins/MauticSocialBundle/Integration/SocialIntegration.php
@@ -21,7 +21,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\Routing\Router;
+use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 abstract class SocialIntegration extends AbstractIntegration
@@ -38,7 +38,7 @@ abstract class SocialIntegration extends AbstractIntegration
         CacheStorageHelper $cacheStorageHelper,
         EntityManager $entityManager,
         RequestStack $requestStack,
-        Router $router,
+        RouterInterface $router,
         Translator $translator,
         Logger $logger,
         EncryptionHelper $encryptionHelper,

--- a/plugins/MauticSocialBundle/Integration/SocialIntegration.php
+++ b/plugins/MauticSocialBundle/Integration/SocialIntegration.php
@@ -2,7 +2,7 @@
 
 namespace MauticPlugin\MauticSocialBundle\Integration;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Helper\CacheStorageHelper;
 use Mautic\CoreBundle\Helper\EncryptionHelper;
 use Mautic\CoreBundle\Helper\PathsHelper;
@@ -36,7 +36,7 @@ abstract class SocialIntegration extends AbstractIntegration
     public function __construct(
         EventDispatcherInterface $eventDispatcher,
         CacheStorageHelper $cacheStorageHelper,
-        EntityManager $entityManager,
+        EntityManagerInterface $entityManager,
         RequestStack $requestStack,
         RouterInterface $router,
         Translator $translator,

--- a/utils/phpstan/src/Rule/PreferInterfaceInConstructorRule.php
+++ b/utils/phpstan/src/Rule/PreferInterfaceInConstructorRule.php
@@ -42,6 +42,8 @@ final class PreferInterfaceInConstructorRule implements Rule
         'Symfony\\Component\\HttpFoundation\\Session\\SessionInterface',
         // route loading relies on the concrete Loader
         'Symfony\\Component\\Config\\Loader\\LoaderInterface',
+        // only the concrete TransportFactory is aliased as a service, see MessengerBundle/Config/services.php
+        'Symfony\\Component\\Messenger\\Transport\\TransportFactoryInterface',
     ];
 
     public function __construct(

--- a/utils/phpstan/src/Rule/PreferInterfaceInConstructorRule.php
+++ b/utils/phpstan/src/Rule/PreferInterfaceInConstructorRule.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Rule;
+
+use PhpParser\Node;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * A constructor dependency must be autowired by its interface, not by the concrete class.
+ *
+ * Typing "Router $router" locks the service to one implementation and blocks decoration, while
+ * "RouterInterface $router" describes what the class actually needs. The interface is discovered by
+ * convention: a param typed "X" is reported when "XInterface" exists and "X" implements it. Only
+ * Symfony and Doctrine classes are checked - Mautic's own classes are left alone.
+ *
+ * @implements Rule<ClassMethod>
+ */
+final class PreferInterfaceInConstructorRule implements Rule
+{
+    /**
+     * @var string[]
+     */
+    /**
+     * Only 3rd-party contracts are enforced - Mautic's own classes are free to be typed directly.
+     *
+     * @var string[]
+     */
+    private const HANDLED_NAMESPACE_PREFIXES = ['Symfony\\', 'Doctrine\\'];
+
+    /**
+     * @var string[]
+     */
+    private const SKIPPED_INTERFACES = [
+        // the concrete Session is the only way to reach getFlashBag()
+        'Symfony\\Component\\HttpFoundation\\Session\\SessionInterface',
+        // route loading relies on the concrete Loader
+        'Symfony\\Component\\Config\\Loader\\LoaderInterface',
+    ];
+
+    public function __construct(
+        private readonly ReflectionProvider $reflectionProvider,
+    ) {
+    }
+
+    public function getNodeType(): string
+    {
+        return ClassMethod::class;
+    }
+
+    /**
+     * @param ClassMethod $node
+     *
+     * @return list<\PHPStan\Rules\IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if ('__construct' !== $node->name->toLowerString()) {
+            return [];
+        }
+
+        $ruleErrors = [];
+
+        foreach ($node->params as $param) {
+            if (!$param->type instanceof Name) {
+                continue;
+            }
+
+            $className     = $scope->resolveName($param->type);
+            $interfaceName = $this->matchImplementedSameNamedInterface($className);
+            if (null === $interfaceName) {
+                continue;
+            }
+
+            $parameterName = $param->var instanceof Node\Expr\Variable && is_string($param->var->name)
+                ? '$'.$param->var->name
+                : '';
+
+            $ruleErrors[] = RuleErrorBuilder::message(sprintf(
+                'Constructor dependency "%s" is typed as concrete "%s". Use the "%s" interface instead.',
+                $parameterName,
+                $className,
+                $interfaceName
+            ))
+                ->identifier('mautic.preferInterfaceInConstructor')
+                ->line($param->getStartLine())
+                ->build();
+        }
+
+        return $ruleErrors;
+    }
+
+    /**
+     * Returns the "<class>Interface" name when the class implements it, null otherwise.
+     */
+    private function matchImplementedSameNamedInterface(string $className): ?string
+    {
+        if (!$this->isHandledNamespace($className)) {
+            return null;
+        }
+
+        if (!$this->reflectionProvider->hasClass($className)) {
+            return null;
+        }
+
+        $classReflection = $this->reflectionProvider->getClass($className);
+        if ($classReflection->isInterface()) {
+            return null;
+        }
+
+        $interfaceName = $className.'Interface';
+        if (in_array($interfaceName, self::SKIPPED_INTERFACES, true)) {
+            return null;
+        }
+
+        if (!$this->reflectionProvider->hasClass($interfaceName)) {
+            return null;
+        }
+
+        if (!$this->reflectionProvider->getClass($interfaceName)->isInterface()) {
+            return null;
+        }
+
+        if (!$classReflection->implementsInterface($interfaceName)) {
+            return null;
+        }
+
+        return $interfaceName;
+    }
+
+    private function isHandledNamespace(string $className): bool
+    {
+        foreach (self::HANDLED_NAMESPACE_PREFIXES as $handledNamespacePrefix) {
+            if (str_starts_with($className, $handledNamespacePrefix)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/ClassWithoutInterfaceConstructor.php
+++ b/utils/phpstan/tests/Rule/Fixture/ClassWithoutInterfaceConstructor.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+
+final class ClassWithoutInterfaceConstructor
+{
+    public function __construct(
+        private readonly RequestStack $requestStack,
+        private readonly SomeModel $someModel,
+    ) {
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/ConcreteClassConstructor.php
+++ b/utils/phpstan/tests/Rule/Fixture/ConcreteClassConstructor.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+use Doctrine\ORM\EntityManager;
+use Symfony\Component\Routing\Router;
+
+final class ConcreteClassConstructor
+{
+    public function __construct(
+        private readonly Router $router,
+        private readonly EntityManager $entityManager,
+    ) {
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/ConfigLoaderConstructor.php
+++ b/utils/phpstan/tests/Rule/Fixture/ConfigLoaderConstructor.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+use Symfony\Component\Config\Loader\Loader;
+
+final class ConfigLoaderConstructor
+{
+    public function __construct(
+        private readonly Loader $loader,
+    ) {
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/GuzzleClientConstructor.php
+++ b/utils/phpstan/tests/Rule/Fixture/GuzzleClientConstructor.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+use GuzzleHttp\Client;
+
+final class GuzzleClientConstructor
+{
+    public function __construct(
+        private readonly Client $client,
+    ) {
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/InterfaceConstructor.php
+++ b/utils/phpstan/tests/Rule/Fixture/InterfaceConstructor.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Routing\RouterInterface;
+
+final class InterfaceConstructor
+{
+    public function __construct(
+        private readonly RouterInterface $router,
+        private readonly EntityManagerInterface $entityManager,
+    ) {
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/NonVendor.php
+++ b/utils/phpstan/tests/Rule/Fixture/NonVendor.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+final class NonVendor implements NonVendorInterface
+{
+}

--- a/utils/phpstan/tests/Rule/Fixture/NonVendorConstructor.php
+++ b/utils/phpstan/tests/Rule/Fixture/NonVendorConstructor.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+final class NonVendorConstructor
+{
+    public function __construct(
+        private readonly NonVendor $nonVendor,
+    ) {
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/NonVendorInterface.php
+++ b/utils/phpstan/tests/Rule/Fixture/NonVendorInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+interface NonVendorInterface
+{
+}

--- a/utils/phpstan/tests/Rule/Fixture/SessionConstructor.php
+++ b/utils/phpstan/tests/Rule/Fixture/SessionConstructor.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+use Symfony\Component\HttpFoundation\Session\Session;
+
+final class SessionConstructor
+{
+    public function __construct(
+        private readonly Session $session,
+    ) {
+    }
+}

--- a/utils/phpstan/tests/Rule/PreferInterfaceInConstructorRuleTest.php
+++ b/utils/phpstan/tests/Rule/PreferInterfaceInConstructorRuleTest.php
@@ -30,35 +30,14 @@ final class PreferInterfaceInConstructorRuleTest extends RuleTestCase
                 14,
             ],
         ]);
-    }
 
-    public function testSkipInterfaceType(): void
-    {
-        $this->analyse([__DIR__.'/Fixture/InterfaceConstructor.php'], []);
-    }
-
-    public function testSkipClassWithoutSameNamedInterface(): void
-    {
-        $this->analyse([__DIR__.'/Fixture/ClassWithoutInterfaceConstructor.php'], []);
-    }
-
-    public function testSkipSession(): void
-    {
-        $this->analyse([__DIR__.'/Fixture/SessionConstructor.php'], []);
-    }
-
-    public function testSkipClassOutsideSymfonyAndDoctrine(): void
-    {
-        $this->analyse([__DIR__.'/Fixture/NonVendorConstructor.php'], []);
-    }
-
-    public function testSkipGuzzleClient(): void
-    {
-        $this->analyse([__DIR__.'/Fixture/GuzzleClientConstructor.php'], []);
-    }
-
-    public function testSkipConfigLoader(): void
-    {
-        $this->analyse([__DIR__.'/Fixture/ConfigLoaderConstructor.php'], []);
+        $this->analyse([
+            __DIR__.'/Fixture/InterfaceConstructor.php',
+            __DIR__.'/Fixture/ClassWithoutInterfaceConstructor.php',
+            __DIR__.'/Fixture/SessionConstructor.php',
+            __DIR__.'/Fixture/NonVendorConstructor.php',
+            __DIR__.'/Fixture/GuzzleClientConstructor.php',
+            __DIR__.'/Fixture/ConfigLoaderConstructor.php',
+        ], []);
     }
 }

--- a/utils/phpstan/tests/Rule/PreferInterfaceInConstructorRuleTest.php
+++ b/utils/phpstan/tests/Rule/PreferInterfaceInConstructorRuleTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use Utils\PHPStan\Rule\PreferInterfaceInConstructorRule;
+
+/**
+ * @extends RuleTestCase<PreferInterfaceInConstructorRule>
+ */
+final class PreferInterfaceInConstructorRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new PreferInterfaceInConstructorRule($this->createReflectionProvider());
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/ConcreteClassConstructor.php'], [
+            [
+                'Constructor dependency "$router" is typed as concrete "Symfony\Component\Routing\Router". Use the "Symfony\Component\Routing\RouterInterface" interface instead.',
+                13,
+            ],
+            [
+                'Constructor dependency "$entityManager" is typed as concrete "Doctrine\ORM\EntityManager". Use the "Doctrine\ORM\EntityManagerInterface" interface instead.',
+                14,
+            ],
+        ]);
+    }
+
+    public function testSkipInterfaceType(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/InterfaceConstructor.php'], []);
+    }
+
+    public function testSkipClassWithoutSameNamedInterface(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/ClassWithoutInterfaceConstructor.php'], []);
+    }
+
+    public function testSkipSession(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/SessionConstructor.php'], []);
+    }
+
+    public function testSkipClassOutsideSymfonyAndDoctrine(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/NonVendorConstructor.php'], []);
+    }
+
+    public function testSkipGuzzleClient(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/GuzzleClientConstructor.php'], []);
+    }
+
+    public function testSkipConfigLoader(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/ConfigLoaderConstructor.php'], []);
+    }
+}


### PR DESCRIPTION
Symfony is unable to autowire specific types like `EntityManager`, `Router` or `UrlGenerator`.
That's why they have to be handled manually, which adds more work and maintenance cost.

Their interface contracts (e.g `EntityManagerInterface`, `RouterInterface` or `UrlGeneratorInterface`) should be used instead to let container handle it :+1: 