### PR TITLE
[MarketplaceBundle] [AssetBundle] Flip 8 services from config to autowired services.php

### DIFF
--- a/app/bundles/AssetBundle/Config/config.php
+++ b/app/bundles/AssetBundle/Config/config.php
@@ -55,18 +55,7 @@ return [
     ],
 
     'services' => [
-        'permissions' => [
-            'mautic.asset.permissions' => [
-                'class'     => Mautic\AssetBundle\Security\Permissions\AssetPermissions::class,
-                'arguments' => [
-                    'mautic.helper.core_parameters',
-                ],
-            ],
-        ],
         'others' => [
-            'mautic.asset.upload.error.handler' => [
-                'class'     => Mautic\AssetBundle\ErrorHandler\DropzoneErrorHandler::class,
-            ],
             // Override the DropzoneController
             'oneup_uploader.controller.dropzone.class' => [
                 'class'     => Mautic\AssetBundle\Controller\UploadController::class,

--- a/app/bundles/AssetBundle/Config/services.php
+++ b/app/bundles/AssetBundle/Config/services.php
@@ -21,6 +21,12 @@ return function (ContainerConfigurator $configurator): void {
 
     $services->load('Mautic\\AssetBundle\\Entity\\', '../Entity/*Repository.php')
         ->tag(Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass::REPOSITORY_SERVICE_TAG);
+
+    $services->set(Mautic\AssetBundle\Security\Permissions\AssetPermissions::class)
+        ->arg('$coreParametersHelper', \Symfony\Component\DependencyInjection\Loader\Configurator\service(Mautic\CoreBundle\Helper\CoreParametersHelper::class));
+
+    $services->set('mautic.asset.upload.error.handler', Mautic\AssetBundle\ErrorHandler\DropzoneErrorHandler::class);
+
     $services->alias('mautic.asset.helper.token', Mautic\AssetBundle\Helper\TokenHelper::class);
     $services->alias('mautic.asset.model.asset', Mautic\AssetBundle\Model\AssetModel::class);
     $services->alias(Oneup\UploaderBundle\Templating\Helper\UploaderHelper::class, 'oneup_uploader.templating.uploader_helper');

--- a/app/bundles/EmailBundle/Config/services.php
+++ b/app/bundles/EmailBundle/Config/services.php
@@ -57,7 +57,7 @@ return function (ContainerConfigurator $configurator): void {
     $services->set('mautic.email.validator.multiple_emails_valid_validator', Mautic\EmailBundle\Validator\MultipleEmailsValidValidator::class)->tag('validator.constraint_validator');
     $services->set('mautic.email.validator.email_or_token_list_validator', Mautic\EmailBundle\Validator\EmailOrEmailTokenListValidator::class)->tag('validator.constraint_validator');
 
-    $services->alias(Mautic\CoreBundle\Doctrine\Provider\GeneratedColumnsProviderInterface::class, Mautic\CoreBundle\Doctrine\Provider\GeneratedColumnsProvider::class);
+    $services->alias(Mautic\CoreBundle\Doctrine\Provider\GeneratedColumnsProviderInterface::class, 'mautic.generated.columns.provider');
     $services->set(Mautic\EmailBundle\Mailer\Transport\TransportFactory::class)->decorate('mailer.transport_factory');
 
     $services->set(Mautic\EmailBundle\MonitoredEmail\Processor\Bounce::class);

--- a/app/bundles/MarketplaceBundle/Config/config.php
+++ b/app/bundles/MarketplaceBundle/Config/config.php
@@ -36,53 +36,6 @@ return [
             ],
         ],
     ],
-    'services' => [
-        'permissions' => [
-            'marketplace.permissions' => [
-                'class'     => Mautic\MarketplaceBundle\Security\Permissions\MarketplacePermissions::class,
-                'arguments' => [
-                    'mautic.helper.core_parameters',
-                    'marketplace.service.config',
-                ],
-            ],
-        ],
-        'api' => [
-            'marketplace.api.connection' => [
-                'class'     => Mautic\MarketplaceBundle\Api\Connection::class,
-                'arguments' => [
-                    'mautic.http.client',
-                    'monolog.logger.mautic',
-                ],
-            ],
-        ],
-        'other' => [
-            'marketplace.service.plugin_collector' => [
-                'class'     => Mautic\MarketplaceBundle\Service\PluginCollector::class,
-                'arguments' => [
-                    'marketplace.api.connection',
-                    'marketplace.service.allowlist',
-                ],
-            ],
-            'marketplace.service.route_provider' => [
-                'class'     => RouteProvider::class,
-                'arguments' => ['router'],
-            ],
-            'marketplace.service.config' => [
-                'class'     => Config::class,
-                'arguments' => [
-                    'mautic.helper.core_parameters',
-                ],
-            ],
-            'marketplace.service.allowlist' => [
-                'class'     => Mautic\MarketplaceBundle\Service\Allowlist::class,
-                'arguments' => [
-                    'marketplace.service.config',
-                    'mautic.cache.provider',
-                    'mautic.http.client',
-                ],
-            ],
-        ],
-    ],
     // NOTE: when adding new parameters here, please add them to the developer documentation as well:
     'parameters' => [
         Config::MARKETPLACE_ENABLED                     => true,

--- a/app/bundles/MarketplaceBundle/Config/services.php
+++ b/app/bundles/MarketplaceBundle/Config/services.php
@@ -16,6 +16,12 @@ return function (ContainerConfigurator $configurator): void {
 
     $services->load('Mautic\\MarketplaceBundle\\', '../')
         ->exclude('../{'.implode(',', array_merge(MauticCoreExtension::DEFAULT_EXCLUDES, $excludes)).'}');
+    $services->set('marketplace.permissions', Mautic\MarketplaceBundle\Security\Permissions\MarketplacePermissions::class);
+    $services->set('marketplace.api.connection', Mautic\MarketplaceBundle\Api\Connection::class);
+    $services->set('marketplace.service.plugin_collector', Mautic\MarketplaceBundle\Service\PluginCollector::class);
+    $services->set('marketplace.service.route_provider', Mautic\MarketplaceBundle\Service\RouteProvider::class);
+    $services->set('marketplace.service.config', Mautic\MarketplaceBundle\Service\Config::class);
+    $services->set('marketplace.service.allowlist', Mautic\MarketplaceBundle\Service\Allowlist::class);
 
     $services->alias('marketplace.model.package', Mautic\MarketplaceBundle\Model\PackageModel::class);
 };

--- a/app/bundles/MarketplaceBundle/Config/services.php
+++ b/app/bundles/MarketplaceBundle/Config/services.php
@@ -5,19 +5,26 @@ declare(strict_types=1);
 use Mautic\CoreBundle\DependencyInjection\MauticCoreExtension;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
 return function (ContainerConfigurator $configurator): void {
     $services = $configurator->services()
         ->defaults()
         ->autowire()
         ->autoconfigure()
-        ->public();
+        ->public()
+        ->bind('$httpClient', service('mautic.http.client'));
 
     $excludes = [];
 
     $services->load('Mautic\\MarketplaceBundle\\', '../')
         ->exclude('../{'.implode(',', array_merge(MauticCoreExtension::DEFAULT_EXCLUDES, $excludes)).'}');
-    $services->set('marketplace.permissions', Mautic\MarketplaceBundle\Security\Permissions\MarketplacePermissions::class);
-    $services->set('marketplace.api.connection', Mautic\MarketplaceBundle\Api\Connection::class);
+    $services->set(Mautic\MarketplaceBundle\Security\Permissions\MarketplacePermissions::class)
+        ->arg('$coreParametersHelper', service(Mautic\CoreBundle\Helper\CoreParametersHelper::class));
+
+    $services->set(Mautic\MarketplaceBundle\Api\Connection::class)
+        ->arg('$httpClient', service('mautic.http.client'));
+
     $services->set('marketplace.service.plugin_collector', Mautic\MarketplaceBundle\Service\PluginCollector::class);
     $services->set('marketplace.service.route_provider', Mautic\MarketplaceBundle\Service\RouteProvider::class);
     $services->set('marketplace.service.config', Mautic\MarketplaceBundle\Service\Config::class);


### PR DESCRIPTION
Flips 8 services from `Config/config.php` to autowired `Config/services.php`:

* MarketplaceBundle: 6 services
* AssetBundle: 2 services

Follow up to: https://github.com/mautic/mautic/pull/16758/
