### PR TITLE
[SmsBundle] flip config.php services to autowired services.php

### DIFF
--- a/app/bundles/SmsBundle/Config/config.php
+++ b/app/bundles/SmsBundle/Config/config.php
@@ -1,25 +1,6 @@
 <?php
 
 return [
-    'services' => [
-        'other' => [
-            'mautic.sms.twilio.transport' => [
-                'class'        => Mautic\SmsBundle\Integration\Twilio\TwilioTransport::class,
-                'arguments'    => [
-                    'mautic.sms.twilio.configuration',
-                    'monolog.logger.mautic',
-                ],
-                'tag'          => 'mautic.sms_transport',
-                'tagArguments' => [
-                    'integrationAlias' => 'Twilio',
-                ],
-                'serviceAliases' => [
-                    'sms_api',
-                    'mautic.sms.api',
-                ],
-            ],
-        ],
-    ],
     'routes' => [
         'main' => [
             'mautic_sms_index' => [

--- a/app/bundles/SmsBundle/Config/services.php
+++ b/app/bundles/SmsBundle/Config/services.php
@@ -21,6 +21,10 @@ return function (ContainerConfigurator $configurator): void {
 
     $services->load('Mautic\\SmsBundle\\Entity\\', '../Entity/*Repository.php')
         ->tag(Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass::REPOSITORY_SERVICE_TAG);
+    $services->set('mautic.sms.twilio.transport', Mautic\SmsBundle\Integration\Twilio\TwilioTransport::class)->tag('mautic.sms_transport', ['integrationAlias' => 'Twilio']);
+    $services->alias(Mautic\SmsBundle\Integration\Twilio\TwilioTransport::class, 'mautic.sms.twilio.transport');
+    $services->alias('sms_api', 'mautic.sms.twilio.transport');
+    $services->alias('mautic.sms.api', 'mautic.sms.twilio.transport');
     $services->set('mautic.helper.sms', Mautic\SmsBundle\Helper\SmsHelper::class)->tag('twig.helper', ['alias' => 'sms_helper']);
     $services->alias(Mautic\SmsBundle\Helper\SmsHelper::class, 'mautic.helper.sms');
     $services->set('mautic.sms.transport_chain', Mautic\SmsBundle\Sms\TransportChain::class)


### PR DESCRIPTION
Moves the `services` of `Config/config.php` to the autowired `Config/services.php` next to it, following what `ServicePass` does with them at compile time.

1 bundle = 1 PR, this one covers the sms bundle.

```diff
diff --git a/app/bundles/SmsBundle/Config/config.php b/app/bundles/SmsBundle/Config/config.php
index c9ccf3e9b9..cce81bfb9b 100644
--- a/app/bundles/SmsBundle/Config/config.php
+++ b/app/bundles/SmsBundle/Config/config.php
@@ -1,25 +1,6 @@
 <?php
 
 return [
-    'services' => [
-        'other' => [
-            'mautic.sms.twilio.transport' => [
-                'class'        => Mautic\SmsBundle\Integration\Twilio\TwilioTransport::class,
-                'arguments'    => [
-                    'mautic.sms.twilio.configuration',
-                    'monolog.logger.mautic',
-                ],
-                'tag'          => 'mautic.sms_transport',
-                'tagArguments' => [
-                    'integrationAlias' => 'Twilio',
-                ],
-                'serviceAliases' => [
-                    'sms_api',
-                    'mautic.sms.api',
-                ],
-            ],
-        ],
-    ],
     'routes' => [
         'main' => [
             'mautic_sms_index' => [
diff --git a/app/bundles/SmsBundle/Config/services.php b/app/bundles/SmsBundle/Config/services.php
index 4dd7e16877..aff2bd597b 100644
--- a/app/bundles/SmsBundle/Config/services.php
+++ b/app/bundles/SmsBundle/Config/services.php
@@ -21,6 +21,10 @@ return function (ContainerConfigurator $configurator): void {
 
     $services->load('Mautic\\SmsBundle\\Entity\\', '../Entity/*Repository.php')
         ->tag(Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass::REPOSITORY_SERVICE_TAG);
+    $services->set('mautic.sms.twilio.transport', Mautic\SmsBundle\Integration\Twilio\TwilioTransport::class)->tag('mautic.sms_transport', ['integrationAlias' => 'Twilio']);
+    $services->alias(Mautic\SmsBundle\Integration\Twilio\TwilioTransport::class, 'mautic.sms.twilio.transport');
+    $services->alias('sms_api', 'mautic.sms.twilio.transport');
+    $services->alias('mautic.sms.api', 'mautic.sms.twilio.transport');
     $services->set('mautic.helper.sms', Mautic\SmsBundle\Helper\SmsHelper::class)->tag('twig.helper', ['alias' => 'sms_helper']);
     $services->alias(Mautic\SmsBundle\Helper\SmsHelper::class, 'mautic.helper.sms');
     $services->set('mautic.sms.transport_chain', Mautic\SmsBundle\Sms\TransportChain::class)
```
