### PR TITLE
[rector] privatize Form Type class properties

### DIFF
--- a/app/bundles/CampaignBundle/Form/Type/CampaignListType.php
+++ b/app/bundles/CampaignBundle/Form/Type/CampaignListType.php
@@ -8,7 +8,6 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * @extends AbstractType<mixed>
@@ -19,7 +18,6 @@ final class CampaignListType extends AbstractType
 
     public function __construct(
         private readonly CampaignModel $model,
-        protected TranslatorInterface $translator,
         CorePermissions $security,
     ) {
         $this->canViewOther = $security->isGranted('campaign:campaigns:viewother');

--- a/app/bundles/ChannelBundle/Form/Type/MessageSendType.php
+++ b/app/bundles/ChannelBundle/Form/Type/MessageSendType.php
@@ -2,7 +2,6 @@
 
 namespace Mautic\ChannelBundle\Form\Type;
 
-use Mautic\ChannelBundle\Model\MessageModel;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ButtonType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -16,8 +15,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 final class MessageSendType extends AbstractType
 {
     public function __construct(
-        protected RouterInterface $router,
-        protected MessageModel $messageModel,
+        private readonly RouterInterface $router,
     ) {
     }
 

--- a/app/bundles/ChannelBundle/Form/Type/MessageType.php
+++ b/app/bundles/ChannelBundle/Form/Type/MessageType.php
@@ -16,7 +16,7 @@ use Symfony\Component\Validator\Constraints\Valid;
 final class MessageType extends AbstractFormStandardType
 {
     public function __construct(
-        protected MessageModel $model,
+        private readonly MessageModel $model,
         CorePermissions $security,
     ) {
         $this->security = $security;

--- a/app/bundles/DashboardBundle/Form/Type/WidgetType.php
+++ b/app/bundles/DashboardBundle/Form/Type/WidgetType.php
@@ -22,8 +22,8 @@ use Symfony\Component\Form\FormEvents;
 final class WidgetType extends AbstractType
 {
     public function __construct(
-        protected EventDispatcherInterface $dispatcher,
-        protected CorePermissions $security,
+        private readonly EventDispatcherInterface $dispatcher,
+        private readonly CorePermissions $security,
     ) {
     }
 

--- a/app/bundles/FormBundle/Form/Type/SubmitActionEmailType.php
+++ b/app/bundles/FormBundle/Form/Type/SubmitActionEmailType.php
@@ -4,7 +4,6 @@ namespace Mautic\FormBundle\Form\Type;
 
 use Mautic\CoreBundle\Form\ToBcBccFieldsTrait;
 use Mautic\CoreBundle\Form\Type\YesNoButtonGroupType;
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\EmailBundle\Form\Type\EmailListType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
@@ -25,7 +24,6 @@ final class SubmitActionEmailType extends AbstractType
 
     public function __construct(
         private TranslatorInterface $translator,
-        protected CoreParametersHelper $coreParametersHelper,
     ) {
     }
 

--- a/app/bundles/LeadBundle/Form/Type/AddToCompanyActionType.php
+++ b/app/bundles/LeadBundle/Form/Type/AddToCompanyActionType.php
@@ -14,7 +14,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 final class AddToCompanyActionType extends AbstractType
 {
     public function __construct(
-        protected RouterInterface $router,
+        private readonly RouterInterface $router,
     ) {
     }
 

--- a/app/bundles/LeadBundle/Form/Type/CampaignEventLeadCampaignsType.php
+++ b/app/bundles/LeadBundle/Form/Type/CampaignEventLeadCampaignsType.php
@@ -16,7 +16,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 final class CampaignEventLeadCampaignsType extends AbstractType
 {
     public function __construct(
-        protected ListModel $listModel,
+        private readonly ListModel $listModel,
     ) {
     }
 

--- a/app/bundles/LeadBundle/Form/Type/CampaignEventLeadFieldValueType.php
+++ b/app/bundles/LeadBundle/Form/Type/CampaignEventLeadFieldValueType.php
@@ -23,9 +23,9 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 final class CampaignEventLeadFieldValueType extends AbstractType
 {
     public function __construct(
-        protected Translator $translator,
-        protected LeadModel $leadModel,
-        protected FieldModel $fieldModel,
+        private readonly Translator $translator,
+        private readonly LeadModel $leadModel,
+        private readonly FieldModel $fieldModel,
     ) {
     }
 

--- a/app/bundles/LeadBundle/Form/Type/CompanyType.php
+++ b/app/bundles/LeadBundle/Form/Type/CompanyType.php
@@ -27,8 +27,8 @@ final class CompanyType extends AbstractType
 
     public function __construct(
         private EntityManagerInterface $em,
-        protected RouterInterface $router,
-        protected TranslatorInterface $translator,
+        private RouterInterface $router,
+        private TranslatorInterface $translator,
     ) {
     }
 

--- a/app/bundles/LeadBundle/Form/Type/ContactFrequencyType.php
+++ b/app/bundles/LeadBundle/Form/Type/ContactFrequencyType.php
@@ -14,7 +14,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 final class ContactFrequencyType extends AbstractType
 {
     public function __construct(
-        protected CoreParametersHelper $coreParametersHelper,
+        private readonly CoreParametersHelper $coreParametersHelper,
     ) {
     }
 

--- a/app/bundles/LeadBundle/Form/Type/LeadFieldsType.php
+++ b/app/bundles/LeadBundle/Form/Type/LeadFieldsType.php
@@ -15,7 +15,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 final class LeadFieldsType extends AbstractType
 {
     public function __construct(
-        protected FieldModel $fieldModel,
+        private readonly FieldModel $fieldModel,
     ) {
     }
 

--- a/app/bundles/LeadBundle/Form/Type/UpdateCompanyActionType.php
+++ b/app/bundles/LeadBundle/Form/Type/UpdateCompanyActionType.php
@@ -16,7 +16,7 @@ final class UpdateCompanyActionType extends AbstractType
     use EntityFieldsBuildFormTrait;
 
     public function __construct(
-        protected FieldModel $fieldModel,
+        private FieldModel $fieldModel,
     ) {
     }
 

--- a/app/bundles/NotificationBundle/Form/Type/MobileNotificationDetailsType.php
+++ b/app/bundles/NotificationBundle/Form/Type/MobileNotificationDetailsType.php
@@ -18,7 +18,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 final class MobileNotificationDetailsType extends AbstractType
 {
     public function __construct(
-        protected IntegrationHelper $integrationHelper,
+        private readonly IntegrationHelper $integrationHelper,
     ) {
     }
 

--- a/app/bundles/NotificationBundle/Form/Type/MobileNotificationSendType.php
+++ b/app/bundles/NotificationBundle/Form/Type/MobileNotificationSendType.php
@@ -15,7 +15,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 final class MobileNotificationSendType extends AbstractType
 {
     public function __construct(
-        protected RouterInterface $router,
+        private readonly RouterInterface $router,
     ) {
     }
 

--- a/app/bundles/NotificationBundle/Form/Type/NotificationSendType.php
+++ b/app/bundles/NotificationBundle/Form/Type/NotificationSendType.php
@@ -15,7 +15,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 final class NotificationSendType extends AbstractType
 {
     public function __construct(
-        protected RouterInterface $router,
+        private readonly RouterInterface $router,
     ) {
     }
 

--- a/app/bundles/PageBundle/Form/Type/TrackingPixelSendType.php
+++ b/app/bundles/PageBundle/Form/Type/TrackingPixelSendType.php
@@ -15,7 +15,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 final class TrackingPixelSendType extends AbstractType
 {
     public function __construct(
-        protected TrackingHelper $trackingHelper,
+        private readonly TrackingHelper $trackingHelper,
     ) {
     }
 

--- a/app/bundles/PluginBundle/Form/Type/FeatureSettingsType.php
+++ b/app/bundles/PluginBundle/Form/Type/FeatureSettingsType.php
@@ -19,9 +19,9 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 final class FeatureSettingsType extends AbstractType
 {
     public function __construct(
-        protected RequestStack $requestStack,
-        protected CoreParametersHelper $coreParametersHelper,
-        protected LoggerInterface $logger,
+        private readonly RequestStack $requestStack,
+        private readonly CoreParametersHelper $coreParametersHelper,
+        private readonly LoggerInterface $logger,
     ) {
     }
 

--- a/app/bundles/ReportBundle/Form/Type/ReportWidgetType.php
+++ b/app/bundles/ReportBundle/Form/Type/ReportWidgetType.php
@@ -14,7 +14,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 final class ReportWidgetType extends AbstractType
 {
     public function __construct(
-        protected ReportModel $model,
+        private readonly ReportModel $model,
     ) {
     }
 

--- a/app/bundles/SmsBundle/Form/Type/SmsSendType.php
+++ b/app/bundles/SmsBundle/Form/Type/SmsSendType.php
@@ -15,7 +15,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 final class SmsSendType extends AbstractType
 {
     public function __construct(
-        protected RouterInterface $router,
+        private readonly RouterInterface $router,
     ) {
     }
 

--- a/app/bundles/UserBundle/Form/Type/ConfigType.php
+++ b/app/bundles/UserBundle/Form/Type/ConfigType.php
@@ -20,8 +20,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 final class ConfigType extends AbstractType
 {
     public function __construct(
-        protected CoreParametersHelper $parameters,
-        protected TranslatorInterface $translator,
+        private readonly CoreParametersHelper $parameters,
+        private readonly TranslatorInterface $translator,
     ) {
     }
 

--- a/plugins/MauticEmailMarketingBundle/Form/Type/ConstantContactType.php
+++ b/plugins/MauticEmailMarketingBundle/Form/Type/ConstantContactType.php
@@ -24,8 +24,8 @@ final class ConstantContactType extends AbstractType
     public function __construct(
         private readonly IntegrationHelper $integrationHelper,
         private readonly PluginModel $pluginModel,
-        protected RequestStack $requestStack,
-        protected CoreParametersHelper $coreParametersHelper,
+        private readonly RequestStack $requestStack,
+        private readonly CoreParametersHelper $coreParametersHelper,
     ) {
     }
 

--- a/plugins/MauticEmailMarketingBundle/Form/Type/IcontactType.php
+++ b/plugins/MauticEmailMarketingBundle/Form/Type/IcontactType.php
@@ -23,8 +23,8 @@ final class IcontactType extends AbstractType
     public function __construct(
         private readonly IntegrationHelper $integrationHelper,
         private readonly PluginModel $pluginModel,
-        protected RequestStack $requestStack,
-        protected CoreParametersHelper $coreParametersHelper,
+        private readonly RequestStack $requestStack,
+        private readonly CoreParametersHelper $coreParametersHelper,
     ) {
     }
 

--- a/plugins/MauticEmailMarketingBundle/Form/Type/MailchimpType.php
+++ b/plugins/MauticEmailMarketingBundle/Form/Type/MailchimpType.php
@@ -25,8 +25,8 @@ final class MailchimpType extends AbstractType
     public function __construct(
         private readonly IntegrationHelper $integrationHelper,
         private readonly PluginModel $pluginModel,
-        protected RequestStack $requestStack,
-        protected CoreParametersHelper $coreParametersHelper,
+        private readonly RequestStack $requestStack,
+        private readonly CoreParametersHelper $coreParametersHelper,
     ) {
     }
 

--- a/plugins/MauticFocusBundle/Form/Type/FocusListType.php
+++ b/plugins/MauticFocusBundle/Form/Type/FocusListType.php
@@ -3,7 +3,6 @@
 namespace MauticPlugin\MauticFocusBundle\Form\Type;
 
 use MauticPlugin\MauticFocusBundle\Entity\FocusRepository;
-use MauticPlugin\MauticFocusBundle\Model\FocusModel;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\Options;
@@ -15,7 +14,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 final class FocusListType extends AbstractType
 {
     public function __construct(
-        protected FocusModel $focusModel,
         private readonly FocusRepository $focusRepository,
     ) {
     }

--- a/plugins/MauticFocusBundle/Form/Type/FocusShowType.php
+++ b/plugins/MauticFocusBundle/Form/Type/FocusShowType.php
@@ -15,7 +15,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 final class FocusShowType extends AbstractType
 {
     public function __construct(
-        protected RouterInterface $router,
+        private readonly RouterInterface $router,
     ) {
     }
 

--- a/plugins/MauticSocialBundle/Form/Type/TweetSendType.php
+++ b/plugins/MauticSocialBundle/Form/Type/TweetSendType.php
@@ -15,7 +15,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 final class TweetSendType extends AbstractType
 {
     public function __construct(
-        protected RouterInterface $router,
+        private readonly RouterInterface $router,
     ) {
     }
 

--- a/plugins/MauticSocialBundle/Form/Type/TweetType.php
+++ b/plugins/MauticSocialBundle/Form/Type/TweetType.php
@@ -26,7 +26,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 final class TweetType extends AbstractType
 {
     public function __construct(
-        protected EntityManagerInterface $em,
+        private readonly EntityManagerInterface $em,
     ) {
     }
 


### PR DESCRIPTION
Split from #16820 — Form Type classes only.

Rector `privatization` prepared set: `protected` properties and promoted constructor params that are never touched outside their own class become `private` (and `readonly` where never reassigned).

```diff
 final class TweetType extends AbstractType
 {
     public function __construct(
-        protected EntityManagerInterface $em,
+        private readonly EntityManagerInterface $em,
     ) {
     }
 }
```

The `rector.php` config change that enables the set stays in #16820.
