### PR TITLE
[rector] privatize controller properties and methods

### DIFF
--- a/app/bundles/CampaignBundle/Controller/AjaxController.php
+++ b/app/bundles/CampaignBundle/Controller/AjaxController.php
@@ -114,7 +114,7 @@ final class AjaxController extends CommonAjaxController
     /**
      * @return LeadEventLog|null
      */
-    protected function getContactEventLog($eventId, $contactId)
+    private function getContactEventLog(int $eventId, int $contactId)
     {
         $contact = $this->leadModel->getEntity($contactId);
         if ($contact) {

--- a/app/bundles/CoreBundle/Controller/ExceptionController.php
+++ b/app/bundles/CoreBundle/Controller/ExceptionController.php
@@ -16,7 +16,7 @@ final class ExceptionController extends CommonController
     {
         $exception      = FlattenException::createFromThrowable($exception, $exception->getCode(), $request->headers->all());
         $class          = $exception->getClass();
-        $currentContent = $this->getAndCleanOutputBuffering($request->headers->get('X-Php-Ob-Level', -1));
+        $currentContent = $this->getAndCleanOutputBuffering((int) $request->headers->get('X-Php-Ob-Level', -1));
         $layout         = 'prod' == MAUTIC_ENV ? 'Error' : 'Exception';
         $code           = $exception->getStatusCode();
 
@@ -112,10 +112,7 @@ final class ExceptionController extends CommonController
         );
     }
 
-    /**
-     * @param int $startObLevel
-     */
-    protected function getAndCleanOutputBuffering($startObLevel): string|false
+    private function getAndCleanOutputBuffering(?int $startObLevel): string|false
     {
         if (ob_get_level() <= $startObLevel) {
             return '';

--- a/app/bundles/CoreBundle/Controller/FileController.php
+++ b/app/bundles/CoreBundle/Controller/FileController.php
@@ -16,9 +16,9 @@ final class FileController extends AjaxController
 {
     public const EDITOR_CKEDITOR = 'ckeditor';
 
-    protected $response = [];
+    private array $response = [];
 
-    protected $statusCode = Response::HTTP_OK;
+    private int $statusCode = Response::HTTP_OK;
 
     /**
      * Uploads a file.

--- a/app/bundles/CoreBundle/Controller/JsController.php
+++ b/app/bundles/CoreBundle/Controller/JsController.php
@@ -55,7 +55,7 @@ final class JsController extends CommonController
     /**
      * Build a JS header for the Mautic embedded JS.
      */
-    protected function getJsHeader(): string
+    private function getJsHeader(): string
     {
         $year = date('Y');
 

--- a/app/bundles/EmailBundle/Controller/EmailMapStatsController.php
+++ b/app/bundles/EmailBundle/Controller/EmailMapStatsController.php
@@ -29,7 +29,7 @@ final class EmailMapStatsController extends AbstractController
     public const LEGEND_TEXT = 'Total: %total (%withCountry with country)';
 
     public function __construct(
-        protected EmailModel $model,
+        private readonly EmailModel $model,
     ) {
     }
 

--- a/app/bundles/LeadBundle/Controller/ListController.php
+++ b/app/bundles/LeadBundle/Controller/ListController.php
@@ -52,10 +52,7 @@ final class ListController extends FormController
 
     public const SEGMENT_CONTACT_FIELDS = ['id', 'company', 'city', 'state', 'country'];
 
-    /**
-     * @var array
-     */
-    protected $listFilters = [];
+    private array $listFilters = [];
 
     /**
      * Generate's default list view.

--- a/app/bundles/SmsBundle/Controller/AjaxController.php
+++ b/app/bundles/SmsBundle/Controller/AjaxController.php
@@ -95,7 +95,7 @@ final class AjaxController extends CommonAjaxController
      *
      * @return array<string, string>
      */
-    protected function getBuilderTokens(string $query): array
+    private function getBuilderTokens(string $query): array
     {
         $components   = $this->emailModel->getBuilderComponents(null, ['tokens'], $query);
         $findTokens   = ['{contactfield=', '{assetlink', '{pagelink'];

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1285,18 +1285,6 @@ parameters:
 			path: app/bundles/CoreBundle/Controller/ExceptionController.php
 
 		-
-			message: '#^Property Mautic\\CoreBundle\\Controller\\FileController\:\:\$response has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/bundles/CoreBundle/Controller/FileController.php
-
-		-
-			message: '#^Property Mautic\\CoreBundle\\Controller\\FileController\:\:\$statusCode has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/bundles/CoreBundle/Controller/FileController.php
-
-		-
 			message: '#^Property Mautic\\CoreBundle\\Controller\\FormController\:\:\$activeLink has no type specified\.$#'
 			identifier: missingType.property
 			count: 1


### PR DESCRIPTION
Split from #16820 — controllers only.

Rector `privatization` prepared set: `protected` properties and methods that are never touched outside their own final class become `private`, and their docblocks turn into native types. Includes the matching `phpstan-baseline.neon` entry removals for `FileController`.

```diff
 final class FileController extends AjaxController
 {
-    protected $response = [];
+    private array $response = [];

-    protected $statusCode = Response::HTTP_OK;
+    private int $statusCode = Response::HTTP_OK;
 }
```

The `rector.php` config change that enables the set stays in #16820.
