### PR TITLE
[cs] apply standalone line for constructor and autowire methods

### DIFF
--- a/app/bundles/AssetBundle/Controller/AssetController.php
+++ b/app/bundles/AssetBundle/Controller/AssetController.php
@@ -20,8 +20,9 @@ final class AssetController extends FormController
     private AuditLogModel $auditLogModel;
 
     #[Required]
-    public function autowireAssetController(AuditLogModel $auditLogModel): void
-    {
+    public function autowireAssetController(
+        AuditLogModel $auditLogModel,
+    ): void {
         $this->auditLogModel = $auditLogModel;
     }
 

--- a/app/bundles/AssetBundle/Controller/PublicController.php
+++ b/app/bundles/AssetBundle/Controller/PublicController.php
@@ -20,8 +20,9 @@ final class PublicController extends AbstractFormController
     private \Mautic\AssetBundle\Entity\AssetRepository $assetRepository;
 
     #[\Symfony\Contracts\Service\Attribute\Required]
-    public function autowirePublicController(\Mautic\AssetBundle\Entity\AssetRepository $assetRepository): void
-    {
+    public function autowirePublicController(
+        \Mautic\AssetBundle\Entity\AssetRepository $assetRepository,
+    ): void {
         $this->assetRepository = $assetRepository;
     }
 

--- a/app/bundles/CacheBundle/Cache/Adapter/RedisAdapter.php
+++ b/app/bundles/CacheBundle/Cache/Adapter/RedisAdapter.php
@@ -25,8 +25,8 @@ class RedisAdapter extends SymfonyRedisAdapter
         int $lifetime,
 
         #[Autowire(env: 'bool:MAUTIC_REDIS_PRIMARY_ONLY')]
-        bool $primaryOnly)
-    {
+        bool $primaryOnly,
+    ) {
         parent::__construct($this->createClient($servers, $primaryOnly), $namespace, $lifetime);
     }
 }

--- a/app/bundles/CacheBundle/Cache/Adapter/RedisTagAwareAdapter.php
+++ b/app/bundles/CacheBundle/Cache/Adapter/RedisTagAwareAdapter.php
@@ -26,8 +26,8 @@ class RedisTagAwareAdapter extends TagAwareAdapter
         int $lifetime,
 
         #[Autowire(env: 'bool:MAUTIC_REDIS_PRIMARY_ONLY')]
-        bool $primaryOnly)
-    {
+        bool $primaryOnly,
+    ) {
         $client = $this->createClient($servers, $primaryOnly);
 
         parent::__construct(

--- a/app/bundles/CampaignBundle/Controller/Api/EventApiController.php
+++ b/app/bundles/CampaignBundle/Controller/Api/EventApiController.php
@@ -27,8 +27,20 @@ class EventApiController extends CommonApiController
 {
     use LeadAccessTrait;
 
-    public function __construct(CorePermissions $security, Translator $translator, EntityResultHelper $entityResultHelper, RouterInterface $router, FormFactoryInterface $formFactory, AppVersion $appVersion, RequestStack $requestStack, ManagerRegistry $doctrine, ModelFactory $modelFactory, EventDispatcherInterface $dispatcher, CoreParametersHelper $coreParametersHelper, EventModel $campaignEventModel)
-    {
+    public function __construct(
+        CorePermissions $security,
+        Translator $translator,
+        EntityResultHelper $entityResultHelper,
+        RouterInterface $router,
+        FormFactoryInterface $formFactory,
+        AppVersion $appVersion,
+        RequestStack $requestStack,
+        ManagerRegistry $doctrine,
+        ModelFactory $modelFactory,
+        EventDispatcherInterface $dispatcher,
+        CoreParametersHelper $coreParametersHelper,
+        EventModel $campaignEventModel,
+    ) {
         $this->model                    = $campaignEventModel;
         $this->entityClass              = Event::class;
         $this->entityNameOne            = 'event';

--- a/app/bundles/CampaignBundle/Controller/SourceController.php
+++ b/app/bundles/CampaignBundle/Controller/SourceController.php
@@ -16,8 +16,9 @@ class SourceController extends CommonFormController
     private CampaignModel $campaignModel;
 
     #[Required]
-    public function autowireSourceController(CampaignModel $campaignModel): void
-    {
+    public function autowireSourceController(
+        CampaignModel $campaignModel,
+    ): void {
         $this->campaignModel = $campaignModel;
     }
 

--- a/app/bundles/CampaignBundle/Model/EventModel.php
+++ b/app/bundles/CampaignBundle/Model/EventModel.php
@@ -27,7 +27,9 @@ class EventModel extends FormModel
 
     #[Required]
     public function autowireEventModel(
-        EventRepository $eventRepository, CampaignRepository $campaignRepository, LeadEventLogRepository $leadEventLogRepository,
+        EventRepository $eventRepository,
+        CampaignRepository $campaignRepository,
+        LeadEventLogRepository $leadEventLogRepository,
     ): void {
         $this->eventRepository = $eventRepository;
         $this->campaignRepository = $campaignRepository;

--- a/app/bundles/CampaignBundle/Model/SummaryModel.php
+++ b/app/bundles/CampaignBundle/Model/SummaryModel.php
@@ -23,8 +23,10 @@ class SummaryModel extends AbstractCommonModel
     private SummaryRepository $summaryRepository;
 
     #[Required]
-    public function autowireSummaryModel(SummaryRepository $summaryRepository, LeadEventLogRepository $leadEventLogRepository): void
-    {
+    public function autowireSummaryModel(
+        SummaryRepository $summaryRepository,
+        LeadEventLogRepository $leadEventLogRepository,
+    ): void {
         $this->summaryRepository = $summaryRepository;
         $this->leadEventLogRepository = $leadEventLogRepository;
     }

--- a/app/bundles/CategoryBundle/Controller/AjaxController.php
+++ b/app/bundles/CategoryBundle/Controller/AjaxController.php
@@ -14,8 +14,9 @@ final class AjaxController extends CommonAjaxController
     private CategoryModel $categoryModel;
 
     #[Required]
-    public function autowireCategoryAjaxController(CategoryModel $categoryModel): void
-    {
+    public function autowireCategoryAjaxController(
+        CategoryModel $categoryModel,
+    ): void {
         $this->categoryModel = $categoryModel;
     }
 

--- a/app/bundles/CategoryBundle/Controller/Api/CategoryApiController.php
+++ b/app/bundles/CategoryBundle/Controller/Api/CategoryApiController.php
@@ -22,8 +22,20 @@ use Symfony\Component\Routing\RouterInterface;
  */
 class CategoryApiController extends CommonApiController
 {
-    public function __construct(CorePermissions $security, Translator $translator, EntityResultHelper $entityResultHelper, RouterInterface $router, FormFactoryInterface $formFactory, AppVersion $appVersion, RequestStack $requestStack, ManagerRegistry $doctrine, ModelFactory $modelFactory, EventDispatcherInterface $dispatcher, CoreParametersHelper $coreParametersHelper, CategoryModel $categoryModel)
-    {
+    public function __construct(
+        CorePermissions $security,
+        Translator $translator,
+        EntityResultHelper $entityResultHelper,
+        RouterInterface $router,
+        FormFactoryInterface $formFactory,
+        AppVersion $appVersion,
+        RequestStack $requestStack,
+        ManagerRegistry $doctrine,
+        ModelFactory $modelFactory,
+        EventDispatcherInterface $dispatcher,
+        CoreParametersHelper $coreParametersHelper,
+        CategoryModel $categoryModel,
+    ) {
         $this->model            = $categoryModel;
         $this->entityClass      = Category::class;
         $this->entityNameOne    = 'category';

--- a/app/bundles/ChannelBundle/Controller/AjaxController.php
+++ b/app/bundles/ChannelBundle/Controller/AjaxController.php
@@ -16,8 +16,9 @@ final class AjaxController extends CommonAjaxController
     private MessageQueueModel $messageQueueModel;
 
     #[Required]
-    public function autowireChannelAjaxController(MessageQueueModel $messageQueueModel): void
-    {
+    public function autowireChannelAjaxController(
+        MessageQueueModel $messageQueueModel,
+    ): void {
         $this->messageQueueModel = $messageQueueModel;
     }
 

--- a/app/bundles/CoreBundle/Controller/AjaxController.php
+++ b/app/bundles/CoreBundle/Controller/AjaxController.php
@@ -29,8 +29,9 @@ class AjaxController extends CommonController
     private NotificationModel $notificationModel;
 
     #[Required]
-    public function autowireCoreAjaxController(NotificationModel $notificationModel): void
-    {
+    public function autowireCoreAjaxController(
+        NotificationModel $notificationModel,
+    ): void {
         $this->notificationModel = $notificationModel;
     }
 

--- a/app/bundles/CoreBundle/Controller/Api/FileApiController.php
+++ b/app/bundles/CoreBundle/Controller/Api/FileApiController.php
@@ -32,8 +32,19 @@ class FileApiController extends CommonApiController
      */
     protected $allowedExtensions = [];
 
-    public function __construct(CorePermissions $security, Translator $translator, EntityResultHelper $entityResultHelper, RouterInterface $router, FormFactoryInterface $formFactory, AppVersion $appVersion, RequestStack $requestStack, ManagerRegistry $doctrine, ModelFactory $modelFactory, EventDispatcherInterface $dispatcher, CoreParametersHelper $coreParametersHelper)
-    {
+    public function __construct(
+        CorePermissions $security,
+        Translator $translator,
+        EntityResultHelper $entityResultHelper,
+        RouterInterface $router,
+        FormFactoryInterface $formFactory,
+        AppVersion $appVersion,
+        RequestStack $requestStack,
+        ManagerRegistry $doctrine,
+        ModelFactory $modelFactory,
+        EventDispatcherInterface $dispatcher,
+        CoreParametersHelper $coreParametersHelper,
+    ) {
         $this->entityNameOne     = 'file';
         $this->entityNameMulti   = 'files';
         $this->allowedExtensions = $coreParametersHelper->get('allowed_extensions');

--- a/app/bundles/CoreBundle/Helper/PathsHelper.php
+++ b/app/bundles/CoreBundle/Helper/PathsHelper.php
@@ -37,8 +37,13 @@ class PathsHelper
 
     private readonly string $importCampaignDir;
 
-    public function __construct(UserHelper $userHelper, CoreParametersHelper $coreParametersHelper, string $cacheDir, string $logsDir, string $rootDir)
-    {
+    public function __construct(
+        UserHelper $userHelper,
+        CoreParametersHelper $coreParametersHelper,
+        string $cacheDir,
+        string $logsDir,
+        string $rootDir,
+    ) {
         $root                         = $rootDir.'/app'; // Do not rename the variable, used in paths_helper.php
         $projectRoot                  = $this->getVendorRootPath();
         $this->user                   = $userHelper->getUser();

--- a/app/bundles/CoreBundle/Model/AuditLogModel.php
+++ b/app/bundles/CoreBundle/Model/AuditLogModel.php
@@ -15,8 +15,9 @@ class AuditLogModel extends AbstractCommonModel
     private AuditLogRepository $auditLogRepository;
 
     #[Required]
-    public function autowireAuditLogModel(AuditLogRepository $auditLogRepository): void
-    {
+    public function autowireAuditLogModel(
+        AuditLogRepository $auditLogRepository,
+    ): void {
         $this->auditLogRepository = $auditLogRepository;
     }
 

--- a/app/bundles/DashboardBundle/Controller/Api/WidgetApiController.php
+++ b/app/bundles/DashboardBundle/Controller/Api/WidgetApiController.php
@@ -33,8 +33,20 @@ class WidgetApiController extends CommonApiController
      */
     protected $model;
 
-    public function __construct(CorePermissions $security, Translator $translator, EntityResultHelper $entityResultHelper, RouterInterface $router, FormFactoryInterface $formFactory, AppVersion $appVersion, RequestStack $requestStack, ManagerRegistry $doctrine, ModelFactory $modelFactory, EventDispatcherInterface $dispatcher, CoreParametersHelper $coreParametersHelper, DashboardModel $dashboardModel)
-    {
+    public function __construct(
+        CorePermissions $security,
+        Translator $translator,
+        EntityResultHelper $entityResultHelper,
+        RouterInterface $router,
+        FormFactoryInterface $formFactory,
+        AppVersion $appVersion,
+        RequestStack $requestStack,
+        ManagerRegistry $doctrine,
+        ModelFactory $modelFactory,
+        EventDispatcherInterface $dispatcher,
+        CoreParametersHelper $coreParametersHelper,
+        DashboardModel $dashboardModel,
+    ) {
         $this->model            = $dashboardModel;
         $this->entityClass      = Widget::class;
         $this->entityNameOne    = 'widget';

--- a/app/bundles/DashboardBundle/Controller/DashboardController.php
+++ b/app/bundles/DashboardBundle/Controller/DashboardController.php
@@ -31,8 +31,9 @@ final class DashboardController extends AbstractFormController
     private DashboardModel $dashboardModel;
 
     #[Required]
-    public function autowireDashboardController(DashboardModel $dashboardModel): void
-    {
+    public function autowireDashboardController(
+        DashboardModel $dashboardModel,
+    ): void {
         $this->dashboardModel = $dashboardModel;
     }
 

--- a/app/bundles/DynamicContentBundle/Controller/Api/DynamicContentApiController.php
+++ b/app/bundles/DynamicContentBundle/Controller/Api/DynamicContentApiController.php
@@ -22,8 +22,20 @@ use Symfony\Component\Routing\RouterInterface;
  */
 class DynamicContentApiController extends CommonApiController
 {
-    public function __construct(CorePermissions $security, Translator $translator, EntityResultHelper $entityResultHelper, RouterInterface $router, FormFactoryInterface $formFactory, AppVersion $appVersion, RequestStack $requestStack, ManagerRegistry $doctrine, ModelFactory $modelFactory, EventDispatcherInterface $dispatcher, CoreParametersHelper $coreParametersHelper, DynamicContentModel $dynamicContentModel)
-    {
+    public function __construct(
+        CorePermissions $security,
+        Translator $translator,
+        EntityResultHelper $entityResultHelper,
+        RouterInterface $router,
+        FormFactoryInterface $formFactory,
+        AppVersion $appVersion,
+        RequestStack $requestStack,
+        ManagerRegistry $doctrine,
+        ModelFactory $modelFactory,
+        EventDispatcherInterface $dispatcher,
+        CoreParametersHelper $coreParametersHelper,
+        DynamicContentModel $dynamicContentModel,
+    ) {
         $this->model            = $dynamicContentModel;
         $this->entityClass      = DynamicContent::class;
         $this->entityNameOne    = 'dynamicContent';

--- a/app/bundles/DynamicContentBundle/Controller/DynamicContentApiController.php
+++ b/app/bundles/DynamicContentBundle/Controller/DynamicContentApiController.php
@@ -18,8 +18,9 @@ class DynamicContentApiController extends CommonController
     private PageModel $pageModel;
 
     #[Required]
-    public function autowireDynamicContentApiController(PageModel $pageModel): void
-    {
+    public function autowireDynamicContentApiController(
+        PageModel $pageModel,
+    ): void {
         $this->pageModel = $pageModel;
     }
 

--- a/app/bundles/DynamicContentBundle/Model/DynamicContentModel.php
+++ b/app/bundles/DynamicContentBundle/Model/DynamicContentModel.php
@@ -39,8 +39,10 @@ class DynamicContentModel extends FormModel implements AjaxLookupModelInterface,
     private DynamicContentRepository $dynamicContentRepository;
 
     #[Required]
-    public function autowireDynamicContentModel(DynamicContentRepository $dynamicContentRepository, StatRepository $statRepository): void
-    {
+    public function autowireDynamicContentModel(
+        DynamicContentRepository $dynamicContentRepository,
+        StatRepository $statRepository,
+    ): void {
         $this->dynamicContentRepository = $dynamicContentRepository;
         $this->statRepository = $statRepository;
     }

--- a/app/bundles/EmailBundle/Controller/AjaxController.php
+++ b/app/bundles/EmailBundle/Controller/AjaxController.php
@@ -34,8 +34,9 @@ final class AjaxController extends CommonAjaxController
     private EmailModel $emailModel;
 
     #[Required]
-    public function autowireEmailAjaxController(EmailModel $emailModel): void
-    {
+    public function autowireEmailAjaxController(
+        EmailModel $emailModel,
+    ): void {
         $this->emailModel = $emailModel;
     }
 

--- a/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
+++ b/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
@@ -44,8 +44,20 @@ class EmailApiController extends CommonApiController
      */
     protected $extraGetEntitiesArguments = ['ignoreListJoin' => true];
 
-    public function __construct(CorePermissions $security, Translator $translator, EntityResultHelper $entityResultHelper, RouterInterface $router, FormFactoryInterface $formFactory, AppVersion $appVersion, RequestStack $requestStack, ManagerRegistry $doctrine, ModelFactory $modelFactory, EventDispatcherInterface $dispatcher, CoreParametersHelper $coreParametersHelper, EmailModel $emailModel)
-    {
+    public function __construct(
+        CorePermissions $security,
+        Translator $translator,
+        EntityResultHelper $entityResultHelper,
+        RouterInterface $router,
+        FormFactoryInterface $formFactory,
+        AppVersion $appVersion,
+        RequestStack $requestStack,
+        ManagerRegistry $doctrine,
+        ModelFactory $modelFactory,
+        EventDispatcherInterface $dispatcher,
+        CoreParametersHelper $coreParametersHelper,
+        EmailModel $emailModel,
+    ) {
         $this->model            = $emailModel;
         $this->entityClass      = Email::class;
         $this->entityNameOne    = 'email';

--- a/app/bundles/EmailBundle/Model/EmailDraftModel.php
+++ b/app/bundles/EmailBundle/Model/EmailDraftModel.php
@@ -16,8 +16,9 @@ class EmailDraftModel extends AbstractCommonModel
     private EmailDraftRepository $emailDraftRepository;
 
     #[Required]
-    public function autowireEmailDraftModel(EmailDraftRepository $emailDraftRepository): void
-    {
+    public function autowireEmailDraftModel(
+        EmailDraftRepository $emailDraftRepository,
+    ): void {
         $this->emailDraftRepository = $emailDraftRepository;
     }
 

--- a/app/bundles/FormBundle/Model/ActionModel.php
+++ b/app/bundles/FormBundle/Model/ActionModel.php
@@ -18,8 +18,9 @@ class ActionModel extends CommonFormModel
     private ActionRepository $actionRepository;
 
     #[Required]
-    public function autowireActionModel(ActionRepository $actionRepository): void
-    {
+    public function autowireActionModel(
+        ActionRepository $actionRepository,
+    ): void {
         $this->actionRepository = $actionRepository;
     }
 

--- a/app/bundles/IntegrationsBundle/Sync/DAO/Sync/Order/OrderResultsDAO.php
+++ b/app/bundles/IntegrationsBundle/Sync/DAO/Sync/Order/OrderResultsDAO.php
@@ -36,8 +36,12 @@ class OrderResultsDAO
      * @param RemappedObjectDAO[] $remappedObjects
      * @param ObjectChangeDAO[]   $deletedObjects
      */
-    public function __construct(array $newObjectMappings, array $updatedObjectMappings, array $remappedObjects, array $deletedObjects)
-    {
+    public function __construct(
+        array $newObjectMappings,
+        array $updatedObjectMappings,
+        array $remappedObjects,
+        array $deletedObjects,
+    ) {
         $this->groupNewObjectMappingsByObjectName($newObjectMappings);
         $this->groupUpdatedObjectMappingsByObjectName($updatedObjectMappings);
         $this->groupRemappedObjectsByObjectName($remappedObjects);

--- a/app/bundles/IntegrationsBundle/Sync/Exception/FieldNotFoundException.php
+++ b/app/bundles/IntegrationsBundle/Sync/Exception/FieldNotFoundException.php
@@ -10,8 +10,12 @@ final class FieldNotFoundException extends \Exception
      * @param int             $code
      * @param \Exception|null $previous
      */
-    public function __construct($field, $object, $code = 0, ?\Throwable $previous = null)
-    {
+    public function __construct(
+        $field,
+        $object,
+        $code = 0,
+        ?\Throwable $previous = null,
+    ) {
         parent::__construct(sprintf('The %s field is not mapped for the %s object.', $field, $object), $code, $previous);
     }
 }

--- a/app/bundles/LeadBundle/Controller/Api/DeviceApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/DeviceApiController.php
@@ -28,8 +28,20 @@ class DeviceApiController extends CommonApiController
 {
     use LeadAccessTrait;
 
-    public function __construct(CorePermissions $security, Translator $translator, EntityResultHelper $entityResultHelper, RouterInterface $router, FormFactoryInterface $formFactory, AppVersion $appVersion, RequestStack $requestStack, ManagerRegistry $doctrine, ModelFactory $modelFactory, EventDispatcherInterface $dispatcher, CoreParametersHelper $coreParametersHelper, DeviceModel $leadDeviceModel)
-    {
+    public function __construct(
+        CorePermissions $security,
+        Translator $translator,
+        EntityResultHelper $entityResultHelper,
+        RouterInterface $router,
+        FormFactoryInterface $formFactory,
+        AppVersion $appVersion,
+        RequestStack $requestStack,
+        ManagerRegistry $doctrine,
+        ModelFactory $modelFactory,
+        EventDispatcherInterface $dispatcher,
+        CoreParametersHelper $coreParametersHelper,
+        DeviceModel $leadDeviceModel,
+    ) {
         $this->model           = $leadDeviceModel;
         $this->entityClass     = LeadDevice::class;
         $this->entityNameOne   = 'device';

--- a/app/bundles/LeadBundle/Controller/Api/NoteApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/NoteApiController.php
@@ -27,8 +27,20 @@ class NoteApiController extends CommonApiController
 {
     use LeadAccessTrait;
 
-    public function __construct(CorePermissions $security, Translator $translator, EntityResultHelper $entityResultHelper, RouterInterface $router, FormFactoryInterface $formFactory, AppVersion $appVersion, RequestStack $requestStack, ManagerRegistry $doctrine, ModelFactory $modelFactory, EventDispatcherInterface $dispatcher, CoreParametersHelper $coreParametersHelper, NoteModel $leadNoteModel)
-    {
+    public function __construct(
+        CorePermissions $security,
+        Translator $translator,
+        EntityResultHelper $entityResultHelper,
+        RouterInterface $router,
+        FormFactoryInterface $formFactory,
+        AppVersion $appVersion,
+        RequestStack $requestStack,
+        ManagerRegistry $doctrine,
+        ModelFactory $modelFactory,
+        EventDispatcherInterface $dispatcher,
+        CoreParametersHelper $coreParametersHelper,
+        NoteModel $leadNoteModel,
+    ) {
         $this->model            = $leadNoteModel;
         $this->entityClass      = LeadNote::class;
         $this->entityNameOne    = 'note';

--- a/app/bundles/LeadBundle/Controller/NoteController.php
+++ b/app/bundles/LeadBundle/Controller/NoteController.php
@@ -18,8 +18,9 @@ final class NoteController extends FormController
     private NoteModel $noteModel;
 
     #[Required]
-    public function autowireNoteController(NoteModel $noteModel): void
-    {
+    public function autowireNoteController(
+        NoteModel $noteModel,
+    ): void {
         $this->noteModel = $noteModel;
     }
 

--- a/app/bundles/LeadBundle/Model/TagModel.php
+++ b/app/bundles/LeadBundle/Model/TagModel.php
@@ -43,8 +43,14 @@ class TagModel extends FormModel
     private TagRepository $tagRepository;
 
     #[Required]
-    public function autowireTagModel(TagRepository $tagRepository, EventRepository $eventRepository, ActionRepository $actionRepository, TriggerEventRepository $triggerEventRepository, LeadListRepository $leadListRepository, ReportRepository $reportRepository): void
-    {
+    public function autowireTagModel(
+        TagRepository $tagRepository,
+        EventRepository $eventRepository,
+        ActionRepository $actionRepository,
+        TriggerEventRepository $triggerEventRepository,
+        LeadListRepository $leadListRepository,
+        ReportRepository $reportRepository,
+    ): void {
         $this->tagRepository = $tagRepository;
         $this->eventRepository = $eventRepository;
         $this->actionRepository = $actionRepository;

--- a/app/bundles/PageBundle/Controller/AjaxController.php
+++ b/app/bundles/PageBundle/Controller/AjaxController.php
@@ -21,8 +21,9 @@ final class AjaxController extends CommonAjaxController
     private PageModel $pageModel;
 
     #[Required]
-    public function autowirePageAjaxController(PageModel $pageModel): void
-    {
+    public function autowirePageAjaxController(
+        PageModel $pageModel,
+    ): void {
         $this->pageModel = $pageModel;
     }
 

--- a/app/bundles/PageBundle/Controller/Api/PageApiController.php
+++ b/app/bundles/PageBundle/Controller/Api/PageApiController.php
@@ -30,8 +30,20 @@ class PageApiController extends CommonApiController
      */
     protected $model;
 
-    public function __construct(CorePermissions $security, Translator $translator, EntityResultHelper $entityResultHelper, RouterInterface $router, FormFactoryInterface $formFactory, AppVersion $appVersion, RequestStack $requestStack, ManagerRegistry $doctrine, ModelFactory $modelFactory, EventDispatcherInterface $dispatcher, CoreParametersHelper $coreParametersHelper, PageModel $pageModel)
-    {
+    public function __construct(
+        CorePermissions $security,
+        Translator $translator,
+        EntityResultHelper $entityResultHelper,
+        RouterInterface $router,
+        FormFactoryInterface $formFactory,
+        AppVersion $appVersion,
+        RequestStack $requestStack,
+        ManagerRegistry $doctrine,
+        ModelFactory $modelFactory,
+        EventDispatcherInterface $dispatcher,
+        CoreParametersHelper $coreParametersHelper,
+        PageModel $pageModel,
+    ) {
         $this->model            = $pageModel;
         $this->entityClass      = Page::class;
         $this->entityNameOne    = 'page';

--- a/app/bundles/PageBundle/Controller/PageController.php
+++ b/app/bundles/PageBundle/Controller/PageController.php
@@ -34,8 +34,9 @@ final class PageController extends FormController
     private PageModel $pageModel;
 
     #[Required]
-    public function autowirePageController(PageModel $pageModel): void
-    {
+    public function autowirePageController(
+        PageModel $pageModel,
+    ): void {
         $this->pageModel = $pageModel;
     }
 

--- a/app/bundles/PluginBundle/Controller/AjaxController.php
+++ b/app/bundles/PluginBundle/Controller/AjaxController.php
@@ -18,8 +18,9 @@ final class AjaxController extends CommonAjaxController
     private PluginModel $pluginModel;
 
     #[Required]
-    public function autowirePluginAjaxController(PluginModel $pluginModel): void
-    {
+    public function autowirePluginAjaxController(
+        PluginModel $pluginModel,
+    ): void {
         $this->pluginModel = $pluginModel;
     }
 

--- a/app/bundles/PluginBundle/Controller/PluginController.php
+++ b/app/bundles/PluginBundle/Controller/PluginController.php
@@ -27,8 +27,10 @@ final class PluginController extends FormController
     private PluginModel $pluginModel;
 
     #[Required]
-    public function autowirePluginController(PluginModel $pluginModel, \Mautic\PluginBundle\Entity\PluginRepository $pluginRepository): void
-    {
+    public function autowirePluginController(
+        PluginModel $pluginModel,
+        \Mautic\PluginBundle\Entity\PluginRepository $pluginRepository,
+    ): void {
         $this->pluginModel = $pluginModel;
         $this->pluginRepository = $pluginRepository;
     }

--- a/app/bundles/PluginBundle/Model/IntegrationEntityModel.php
+++ b/app/bundles/PluginBundle/Model/IntegrationEntityModel.php
@@ -16,8 +16,9 @@ class IntegrationEntityModel extends FormModel
     private IntegrationEntityRepository $integrationEntityRepository;
 
     #[Required]
-    public function autowireIntegrationEntityModel(IntegrationEntityRepository $integrationEntityRepository): void
-    {
+    public function autowireIntegrationEntityModel(
+        IntegrationEntityRepository $integrationEntityRepository,
+    ): void {
         $this->integrationEntityRepository = $integrationEntityRepository;
     }
 

--- a/app/bundles/PointBundle/Controller/AjaxController.php
+++ b/app/bundles/PointBundle/Controller/AjaxController.php
@@ -16,8 +16,9 @@ final class AjaxController extends CommonAjaxController
     private PointModel $pointModel;
 
     #[Required]
-    public function autowirePointAjaxController(PointModel $pointModel): void
-    {
+    public function autowirePointAjaxController(
+        PointModel $pointModel,
+    ): void {
         $this->pointModel = $pointModel;
     }
 

--- a/app/bundles/PointBundle/Controller/PointController.php
+++ b/app/bundles/PointBundle/Controller/PointController.php
@@ -17,8 +17,9 @@ final class PointController extends AbstractFormController
     private PointModel $pointModel;
 
     #[Required]
-    public function autowirePointController(PointModel $pointModel): void
-    {
+    public function autowirePointController(
+        PointModel $pointModel,
+    ): void {
         $this->pointModel = $pointModel;
     }
 

--- a/app/bundles/PointBundle/Controller/TriggerController.php
+++ b/app/bundles/PointBundle/Controller/TriggerController.php
@@ -20,8 +20,10 @@ final class TriggerController extends FormController
     private TriggerModel $triggerModel;
 
     #[Required]
-    public function autowireTriggerController(TriggerEventModel $triggerEventModel, TriggerModel $triggerModel): void
-    {
+    public function autowireTriggerController(
+        TriggerEventModel $triggerEventModel,
+        TriggerModel $triggerModel,
+    ): void {
         $this->triggerEventModel = $triggerEventModel;
         $this->triggerModel      = $triggerModel;
     }

--- a/app/bundles/PointBundle/Controller/TriggerEventController.php
+++ b/app/bundles/PointBundle/Controller/TriggerEventController.php
@@ -16,8 +16,9 @@ final class TriggerEventController extends CommonFormController
     private TriggerModel $triggerModel;
 
     #[Required]
-    public function autowireTriggerEventController(TriggerModel $triggerModel): void
-    {
+    public function autowireTriggerEventController(
+        TriggerModel $triggerModel,
+    ): void {
         $this->triggerModel = $triggerModel;
     }
 

--- a/app/bundles/PointBundle/Model/PointGroupModel.php
+++ b/app/bundles/PointBundle/Model/PointGroupModel.php
@@ -27,8 +27,9 @@ class PointGroupModel extends CommonFormModel implements GlobalSearchInterface
     private GroupRepository $groupRepository;
 
     #[Required]
-    public function autowirePointGroupModel(GroupRepository $groupRepository): void
-    {
+    public function autowirePointGroupModel(
+        GroupRepository $groupRepository,
+    ): void {
         $this->groupRepository = $groupRepository;
     }
 

--- a/app/bundles/PointBundle/Model/TriggerEventModel.php
+++ b/app/bundles/PointBundle/Model/TriggerEventModel.php
@@ -19,8 +19,9 @@ class TriggerEventModel extends CommonFormModel
     private TriggerEventRepository $triggerEventRepository;
 
     #[Required]
-    public function autowireTriggerEventModel(TriggerEventRepository $triggerEventRepository): void
-    {
+    public function autowireTriggerEventModel(
+        TriggerEventRepository $triggerEventRepository,
+    ): void {
         $this->triggerEventRepository = $triggerEventRepository;
     }
 

--- a/app/bundles/ReportBundle/Controller/AjaxController.php
+++ b/app/bundles/ReportBundle/Controller/AjaxController.php
@@ -13,8 +13,9 @@ final class AjaxController extends CommonAjaxController
     private ReportModel $reportModel;
 
     #[Required]
-    public function autowireReportAjaxController(ReportModel $reportModel): void
-    {
+    public function autowireReportAjaxController(
+        ReportModel $reportModel,
+    ): void {
         $this->reportModel = $reportModel;
     }
 

--- a/app/bundles/ReportBundle/Controller/ScheduleController.php
+++ b/app/bundles/ReportBundle/Controller/ScheduleController.php
@@ -14,8 +14,9 @@ final class ScheduleController extends CommonAjaxController
     private ReportModel $reportModel;
 
     #[Required]
-    public function autowireScheduleController(ReportModel $reportModel): void
-    {
+    public function autowireScheduleController(
+        ReportModel $reportModel,
+    ): void {
         $this->reportModel = $reportModel;
     }
 

--- a/app/bundles/SmsBundle/Controller/Api/SmsApiController.php
+++ b/app/bundles/SmsBundle/Controller/Api/SmsApiController.php
@@ -34,8 +34,20 @@ class SmsApiController extends CommonApiController
      */
     protected $model;
 
-    public function __construct(CorePermissions $security, Translator $translator, EntityResultHelper $entityResultHelper, RouterInterface $router, FormFactoryInterface $formFactory, AppVersion $appVersion, RequestStack $requestStack, ManagerRegistry $doctrine, ModelFactory $modelFactory, EventDispatcherInterface $dispatcher, CoreParametersHelper $coreParametersHelper, SmsModel $smsModel)
-    {
+    public function __construct(
+        CorePermissions $security,
+        Translator $translator,
+        EntityResultHelper $entityResultHelper,
+        RouterInterface $router,
+        FormFactoryInterface $formFactory,
+        AppVersion $appVersion,
+        RequestStack $requestStack,
+        ManagerRegistry $doctrine,
+        ModelFactory $modelFactory,
+        EventDispatcherInterface $dispatcher,
+        CoreParametersHelper $coreParametersHelper,
+        SmsModel $smsModel,
+    ) {
         $this->model           = $smsModel;
         $this->entityClass     = Sms::class;
         $this->entityNameOne   = 'sms';

--- a/app/bundles/StageBundle/Controller/StageController.php
+++ b/app/bundles/StageBundle/Controller/StageController.php
@@ -23,7 +23,8 @@ final class StageController extends AbstractFormController
 
     #[Required]
     public function autowireStageController(
-        StageModel $stageModel, \Mautic\StageBundle\Entity\StageRepository $stageRepository,
+        StageModel $stageModel,
+        \Mautic\StageBundle\Entity\StageRepository $stageRepository,
     ): void {
         $this->stageModel = $stageModel;
         $this->stageRepository = $stageRepository;

--- a/app/bundles/UserBundle/Controller/Api/RoleApiController.php
+++ b/app/bundles/UserBundle/Controller/Api/RoleApiController.php
@@ -28,8 +28,20 @@ class RoleApiController extends CommonApiController
      */
     protected $model;
 
-    public function __construct(CorePermissions $security, Translator $translator, EntityResultHelper $entityResultHelper, RouterInterface $router, FormFactoryInterface $formFactory, AppVersion $appVersion, RequestStack $requestStack, ManagerRegistry $doctrine, ModelFactory $modelFactory, EventDispatcherInterface $dispatcher, CoreParametersHelper $coreParametersHelper, RoleModel $roleModel)
-    {
+    public function __construct(
+        CorePermissions $security,
+        Translator $translator,
+        EntityResultHelper $entityResultHelper,
+        RouterInterface $router,
+        FormFactoryInterface $formFactory,
+        AppVersion $appVersion,
+        RequestStack $requestStack,
+        ManagerRegistry $doctrine,
+        ModelFactory $modelFactory,
+        EventDispatcherInterface $dispatcher,
+        CoreParametersHelper $coreParametersHelper,
+        RoleModel $roleModel,
+    ) {
         $this->model            = $roleModel;
         $this->entityClass      = Role::class;
         $this->entityNameOne    = 'role';

--- a/app/bundles/UserBundle/Controller/PublicController.php
+++ b/app/bundles/UserBundle/Controller/PublicController.php
@@ -24,7 +24,8 @@ final class PublicController extends FormController
 
     #[Required]
     public function autowirePublicController(
-        UserModel $userModel, \Mautic\UserBundle\Entity\UserRepository $userRepository,
+        UserModel $userModel,
+        \Mautic\UserBundle\Entity\UserRepository $userRepository,
     ): void {
         $this->userModel = $userModel;
         $this->userRepository = $userRepository;

--- a/app/bundles/UserBundle/Model/RoleModel.php
+++ b/app/bundles/UserBundle/Model/RoleModel.php
@@ -30,8 +30,11 @@ class RoleModel extends FormModel implements GlobalSearchInterface
     private RoleRepository $roleRepository;
 
     #[Required]
-    public function autowireRoleModel(RoleRepository $roleRepository, PermissionRepository $permissionRepository, UserRepository $userRepository): void
-    {
+    public function autowireRoleModel(
+        RoleRepository $roleRepository,
+        PermissionRepository $permissionRepository,
+        UserRepository $userRepository,
+    ): void {
         $this->roleRepository = $roleRepository;
         $this->permissionRepository = $permissionRepository;
         $this->userRepository = $userRepository;

--- a/app/bundles/WebhookBundle/Controller/WebhookController.php
+++ b/app/bundles/WebhookBundle/Controller/WebhookController.php
@@ -19,8 +19,19 @@ use Symfony\Component\HttpFoundation\Response;
 
 final class WebhookController extends FormController
 {
-    public function __construct(FormFactoryInterface $formFactory, FormFieldHelper $fieldHelper, ManagerRegistry $doctrine, ModelFactory $modelFactory, UserHelper $userHelper, CoreParametersHelper $coreParametersHelper, EventDispatcherInterface $dispatcher, Translator $translator, FlashBag $flashBag, RequestStack $requestStack, CorePermissions $security)
-    {
+    public function __construct(
+        FormFactoryInterface $formFactory,
+        FormFieldHelper $fieldHelper,
+        ManagerRegistry $doctrine,
+        ModelFactory $modelFactory,
+        UserHelper $userHelper,
+        CoreParametersHelper $coreParametersHelper,
+        EventDispatcherInterface $dispatcher,
+        Translator $translator,
+        FlashBag $flashBag,
+        RequestStack $requestStack,
+        CorePermissions $security,
+    ) {
         $this->setStandardParameters(
             'webhook.webhook', // model name
             'webhook:webhooks', // permission base

--- a/ecs.php
+++ b/ecs.php
@@ -27,14 +27,15 @@ return ECSConfig::configure()
         Symplify\CodingStandard\Fixer\Spacing\MethodChainingNewlineFixer::class,
         PhpCsFixer\Fixer\ControlStructure\YodaStyleFixer::class,
     ])
-    ->withRules([
-        Symplify\CodingStandard\Fixer\Spacing\StandaloneLinePromotedPropertyFixer::class,
-        Symplify\CodingStandard\Fixer\Spacing\StandaloneLineSymfonyAttributeParamFixer::class,
-    ])
+//    ->withRules([
+//        Symplify\CodingStandard\Fixer\Spacing\StandaloneLinePromotedPropertyFixer::class,
+//        Symplify\CodingStandard\Fixer\Spacing\StandaloneLineSymfonyAttributeParamFixer::class,
+//    ])
     ->withPreparedSets(
         comments: true,
         docblocks: true,
         namespaces: true,
         cleanup: true,
         controlStructures: true,
+        standaloneLine: true,
     );

--- a/plugins/MauticCrmBundle/Integration/HubspotIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/HubspotIntegration.php
@@ -41,8 +41,9 @@ class HubspotIntegration extends CrmAbstractIntegration
     private StageRepository $stageRepository;
 
     #[Required]
-    public function autowireHubspotIntegration(StageRepository $stageRepository): void
-    {
+    public function autowireHubspotIntegration(
+        StageRepository $stageRepository,
+    ): void {
         $this->stageRepository = $stageRepository;
     }
 

--- a/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
@@ -41,8 +41,9 @@ class SugarcrmIntegration extends CrmAbstractIntegration
     private CompanyRepository $companyRepository;
 
     #[Required]
-    public function autowireSugarcrmIntegration(CompanyRepository $companyRepository): void
-    {
+    public function autowireSugarcrmIntegration(
+        CompanyRepository $companyRepository,
+    ): void {
         $this->companyRepository = $companyRepository;
     }
 

--- a/plugins/MauticFocusBundle/Controller/Api/FocusApiController.php
+++ b/plugins/MauticFocusBundle/Controller/Api/FocusApiController.php
@@ -28,8 +28,20 @@ class FocusApiController extends CommonApiController
      */
     protected $model;
 
-    public function __construct(CorePermissions $security, Translator $translator, EntityResultHelper $entityResultHelper, RouterInterface $router, FormFactoryInterface $formFactory, AppVersion $appVersion, RequestStack $requestStack, ManagerRegistry $doctrine, ModelFactory $modelFactory, EventDispatcherInterface $dispatcher, CoreParametersHelper $coreParametersHelper, FocusModel $focusModel)
-    {
+    public function __construct(
+        CorePermissions $security,
+        Translator $translator,
+        EntityResultHelper $entityResultHelper,
+        RouterInterface $router,
+        FormFactoryInterface $formFactory,
+        AppVersion $appVersion,
+        RequestStack $requestStack,
+        ManagerRegistry $doctrine,
+        ModelFactory $modelFactory,
+        EventDispatcherInterface $dispatcher,
+        CoreParametersHelper $coreParametersHelper,
+        FocusModel $focusModel,
+    ) {
         $this->model           = $focusModel;
         $this->entityClass     = Focus::class;
         $this->entityNameOne   = 'focus';

--- a/plugins/MauticSocialBundle/Controller/Api/TweetApiController.php
+++ b/plugins/MauticSocialBundle/Controller/Api/TweetApiController.php
@@ -27,8 +27,20 @@ class TweetApiController extends CommonApiController
      */
     protected $model;
 
-    public function __construct(CorePermissions $security, Translator $translator, EntityResultHelper $entityResultHelper, RouterInterface $router, FormFactoryInterface $formFactory, AppVersion $appVersion, RequestStack $requestStack, ManagerRegistry $doctrine, ModelFactory $modelFactory, EventDispatcherInterface $dispatcher, CoreParametersHelper $coreParametersHelper, TweetModel $tweetModel)
-    {
+    public function __construct(
+        CorePermissions $security,
+        Translator $translator,
+        EntityResultHelper $entityResultHelper,
+        RouterInterface $router,
+        FormFactoryInterface $formFactory,
+        AppVersion $appVersion,
+        RequestStack $requestStack,
+        ManagerRegistry $doctrine,
+        ModelFactory $modelFactory,
+        EventDispatcherInterface $dispatcher,
+        CoreParametersHelper $coreParametersHelper,
+        TweetModel $tweetModel,
+    ) {
         $this->model           = $tweetModel;
         $this->entityClass     = Tweet::class;
         $this->entityNameOne   = 'tweet';

--- a/plugins/MauticSocialBundle/Model/MonitoringModel.php
+++ b/plugins/MauticSocialBundle/Model/MonitoringModel.php
@@ -24,8 +24,9 @@ class MonitoringModel extends FormModel
     private MonitoringRepository $monitoringRepository;
 
     #[Required]
-    public function autowireMonitoringModel(MonitoringRepository $monitoringRepository): void
-    {
+    public function autowireMonitoringModel(
+        MonitoringRepository $monitoringRepository,
+    ): void {
         $this->monitoringRepository = $monitoringRepository;
     }
 

--- a/plugins/MauticSocialBundle/Model/PostCountModel.php
+++ b/plugins/MauticSocialBundle/Model/PostCountModel.php
@@ -15,8 +15,9 @@ class PostCountModel extends AbstractCommonModel
     private PostCountRepository $postCountRepository;
 
     #[Required]
-    public function autowirePostCountModel(PostCountRepository $postCountRepository): void
-    {
+    public function autowirePostCountModel(
+        PostCountRepository $postCountRepository,
+    ): void {
         $this->postCountRepository = $postCountRepository;
     }
 

--- a/plugins/MauticSocialBundle/Model/TweetModel.php
+++ b/plugins/MauticSocialBundle/Model/TweetModel.php
@@ -30,8 +30,10 @@ class TweetModel extends FormModel implements AjaxLookupModelInterface
     private TweetRepository $tweetRepository;
 
     #[Required]
-    public function autowireTweetModel(TweetRepository $tweetRepository, TweetStatRepository $tweetStatRepository): void
-    {
+    public function autowireTweetModel(
+        TweetRepository $tweetRepository,
+        TweetStatRepository $tweetStatRepository,
+    ): void {
         $this->tweetRepository = $tweetRepository;
         $this->tweetStatRepository = $tweetStatRepository;
     }

--- a/plugins/MauticTagManagerBundle/Controller/BatchTagController.php
+++ b/plugins/MauticTagManagerBundle/Controller/BatchTagController.php
@@ -16,7 +16,8 @@ final class BatchTagController extends AbstractFormController
 
     #[Required]
     public function autowireBatchTagController(
-        TagModel $tagModel, \MauticPlugin\MauticTagManagerBundle\Entity\TagRepository $tagRepository,
+        TagModel $tagModel,
+        \MauticPlugin\MauticTagManagerBundle\Entity\TagRepository $tagRepository,
     ): void {
         $this->tagRepository = $tagRepository;
     }

--- a/plugins/MauticTagManagerBundle/Model/TagModel.php
+++ b/plugins/MauticTagManagerBundle/Model/TagModel.php
@@ -17,8 +17,9 @@ class TagModel extends BaseTagModel implements GlobalSearchInterface
     private TagRepository $tagRepository;
 
     #[Required]
-    public function autowirePluginTagModel(TagRepository $tagRepository): void
-    {
+    public function autowirePluginTagModel(
+        TagRepository $tagRepository,
+    ): void {
         $this->tagRepository = $tagRepository;
     }
 


### PR DESCRIPTION
This will improve readability for dependency diffs,
make it more visible that #[Required(...)] methods are constructor-like,
and gives united standard to handle deps.

Fully automated, part of ECS run :+1: 