### PR TITLE
[symfony] Build RequestStack via constructor instead of push() in tests

### DIFF
--- a/app/bundles/DashboardBundle/Tests/Controller/DashboardControllerTest.php
+++ b/app/bundles/DashboardBundle/Tests/Controller/DashboardControllerTest.php
@@ -63,9 +63,7 @@ final class DashboardControllerTest extends \PHPUnit\Framework\TestCase
         $this->routerMock         = $this->createMock(RouterInterface::class);
         $this->containerMock      = $this->createMock(Container::class);
         $this->translatorMock     = $this->createMock(Translator::class);
-        $requestStack             = new RequestStack();
-
-        $requestStack->push($this->requestMock);
+        $requestStack             = new RequestStack([$this->requestMock]);
 
         $this->controller = new DashboardController(
             $this->createStub(ManagerRegistry::class),

--- a/app/bundles/DynamicContentBundle/Tests/Unit/EventListener/BuildJsSubscriberTest.php
+++ b/app/bundles/DynamicContentBundle/Tests/Unit/EventListener/BuildJsSubscriberTest.php
@@ -32,8 +32,7 @@ final class BuildJsSubscriberTest extends TestCase
         $translator = $this->createStub(TranslatorInterface::class);
         $translator->method('trans')->willReturn('Please wait');
 
-        $requestStack = new RequestStack();
-        $requestStack->push(Request::create('https://mautic.example'));
+        $requestStack = new RequestStack([Request::create('https://mautic.example')]);
 
         $router = $this->createStub(RouterInterface::class);
         $router->method('generate')->willReturn('https://mautic.example/dwc/slotNamePlaceholder');

--- a/app/bundles/LeadBundle/Tests/Model/LeadModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/LeadModelTest.php
@@ -142,8 +142,7 @@ final class LeadModelTest extends \PHPUnit\Framework\TestCase
     {
         parent::setUp();
 
-        $this->requestStack             = new RequestStack();
-        $this->requestStack->push(new Request());
+        $this->requestStack             = new RequestStack([new Request()]);
         $this->fieldModelMock                   = $this->createMock(FieldModel::class);
         $this->fieldsWithUniqueIdentifier       = $this->createMock(FieldsWithUniqueIdentifier::class);
         $this->companyModelMock                 = $this->createMock(CompanyModel::class);

--- a/app/bundles/LeadBundle/Tests/Tracker/ContactTrackerTest.php
+++ b/app/bundles/LeadBundle/Tests/Tracker/ContactTrackerTest.php
@@ -77,15 +77,13 @@ final class ContactTrackerTest extends \PHPUnit\Framework\TestCase
         $this->dispatcherMock             = $this->createMock(EventDispatcher::class);
         $this->leadFieldModelMock         = $this->createMock(FieldModel::class);
         $this->ipLookupHelperMock         = $this->createMock(IpLookupHelper::class);
-        $this->requestStack               = new RequestStack();
+        $this->requestStack               = new RequestStack([new Request()]);
 
         $this->securityMock->method('isAnonymous')
             ->willReturn(true);
 
         $this->ipLookupHelperMock->method('isRequestTrackable')
             ->willReturn(true);
-
-        $this->requestStack->push(new Request());
     }
 
     public function testSystemContactIsUsedOverTrackedContact(): void

--- a/plugins/GrapesJsBuilderBundle/Tests/Unit/EventSubscriber/InjectCustomContentSubscriberTest.php
+++ b/plugins/GrapesJsBuilderBundle/Tests/Unit/EventSubscriber/InjectCustomContentSubscriberTest.php
@@ -50,8 +50,7 @@ final class InjectCustomContentSubscriberTest extends TestCase
 
     public function testInjectViewCustomContentExitsWhenPluginNotPublished(): void
     {
-        $requestStack = new RequestStack();
-        $requestStack->push(new Request());
+        $requestStack = new RequestStack([new Request()]);
         $this->config->method('isPublished')->willReturn(false);
 
         $subscriber = new InjectCustomContentSubscriber($this->config, $this->createStub(GrapesJsBuilderModel::class), $this->twig, $requestStack, $this->router, $this->grapesJsBuilderRepository);
@@ -71,8 +70,7 @@ final class InjectCustomContentSubscriberTest extends TestCase
         ]);
         $request->setMethod('POST');
 
-        $requestStack = new RequestStack();
-        $requestStack->push($request);
+        $requestStack = new RequestStack([$request]);
 
         $this->grapesJsBuilderRepository->method('findOneBy')->willReturn(null);
 
@@ -93,8 +91,7 @@ final class InjectCustomContentSubscriberTest extends TestCase
 
     public function testInjectViewCustomContentUsesStoredMjmlOnGet(): void
     {
-        $requestStack = new RequestStack();
-        $requestStack->push(new Request([], [], [], [], [], ['REQUEST_METHOD' => 'GET']));
+        $requestStack = new RequestStack([new Request([], [], [], [], [], ['REQUEST_METHOD' => 'GET'])]);
 
         $grapesJsBuilder = $this->createMock(GrapesJsBuilder::class);
         $grapesJsBuilder->method('getCustomMjml')->willReturn('<mjml>stored</mjml>');
@@ -118,8 +115,7 @@ final class InjectCustomContentSubscriberTest extends TestCase
 
     public function testInjectViewCustomContentInjectsPageHeaderVars(): void
     {
-        $requestStack = new RequestStack();
-        $requestStack->push(new Request());
+        $requestStack = new RequestStack([new Request()]);
 
         $this->config->method('isPublished')->willReturn(true);
 

--- a/plugins/GrapesJsBuilderBundle/Tests/Unit/Model/GrapesJsBuilderModelEditorStateTest.php
+++ b/plugins/GrapesJsBuilderBundle/Tests/Unit/Model/GrapesJsBuilderModelEditorStateTest.php
@@ -28,14 +28,13 @@ final class GrapesJsBuilderModelEditorStateTest extends TestCase
 {
     public function testAddOrEditEntityStoresDecodedEditorStateAndCustomHtmlFallback(): void
     {
-        $requestStack = new RequestStack();
-        $requestStack->push(new Request([], [
+        $requestStack = new RequestStack([new Request([], [
             'grapesjsbuilder' => [
                 'customMjml'  => '<mjml/>',
                 'editorState' => '{"pages":[{"id":"main"}]}',
             ],
             'customHtml' => '<html/>',
-        ]));
+        ])]);
 
         /** @var MockObject&EmailRepository $emailRepository */
         $emailRepository = $this->createMock(EmailRepository::class);
@@ -75,13 +74,12 @@ final class GrapesJsBuilderModelEditorStateTest extends TestCase
 
     public function testAddOrEditEntitySkipsWhenTranslationChildrenAreUpdating(): void
     {
-        $requestStack = new RequestStack();
-        $requestStack->push(new Request([], [
+        $requestStack = new RequestStack([new Request([], [
             'grapesjsbuilder' => [
                 'customMjml'  => '<mjml/>',
                 'editorState' => '{"pages":[]}',
             ],
-        ]));
+        ])]);
 
         /** @var MockObject&EmailRepository $emailRepository */
         $emailRepository = $this->createMock(EmailRepository::class);
@@ -102,12 +100,11 @@ final class GrapesJsBuilderModelEditorStateTest extends TestCase
 
     public function testAddOrEditPageEntityPersistsOnlyWhenEditorStateProvided(): void
     {
-        $requestStack = new RequestStack();
-        $requestStack->push(new Request([], [
+        $requestStack = new RequestStack([new Request([], [
             'grapesjsbuilder' => [
                 'editorState' => ['pages' => [['id' => 'landing']]],
             ],
-        ]));
+        ])]);
 
         /** @var MockObject&EmailModel $emailModel */
         $emailModel = $this->createStub(EmailModel::class);
@@ -130,12 +127,11 @@ final class GrapesJsBuilderModelEditorStateTest extends TestCase
         $this->assertIsArray($content['grapesjsbuilder']);
         $this->assertSame(['pages' => [['id' => 'landing']]], $content['grapesjsbuilder']['editorState']);
 
-        $requestStackNoEditor = new RequestStack();
-        $requestStackNoEditor->push(new Request([], [
+        $requestStackNoEditor = new RequestStack([new Request([], [
             'grapesjsbuilder' => [
                 'customMjml' => '<mjml/>',
             ],
-        ]));
+        ])]);
 
         /** @var MockObject&EntityManager $entityManagerNoEditor */
         $entityManagerNoEditor = $this->createMock(EntityManager::class);


### PR DESCRIPTION
Tiny DX improvement, as RequestStack can be used with ctor defined Request in tests.