### PR TITLE
[phpstan] enable NoServicesInBundleConfigRule

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -250,7 +250,7 @@ rules:
 	- Utils\PHPStan\Rule\PreferInterfaceInConstructorRule
 	- Utils\PHPStan\Rule\NoPropertyToPropertyAssignRule
 
-	#- Utils\PHPStan\Rule\NoServicesInBundleConfigRule
+	- Utils\PHPStan\Rule\NoServicesInBundleConfigRule
 	#- Utils\PHPStan\Rule\NoUnusedServiceAliasRule
 
 #services:


### PR DESCRIPTION
Enables `NoServicesInBundleConfigRule`, so no bundle `config.php` can bring the `services` key back:

```diff
-	#- Utils\PHPStan\Rule\NoServicesInBundleConfigRule
+	- Utils\PHPStan\Rule\NoServicesInBundleConfigRule
```

**Merge last.** The rule is green only once every bundle PR of this series is in.
