### PR TITLE
[LeadBundle] flip config.php services to autowired services.php

### DIFF
--- a/app/bundles/LeadBundle/Config/config.php
+++ b/app/bundles/LeadBundle/Config/config.php
@@ -326,41 +326,6 @@ return [
             'class' => Mautic\LeadBundle\Entity\LeadList::class,
         ],
     ],
-    'services' => [
-        'events' => [
-            'mautic.lead.serializer.subscriber' => [
-                'class'     => Mautic\LeadBundle\EventListener\SerializerSubscriber::class,
-                'arguments' => [
-                    'request_stack',
-                ],
-                'tag'          => 'jms_serializer.event_subscriber',
-                'tagArguments' => [
-                    'event' => JMS\Serializer\EventDispatcher\Events::POST_SERIALIZE,
-                ],
-            ],
-        ],
-        'other' => [
-            Mautic\LeadBundle\Form\Validator\Constraints\FieldAliasKeywordValidator::class => [
-                'class'     => Mautic\LeadBundle\Form\Validator\Constraints\FieldAliasKeywordValidator::class,
-                'tag'       => 'validator.constraint_validator',
-                'arguments' => [
-                    'mautic.lead.model.list',
-                    'mautic.helper.field.alias',
-                    '@doctrine.orm.entity_manager',
-                    'translator',
-                    'mautic.lead.repository.lead_segment_filter_descriptor',
-                ],
-            ],
-            Mautic\CoreBundle\Form\Validator\Constraints\FileEncodingValidator::class => [
-                'class'     => Mautic\CoreBundle\Form\Validator\Constraints\FileEncodingValidator::class,
-                'tag'       => 'validator.constraint_validator',
-                'arguments' => [
-                    'mautic.lead.model.list',
-                    'mautic.helper.field.alias',
-                ],
-            ],
-        ],
-    ],
     'parameters' => [
         'parallel_import_limit'               => 1,
         'background_import_if_more_rows_than' => 0,

--- a/app/bundles/LeadBundle/Config/services.php
+++ b/app/bundles/LeadBundle/Config/services.php
@@ -30,6 +30,10 @@ return function (ContainerConfigurator $configurator): void {
 
     $services->load('Mautic\\LeadBundle\\Entity\\', '../Entity/*Repository.php')
         ->tag(Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass::REPOSITORY_SERVICE_TAG);
+    $services->set('mautic.lead.serializer.subscriber', Mautic\LeadBundle\EventListener\SerializerSubscriber::class)->tag('jms_serializer.event_subscriber', ['event' => JMS\Serializer\EventDispatcher\Events::POST_SERIALIZE]);
+    $services->alias(Mautic\LeadBundle\EventListener\SerializerSubscriber::class, 'mautic.lead.serializer.subscriber');
+    $services->set(Mautic\LeadBundle\Form\Validator\Constraints\FieldAliasKeywordValidator::class)->tag('validator.constraint_validator');
+    $services->set(Mautic\CoreBundle\Form\Validator\Constraints\FileEncodingValidator::class)->tag('validator.constraint_validator');
     $services->set('mautic.validator.leadlistaccess', Mautic\LeadBundle\Form\Validator\Constraints\LeadListAccessValidator::class)->tag('validator.constraint_validator', ['alias' => 'leadlist_access']);
     $services->alias(Mautic\LeadBundle\Form\Validator\Constraints\LeadListAccessValidator::class, 'mautic.validator.leadlistaccess');
     $services->set('mautic.lead.constraint.alias', Mautic\LeadBundle\Form\Validator\Constraints\UniqueUserAliasValidator::class)->tag('validator.constraint_validator', ['alias' => 'uniqueleadlist']);


### PR DESCRIPTION
Moves the `services` of `Config/config.php` to the autowired `Config/services.php` next to it, following what `ServicePass` does with them at compile time.

1 bundle = 1 PR, this one covers the lead bundle.

```diff
diff --git a/app/bundles/LeadBundle/Config/config.php b/app/bundles/LeadBundle/Config/config.php
index 974a8fb722..c2e82ba079 100644
--- a/app/bundles/LeadBundle/Config/config.php
+++ b/app/bundles/LeadBundle/Config/config.php
@@ -326,41 +326,6 @@ return [
             'class' => Mautic\LeadBundle\Entity\LeadList::class,
         ],
     ],
-    'services' => [
-        'events' => [
-            'mautic.lead.serializer.subscriber' => [
-                'class'     => Mautic\LeadBundle\EventListener\SerializerSubscriber::class,
-                'arguments' => [
-                    'request_stack',
-                ],
-                'tag'          => 'jms_serializer.event_subscriber',
-                'tagArguments' => [
-                    'event' => JMS\Serializer\EventDispatcher\Events::POST_SERIALIZE,
-                ],
-            ],
-        ],
-        'other' => [
-            Mautic\LeadBundle\Form\Validator\Constraints\FieldAliasKeywordValidator::class => [
-                'class'     => Mautic\LeadBundle\Form\Validator\Constraints\FieldAliasKeywordValidator::class,
-                'tag'       => 'validator.constraint_validator',
-                'arguments' => [
-                    'mautic.lead.model.list',
-                    'mautic.helper.field.alias',
-                    '@doctrine.orm.entity_manager',
-                    'translator',
-                    'mautic.lead.repository.lead_segment_filter_descriptor',
-                ],
-            ],
-            Mautic\CoreBundle\Form\Validator\Constraints\FileEncodingValidator::class => [
-                'class'     => Mautic\CoreBundle\Form\Validator\Constraints\FileEncodingValidator::class,
-                'tag'       => 'validator.constraint_validator',
-                'arguments' => [
-                    'mautic.lead.model.list',
-                    'mautic.helper.field.alias',
-                ],
-            ],
-        ],
-    ],
     'parameters' => [
         'parallel_import_limit'               => 1,
         'background_import_if_more_rows_than' => 0,
diff --git a/app/bundles/LeadBundle/Config/services.php b/app/bundles/LeadBundle/Config/services.php
index af594a2bc3..c7d6f1e326 100644
--- a/app/bundles/LeadBundle/Config/services.php
+++ b/app/bundles/LeadBundle/Config/services.php
@@ -30,6 +30,10 @@ return function (ContainerConfigurator $configurator): void {
 
     $services->load('Mautic\\LeadBundle\\Entity\\', '../Entity/*Repository.php')
         ->tag(Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass::REPOSITORY_SERVICE_TAG);
+    $services->set('mautic.lead.serializer.subscriber', Mautic\LeadBundle\EventListener\SerializerSubscriber::class)->tag('jms_serializer.event_subscriber', ['event' => JMS\Serializer\EventDispatcher\Events::POST_SERIALIZE]);
+    $services->alias(Mautic\LeadBundle\EventListener\SerializerSubscriber::class, 'mautic.lead.serializer.subscriber');
+    $services->set(Mautic\LeadBundle\Form\Validator\Constraints\FieldAliasKeywordValidator::class)->tag('validator.constraint_validator');
+    $services->set(Mautic\CoreBundle\Form\Validator\Constraints\FileEncodingValidator::class)->tag('validator.constraint_validator');
     $services->set('mautic.validator.leadlistaccess', Mautic\LeadBundle\Form\Validator\Constraints\LeadListAccessValidator::class)->tag('validator.constraint_validator', ['alias' => 'leadlist_access']);
     $services->alias(Mautic\LeadBundle\Form\Validator\Constraints\LeadListAccessValidator::class, 'mautic.validator.leadlistaccess');
     $services->set('mautic.lead.constraint.alias', Mautic\LeadBundle\Form\Validator\Constraints\UniqueUserAliasValidator::class)->tag('validator.constraint_validator', ['alias' => 'uniqueleadlist']);
```
