### PR TITLE
[rector] privatize dashboard subscriber properties

### DIFF
--- a/app/bundles/AssetBundle/EventListener/DashboardSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/DashboardSubscriber.php
@@ -39,8 +39,8 @@ final class DashboardSubscriber extends MainDashboardSubscriber
     ];
 
     public function __construct(
-        protected AssetModel $assetModel,
-        protected RouterInterface $router,
+        private readonly AssetModel $assetModel,
+        private readonly RouterInterface $router,
     ) {
     }
 

--- a/app/bundles/CampaignBundle/EventListener/DashboardSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/DashboardSubscriber.php
@@ -37,8 +37,8 @@ final class DashboardSubscriber extends MainDashboardSubscriber
     ];
 
     public function __construct(
-        protected CampaignModel $campaignModel,
-        protected EventModel $campaignEventModel,
+        private readonly CampaignModel $campaignModel,
+        private readonly EventModel $campaignEventModel,
     ) {
     }
 

--- a/app/bundles/CoreBundle/EventListener/DashboardSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/DashboardSubscriber.php
@@ -42,7 +42,7 @@ final class DashboardSubscriber extends MainDashboardSubscriber
         private readonly RouterInterface $router,
         private readonly CorePermissions $security,
         private readonly EventDispatcherInterface $dispatcher,
-        protected ModelFactory $modelFactory,
+        private readonly ModelFactory $modelFactory,
     ) {
     }
 

--- a/app/bundles/EmailBundle/EventListener/DashboardBestHoursSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/DashboardBestHoursSubscriber.php
@@ -39,7 +39,7 @@ final class DashboardBestHoursSubscriber extends MainDashboardSubscriber
     ];
 
     public function __construct(
-        protected EmailModel $emailModel,
+        private readonly EmailModel $emailModel,
     ) {
     }
 

--- a/app/bundles/EmailBundle/EventListener/DashboardSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/DashboardSubscriber.php
@@ -55,7 +55,7 @@ final class DashboardSubscriber extends MainDashboardSubscriber
     ];
 
     public function __construct(
-        protected EmailModel $emailModel,
+        private readonly EmailModel $emailModel,
         private readonly RouterInterface $router,
     ) {
     }

--- a/app/bundles/FormBundle/EventListener/DashboardSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/DashboardSubscriber.php
@@ -40,8 +40,8 @@ final class DashboardSubscriber extends MainDashboardSubscriber
     ];
 
     public function __construct(
-        protected SubmissionModel $formSubmissionModel,
-        protected FormModel $formModel,
+        private readonly SubmissionModel $formSubmissionModel,
+        private readonly FormModel $formModel,
         private readonly RouterInterface $router,
     ) {
     }

--- a/app/bundles/LeadBundle/EventListener/DashboardSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/DashboardSubscriber.php
@@ -56,11 +56,11 @@ final class DashboardSubscriber extends MainDashboardSubscriber
     ];
 
     public function __construct(
-        protected LeadModel $leadModel,
-        protected ListModel $leadListModel,
-        protected RouterInterface $router,
-        protected TranslatorInterface $translator,
-        protected DateHelper $dateHelper,
+        private readonly LeadModel $leadModel,
+        private readonly ListModel $leadListModel,
+        private readonly RouterInterface $router,
+        private readonly TranslatorInterface $translator,
+        private readonly DateHelper $dateHelper,
     ) {
     }
 

--- a/app/bundles/PageBundle/EventListener/DashboardSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/DashboardSubscriber.php
@@ -44,8 +44,8 @@ final class DashboardSubscriber extends MainDashboardSubscriber
     ];
 
     public function __construct(
-        protected PageModel $pageModel,
-        protected RouterInterface $router,
+        private readonly PageModel $pageModel,
+        private readonly RouterInterface $router,
     ) {
     }
 

--- a/app/bundles/PointBundle/EventListener/DashboardSubscriber.php
+++ b/app/bundles/PointBundle/EventListener/DashboardSubscriber.php
@@ -35,7 +35,7 @@ final class DashboardSubscriber extends MainDashboardSubscriber
     ];
 
     public function __construct(
-        protected PointModel $pointModel,
+        private readonly PointModel $pointModel,
     ) {
     }
 

--- a/app/bundles/ReportBundle/EventListener/DashboardSubscriber.php
+++ b/app/bundles/ReportBundle/EventListener/DashboardSubscriber.php
@@ -43,8 +43,8 @@ final class DashboardSubscriber extends MainDashboardSubscriber
     ];
 
     public function __construct(
-        protected ReportModel $reportModel,
-        protected CorePermissions $security,
+        private readonly ReportModel $reportModel,
+        private readonly CorePermissions $security,
     ) {
     }
 

--- a/app/bundles/StageBundle/EventListener/DashboardSubscriber.php
+++ b/app/bundles/StageBundle/EventListener/DashboardSubscriber.php
@@ -35,7 +35,7 @@ final class DashboardSubscriber extends MainDashboardSubscriber
     ];
 
     public function __construct(
-        protected StageModel $stageModel,
+        private readonly StageModel $stageModel,
     ) {
     }
 


### PR DESCRIPTION
Split from #16820 — dashboard subscribers only.

Rector `privatization` prepared set: `protected` promoted constructor params that are never touched outside their own class become `private readonly`.

```diff
 final class DashboardSubscriber extends MainDashboardSubscriber
 {
     public function __construct(
-        protected LeadModel $leadModel,
-        protected ListModel $leadListModel,
-        protected RouterInterface $router,
+        private readonly LeadModel $leadModel,
+        private readonly ListModel $leadListModel,
+        private readonly RouterInterface $router,
     ) {
     }
 }
```

The `rector.php` config change that enables the set stays in #16820.
