### PR TITLE
[AssetBundle] Flip 2 services from config to autowired services.php

### DIFF
--- a/app/bundles/AssetBundle/Config/config.php
+++ b/app/bundles/AssetBundle/Config/config.php
@@ -55,18 +55,7 @@ return [
     ],
 
     'services' => [
-        'permissions' => [
-            'mautic.asset.permissions' => [
-                'class'     => Mautic\AssetBundle\Security\Permissions\AssetPermissions::class,
-                'arguments' => [
-                    'mautic.helper.core_parameters',
-                ],
-            ],
-        ],
         'others' => [
-            'mautic.asset.upload.error.handler' => [
-                'class'     => Mautic\AssetBundle\ErrorHandler\DropzoneErrorHandler::class,
-            ],
             // Override the DropzoneController
             'oneup_uploader.controller.dropzone.class' => [
                 'class'     => Mautic\AssetBundle\Controller\UploadController::class,

--- a/app/bundles/AssetBundle/Config/services.php
+++ b/app/bundles/AssetBundle/Config/services.php
@@ -21,6 +21,12 @@ return function (ContainerConfigurator $configurator): void {
 
     $services->load('Mautic\\AssetBundle\\Entity\\', '../Entity/*Repository.php')
         ->tag(Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass::REPOSITORY_SERVICE_TAG);
+
+    $services->set(Mautic\AssetBundle\Security\Permissions\AssetPermissions::class)
+        ->arg('$coreParametersHelper', \Symfony\Component\DependencyInjection\Loader\Configurator\service(Mautic\CoreBundle\Helper\CoreParametersHelper::class));
+
+    $services->set('mautic.asset.upload.error.handler', Mautic\AssetBundle\ErrorHandler\DropzoneErrorHandler::class);
+
     $services->alias('mautic.asset.helper.token', Mautic\AssetBundle\Helper\TokenHelper::class);
     $services->alias('mautic.asset.model.asset', Mautic\AssetBundle\Model\AssetModel::class);
     $services->alias(Oneup\UploaderBundle\Templating\Helper\UploaderHelper::class, 'oneup_uploader.templating.uploader_helper');

--- a/app/bundles/LeadBundle/Tests/Controller/Api/CustomFieldsApiControllerTraitTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/CustomFieldsApiControllerTraitTest.php
@@ -88,8 +88,9 @@ final class CustomFieldsApiControllerTraitTest extends \PHPUnit\Framework\TestCa
 
             private string $entityNameOne = 'lead';
 
-            public function __construct(private object $model)
-            {
+            public function __construct(
+                private object $model,
+            ) {
             }
 
             public function getModel(?string $name): object


### PR DESCRIPTION
Flips 2 services from `Config/config.php` to autowired `Config/services.php`.

Follow up to: https://github.com/mautic/mautic/pull/16758/