### PR TITLE
docs(grapesjs): update stale PHPUnit and Symfony testing doc links

### DIFF
--- a/plugins/GrapesJsBuilderBundle/.github/CONTRIBUTING.md
+++ b/plugins/GrapesJsBuilderBundle/.github/CONTRIBUTING.md
@@ -28,7 +28,7 @@ All code styling is handled automatically by the aforementioned git hook. In cas
 
 #### Automated Tests
 
-All code contributions should include adequate and appropriate unit tests using [PHPUnit](https://phpunit.de/manual/5.7/en/index.html) and/or Symfony functional tests ([https://symfony.com/doc/2.8/testing.html](https://symfony.com/doc/2.8/testing.html)). Pull Requests without these tests will not be merged.
+All code contributions should include adequate and appropriate unit tests using [PHPUnit](https://docs.phpunit.de/en/10.5/) and/or Symfony functional tests ([https://symfony.com/doc/current/testing.html](https://symfony.com/doc/current/testing.html)). Pull Requests without these tests will not be merged.
 
 #### Pull Request Description
 


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | Self-sourced docs drift

## Problem

`plugins/GrapesJsBuilderBundle/.github/CONTRIBUTING.md` still told contributors to use PHPUnit 5.7 and Symfony 2.8 testing documentation, while Mautic 7.x uses PHPUnit 10.5 (`composer.json`: `^10.5.62`) and current Symfony docs.

## Fix

Update the Automated Tests section to point at:
- `https://docs.phpunit.de/en/10.5/`
- `https://symfony.com/doc/current/testing.html`

This matches the Symfony coding-standards link style already used in the same file.

## Verification

- `python3 ../scripts/preflight_ship.py --repo mautic/mautic --local . --branch 7.x --file plugins/GrapesJsBuilderBundle/.github/CONTRIBUTING.md --must-contain 'phpunit.de/manual/5.7' --must-not-contain 'docs.phpunit.de/en/10.5' --search 'GrapesJs CONTRIBUTING phpunit'` → PREFLIGHT CLEAR
- `curl -I` on both replacement URLs → HTTP 200

---
### Steps to test this PR:

1. Open `plugins/GrapesJsBuilderBundle/.github/CONTRIBUTING.md` and confirm the Automated Tests links target PHPUnit 10.5 and current Symfony testing docs.
2. Follow each link in a browser and confirm the pages load.