### PR TITLE
[AssetBundle] flip config.php services to autowired services.php

### DIFF
--- a/app/bundles/AssetBundle/Config/config.php
+++ b/app/bundles/AssetBundle/Config/config.php
@@ -54,15 +54,6 @@ return [
         ],
     ],
 
-    'services' => [
-        'others' => [
-            // Override the DropzoneController
-            'oneup_uploader.controller.dropzone.class' => [
-                'class'     => Mautic\AssetBundle\Controller\UploadController::class,
-            ],
-        ],
-    ],
-
     'parameters' => [
         'upload_dir'          => '%mautic.application_dir%/media/files',
         'max_size'            => '6',

--- a/app/bundles/AssetBundle/Config/services.php
+++ b/app/bundles/AssetBundle/Config/services.php
@@ -6,6 +6,9 @@ use Mautic\CoreBundle\DependencyInjection\MauticCoreExtension;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return function (ContainerConfigurator $configurator): void {
+    $parameters = $configurator->parameters();
+    $parameters->set('oneup_uploader.controller.dropzone.class', Mautic\AssetBundle\Controller\UploadController::class);
+
     $services = $configurator->services()
         ->defaults()
         ->autowire()
@@ -21,6 +24,7 @@ return function (ContainerConfigurator $configurator): void {
 
     $services->load('Mautic\\AssetBundle\\Entity\\', '../Entity/*Repository.php')
         ->tag(Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass::REPOSITORY_SERVICE_TAG);
+
     $services->set('mautic.asset.fixture.asset', Mautic\AssetBundle\DataFixtures\ORM\LoadAssetData::class)->tag(Doctrine\Bundle\FixturesBundle\DependencyInjection\CompilerPass\FixturesCompilerPass::FIXTURE_TAG);
     $services->alias(Mautic\AssetBundle\DataFixtures\ORM\LoadAssetData::class, 'mautic.asset.fixture.asset');
     $services->set('mautic.asset.permissions', Mautic\AssetBundle\Security\Permissions\AssetPermissions::class)->tag('mautic.permissions');

--- a/app/bundles/CoreBundle/Tests/Functional/DependencyInjection/AbstractContainerSmokeTestCase.php
+++ b/app/bundles/CoreBundle/Tests/Functional/DependencyInjection/AbstractContainerSmokeTestCase.php
@@ -51,7 +51,6 @@ abstract class AbstractContainerSmokeTestCase extends TestCase
         \Mautic\LeadBundle\Controller\Api\FieldApiController::class,
         'fos_oauth_server.controller.authorize',
         'mautic.helper.token_builder',
-        'oneup_uploader.controller.dropzone.class',
     ];
 
     /**


### PR DESCRIPTION
Moves the `services` of `Config/config.php` to the autowired `Config/services.php` next to it, following what `ServicePass` does with them at compile time.

1 bundle = 1 PR, this one covers the asset bundle.

```diff
diff --git a/app/bundles/AssetBundle/Config/config.php b/app/bundles/AssetBundle/Config/config.php
index 7b363ace63..f870c4b12e 100644
--- a/app/bundles/AssetBundle/Config/config.php
+++ b/app/bundles/AssetBundle/Config/config.php
@@ -54,15 +54,6 @@ return [
         ],
     ],
 
-    'services' => [
-        'others' => [
-            // Override the DropzoneController
-            'oneup_uploader.controller.dropzone.class' => [
-                'class'     => Mautic\AssetBundle\Controller\UploadController::class,
-            ],
-        ],
-    ],
-
     'parameters' => [
         'upload_dir'          => '%mautic.application_dir%/media/files',
         'max_size'            => '6',
diff --git a/app/bundles/AssetBundle/Config/services.php b/app/bundles/AssetBundle/Config/services.php
index 9e1005da44..12e8db3cf0 100644
--- a/app/bundles/AssetBundle/Config/services.php
+++ b/app/bundles/AssetBundle/Config/services.php
@@ -6,6 +6,9 @@ use Mautic\CoreBundle\DependencyInjection\MauticCoreExtension;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return function (ContainerConfigurator $configurator): void {
+    $parameters = $configurator->parameters();
+    $parameters->set('oneup_uploader.controller.dropzone.class', Mautic\AssetBundle\Controller\UploadController::class);
+
     $services = $configurator->services()
         ->defaults()
         ->autowire()
@@ -21,6 +24,7 @@ return function (ContainerConfigurator $configurator): void {
 
     $services->load('Mautic\\AssetBundle\\Entity\\', '../Entity/*Repository.php')
         ->tag(Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass::REPOSITORY_SERVICE_TAG);
+
     $services->set('mautic.asset.fixture.asset', Mautic\AssetBundle\DataFixtures\ORM\LoadAssetData::class)->tag(Doctrine\Bundle\FixturesBundle\DependencyInjection\CompilerPass\FixturesCompilerPass::FIXTURE_TAG);
     $services->alias(Mautic\AssetBundle\DataFixtures\ORM\LoadAssetData::class, 'mautic.asset.fixture.asset');
     $services->set('mautic.asset.permissions', Mautic\AssetBundle\Security\Permissions\AssetPermissions::class)->tag('mautic.permissions');
diff --git a/app/bundles/CoreBundle/Tests/Functional/DependencyInjection/AbstractContainerSmokeTestCase.php b/app/bundles/CoreBundle/Tests/Functional/DependencyInjection/AbstractContainerSmokeTestCase.php
index d9f8e8e289..ff700fb84c 100644
--- a/app/bundles/CoreBundle/Tests/Functional/DependencyInjection/AbstractContainerSmokeTestCase.php
+++ b/app/bundles/CoreBundle/Tests/Functional/DependencyInjection/AbstractContainerSmokeTestCase.php
@@ -51,7 +51,6 @@ abstract class AbstractContainerSmokeTestCase extends TestCase
         \Mautic\LeadBundle\Controller\Api\FieldApiController::class,
         'fos_oauth_server.controller.authorize',
         'mautic.helper.token_builder',
-        'oneup_uploader.controller.dropzone.class',
     ];
 
     /**
```
