### PR TITLE
[rector] privatize Event class properties

### DIFF
--- a/app/bundles/ApiBundle/Event/ApiEntityEvent.php
+++ b/app/bundles/ApiBundle/Event/ApiEntityEvent.php
@@ -12,7 +12,7 @@ final class ApiEntityEvent extends CommonEvent
      */
     public function __construct(
         protected $entity,
-        protected array $entityRequestParameters,
+        private readonly array $entityRequestParameters,
         private readonly Request $request,
     ) {
     }

--- a/app/bundles/AssetBundle/Event/AssetLoadEvent.php
+++ b/app/bundles/AssetBundle/Event/AssetLoadEvent.php
@@ -9,7 +9,7 @@ final class AssetLoadEvent extends CommonEvent
 {
     public function __construct(
         Download $download,
-        protected bool $unique,
+        private readonly bool $unique,
     ) {
         $this->entity = $download;
     }

--- a/app/bundles/CampaignBundle/Event/CampaignBuilderEvent.php
+++ b/app/bundles/CampaignBundle/Event/CampaignBuilderEvent.php
@@ -179,7 +179,7 @@ final class CampaignBuilderEvent extends Event
      *
      * @return array
      */
-    protected function sort($property)
+    private function sort(string $property)
     {
         if (empty($this->sortCache[$property])) {
             uasort(

--- a/app/bundles/CampaignBundle/Event/CampaignDecisionEvent.php
+++ b/app/bundles/CampaignBundle/Event/CampaignDecisionEvent.php
@@ -10,19 +10,19 @@ use Symfony\Contracts\EventDispatcher\Event;
  */
 final class CampaignDecisionEvent extends Event
 {
-    protected $decisionTriggered = false;
+    private $decisionTriggered = false;
 
     /**
      * @param LeadEventLog[] $logs
      */
     public function __construct(
-        protected $lead,
-        protected $decisionType,
-        protected $decisionEventDetails,
-        protected $events,
-        protected $eventSettings,
-        protected $isRootLevel = false,
-        protected $logs = [],
+        private $lead,
+        private $decisionType,
+        private $decisionEventDetails,
+        private $events,
+        private $eventSettings,
+        private $isRootLevel = false,
+        private $logs = [],
     ) {
     }
 

--- a/app/bundles/CampaignBundle/Event/CampaignTriggerEvent.php
+++ b/app/bundles/CampaignBundle/Event/CampaignTriggerEvent.php
@@ -7,13 +7,10 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 final class CampaignTriggerEvent extends Event
 {
-    /**
-     * @var bool
-     */
-    protected $triggerCampaign = true;
+    private bool $triggerCampaign = true;
 
     public function __construct(
-        protected Campaign $campaign,
+        private readonly Campaign $campaign,
     ) {
     }
 
@@ -25,10 +22,7 @@ final class CampaignTriggerEvent extends Event
         return $this->campaign;
     }
 
-    /**
-     * @return bool
-     */
-    public function shouldTrigger()
+    public function shouldTrigger(): bool
     {
         return $this->triggerCampaign;
     }

--- a/app/bundles/CategoryBundle/Event/CategoryTypesEvent.php
+++ b/app/bundles/CategoryBundle/Event/CategoryTypesEvent.php
@@ -10,7 +10,7 @@ final class CategoryTypesEvent extends CommonEvent
     /**
      * @var array
      */
-    protected $types = [];
+    private $types = [];
 
     /**
      * Returns the array of Category Types.

--- a/app/bundles/ChannelBundle/Event/ChannelBroadcastEvent.php
+++ b/app/bundles/ChannelBundle/Event/ChannelBroadcastEvent.php
@@ -9,10 +9,8 @@ final class ChannelBroadcastEvent extends Event
 {
     /**
      * Number of contacts successfully processed and/or failed per channel.
-     *
-     * @var array
      */
-    protected $results = [];
+    private array $results = [];
 
     /**
      * Min contact ID filter can be used for process parallelization.
@@ -46,12 +44,12 @@ final class ChannelBroadcastEvent extends Event
         /**
          * Specific channel.
          */
-        protected ?string $channel,
+        private readonly ?string $channel,
         /**
          * Specific ID of a specific channel.
          */
-        protected string|int|null $id,
-        protected OutputInterface $output,
+        private readonly string|int|null $id,
+        private readonly OutputInterface $output,
     ) {
     }
 
@@ -79,10 +77,7 @@ final class ChannelBroadcastEvent extends Event
         ];
     }
 
-    /**
-     * @return array
-     */
-    public function getResults()
+    public function getResults(): array
     {
         return $this->results;
     }

--- a/app/bundles/ChannelBundle/Event/ChannelEvent.php
+++ b/app/bundles/ChannelBundle/Event/ChannelEvent.php
@@ -7,15 +7,9 @@ use Mautic\CoreBundle\Event\CommonEvent;
 
 final class ChannelEvent extends CommonEvent
 {
-    /**
-     * @var array
-     */
-    protected $channels = [];
+    private array $channels = [];
 
-    /**
-     * @var array
-     */
-    protected $featureChannels = [];
+    private array $featureChannels = [];
 
     /**
      * Adds a submit action to the list of available actions.
@@ -46,10 +40,8 @@ final class ChannelEvent extends CommonEvent
 
     /**
      * Returns registered channels with their configs.
-     *
-     * @return array
      */
-    public function getChannelConfigs()
+    public function getChannelConfigs(): array
     {
         return $this->channels;
     }
@@ -87,10 +79,7 @@ final class ChannelEvent extends CommonEvent
         return $this->channels[$channel][MessageModel::CHANNEL_FEATURE]['nameColumn'] ?? 'name';
     }
 
-    /**
-     * @return array
-     */
-    public function getFeatureChannels()
+    public function getFeatureChannels(): array
     {
         return $this->featureChannels;
     }

--- a/app/bundles/CoreBundle/Event/BuildJsEvent.php
+++ b/app/bundles/CoreBundle/Event/BuildJsEvent.php
@@ -13,8 +13,8 @@ final class BuildJsEvent extends Event
      * @param BuildJsScope[] $acceptedScopes
      */
     public function __construct(
-        protected $js,
-        protected $debugMode = false,
+        private $js,
+        private $debugMode = false,
         private readonly array $acceptedScopes = [
             BuildJsScope::RUNTIME,
             BuildJsScope::ESSENTIAL,

--- a/app/bundles/CoreBundle/Event/CommandListEvent.php
+++ b/app/bundles/CoreBundle/Event/CommandListEvent.php
@@ -6,17 +6,12 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 final class CommandListEvent extends Event
 {
-    /**
-     * @var array
-     */
-    protected $commands = [];
+    private array $commands = [];
 
     /**
      * Returns the list of currently stored commands.
-     *
-     * @return mixed
      */
-    public function getCommands()
+    public function getCommands(): array
     {
         return $this->commands;
     }

--- a/app/bundles/CoreBundle/Event/CustomButtonEvent.php
+++ b/app/bundles/CoreBundle/Event/CustomButtonEvent.php
@@ -10,13 +10,13 @@ final class CustomButtonEvent extends AbstractCustomRequestEvent
     /**
      * @var array
      */
-    protected $buttons = [];
+    private $buttons = [];
 
     public function __construct(
-        protected $location,
+        private $location,
         Request $request,
         array $buttons = [],
-        protected $item = null,
+        private $item = null,
     ) {
         parent::__construct($request);
 
@@ -115,7 +115,7 @@ final class CustomButtonEvent extends AbstractCustomRequestEvent
     /**
      * Generate a button ID that can be overridden by other plugins.
      */
-    protected function generateButtonKey(array $button): string
+    private function generateButtonKey(array $button): string
     {
         $buttonKey = '';
         if (!empty($button['btnText'])) {

--- a/app/bundles/CoreBundle/Event/CustomContentEvent.php
+++ b/app/bundles/CoreBundle/Event/CustomContentEvent.php
@@ -9,21 +9,18 @@ final class CustomContentEvent extends Event
     /**
      * @var array
      */
-    protected $content = [];
+    private $content = [];
 
-    /**
-     * @var array
-     */
-    protected $templates = [];
+    private array $templates = [];
 
     /**
      * @param string      $viewName
      * @param string|null $context
      */
     public function __construct(
-        protected $viewName,
-        protected $context = null,
-        protected array $vars = [],
+        private $viewName,
+        private $context = null,
+        private readonly array $vars = [],
     ) {
     }
 
@@ -86,10 +83,7 @@ final class CustomContentEvent extends Event
         return $this->content;
     }
 
-    /**
-     * @return array
-     */
-    public function getTemplates()
+    public function getTemplates(): array
     {
         return $this->templates;
     }

--- a/app/bundles/CoreBundle/Event/CustomTemplateEvent.php
+++ b/app/bundles/CoreBundle/Event/CustomTemplateEvent.php
@@ -6,7 +6,7 @@ use Symfony\Component\HttpFoundation\Request;
 
 final class CustomTemplateEvent extends AbstractCustomRequestEvent
 {
-    protected string $template;
+    private string $template;
 
     /**
      * @param array<string, string> $vars
@@ -14,7 +14,7 @@ final class CustomTemplateEvent extends AbstractCustomRequestEvent
     public function __construct(
         ?Request $request = null,
         string $template = '',
-        protected array $vars = [],
+        private array $vars = [],
     ) {
         parent::__construct($request);
 

--- a/app/bundles/CoreBundle/Event/GlobalSearchEvent.php
+++ b/app/bundles/CoreBundle/Event/GlobalSearchEvent.php
@@ -9,12 +9,9 @@ final class GlobalSearchEvent extends Event
 {
     public const RESULTS_LIMIT = 3;
 
-    /**
-     * @var array
-     */
-    protected $results = [];
+    private array $results = [];
 
-    protected string $searchString;
+    private readonly string $searchString;
 
     /**
      * @param string     $searchString
@@ -22,7 +19,7 @@ final class GlobalSearchEvent extends Event
      */
     public function __construct(
         $searchString,
-        protected $translator,
+        private $translator,
     ) {
         $this->searchString = strtolower(trim(strip_tags($searchString)));
     }
@@ -50,10 +47,8 @@ final class GlobalSearchEvent extends Event
 
     /**
      * Returns the results.
-     *
-     * @return array
      */
-    public function getResults()
+    public function getResults(): array
     {
         uksort($this->results, strnatcmp(...));
 

--- a/app/bundles/CoreBundle/Event/IconEvent.php
+++ b/app/bundles/CoreBundle/Event/IconEvent.php
@@ -10,10 +10,10 @@ final class IconEvent extends Event
     /**
      * @var array
      */
-    protected $icons = [];
+    private $icons = [];
 
     public function __construct(
-        protected CorePermissions $security,
+        private readonly CorePermissions $security,
     ) {
     }
 

--- a/app/bundles/CoreBundle/Event/MenuEvent.php
+++ b/app/bundles/CoreBundle/Event/MenuEvent.php
@@ -10,14 +10,14 @@ final class MenuEvent extends Event
     /**
      * @var array
      */
-    protected $menuItems = ['children' => []];
+    private $menuItems = ['children' => []];
 
     /**
      * @param string $type
      */
     public function __construct(
-        protected MenuHelper $helper,
-        protected $type = 'main',
+        private readonly MenuHelper $helper,
+        private $type = 'main',
     ) {
     }
 

--- a/app/bundles/CoreBundle/Event/RouteEvent.php
+++ b/app/bundles/CoreBundle/Event/RouteEvent.php
@@ -8,14 +8,14 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 final class RouteEvent extends Event
 {
-    protected RouteCollection $collection;
+    private readonly RouteCollection $collection;
 
     /**
      * @param string $type
      */
     public function __construct(
-        protected Loader $loader,
-        protected $type = 'main',
+        private readonly Loader $loader,
+        private $type = 'main',
     ) {
         $this->collection = new RouteCollection();
     }

--- a/app/bundles/CoreBundle/Event/UpgradeEvent.php
+++ b/app/bundles/CoreBundle/Event/UpgradeEvent.php
@@ -7,7 +7,7 @@ use Symfony\Contracts\EventDispatcher\Event;
 final class UpgradeEvent extends Event
 {
     public function __construct(
-        protected array $status,
+        private array $status,
     ) {
     }
 

--- a/app/bundles/DashboardBundle/Event/WidgetFormEvent.php
+++ b/app/bundles/DashboardBundle/Event/WidgetFormEvent.php
@@ -7,9 +7,9 @@ use Mautic\DashboardBundle\Entity\Widget;
 
 final class WidgetFormEvent extends CommonEvent
 {
-    protected $form;
+    private $form;
 
-    protected $type;
+    private $type;
 
     /**
      * Set the widget type.

--- a/app/bundles/DashboardBundle/Event/WidgetTypeListEvent.php
+++ b/app/bundles/DashboardBundle/Event/WidgetTypeListEvent.php
@@ -9,20 +9,11 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class WidgetTypeListEvent extends CommonEvent
 {
-    /**
-     * @var array
-     */
-    protected $widgetTypes = [];
+    private array $widgetTypes = [];
 
-    /**
-     * @var TranslatorInterface
-     */
-    protected $translator;
+    private ?TranslatorInterface $translator = null;
 
-    /**
-     * @var CorePermissions
-     */
-    protected $security;
+    private ?CorePermissions $security = null;
 
     /**
      * Adds a new widget type to the widget types list.
@@ -78,10 +69,8 @@ final class WidgetTypeListEvent extends CommonEvent
 
     /**
      * Returns the array of widget types.
-     *
-     * @return array
      */
-    public function getTypes()
+    public function getTypes(): array
     {
         return $this->widgetTypes;
     }

--- a/app/bundles/LeadBundle/Event/LeadListFilteringEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadListFilteringEvent.php
@@ -11,9 +11,9 @@ use Mautic\LeadBundle\Segment\Query\QueryBuilder;
  */
 final class LeadListFilteringEvent extends CommonEvent
 {
-    protected bool $isFilteringDone;
+    private bool $isFilteringDone;
 
-    protected string $subQuery;
+    private string $subQuery;
 
     private readonly string $leadsTableAlias;
 
@@ -25,11 +25,11 @@ final class LeadListFilteringEvent extends CommonEvent
      * @param QueryBuilder $queryBuilder
      */
     public function __construct(
-        protected $details,
-        protected $leadId,
-        protected $alias,
-        protected $func,
-        protected $queryBuilder,
+        private $details,
+        private $leadId,
+        private $alias,
+        private $func,
+        private $queryBuilder,
         EntityManagerInterface $entityManager,
     ) {
         $this->em              = $entityManager;

--- a/app/bundles/LeadBundle/Event/LeadListFiltersChoicesEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadListFiltersChoicesEvent.php
@@ -15,9 +15,9 @@ final class LeadListFiltersChoicesEvent extends AbstractCustomRequestEvent
      * @param mixed[] $operators Please refer to ListModel.php, inside getChoiceFields method, for default operators availabled.
      */
     public function __construct(
-        protected $choices,
-        protected $operators,
-        protected TranslatorInterface $translator,
+        private $choices,
+        private $operators,
+        private readonly TranslatorInterface $translator,
         ?Request $request = null,
         private readonly string $search = '',
     ) {

--- a/app/bundles/LeadBundle/Event/LeadListFiltersOperatorsEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadListFiltersOperatorsEvent.php
@@ -3,19 +3,16 @@
 namespace Mautic\LeadBundle\Event;
 
 use Mautic\CoreBundle\Event\CommonEvent;
-use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class LeadListFiltersOperatorsEvent extends CommonEvent
 {
     /**
      * @deprecated to be removed in Mautic 3
      *
-     * @param array               $operators  @deprecated to be removed in Mautic 3. Subscribe operators instead.
-     * @param TranslatorInterface $translator @deprecated to be removed in Mautic 3
+     * @param array $operators @deprecated to be removed in Mautic 3. Subscribe operators instead.
      */
     public function __construct(
-        protected $operators,
-        protected TranslatorInterface $translator,
+        private $operators,
     ) {
     }
 

--- a/app/bundles/LeadBundle/Event/LeadTimelineEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadTimelineEvent.php
@@ -11,17 +11,15 @@ final class LeadTimelineEvent extends Event
 {
     /**
      * Container with all filtered events.
-     *
-     * @var array
      */
-    protected $events = [];
+    private array $events = [];
 
     /**
      * Container with all registered events types.
      *
      * @var array
      */
-    protected $eventTypes = [];
+    private $eventTypes = [];
 
     /**
      * Array of filters
@@ -31,54 +29,36 @@ final class LeadTimelineEvent extends Event
      *
      * @var mixed[]
      */
-    protected array $filters;
+    private array $filters;
 
     /**
      * @var array<string, int>
      */
-    protected $totalEvents = [];
+    private array $totalEvents = [];
 
-    /**
-     * @var array
-     */
-    protected $totalEventsByUnit = [];
+    private array $totalEventsByUnit = [];
 
-    /**
-     * @var bool
-     */
-    protected $countOnly = false;
+    private bool $countOnly = false;
 
-    /**
-     * @var \DateTimeInterface|null
-     */
-    protected $dateFrom;
+    private ?\DateTime $dateFrom = null;
 
-    /**
-     * @var \DateTimeInterface|null
-     */
-    protected $dateTo;
+    private ?\DateTime $dateTo = null;
 
     /**
      * Time unit to group counts by (M = month, D = day, Y = year, null = no grouping).
      *
      * @var string
      */
-    protected $groupUnit;
+    private $groupUnit;
 
-    /**
-     * @var ChartQuery
-     */
-    protected $chartQuery;
+    private ?ChartQuery $chartQuery = null;
 
-    /**
-     * @var bool
-     */
-    protected $fetchTypesOnly = false;
+    private bool $fetchTypesOnly = false;
 
     /**
      * @var array
      */
-    protected $serializerGroups = [
+    private $serializerGroups = [
         'ipAddressList',
     ];
 
@@ -90,13 +70,13 @@ final class LeadTimelineEvent extends Event
      * @param string|null $siteDomain
      */
     public function __construct(
-        protected ?Lead $lead = null,
+        private readonly ?Lead $lead = null,
         array $filters = [],
-        protected ?array $orderBy = null,
-        protected $page = 1,
-        protected $limit = 25,
-        protected $forTimeline = true,
-        protected $siteDomain = null,
+        private ?array $orderBy = null,
+        private $page = 1,
+        private $limit = 25,
+        private $forTimeline = true,
+        private $siteDomain = null,
     ) {
         $this->filters = !empty($filters)
             ? $filters
@@ -380,10 +360,8 @@ final class LeadTimelineEvent extends Event
 
     /**
      * Check if the event is getting an engagement count only.
-     *
-     * @return bool
      */
-    public function isEngagementCount()
+    public function isEngagementCount(): bool
     {
         return $this->countOnly;
     }
@@ -484,10 +462,8 @@ final class LeadTimelineEvent extends Event
 
     /**
      * Get chart query helper to format dates.
-     *
-     * @return ChartQuery
      */
-    public function getChartQuery()
+    public function getChartQuery(): ?ChartQuery
     {
         return $this->chartQuery;
     }

--- a/app/bundles/LeadBundle/Event/LeadUtmTagsEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadUtmTagsEvent.php
@@ -12,7 +12,7 @@ final class LeadUtmTagsEvent extends CommonEvent
      */
     public function __construct(
         Lead $lead,
-        protected array $utmtags,
+        private readonly array $utmtags,
     ) {
         $this->entity  = $lead;
     }

--- a/app/bundles/LeadBundle/Event/ListPreProcessListEvent.php
+++ b/app/bundles/LeadBundle/Event/ListPreProcessListEvent.php
@@ -6,13 +6,13 @@ use Mautic\CoreBundle\Event\CommonEvent;
 
 final class ListPreProcessListEvent extends CommonEvent
 {
-    protected $result;
+    private $result;
 
     /**
      * @param bool $isNew
      */
     public function __construct(
-        protected array $list,
+        private array $list,
         $isNew = false,
     ) {
         $this->isNew = $isNew;

--- a/app/bundles/LeadBundle/Event/PointsChangeEvent.php
+++ b/app/bundles/LeadBundle/Event/PointsChangeEvent.php
@@ -7,9 +7,9 @@ use Mautic\LeadBundle\Entity\Lead;
 
 final class PointsChangeEvent extends CommonEvent
 {
-    protected int $old;
+    private readonly int $old;
 
-    protected int $new;
+    private readonly int $new;
 
     public function __construct(Lead &$lead, $old, $new)
     {

--- a/app/bundles/LeadBundle/Provider/FilterOperatorProvider.php
+++ b/app/bundles/LeadBundle/Provider/FilterOperatorProvider.php
@@ -28,7 +28,7 @@ final class FilterOperatorProvider implements FilterOperatorProviderInterface
     public function getAllOperators(): array
     {
         if (empty($this->cachedOperators)) {
-            $event = new LeadListFiltersOperatorsEvent([], $this->translator);
+            $event = new LeadListFiltersOperatorsEvent([]);
 
             $this->dispatcher->dispatch($event, LeadEvents::LIST_FILTERS_OPERATORS_ON_GENERATE);
 

--- a/app/bundles/LeadBundle/Tests/EventListener/FilterOperatorSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/FilterOperatorSubscriberTest.php
@@ -64,7 +64,7 @@ final class FilterOperatorSubscriberTest extends TestCase
 
     public function testOnListOperatorsGenerate(): void
     {
-        $event = new LeadListFiltersOperatorsEvent([], $this->translator);
+        $event = new LeadListFiltersOperatorsEvent([]);
 
         $this->subscriber->onListOperatorsGenerate($event);
 

--- a/app/bundles/NotificationBundle/Event/NotificationSendEvent.php
+++ b/app/bundles/NotificationBundle/Event/NotificationSendEvent.php
@@ -11,9 +11,9 @@ final class NotificationSendEvent extends CommonEvent
      * @param string $message
      */
     public function __construct(
-        protected $message,
-        protected $heading,
-        protected Lead $lead,
+        private $message,
+        private $heading,
+        private readonly Lead $lead,
     ) {
     }
 

--- a/app/bundles/PageBundle/Event/VideoHitEvent.php
+++ b/app/bundles/PageBundle/Event/VideoHitEvent.php
@@ -9,8 +9,8 @@ final class VideoHitEvent extends CommonEvent
 {
     public function __construct(
         VideoHit $hit,
-        protected $request,
-        protected $code,
+        private $request,
+        private $code,
     ) {
         $this->entity  = $hit;
     }

--- a/app/bundles/PointBundle/Event/PointActionEvent.php
+++ b/app/bundles/PointBundle/Event/PointActionEvent.php
@@ -9,8 +9,8 @@ use Mautic\PointBundle\Entity\Point;
 final class PointActionEvent extends CommonEvent
 {
     public function __construct(
-        protected Point $point,
-        protected Lead $lead,
+        private Point $point,
+        private Lead $lead,
     ) {
     }
 

--- a/app/bundles/UserBundle/Event/AuthenticationContentEvent.php
+++ b/app/bundles/UserBundle/Event/AuthenticationContentEvent.php
@@ -10,15 +10,15 @@ final class AuthenticationContentEvent extends Event
     /**
      * @var array
      */
-    protected $content = [];
+    private $content = [];
 
     /**
      * @var bool
      */
-    protected $postLogout = false;
+    private $postLogout = false;
 
     public function __construct(
-        protected Request $request,
+        private readonly Request $request,
     ) {
         $this->postLogout = $request->getSession()->get('post_logout', false);
     }

--- a/app/bundles/WebhookBundle/Event/WebhookQueueEvent.php
+++ b/app/bundles/WebhookBundle/Event/WebhookQueueEvent.php
@@ -13,7 +13,7 @@ final class WebhookQueueEvent extends CommonEvent
      */
     public function __construct(
         WebhookQueue $webhookQueue,
-        protected Webhook $webhook,
+        private Webhook $webhook,
         $isNew = false,
     ) {
         $this->entity  = $webhookQueue;

--- a/plugins/MauticSocialBundle/Event/SocialMonitorEvent.php
+++ b/plugins/MauticSocialBundle/Event/SocialMonitorEvent.php
@@ -7,9 +7,9 @@ use MauticPlugin\MauticSocialBundle\Entity\Monitoring;
 
 final class SocialMonitorEvent extends CommonEvent
 {
-    protected int $newLeadCount;
+    private readonly int $newLeadCount;
 
-    protected int $updatedLeadCount;
+    private readonly int $updatedLeadCount;
 
     /**
      * @param string $integrationName
@@ -17,9 +17,9 @@ final class SocialMonitorEvent extends CommonEvent
      * @param int    $updatedLeadCount
      */
     public function __construct(
-        protected $integrationName,
+        private $integrationName,
         Monitoring $monitoring,
-        protected array $leadIds,
+        private readonly array $leadIds,
         $newLeadCount,
         $updatedLeadCount,
     ) {


### PR DESCRIPTION
Split from #16820 — Event classes only.

Rector `privatization` prepared set: `protected` properties that are never touched outside their own class become `private`, and the freed docblocks turn into native property/return types.

```diff
 final class ChannelEvent extends CommonEvent
 {
-    /**
-     * @var array
-     */
-    protected $channels = [];
+    private array $channels = [];

-    /**
-     * @return array
-     */
-    public function getChannelConfigs()
+    public function getChannelConfigs(): array
     {
         return $this->channels;
     }
 }
```

The `rector.php` config change that enables the set stays in #16820.
