### PR TITLE
[CoreBundle] flip config.php services to autowired services.php

### DIFF
--- a/app/bundles/CoreBundle/Config/config.php
+++ b/app/bundles/CoreBundle/Config/config.php
@@ -154,15 +154,6 @@ return [
         ],
     ],
     'services' => [
-        'helpers' => [
-            'mautic.helper.core_parameters' => [
-                'class'     => Mautic\CoreBundle\Helper\CoreParametersHelper::class,
-                'arguments' => [
-                    'service_container',
-                ],
-                'serviceAlias' => 'mautic.config',
-            ],
-        ],
         'menus' => [
             'mautic.menu.main' => [
                 'alias' => 'main',
@@ -185,24 +176,6 @@ return [
                     'template' => '@MauticCore/Menu/profile_inline.html.twig',
                 ],
             ],
-        ],
-        'other' => [
-            'mautic.ip_lookup' => [
-                'class'     => Mautic\CoreBundle\IpLookup\AbstractLookup::class, // bogus just to make cache compilation happy
-                'factory'   => ['@mautic.ip_lookup.factory', 'getService'],
-                'arguments' => [
-                    '%mautic.ip_lookup_service%',
-                    '%mautic.ip_lookup_auth%',
-                    '%mautic.ip_lookup_config%',
-                    'mautic.http.client',
-                ],
-            ],
-            'mautic.native.connector' => [
-                'class'     => Symfony\Contracts\HttpClient\HttpClientInterface::class,
-                'factory'   => [Symfony\Component\HttpClient\HttpClient::class, 'create'],
-            ],
-
-            'twig.controller.exception.class' => Mautic\CoreBundle\Controller\ExceptionController::class,
         ],
     ],
 

--- a/app/bundles/CoreBundle/Config/services.php
+++ b/app/bundles/CoreBundle/Config/services.php
@@ -11,6 +11,9 @@ use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 use Twig\Extra\String\StringExtension;
 
 return function (ContainerConfigurator $configurator): void {
+    $parameters = $configurator->parameters();
+    $parameters->set('twig.controller.exception.class', Mautic\CoreBundle\Controller\ExceptionController::class);
+
     $services = $configurator->services()
         ->defaults()
         ->autowire()
@@ -50,6 +53,19 @@ return function (ContainerConfigurator $configurator): void {
         ->exclude('../{'.implode(',', array_merge(MauticCoreExtension::DEFAULT_EXCLUDES, $excludes)).'}');
 
     $services->load('Mautic\\CoreBundle\\Entity\\', '../Entity/*Repository.php');
+
+    $services->set('mautic.helper.core_parameters', Mautic\CoreBundle\Helper\CoreParametersHelper::class)->tag('twig.helper');
+
+    $services->alias(Mautic\CoreBundle\Helper\CoreParametersHelper::class, 'mautic.helper.core_parameters');
+    $services->alias('mautic.config', 'mautic.helper.core_parameters');
+
+    $services->set('mautic.ip_lookup', Mautic\CoreBundle\IpLookup\AbstractLookup::class)
+        ->factory([service('mautic.ip_lookup.factory'), 'getService'])
+        ->args([param('mautic.ip_lookup_service'), param('mautic.ip_lookup_auth'), param('mautic.ip_lookup_config'), service('mautic.http.client')]);
+    $services->alias(Mautic\CoreBundle\IpLookup\AbstractLookup::class, 'mautic.ip_lookup');
+    $services->set('mautic.native.connector', Symfony\Contracts\HttpClient\HttpClientInterface::class)
+        ->factory([Symfony\Component\HttpClient\HttpClient::class, 'create']);
+    $services->alias(Symfony\Contracts\HttpClient\HttpClientInterface::class, 'mautic.native.connector');
     $services->set('mautic.translation.loader', Mautic\CoreBundle\Loader\TranslationLoader::class)->tag('translation.loader', ['alias' => 'mautic']);
     $services->alias(Mautic\CoreBundle\Loader\TranslationLoader::class, 'mautic.translation.loader');
     $services->set('mautic.helper.theme', Mautic\CoreBundle\Helper\ThemeHelper::class)


### PR DESCRIPTION
Moves the `services` of `Config/config.php` to the autowired `Config/services.php` next to it, following what `ServicePass` does with them at compile time.

1 bundle = 1 PR, this one covers the core bundle.

```diff
diff --git a/app/bundles/CoreBundle/Config/config.php b/app/bundles/CoreBundle/Config/config.php
index f4bdfb1b14..e656adc76a 100644
--- a/app/bundles/CoreBundle/Config/config.php
+++ b/app/bundles/CoreBundle/Config/config.php
@@ -154,15 +154,6 @@ return [
         ],
     ],
     'services' => [
-        'helpers' => [
-            'mautic.helper.core_parameters' => [
-                'class'     => Mautic\CoreBundle\Helper\CoreParametersHelper::class,
-                'arguments' => [
-                    'service_container',
-                ],
-                'serviceAlias' => 'mautic.config',
-            ],
-        ],
         'menus' => [
             'mautic.menu.main' => [
                 'alias' => 'main',
@@ -186,24 +177,6 @@ return [
                 ],
             ],
         ],
-        'other' => [
-            'mautic.ip_lookup' => [
-                'class'     => Mautic\CoreBundle\IpLookup\AbstractLookup::class, // bogus just to make cache compilation happy
-                'factory'   => ['@mautic.ip_lookup.factory', 'getService'],
-                'arguments' => [
-                    '%mautic.ip_lookup_service%',
-                    '%mautic.ip_lookup_auth%',
-                    '%mautic.ip_lookup_config%',
-                    'mautic.http.client',
-                ],
-            ],
-            'mautic.native.connector' => [
-                'class'     => Symfony\Contracts\HttpClient\HttpClientInterface::class,
-                'factory'   => [Symfony\Component\HttpClient\HttpClient::class, 'create'],
-            ],
-
-            'twig.controller.exception.class' => Mautic\CoreBundle\Controller\ExceptionController::class,
-        ],
     ],
 
     'ip_lookup_services' => [
diff --git a/app/bundles/CoreBundle/Config/services.php b/app/bundles/CoreBundle/Config/services.php
index c63b8592d7..96b97a2837 100644
--- a/app/bundles/CoreBundle/Config/services.php
+++ b/app/bundles/CoreBundle/Config/services.php
@@ -11,6 +11,9 @@ use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 use Twig\Extra\String\StringExtension;
 
 return function (ContainerConfigurator $configurator): void {
+    $parameters = $configurator->parameters();
+    $parameters->set('twig.controller.exception.class', Mautic\CoreBundle\Controller\ExceptionController::class);
+
     $services = $configurator->services()
         ->defaults()
         ->autowire()
@@ -50,6 +53,19 @@ return function (ContainerConfigurator $configurator): void {
         ->exclude('../{'.implode(',', array_merge(MauticCoreExtension::DEFAULT_EXCLUDES, $excludes)).'}');
 
     $services->load('Mautic\\CoreBundle\\Entity\\', '../Entity/*Repository.php');
+
+    $services->set('mautic.helper.core_parameters', Mautic\CoreBundle\Helper\CoreParametersHelper::class)->tag('twig.helper');
+
+    $services->alias(Mautic\CoreBundle\Helper\CoreParametersHelper::class, 'mautic.helper.core_parameters');
+    $services->alias('mautic.config', 'mautic.helper.core_parameters');
+
+    $services->set('mautic.ip_lookup', Mautic\CoreBundle\IpLookup\AbstractLookup::class)
+        ->factory([service('mautic.ip_lookup.factory'), 'getService'])
+        ->args([param('mautic.ip_lookup_service'), param('mautic.ip_lookup_auth'), param('mautic.ip_lookup_config'), service('mautic.http.client')]);
+    $services->alias(Mautic\CoreBundle\IpLookup\AbstractLookup::class, 'mautic.ip_lookup');
+    $services->set('mautic.native.connector', Symfony\Contracts\HttpClient\HttpClientInterface::class)
+        ->factory([Symfony\Component\HttpClient\HttpClient::class, 'create']);
+    $services->alias(Symfony\Contracts\HttpClient\HttpClientInterface::class, 'mautic.native.connector');
     $services->set('mautic.translation.loader', Mautic\CoreBundle\Loader\TranslationLoader::class)->tag('translation.loader', ['alias' => 'mautic']);
     $services->alias(Mautic\CoreBundle\Loader\TranslationLoader::class, 'mautic.translation.loader');
     $services->set('mautic.helper.theme', Mautic\CoreBundle\Helper\ThemeHelper::class)
```
