### PR TITLE
[UserBundle] flip config.php services to autowired services.php

### DIFF
--- a/app/bundles/UserBundle/Config/config.php
+++ b/app/bundles/UserBundle/Config/config.php
@@ -127,57 +127,6 @@ return [
             ],
         ],
     ],
-
-    'services' => [
-        'other' => [
-            // Authentication
-            'mautic.user.manager' => [
-                'class'     => Doctrine\ORM\EntityManager::class,
-                'arguments' => Mautic\UserBundle\Entity\User::class,
-                'factory'   => ['@doctrine', 'getManagerForClass'],
-            ],
-            'mautic.permission.manager' => [
-                'class'     => Doctrine\ORM\EntityManager::class,
-                'arguments' => Mautic\UserBundle\Entity\Permission::class,
-                'factory'   => ['@doctrine', 'getManagerForClass'],
-            ],
-            'mautic.security.logout_handler' => [
-                'class'        => Mautic\UserBundle\EventListener\LogoutListener::class,
-                'tagArguments' => [
-                    'event'      => Symfony\Component\Security\Http\Event\LogoutEvent::class,
-                ],
-                'tag'          => 'kernel.event_listener',
-                'arguments'    => [
-                    'mautic.user.model.user',
-                    'event_dispatcher',
-                    'mautic.helper.user',
-                ],
-            ],
-
-            'mautic.security.saml.entity_descriptor_provider' => [
-                'class'     => LightSaml\Builder\EntityDescriptor\SimpleEntityDescriptorBuilder::class,
-                'factory'   => [Mautic\UserBundle\Security\SAML\EntityDescriptorProviderFactory::class, 'build'],
-                'arguments' => [
-                    '%lightsaml.own.entity_id%',
-                    'router',
-                    '%lightsaml.route.login_check%',
-                    'lightsaml.own.credential_store',
-                ],
-            ],
-
-            'mautic.security.saml.username_mapper' => [
-                'class'     => Mautic\UserBundle\Security\SAML\User\UserMapper::class,
-                'arguments' => [
-                    [
-                        'email'     => '%mautic.saml_idp_email_attribute%',
-                        'username'  => '%mautic.saml_idp_username_attribute%',
-                        'firstname' => '%mautic.saml_idp_firstname_attribute%',
-                        'lastname'  => '%mautic.saml_idp_lastname_attribute%',
-                    ],
-                ],
-            ],
-        ],
-    ],
     'parameters' => [
         'saml_idp_metadata'            => '',
         'saml_idp_entity_id'           => '',

--- a/app/bundles/UserBundle/Config/services.php
+++ b/app/bundles/UserBundle/Config/services.php
@@ -86,6 +86,23 @@ return function (ContainerConfigurator $configurator): void {
     $services->alias(LightSaml\SymfonyBridgeBundle\Bridge\Container\BuildContainer::class, 'lightsaml.container.build');
     $services->load('LightSaml\\SpBundle\\Controller\\', '%kernel.project_dir%/vendor/javer/sp-bundle/src/LightSaml/SpBundle/Controller/*.php')
         ->tag('controller.service_arguments');
+    $services->set('mautic.security.logout_handler', Mautic\UserBundle\EventListener\LogoutListener::class)->tag('kernel.event_listener', ['event' => Symfony\Component\Security\Http\Event\LogoutEvent::class]);
+    $services->alias(Mautic\UserBundle\EventListener\LogoutListener::class, 'mautic.security.logout_handler');
+    $services->set('mautic.security.saml.username_mapper', Mautic\UserBundle\Security\SAML\User\UserMapper::class)
+        ->arg('$attributes', ['email' => param('mautic.saml_idp_email_attribute'), 'username' => param('mautic.saml_idp_username_attribute'), 'firstname' => param('mautic.saml_idp_firstname_attribute'), 'lastname' => param('mautic.saml_idp_lastname_attribute')]);
+    $services->alias(Mautic\UserBundle\Security\SAML\User\UserMapper::class, 'mautic.security.saml.username_mapper');
+    $services->set('mautic.user.manager', Doctrine\ORM\EntityManager::class)
+        ->factory([service('doctrine'), 'getManagerForClass'])
+        ->args([Mautic\UserBundle\Entity\User::class]);
+    $services->alias(Doctrine\ORM\EntityManager::class, 'mautic.user.manager');
+    $services->set('mautic.permission.manager', Doctrine\ORM\EntityManager::class)
+        ->factory([service('doctrine'), 'getManagerForClass'])
+        ->args([Mautic\UserBundle\Entity\Permission::class]);
+    $services->alias(Doctrine\ORM\EntityManager::class, 'mautic.permission.manager');
+    $services->set('mautic.security.saml.entity_descriptor_provider', LightSaml\Builder\EntityDescriptor\SimpleEntityDescriptorBuilder::class)
+        ->factory([Mautic\UserBundle\Security\SAML\EntityDescriptorProviderFactory::class, 'build'])
+        ->args([param('lightsaml.own.entity_id'), service('router'), param('lightsaml.route.login_check'), service('lightsaml.own.credential_store')]);
+    $services->alias(LightSaml\Builder\EntityDescriptor\SimpleEntityDescriptorBuilder::class, 'mautic.security.saml.entity_descriptor_provider');
     $services->set('mautic.user.fixture.role', Mautic\UserBundle\DataFixtures\ORM\LoadRoleData::class)->tag(Doctrine\Bundle\FixturesBundle\DependencyInjection\CompilerPass\FixturesCompilerPass::FIXTURE_TAG);
     $services->alias(Mautic\UserBundle\DataFixtures\ORM\LoadRoleData::class, 'mautic.user.fixture.role');
     $services->set('mautic.user.fixture.user', Mautic\UserBundle\DataFixtures\ORM\LoadUserData::class)->tag(Doctrine\Bundle\FixturesBundle\DependencyInjection\CompilerPass\FixturesCompilerPass::FIXTURE_TAG);


### PR DESCRIPTION
Moves the `services` of `Config/config.php` to the autowired `Config/services.php` next to it, following what `ServicePass` does with them at compile time.

1 bundle = 1 PR, this one covers the user bundle.

```diff
diff --git a/app/bundles/UserBundle/Config/config.php b/app/bundles/UserBundle/Config/config.php
index 0ab2aeebca..cd09e64a3e 100644
--- a/app/bundles/UserBundle/Config/config.php
+++ b/app/bundles/UserBundle/Config/config.php
@@ -127,57 +127,6 @@ return [
             ],
         ],
     ],
-
-    'services' => [
-        'other' => [
-            // Authentication
-            'mautic.user.manager' => [
-                'class'     => Doctrine\ORM\EntityManager::class,
-                'arguments' => Mautic\UserBundle\Entity\User::class,
-                'factory'   => ['@doctrine', 'getManagerForClass'],
-            ],
-            'mautic.permission.manager' => [
-                'class'     => Doctrine\ORM\EntityManager::class,
-                'arguments' => Mautic\UserBundle\Entity\Permission::class,
-                'factory'   => ['@doctrine', 'getManagerForClass'],
-            ],
-            'mautic.security.logout_handler' => [
-                'class'        => Mautic\UserBundle\EventListener\LogoutListener::class,
-                'tagArguments' => [
-                    'event'      => Symfony\Component\Security\Http\Event\LogoutEvent::class,
-                ],
-                'tag'          => 'kernel.event_listener',
-                'arguments'    => [
-                    'mautic.user.model.user',
-                    'event_dispatcher',
-                    'mautic.helper.user',
-                ],
-            ],
-
-            'mautic.security.saml.entity_descriptor_provider' => [
-                'class'     => LightSaml\Builder\EntityDescriptor\SimpleEntityDescriptorBuilder::class,
-                'factory'   => [Mautic\UserBundle\Security\SAML\EntityDescriptorProviderFactory::class, 'build'],
-                'arguments' => [
-                    '%lightsaml.own.entity_id%',
-                    'router',
-                    '%lightsaml.route.login_check%',
-                    'lightsaml.own.credential_store',
-                ],
-            ],
-
-            'mautic.security.saml.username_mapper' => [
-                'class'     => Mautic\UserBundle\Security\SAML\User\UserMapper::class,
-                'arguments' => [
-                    [
-                        'email'     => '%mautic.saml_idp_email_attribute%',
-                        'username'  => '%mautic.saml_idp_username_attribute%',
-                        'firstname' => '%mautic.saml_idp_firstname_attribute%',
-                        'lastname'  => '%mautic.saml_idp_lastname_attribute%',
-                    ],
-                ],
-            ],
-        ],
-    ],
     'parameters' => [
         'saml_idp_metadata'            => '',
         'saml_idp_entity_id'           => '',
diff --git a/app/bundles/UserBundle/Config/services.php b/app/bundles/UserBundle/Config/services.php
index 994bad31cb..e48a88dec9 100644
--- a/app/bundles/UserBundle/Config/services.php
+++ b/app/bundles/UserBundle/Config/services.php
@@ -86,6 +86,23 @@ return function (ContainerConfigurator $configurator): void {
     $services->alias(LightSaml\SymfonyBridgeBundle\Bridge\Container\BuildContainer::class, 'lightsaml.container.build');
     $services->load('LightSaml\\SpBundle\\Controller\\', '%kernel.project_dir%/vendor/javer/sp-bundle/src/LightSaml/SpBundle/Controller/*.php')
         ->tag('controller.service_arguments');
+    $services->set('mautic.security.logout_handler', Mautic\UserBundle\EventListener\LogoutListener::class)->tag('kernel.event_listener', ['event' => Symfony\Component\Security\Http\Event\LogoutEvent::class]);
+    $services->alias(Mautic\UserBundle\EventListener\LogoutListener::class, 'mautic.security.logout_handler');
+    $services->set('mautic.security.saml.username_mapper', Mautic\UserBundle\Security\SAML\User\UserMapper::class)
+        ->arg('$attributes', ['email' => param('mautic.saml_idp_email_attribute'), 'username' => param('mautic.saml_idp_username_attribute'), 'firstname' => param('mautic.saml_idp_firstname_attribute'), 'lastname' => param('mautic.saml_idp_lastname_attribute')]);
+    $services->alias(Mautic\UserBundle\Security\SAML\User\UserMapper::class, 'mautic.security.saml.username_mapper');
+    $services->set('mautic.user.manager', Doctrine\ORM\EntityManager::class)
+        ->factory([service('doctrine'), 'getManagerForClass'])
+        ->args([Mautic\UserBundle\Entity\User::class]);
+    $services->alias(Doctrine\ORM\EntityManager::class, 'mautic.user.manager');
+    $services->set('mautic.permission.manager', Doctrine\ORM\EntityManager::class)
+        ->factory([service('doctrine'), 'getManagerForClass'])
+        ->args([Mautic\UserBundle\Entity\Permission::class]);
+    $services->alias(Doctrine\ORM\EntityManager::class, 'mautic.permission.manager');
+    $services->set('mautic.security.saml.entity_descriptor_provider', LightSaml\Builder\EntityDescriptor\SimpleEntityDescriptorBuilder::class)
+        ->factory([Mautic\UserBundle\Security\SAML\EntityDescriptorProviderFactory::class, 'build'])
+        ->args([param('lightsaml.own.entity_id'), service('router'), param('lightsaml.route.login_check'), service('lightsaml.own.credential_store')]);
+    $services->alias(LightSaml\Builder\EntityDescriptor\SimpleEntityDescriptorBuilder::class, 'mautic.security.saml.entity_descriptor_provider');
     $services->set('mautic.user.fixture.role', Mautic\UserBundle\DataFixtures\ORM\LoadRoleData::class)->tag(Doctrine\Bundle\FixturesBundle\DependencyInjection\CompilerPass\FixturesCompilerPass::FIXTURE_TAG);
     $services->alias(Mautic\UserBundle\DataFixtures\ORM\LoadRoleData::class, 'mautic.user.fixture.role');
     $services->set('mautic.user.fixture.user', Mautic\UserBundle\DataFixtures\ORM\LoadUserData::class)->tag(Doctrine\Bundle\FixturesBundle\DependencyInjection\CompilerPass\FixturesCompilerPass::FIXTURE_TAG);
```
