### PR TITLE
[PageBundle] Flip 3 services from config to autowired services.php

### DIFF
--- a/app/bundles/PageBundle/Config/config.php
+++ b/app/bundles/PageBundle/Config/config.php
@@ -89,15 +89,6 @@ return [
     ],
 
     'services' => [
-        'events' => [
-            'mautic.page.segment_tracking_subscriber' => [
-                'class'     => Mautic\PageBundle\EventListener\SegmentTrackingSubscriber::class,
-                'arguments' => [
-                    'mautic.helper.core_parameters',
-                    'mautic.lead.repository.lead_list',
-                ],
-            ],
-        ],
         'fixtures' => [
             'mautic.page.fixture.page_category' => [
                 'class'     => Mautic\PageBundle\DataFixtures\ORM\LoadPageCategoryData::class,
@@ -113,21 +104,6 @@ return [
                 'class'     => Mautic\PageBundle\DataFixtures\ORM\LoadPageHitData::class,
                 'tag'       => Doctrine\Bundle\FixturesBundle\DependencyInjection\CompilerPass\FixturesCompilerPass::FIXTURE_TAG,
                 'arguments' => ['mautic.page.model.page'],
-            ],
-        ],
-        'other' => [
-            'mautic.page.helper.token' => [
-                'class'     => Mautic\PageBundle\Helper\TokenHelper::class,
-                'arguments' => 'mautic.page.model.page',
-            ],
-            'mautic.page.helper.tracking' => [
-                'class'     => Mautic\PageBundle\Helper\TrackingHelper::class,
-                'arguments' => [
-                    'mautic.tracker.contact',
-                    'mautic.cache.provider',
-                    'mautic.helper.core_parameters',
-                    'request_stack',
-                ],
             ],
         ],
     ],

--- a/app/bundles/PageBundle/Config/services.php
+++ b/app/bundles/PageBundle/Config/services.php
@@ -20,6 +20,9 @@ return function (ContainerConfigurator $configurator): void {
 
     $services->load('Mautic\\PageBundle\\Entity\\', '../Entity/*Repository.php')
         ->tag(Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass::REPOSITORY_SERVICE_TAG);
+    $services->set('mautic.page.segment_tracking_subscriber', Mautic\PageBundle\EventListener\SegmentTrackingSubscriber::class);
+    $services->set('mautic.page.helper.token', Mautic\PageBundle\Helper\TokenHelper::class);
+    $services->set('mautic.page.helper.tracking', Mautic\PageBundle\Helper\TrackingHelper::class);
 
     $services->get(Mautic\PageBundle\Model\PageModel::class)->call('setCatInUrl', ['%mautic.cat_in_page_url%']);
     $services->alias('mautic.page.model.page', Mautic\PageBundle\Model\PageModel::class);


### PR DESCRIPTION
Flips 3 services from `Config/config.php` to autowired `Config/services.php`.

Follow up to: https://github.com/mautic/mautic/pull/16758/