### PR TITLE
Fix maintenance cleanup dry-run count for expired user tokens

### DIFF
--- a/app/bundles/UserBundle/Entity/UserTokenRepository.php
+++ b/app/bundles/UserBundle/Entity/UserTokenRepository.php
@@ -48,17 +48,17 @@ final class UserTokenRepository extends CommonRepository implements UserTokenRep
 
     public function deleteExpired($isDryRun = false): int
     {
-        $qb = $this->createQueryBuilder('ut');
+        $qb = $this->createQueryBuilder('ut')
+            ->where('ut.expiration <= :current_datetime')
+            ->setParameter('current_datetime', new \DateTime());
 
         if ($isDryRun) {
-            $qb->select('count(ut.id) as records');
-        } else {
-            $qb->delete(UserToken::class, 'ut');
+            return (int) $qb->select('count(ut.id)')
+                ->getQuery()
+                ->getSingleScalarResult();
         }
 
-        return (int) $qb
-            ->where('ut.expiration <= :current_datetime')
-            ->setParameter('current_datetime', new \DateTime())
+        return (int) $qb->delete(UserToken::class, 'ut')
             ->getQuery()
             ->execute();
     }

--- a/app/bundles/UserBundle/Tests/Functional/Entity/UserTokenRepositoryTest.php
+++ b/app/bundles/UserBundle/Tests/Functional/Entity/UserTokenRepositoryTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\UserBundle\Tests\Functional\Entity;
+
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\UserBundle\Entity\User;
+use Mautic\UserBundle\Entity\UserToken;
+use Mautic\UserBundle\Entity\UserTokenRepository;
+
+final class UserTokenRepositoryTest extends MauticMysqlTestCase
+{
+    private UserTokenRepository $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repository = $this->em->getRepository(UserToken::class);
+
+        // Guarantee a deterministic starting point regardless of fixtures.
+        $table = $this->em->getClassMetadata(UserToken::class)->getTableName();
+        $this->em->getConnection()->executeStatement("DELETE FROM {$table}");
+    }
+
+    public function testDeleteExpiredDryRunReturnsRealCount(): void
+    {
+        $user = $this->em->find(User::class, 1);
+        $this->assertInstanceOf(User::class, $user);
+
+        // Three expired tokens and one that is still valid.
+        $this->createToken($user, new \DateTime('-2 days'));
+        $this->createToken($user, new \DateTime('-1 day'));
+        $this->createToken($user, new \DateTime('-1 hour'));
+        $this->createToken($user, new \DateTime('+1 day'));
+        $this->em->flush();
+        $this->em->clear();
+
+        // The dry run must report the real number of expired tokens, not a constant 1.
+        $this->assertSame(3, $this->repository->deleteExpired(true));
+        // The dry run must not delete anything.
+        $this->assertSame(4, (int) $this->repository->count([]));
+        // The real run deletes exactly the expired tokens and returns the same count.
+        $this->assertSame(3, $this->repository->deleteExpired(false));
+        $this->assertSame(1, (int) $this->repository->count([]));
+    }
+
+    public function testDeleteExpiredDryRunReturnsZeroWhenNothingExpired(): void
+    {
+        $user = $this->em->find(User::class, 1);
+        $this->assertInstanceOf(User::class, $user);
+
+        $this->createToken($user, new \DateTime('+1 day'));
+        $this->em->flush();
+        $this->em->clear();
+
+        $this->assertSame(0, $this->repository->deleteExpired(true));
+    }
+
+    private function createToken(User $user, \DateTime $expiration): void
+    {
+        $token = new UserToken();
+        $token->setUser($user);
+        $token->setAuthorizator('reset-password');
+        $token->setSecret(bin2hex(random_bytes(16)));
+        $token->setExpiration($expiration);
+        $token->setOneTimeOnly(true);
+        $this->em->persist($token);
+    }
+}


### PR DESCRIPTION
<!--
==================================================================
PR TITLE (paste into the GitHub title field):

Fix maintenance cleanup dry-run count for expired user tokens

------------------------------------------------------------------
BASE BRANCH:
This is a bug fix. Per Mautic's PR template, submit it against the
LOWEST maintained a.b bug-fix branch where the bug still applies
(the code is identical in 5.x, 6.x, 7.0 and 7.x). Check the current
maintained branches and pick the lowest a.b (e.g. 6.0 / 5.x point
branch) as the PR base. Lower branches get merged upward.
------------------------------------------------------------------
Everything BELOW this comment block is the paste-ready PR body.
==================================================================
-->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch) | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️
| Related user documentation PR URL      | —
| Related developer documentation PR URL | —
| Issue(s) addressed                     | Fixes #16770

## Description

`php bin/console mautic:maintenance:cleanup --dry-run` (with or without `--gdpr`)
**always** reports `1` under "User tokens" — even when the `user_tokens` table has
no expired rows at all, and equally when it has many. The reported figure is
constant and never reflects reality. The non-dry-run path deletes the correct
number of rows, so only the dry-run count is misleading.

**Root cause** — `app/bundles/UserBundle/Entity/UserTokenRepository.php::deleteExpired()`:

```php
if ($isDryRun) {
    $qb->select('count(ut.id) as records');
} else {
    $qb->delete(UserToken::class, 'ut');
}

return (int) $qb
    ->where('ut.expiration <= :current_datetime')
    ->setParameter('current_datetime', new \DateTime())
    ->getQuery()
    ->execute();
```

In dry-run mode `->execute()` returns a result **array**. A `COUNT(...)` without
`GROUP BY` always returns exactly one row, so the result is `[['records' => N]]` —
a non-empty array even when `N = 0`. Casting a non-empty array to `(int)` yields
`1` in PHP (and emits an "Array to int conversion" warning on PHP 8). An empty
array (which would cast to `0`) can never occur here, so the dry-run count is a
constant `1`. The delete branch returns the affected-rows integer from
`execute()`, which is why the real run is correct.

Reached via `CoreBundle/EventListener/MaintenanceSubscriber`, which calls
`deleteExpired($event->isDryRun())` and passes no SQL to `setStat()` (so this
category also never appears in the command's dev-env "Debug" SQL output).

**Fix** — count via `getSingleScalarResult()` so a real scalar is returned. This
also realigns the method with its own documented interface contract:
`UserTokenRepositoryInterface::deleteExpired()` declares
`@return int Number of selected or deleted rows`, which the previous dry-run path
did not honour (it returned a constant `1`). Restoring that contract is therefore a
bug fix, not a behavioural/API change — a caller relying on the constant `1` was
relying on the bug.

**Scope** — user tokens only. All other cleanup categories compute their dry-run
count via the DBAL query builder (`->executeQuery()->fetchOne()`), which returns a
proper scalar, and are unaffected: audit log & notifications
(`CoreBundle/EventListener/MaintenanceSubscriber::cleanupData()`), visitors
(`LeadBundle/EventListener/MaintenanceSubscriber`), page hits and UTM tags
(`PageBundle/EventListener/MaintenanceSubscriber::cleanData()`). `deleteExpired()`
is the only cleanup routine that counts via the ORM query
(`getQuery()->execute()`) instead of DBAL, which is what triggers the bug.

**Behaviour change**

| Situation (expired user tokens) | Before (`--dry-run`) | After (`--dry-run`) |
| ------------------------------- | -------------------- | ------------------- |
| 0 expired                       | 1                    | 0                   |
| 3 expired                       | 1                    | 3                   |

No BC break: only the dry-run reporting number changes to the correct value;
deletion behaviour is unchanged.

---
### 📋 Steps to test this PR:

1. Open this PR on Gitpod or pull it down for testing locally (see the
   [testing docs](https://contribute.mautic.org/contributing-to-mautic/tester)).
2. Run the included functional test — it fails on the current code and passes with
   this fix:
   ```
   bin/phpunit app/bundles/UserBundle/Tests/Functional/Entity/UserTokenRepositoryTest.php
   ```
3. Manual reproduction on an instance:
   - With **no** expired user tokens, run
     `php bin/console mautic:maintenance:cleanup --gdpr --dry-run`
     → before: "User tokens" shows `1`; after: shows `0`.
   - Insert 3 rows into `user_tokens` with `expiration <= NOW()` (e.g. trigger
     several password resets and let them expire), then run the command again
     → before: still `1`; after: shows `3`.
   - Confirm a real run (without `--dry-run`) reports and deletes the correct
     number both before and after (that path was already correct).
