### PR TITLE
[InstallBundle] Flip 3 services from config to autowired services.php

### DIFF
--- a/app/bundles/InstallBundle/Config/config.php
+++ b/app/bundles/InstallBundle/Config/config.php
@@ -61,38 +61,6 @@ return [
                     'priority' => 0,
                 ],
             ],
-            'mautic.install.configurator.step.doctrine' => [
-                'class'     => Mautic\InstallBundle\Configurator\Step\DoctrineStep::class,
-                'arguments' => [
-                    'mautic.configurator',
-                ],
-                'tag'          => 'mautic.configurator.step',
-                'tagArguments' => [
-                    'priority' => 1,
-                ],
-            ],
-            'mautic.install.configurator.step.user' => [
-                'class'        => Mautic\InstallBundle\Configurator\Step\UserStep::class,
-                'tag'          => 'mautic.configurator.step',
-                'tagArguments' => [
-                    'priority' => 2,
-                ],
-            ],
-            'mautic.install.service' => [
-                'class'     => Mautic\InstallBundle\Install\InstallService::class,
-                'arguments' => [
-                    'mautic.configurator',
-                    'mautic.helper.cache',
-                    'mautic.helper.paths',
-                    'doctrine.orm.entity_manager',
-                    'translator',
-                    'kernel',
-                    'validator',
-                    'security.password_hasher',
-                    'mautic.doctrine.loader.mautic_fixtures_loader',
-                    'mautic.user.repository',
-                ],
-            ],
         ],
     ],
 ];

--- a/app/bundles/InstallBundle/Config/services.php
+++ b/app/bundles/InstallBundle/Config/services.php
@@ -16,6 +16,12 @@ return function (ContainerConfigurator $configurator): void {
         'Helper/SchemaHelper.php',
     ];
 
+    $services->set(Mautic\CoreBundle\Doctrine\Loader\MauticFixturesLoader::class);
+    $services->alias(Mautic\CoreBundle\Doctrine\Loader\FixturesLoaderInterface::class, Mautic\CoreBundle\Doctrine\Loader\MauticFixturesLoader::class);
+
     $services->load('Mautic\\InstallBundle\\', '../')
         ->exclude('../{'.implode(',', array_merge(MauticCoreExtension::DEFAULT_EXCLUDES, $excludes)).'}');
+    $services->set('mautic.install.configurator.step.doctrine', Mautic\InstallBundle\Configurator\Step\DoctrineStep::class)->tag('mautic.configurator.step', ['priority' => 1]);
+    $services->set('mautic.install.configurator.step.user', Mautic\InstallBundle\Configurator\Step\UserStep::class)->tag('mautic.configurator.step', ['priority' => 2]);
+    $services->set('mautic.install.service', Mautic\InstallBundle\Install\InstallService::class);
 };

--- a/app/bundles/LeadBundle/Tests/Controller/Api/CustomFieldsApiControllerTraitTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/CustomFieldsApiControllerTraitTest.php
@@ -88,8 +88,9 @@ final class CustomFieldsApiControllerTraitTest extends \PHPUnit\Framework\TestCa
 
             private string $entityNameOne = 'lead';
 
-            public function __construct(private object $model)
-            {
+            public function __construct(
+                private object $model,
+            ) {
             }
 
             public function getModel(?string $name): object


### PR DESCRIPTION
Flips 3 services from `Config/config.php` to autowired `Config/services.php`.

Follow up to: https://github.com/mautic/mautic/pull/16758/