### PR TITLE
Migrate MauticTagManagerBundle off deprecated AbstractIntegration

### DIFF
--- a/app/bundles/CoreBundle/Tests/Functional/DependencyInjection/TaggedServiceWiringSmokeTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/DependencyInjection/TaggedServiceWiringSmokeTest.php
@@ -20,10 +20,10 @@ final class TaggedServiceWiringSmokeTest extends AbstractContainerSmokeTestCase
     private const EXPECTED_COLLECTED_SERVICE_COUNTS = [
         'mautic.email.stats.helper_container'                     => 6,
         'mautic.helper.update_checks'                             => 2,
-        'mautic.integrations.helper'                              => 2,
+        'mautic.integrations.helper'                              => 3,
         'mautic.integrations.helper.auth_integrations'            => 0,
         'mautic.integrations.helper.builder_integrations'         => 1,
-        'mautic.integrations.helper.config_integrations'          => 2,
+        'mautic.integrations.helper.config_integrations'          => 3,
         'mautic.integrations.helper.sync_integrations'            => 0,
         'mautic.integrations.sync.notification.handler_container' => 2,
         'mautic.sms.callback_handler_container'                   => 1,

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -12861,27 +12861,3 @@ parameters:
 			count: 2
 			path: plugins/MauticSocialBundle/Security/Permissions/MauticSocialPermissions.php
 
-		-
-			message: '#^Instead of assigning service property to a variable, use the property directly$#'
-			identifier: symplify.noJustPropertyAssign
-			count: 1
-			path: plugins/MauticTagManagerBundle/Controller/TagController.php
-
-		-
-			message: '#^Method MauticPlugin\\MauticTagManagerBundle\\Entity\\TagRepository\:\:countByLeads\(\) has parameter \$tagIds with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: plugins/MauticTagManagerBundle/Entity/TagRepository.php
-
-		-
-			message: '#^Method MauticPlugin\\MauticTagManagerBundle\\Entity\\TagRepository\:\:countOccurrences\(\) has parameter \$tag with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: plugins/MauticTagManagerBundle/Entity/TagRepository.php
-
-		-
-			message: '#^Parameter \#1 \$permissionNames of method Mautic\\CoreBundle\\Security\\Permissions\\AbstractPermissions\:\:addStandardPermissions\(\) expects array, string given\.$#'
-			identifier: argument.type
-			count: 1
-			path: plugins/MauticTagManagerBundle/Security/Permissions/TagManagerPermissions.php
-

--- a/plugins/MauticTagManagerBundle/Config/config.php
+++ b/plugins/MauticTagManagerBundle/Config/config.php
@@ -25,31 +25,6 @@ return [
             ],
         ],
     ],
-    'services'    => [
-        'integrations' => [
-            'mautic.integration.tagmanager' => [
-                'class'     => MauticPlugin\MauticTagManagerBundle\Integration\TagManagerIntegration::class,
-                'arguments' => [
-                    'event_dispatcher',
-                    'mautic.helper.cache_storage',
-                    'doctrine.orm.entity_manager',
-                    'request_stack',
-                    'router',
-                    'translator',
-                    'monolog.logger.mautic',
-                    'mautic.helper.encryption',
-                    'mautic.lead.model.lead',
-                    'mautic.lead.model.company',
-                    'mautic.helper.paths',
-                    'mautic.core.model.notification',
-                    'mautic.lead.model.field',
-                    'mautic.plugin.model.integration_entity',
-                    'mautic.lead.model.dnc',
-                    'mautic.lead.field.fields_with_unique_identifier',
-                ],
-            ],
-        ],
-    ],
     'menu' => [
         'main' => [
             'tagmanager.menu.index' => [

--- a/plugins/MauticTagManagerBundle/Config/services.php
+++ b/plugins/MauticTagManagerBundle/Config/services.php
@@ -24,4 +24,6 @@ return function (ContainerConfigurator $configurator): void {
 
     $services->alias('mautic.tagmanager.model.tag', MauticPlugin\MauticTagManagerBundle\Model\TagModel::class);
     $services->alias('mautic.tagmanager.repository.tag', MauticPlugin\MauticTagManagerBundle\Entity\TagRepository::class);
+    $services->alias('mautic.integration.tagmanager', MauticPlugin\MauticTagManagerBundle\Integration\TagManagerIntegration::class);
+    $services->alias('mautic.integration.tagmanager.config', MauticPlugin\MauticTagManagerBundle\Integration\Support\ConfigSupport::class);
 };

--- a/plugins/MauticTagManagerBundle/Controller/TagController.php
+++ b/plugins/MauticTagManagerBundle/Controller/TagController.php
@@ -454,8 +454,6 @@ final class TagController extends FormController
      */
     public function viewAction(Request $request, TagDependencies $tagDependencies, int $objectId): Response
     {
-        $security = $this->security;
-
         $tag = $this->leadTagModel->getEntity($objectId);
 
         // set the page we came from
@@ -489,7 +487,7 @@ final class TagController extends FormController
             'returnUrl'      => $this->generateUrl('mautic_tagmanager_action', ['objectAction' => 'view', 'objectId' => $tag->getId()]),
             'viewParameters' => [
                 'tag'        => $tag,
-                'security'   => $security,
+                'security'   => $this->security,
                 'usageStats' => $tagDependencies->getChannelsIds($tag),
             ],
             'contentTemplate' => '@MauticTagManager/Tag/details.html.twig',

--- a/plugins/MauticTagManagerBundle/Entity/TagRepository.php
+++ b/plugins/MauticTagManagerBundle/Entity/TagRepository.php
@@ -24,6 +24,9 @@ class TagRepository extends BaseTagRepository
         return 'lt';
     }
 
+    /**
+     * @param string $tag
+     */
     public function countOccurrences($tag): int
     {
         $q = $this->getEntityManager()->getConnection()->createQueryBuilder();
@@ -39,7 +42,9 @@ class TagRepository extends BaseTagRepository
     /**
      * Get a count of leads that belong to the tag.
      *
-     * @return array
+     * @param int|int[] $tagIds
+     *
+     * @return int|array<int, int>
      */
     public function countByLeads($tagIds)
     {

--- a/plugins/MauticTagManagerBundle/Integration/Support/ConfigSupport.php
+++ b/plugins/MauticTagManagerBundle/Integration/Support/ConfigSupport.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MauticPlugin\MauticTagManagerBundle\Integration\Support;
+
+use Mautic\IntegrationsBundle\Integration\DefaultConfigFormTrait;
+use Mautic\IntegrationsBundle\Integration\Interfaces\ConfigFormInterface;
+use MauticPlugin\MauticTagManagerBundle\Integration\TagManagerIntegration;
+
+final class ConfigSupport extends TagManagerIntegration implements ConfigFormInterface
+{
+    use DefaultConfigFormTrait;
+}

--- a/plugins/MauticTagManagerBundle/Integration/TagManagerIntegration.php
+++ b/plugins/MauticTagManagerBundle/Integration/TagManagerIntegration.php
@@ -1,10 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace MauticPlugin\MauticTagManagerBundle\Integration;
 
-use Mautic\PluginBundle\Integration\AbstractIntegration;
+use Mautic\IntegrationsBundle\Integration\BasicIntegration;
+use Mautic\IntegrationsBundle\Integration\Interfaces\BasicInterface;
 
-class TagManagerIntegration extends AbstractIntegration
+class TagManagerIntegration extends BasicIntegration implements BasicInterface
 {
     public const PLUGIN_NAME = 'TagManager';
 
@@ -18,12 +21,8 @@ class TagManagerIntegration extends AbstractIntegration
         return 'Tag Manager';
     }
 
-    /**
-     * Return's authentication method such as oauth2, oauth1a, key, etc.
-     */
-    public function getAuthenticationType(): string
+    public function getIcon(): string
     {
-        // Just use none for now and I'll build in "basic" later
-        return 'none';
+        return 'plugins/MauticTagManagerBundle/Assets/img/tagmanager.png';
     }
 }

--- a/plugins/MauticTagManagerBundle/Security/Permissions/TagManagerPermissions.php
+++ b/plugins/MauticTagManagerBundle/Security/Permissions/TagManagerPermissions.php
@@ -14,7 +14,7 @@ class TagManagerPermissions extends AbstractPermissions
     {
         parent::__construct($params);
 
-        $this->addStandardPermissions('tagManager', false);
+        $this->addStandardPermissions(['tagManager'], false);
     }
 
     public function getName(): string

--- a/plugins/MauticTagManagerBundle/Tests/Unit/Integration/TagManagerIntegrationTest.php
+++ b/plugins/MauticTagManagerBundle/Tests/Unit/Integration/TagManagerIntegrationTest.php
@@ -15,11 +15,7 @@ final class TagManagerIntegrationTest extends TestCase
     {
         parent::setUp();
 
-        $this->tagManagerIntegration = new class() extends TagManagerIntegration {
-            public function __construct()
-            {
-            }
-        };
+        $this->tagManagerIntegration = new TagManagerIntegration();
     }
 
     public function testGetNameReturnsName(): void
@@ -34,9 +30,8 @@ final class TagManagerIntegrationTest extends TestCase
         $this->assertNotEmpty($displayName);
     }
 
-    public function testGetAuthenticationTypeReturnsNonEmptyValue(): void
+    public function testGetIconReturnsExpectedPath(): void
     {
-        $authenticationType = $this->tagManagerIntegration->getAuthenticationType();
-        $this->assertNotEmpty($authenticationType);
+        $this->assertSame('plugins/MauticTagManagerBundle/Assets/img/tagmanager.png', $this->tagManagerIntegration->getIcon());
     }
 }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

This PR migrates `MauticTagManagerBundle` away from the deprecated `Mautic\PluginBundle\Integration\AbstractIntegration` class onto `IntegrationsBundle`'s `BasicIntegration/BasicInterface` architecture (same pattern already used by `GrapesJsBuilderBundle` and `MauticClearbitBundle`), and resolves several PHPStan errors in the baseline along the way.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on GitHub Codespaces or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Go to Settings → Plugins and verify that the Tag Manager plugin is listed.
3. Enable the plugin and verify that no errors occur.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->