### PR TITLE
[config fix] pass tag alias as argument

### DIFF
--- a/app/bundles/ChannelBundle/Config/services.php
+++ b/app/bundles/ChannelBundle/Config/services.php
@@ -28,5 +28,6 @@ return function (ContainerConfigurator $configurator): void {
     $services->alias('mautic.channel.model.frequency.action', Mautic\ChannelBundle\Model\FrequencyActionModel::class);
     $services->alias('mautic.channel.repository.message_queue', Mautic\ChannelBundle\Entity\MessageQueueRepository::class);
 
-    $services->alias('channel', Mautic\ChannelBundle\Helper\ChannelListHelper::class);
+    $services->set(Mautic\ChannelBundle\Helper\ChannelListHelper::class)
+        ->tag('twig.helper', ['alias' => 'channel']);
 };

--- a/app/bundles/FormBundle/Config/services.php
+++ b/app/bundles/FormBundle/Config/services.php
@@ -47,8 +47,10 @@ return function (ContainerConfigurator $configurator): void {
     $services->alias(Mautic\FormBundle\Helper\PropertiesAccessor::class, 'mautic.form.helper.properties.accessor');
     $services->set('mautic.form.validator.upload_field_validator', Mautic\FormBundle\Validator\UploadFieldValidator::class);
     $services->alias(Mautic\FormBundle\Validator\UploadFieldValidator::class, 'mautic.form.validator.upload_field_validator');
-    $services->set('mautic.form.validator.constraint.file_extension_constraint_validator', Mautic\FormBundle\Validator\Constraint\FileExtensionConstraintValidator::class)->tag('validator.constraint_validator')->tag('file_extension_constraint_validator');
-    $services->alias(Mautic\FormBundle\Validator\Constraint\FileExtensionConstraintValidator::class, 'mautic.form.validator.constraint.file_extension_constraint_validator');
+
+    $services->set(Mautic\FormBundle\Validator\Constraint\FileExtensionConstraintValidator::class)
+        ->tag('validator.constraint_validator', ['alias' => 'file_extension_constraint_validator']);
+
     $services->set('mautic.form.command.form_submissions_records_clean', Mautic\FormBundle\Command\DeleteOrphanSubmissionRecordsFromFormResultsTableCommand::class)->tag('console.command');
     $services->alias(Mautic\FormBundle\Command\DeleteOrphanSubmissionRecordsFromFormResultsTableCommand::class, 'mautic.form.command.form_submissions_records_clean');
     $services->set('mautic.form.command.form_submissions_table_clean', Mautic\FormBundle\Command\DeleteOrphanFormResultsTableCommand::class)->tag('console.command');

--- a/app/bundles/ReportBundle/Config/services.php
+++ b/app/bundles/ReportBundle/Config/services.php
@@ -45,5 +45,6 @@ return function (ContainerConfigurator $configurator): void {
     $services->alias('mautic.report.model.report_file_writer', Mautic\ReportBundle\Model\ReportFileWriter::class);
     $services->alias('mautic.report.model.export_handler', Mautic\ReportBundle\Model\ExportHandler::class);
 
-    $services->alias('report', Mautic\ReportBundle\Helper\ReportHelper::class);
+    $services->set(Mautic\ReportBundle\Helper\ReportHelper::class)
+        ->tag('twig.helper', ['alias' => 'report']);
 };


### PR DESCRIPTION
This PR fixes incorrect conversion of "alias" key from: https://github.com/mautic/mautic/pull/16826/files

Please double check I got it right. The magic seems to happen in `\Mautic\CoreBundle\DependencyInjection\Compiler\ServicePass`