### PR TITLE
fix(theme): accept theme zips with a wrapper folder

### DIFF
--- a/app/bundles/CoreBundle/Helper/ThemeHelper.php
+++ b/app/bundles/CoreBundle/Helper/ThemeHelper.php
@@ -407,7 +407,7 @@ class ThemeHelper implements ThemeHelperInterface
 
         if (!is_dir($themePath) && !mkdir($themePath, 0755, true) && !is_dir($themePath)) {
             $zipper->close();
-            throw new \Exception('mautic.core.update.error_extracting_package');
+            throw new \Exception($this->translator->trans('mautic.core.update.error_extracting_package'));
         }
 
         foreach ($allowedFiles as $file) {
@@ -420,13 +420,13 @@ class ThemeHelper implements ThemeHelperInterface
                 $destination = $this->getSafeThemeDestination($themePath, $targetFile);
             } catch (\Exception) {
                 $zipper->close();
-                throw new \Exception('mautic.core.update.error_extracting_package');
+                throw new \Exception($this->translator->trans('mautic.core.update.error_extracting_package'));
             }
 
             if (str_ends_with($file, '/')) {
                 if (!is_dir($destination) && !mkdir($destination, 0755, true) && !is_dir($destination)) {
                     $zipper->close();
-                    throw new \Exception('mautic.core.update.error_extracting_package');
+                    throw new \Exception($this->translator->trans('mautic.core.update.error_extracting_package'));
                 }
 
                 continue;
@@ -435,21 +435,21 @@ class ThemeHelper implements ThemeHelperInterface
             $stream = $zipper->getStream($file);
             if (!$stream) {
                 $zipper->close();
-                throw new \Exception('mautic.core.update.error_extracting_package');
+                throw new \Exception($this->translator->trans('mautic.core.update.error_extracting_package'));
             }
 
             $destinationDir = dirname($destination);
             if (!is_dir($destinationDir) && !mkdir($destinationDir, 0755, true) && !is_dir($destinationDir)) {
                 fclose($stream);
                 $zipper->close();
-                throw new \Exception('mautic.core.update.error_extracting_package');
+                throw new \Exception($this->translator->trans('mautic.core.update.error_extracting_package'));
             }
 
             $target = fopen($destination, 'wb');
             if (!$target) {
                 fclose($stream);
                 $zipper->close();
-                throw new \Exception('mautic.core.update.error_extracting_package');
+                throw new \Exception($this->translator->trans('mautic.core.update.error_extracting_package'));
             }
 
             while (!feof($stream)) {
@@ -458,7 +458,7 @@ class ThemeHelper implements ThemeHelperInterface
                     fclose($target);
                     fclose($stream);
                     $zipper->close();
-                    throw new \Exception('mautic.core.update.error_extracting_package');
+                    throw new \Exception($this->translator->trans('mautic.core.update.error_extracting_package'));
                 }
 
                 if ('' !== $chunk) {
@@ -509,7 +509,7 @@ class ThemeHelper implements ThemeHelperInterface
         $destination = Path::canonicalize($themePath.'/'.$relativePath);
 
         if ($destination !== $themeRoot && !Path::isBasePath($themeRoot, $destination)) {
-            throw new \Exception('mautic.core.update.error_extracting_package');
+            throw new \Exception($this->translator->trans('mautic.core.update.error_extracting_package'));
         }
 
         return $destination;

--- a/app/bundles/CoreBundle/Helper/ThemeHelper.php
+++ b/app/bundles/CoreBundle/Helper/ThemeHelper.php
@@ -344,6 +344,7 @@ class ThemeHelper implements ThemeHelperInterface
         $requiredFiles      = ['config.json', 'html/message.html.twig'];
         $foundRequiredFiles = [];
         $allowedFiles       = [];
+        $zipEntries         = [];
         $allowedExtensions  = $this->coreParametersHelper->get('theme_import_allowed_extensions');
 
         $config = [];
@@ -353,6 +354,7 @@ class ThemeHelper implements ThemeHelperInterface
                 $entry = substr($entry, 1);
             }
 
+            $zipEntries[] = $entry;
             $extension = pathinfo($entry, PATHINFO_EXTENSION);
 
             // Check for required files
@@ -365,7 +367,7 @@ class ThemeHelper implements ThemeHelperInterface
                 $allowedFiles[] = $entry;
             }
 
-            if ('config.json' === $entry) {
+            if ('config.json' === basename($entry)) {
                 $config = json_decode($zipper->getFromName($entry), true);
             }
         }
@@ -381,18 +383,125 @@ class ThemeHelper implements ThemeHelperInterface
             }
         }
 
+        $archivePrefix = $this->getThemeArchivePrefix($zipEntries, $requiredFiles);
         if ($missingFiles = array_diff($requiredFiles, $foundRequiredFiles)) {
-            throw new FileNotFoundException($this->translator->trans('mautic.core.theme.missing.files', ['%files%' => implode(', ', $missingFiles)], 'validators'));
+            if (null === $archivePrefix) {
+                throw new FileNotFoundException($this->translator->trans('mautic.core.theme.missing.files', ['%files%' => implode(', ', $missingFiles)], 'validators'));
+            }
+
+            foreach ($missingFiles as $missingFile) {
+                if (in_array($archivePrefix.'/'.$missingFile, $zipEntries, true)) {
+                    $foundRequiredFiles[] = $missingFile;
+                }
+            }
+
+            $missingFiles = array_diff($requiredFiles, $foundRequiredFiles);
+            if ($missingFiles) {
+                throw new FileNotFoundException($this->translator->trans('mautic.core.theme.missing.files', ['%files%' => implode(', ', $missingFiles)], 'validators'));
+            }
         }
 
-        // Extract the archive file now
-        if (!$zipper->extractTo($themePath, $allowedFiles)) {
+        if (!is_dir($themePath) && !mkdir($themePath, 0755, true) && !is_dir($themePath)) {
+            $zipper->close();
             throw new \Exception('mautic.core.update.error_extracting_package');
+        }
+
+        foreach ($allowedFiles as $file) {
+            $targetFile = $file;
+            if (null !== $archivePrefix && str_starts_with($file, $archivePrefix.'/')) {
+                $targetFile = substr($file, strlen($archivePrefix) + 1);
+            }
+
+            $destination = $themePath.'/'.$targetFile;
+            if (str_ends_with($file, '/')) {
+                if (!is_dir($destination) && !mkdir($destination, 0755, true) && !is_dir($destination)) {
+                    $zipper->close();
+                    throw new \Exception('mautic.core.update.error_extracting_package');
+                }
+
+                continue;
+            }
+
+            $stream = $zipper->getStream($file);
+            if (!$stream) {
+                $zipper->close();
+                throw new \Exception('mautic.core.update.error_extracting_package');
+            }
+
+            $destinationDir = dirname($destination);
+            if (!is_dir($destinationDir) && !mkdir($destinationDir, 0755, true) && !is_dir($destinationDir)) {
+                fclose($stream);
+                $zipper->close();
+                throw new \Exception('mautic.core.update.error_extracting_package');
+            }
+
+            $target = fopen($destination, 'wb');
+            if (!$target) {
+                fclose($stream);
+                $zipper->close();
+                throw new \Exception('mautic.core.update.error_extracting_package');
+            }
+
+            while (!feof($stream)) {
+                $chunk = fread($stream, 8192);
+                if (false === $chunk) {
+                    fclose($target);
+                    fclose($stream);
+                    $zipper->close();
+                    throw new \Exception('mautic.core.update.error_extracting_package');
+                }
+
+                if ('' !== $chunk) {
+                    fwrite($target, $chunk);
+                }
+            }
+
+            fclose($target);
+            fclose($stream);
         }
         $zipper->close();
         unlink($zipFile);
 
         return true;
+    }
+
+    /**
+     * @param string[] $zipEntries
+     * @param string[] $requiredFiles
+     */
+    private function getThemeArchivePrefix(array $zipEntries, array $requiredFiles): ?string
+    {
+        $prefixes = [];
+
+        foreach ($zipEntries as $entry) {
+            if (str_ends_with($entry, '/')) {
+                continue;
+            }
+
+            $parts = explode('/', $entry, 2);
+            if (2 !== count($parts)) {
+                return null;
+            }
+
+            $prefixes[$parts[0]] = true;
+        }
+
+        if (1 !== count($prefixes)) {
+            return null;
+        }
+
+        $prefix = array_key_first($prefixes);
+        if (null === $prefix) {
+            return null;
+        }
+
+        foreach ($requiredFiles as $requiredFile) {
+            if (!in_array($prefix.'/'.$requiredFile, $zipEntries, true)) {
+                return null;
+            }
+        }
+
+        return $prefix;
     }
 
     /**

--- a/app/bundles/CoreBundle/Helper/ThemeHelper.php
+++ b/app/bundles/CoreBundle/Helper/ThemeHelper.php
@@ -355,7 +355,7 @@ class ThemeHelper implements ThemeHelperInterface
 
             if ($this->isUnsafeArchivePath($entry)) {
                 $zipper->close();
-                throw new \Exception('mautic.core.update.error_extracting_package');
+                throw new \Exception($this->translator->trans('mautic.core.update.error_extracting_package'));
             }
 
             $zipEntries[] = $entry;
@@ -502,7 +502,7 @@ class ThemeHelper implements ThemeHelperInterface
     private function getSafeThemeDestination(string $themePath, string $relativePath): string
     {
         if ($this->isUnsafeArchivePath($relativePath)) {
-            throw new \Exception('mautic.core.update.error_extracting_package');
+            throw new \Exception($this->translator->trans('mautic.core.update.error_extracting_package'));
         }
 
         $themeRoot   = Path::canonicalize($themePath);

--- a/app/bundles/CoreBundle/Helper/ThemeHelper.php
+++ b/app/bundles/CoreBundle/Helper/ThemeHelper.php
@@ -10,6 +10,7 @@ use Mautic\CoreBundle\Twig\Sandbox\ThemeSandboxPolicy;
 use Mautic\IntegrationsBundle\Exception\IntegrationNotFoundException;
 use Mautic\IntegrationsBundle\Helper\BuilderIntegrationsHelper;
 use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -350,12 +351,15 @@ class ThemeHelper implements ThemeHelperInterface
         $config = [];
         for ($i = 0; $i < $zipper->numFiles; ++$i) {
             $entry = $zipper->getNameIndex($i);
-            if (str_starts_with($entry, '/')) {
-                $entry = substr($entry, 1);
+            $entry = str_replace('\\', '/', $entry);
+
+            if ($this->isUnsafeArchivePath($entry)) {
+                $zipper->close();
+                throw new \Exception('mautic.core.update.error_extracting_package');
             }
 
             $zipEntries[] = $entry;
-            $extension = pathinfo($entry, PATHINFO_EXTENSION);
+            $extension    = pathinfo($entry, PATHINFO_EXTENSION);
 
             // Check for required files
             if (in_array($entry, $requiredFiles)) {
@@ -412,7 +416,18 @@ class ThemeHelper implements ThemeHelperInterface
                 $targetFile = substr($file, strlen($archivePrefix) + 1);
             }
 
-            $destination = $themePath.'/'.$targetFile;
+            if ($this->isUnsafeArchivePath($targetFile)) {
+                $zipper->close();
+                throw new \Exception('mautic.core.update.error_extracting_package');
+            }
+
+            try {
+                $destination = $this->getSafeThemeDestination($themePath, $targetFile);
+            } catch (\Exception) {
+                $zipper->close();
+                throw new \Exception('mautic.core.update.error_extracting_package');
+            }
+
             if (str_ends_with($file, '/')) {
                 if (!is_dir($destination) && !mkdir($destination, 0755, true) && !is_dir($destination)) {
                     $zipper->close();
@@ -463,6 +478,56 @@ class ThemeHelper implements ThemeHelperInterface
         unlink($zipFile);
 
         return true;
+    }
+
+    /**
+     * Reject absolute paths and parent-directory segments that could escape the theme directory.
+     */
+    private function isUnsafeArchivePath(string $path): bool
+    {
+        if ('' === $path) {
+            return false;
+        }
+
+        $normalized = str_replace('\\', '/', $path);
+
+        if (Path::isAbsolute($normalized)) {
+            return true;
+        }
+
+        $trimmed = rtrim($normalized, '/');
+        if ('' === $trimmed) {
+            return false;
+        }
+
+        foreach (explode('/', $trimmed) as $segment) {
+            if ('..' === $segment) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Build a destination path under the theme directory, rejecting zip-slip escapes.
+     *
+     * @throws \Exception
+     */
+    private function getSafeThemeDestination(string $themePath, string $relativePath): string
+    {
+        if ($this->isUnsafeArchivePath($relativePath)) {
+            throw new \Exception('mautic.core.update.error_extracting_package');
+        }
+
+        $themeRoot   = Path::canonicalize($themePath);
+        $destination = Path::canonicalize($themePath.'/'.$relativePath);
+
+        if ($destination !== $themeRoot && !Path::isBasePath($themeRoot, $destination)) {
+            throw new \Exception('mautic.core.update.error_extracting_package');
+        }
+
+        return $destination;
     }
 
     /**

--- a/app/bundles/CoreBundle/Helper/ThemeHelper.php
+++ b/app/bundles/CoreBundle/Helper/ThemeHelper.php
@@ -416,11 +416,6 @@ class ThemeHelper implements ThemeHelperInterface
                 $targetFile = substr($file, strlen($archivePrefix) + 1);
             }
 
-            if ($this->isUnsafeArchivePath($targetFile)) {
-                $zipper->close();
-                throw new \Exception('mautic.core.update.error_extracting_package');
-            }
-
             try {
                 $destination = $this->getSafeThemeDestination($themePath, $targetFile);
             } catch (\Exception) {
@@ -490,23 +485,13 @@ class ThemeHelper implements ThemeHelperInterface
         }
 
         $normalized = str_replace('\\', '/', $path);
-
         if (Path::isAbsolute($normalized)) {
             return true;
         }
 
         $trimmed = rtrim($normalized, '/');
-        if ('' === $trimmed) {
-            return false;
-        }
 
-        foreach (explode('/', $trimmed) as $segment) {
-            if ('..' === $segment) {
-                return true;
-            }
-        }
-
-        return false;
+        return '' !== $trimmed && in_array('..', explode('/', $trimmed), true);
     }
 
     /**

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/ThemeHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/ThemeHelperTest.php
@@ -216,13 +216,18 @@ final class ThemeHelperTest extends TestCase
         }
         $zip->close();
 
+        $this->translator->expects($this->once())
+            ->method('trans')
+            ->with('mautic.core.update.error_extracting_package')
+            ->willReturn('some translation');
+
         $thrown = false;
 
         try {
             $this->themeHelper->install($zipPath);
         } catch (\Exception $exception) {
             $thrown = true;
-            $this->assertSame('mautic.core.update.error_extracting_package', $exception->getMessage());
+            $this->assertSame('some translation', $exception->getMessage());
         } finally {
             $filesystem = new Filesystem();
             foreach ($escapedPaths as $escapedPath) {

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/ThemeHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/ThemeHelperTest.php
@@ -14,6 +14,7 @@ use Mautic\IntegrationsBundle\Helper\BuilderIntegrationsHelper;
 use Mautic\IntegrationsBundle\Integration\Interfaces\BuilderInterface;
 use Mautic\PluginBundle\Entity\Integration;
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Finder\Finder;
@@ -193,7 +194,12 @@ final class ThemeHelperTest extends TestCase
         }
     }
 
-    public function testThemeInstallRejectsParentDirectoryZipSlip(): void
+    /**
+     * @param list<array{0: string, 1: string}> $zipEntries
+     * @param list<string>                      $escapedPaths absolute paths that must not be written
+     */
+    #[DataProvider('zipSlipThemeInstallProvider')]
+    public function testThemeInstallRejectsZipSlipEntries(array $zipEntries, array $escapedPaths): void
     {
         $themeRoot = sys_get_temp_dir().'/theme_install_'.uniqid();
         $this->pathsHelper->method('getSystemPath')
@@ -205,9 +211,9 @@ final class ThemeHelperTest extends TestCase
 
         $zip = new \ZipArchive();
         $zip->open($zipPath, \ZipArchive::CREATE);
-        $zip->addFromString('config.json', json_encode(['features' => []], JSON_THROW_ON_ERROR));
-        $zip->addFromString('html/message.html.twig', '<p>Message</p>');
-        $zip->addFromString('../outside.txt', 'zip-slip');
+        foreach ($zipEntries as [$name, $contents]) {
+            $zip->addFromString($name, $contents);
+        }
         $zip->close();
 
         $thrown = false;
@@ -219,7 +225,9 @@ final class ThemeHelperTest extends TestCase
             $this->assertSame('mautic.core.update.error_extracting_package', $exception->getMessage());
         } finally {
             $filesystem = new Filesystem();
-            $this->assertFileDoesNotExist($themeRoot.'/outside.txt');
+            foreach ($escapedPaths as $escapedPath) {
+                $this->assertFileDoesNotExist(str_replace('{themeRoot}', $themeRoot, $escapedPath));
+            }
             $this->assertDirectoryDoesNotExist($themeRoot.'/'.$zipName);
             $filesystem->remove([$themeRoot, $zipPath]);
         }
@@ -227,73 +235,42 @@ final class ThemeHelperTest extends TestCase
         $this->assertTrue($thrown);
     }
 
-    public function testThemeInstallRejectsAbsolutePathZipSlip(): void
+    /**
+     * @return \Generator<string, array{0: list<array{0: string, 1: string}>, 1: list<string>}>
+     */
+    public static function zipSlipThemeInstallProvider(): \Generator
     {
-        $themeRoot = sys_get_temp_dir().'/theme_install_'.uniqid();
-        $this->pathsHelper->method('getSystemPath')
-            ->with('themes', true)
-            ->willReturn($themeRoot);
+        $config  = json_encode(['features' => []], JSON_THROW_ON_ERROR);
+        $message = '<p>Message</p>';
+        $page    = '<p>Page</p>';
 
-        $zipPath = sys_get_temp_dir().'/theme_install_'.uniqid().'.zip';
-        $zipName = basename($zipPath, '.zip');
+        yield 'parent directory entry' => [
+            [
+                ['config.json', $config],
+                ['html/message.html.twig', $message],
+                ['../outside.txt', 'zip-slip'],
+            ],
+            ['{themeRoot}/outside.txt'],
+        ];
 
-        $zip = new \ZipArchive();
-        $zip->open($zipPath, \ZipArchive::CREATE);
-        $zip->addFromString('config.json', json_encode(['features' => []], JSON_THROW_ON_ERROR));
-        $zip->addFromString('html/message.html.twig', '<p>Message</p>');
-        $zip->addFromString('/tmp/absolute-theme-slip.txt', 'zip-slip');
-        $zip->close();
+        yield 'absolute path entry' => [
+            [
+                ['config.json', $config],
+                ['html/message.html.twig', $message],
+                ['/tmp/absolute-theme-slip.txt', 'zip-slip'],
+            ],
+            ['/tmp/absolute-theme-slip.txt'],
+        ];
 
-        $thrown = false;
-
-        try {
-            $this->themeHelper->install($zipPath);
-        } catch (\Exception $exception) {
-            $thrown = true;
-            $this->assertSame('mautic.core.update.error_extracting_package', $exception->getMessage());
-        } finally {
-            $filesystem = new Filesystem();
-            $this->assertFileDoesNotExist('/tmp/absolute-theme-slip.txt');
-            $this->assertDirectoryDoesNotExist($themeRoot.'/'.$zipName);
-            $filesystem->remove([$themeRoot, $zipPath]);
-        }
-
-        $this->assertTrue($thrown);
-    }
-
-    public function testThemeInstallRejectsWrappedParentDirectoryZipSlip(): void
-    {
-        $themeRoot = sys_get_temp_dir().'/theme_install_'.uniqid();
-        $this->pathsHelper->method('getSystemPath')
-            ->with('themes', true)
-            ->willReturn($themeRoot);
-
-        $zipPath = sys_get_temp_dir().'/theme_install_'.uniqid().'.zip';
-        $zipName = basename($zipPath, '.zip');
-
-        $zip = new \ZipArchive();
-        $zip->open($zipPath, \ZipArchive::CREATE);
-        $zip->addFromString('my-theme/config.json', json_encode(['features' => []], JSON_THROW_ON_ERROR));
-        $zip->addFromString('my-theme/html/message.html.twig', '<p>Message</p>');
-        $zip->addFromString('my-theme/html/page.html.twig', '<p>Page</p>');
-        $zip->addFromString('my-theme/../../outside.txt', 'zip-slip');
-        $zip->close();
-
-        $thrown = false;
-
-        try {
-            $this->themeHelper->install($zipPath);
-        } catch (\Exception $exception) {
-            $thrown = true;
-            $this->assertSame('mautic.core.update.error_extracting_package', $exception->getMessage());
-        } finally {
-            $filesystem = new Filesystem();
-            $this->assertFileDoesNotExist($themeRoot.'/outside.txt');
-            $this->assertDirectoryDoesNotExist($themeRoot.'/'.$zipName);
-            $filesystem->remove([$themeRoot, $zipPath]);
-        }
-
-        $this->assertTrue($thrown);
+        yield 'wrapped parent directory entry' => [
+            [
+                ['my-theme/config.json', $config],
+                ['my-theme/html/message.html.twig', $message],
+                ['my-theme/html/page.html.twig', $page],
+                ['my-theme/../../outside.txt', 'zip-slip'],
+            ],
+            ['{themeRoot}/outside.txt'],
+        ];
     }
 
     public function testThemeFallbackToDefaultIfTemplateIsMissing(): void

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/ThemeHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/ThemeHelperTest.php
@@ -164,6 +164,35 @@ final class ThemeHelperTest extends TestCase
         $fs->remove(__DIR__.'/resource/themes/good-tmp');
     }
 
+    public function testThemeIsInstalledFromSingleTopLevelFolder(): void
+    {
+        $themeRoot = sys_get_temp_dir().'/theme_install_'.uniqid();
+        $this->pathsHelper->method('getSystemPath')
+            ->with('themes', true)
+            ->willReturn($themeRoot);
+
+        $zipPath = sys_get_temp_dir().'/theme_install_'.uniqid().'.zip';
+        $zipName = basename($zipPath, '.zip');
+
+        $zip = new \ZipArchive();
+        $zip->open($zipPath, \ZipArchive::CREATE);
+        $zip->addFromString('my-theme/config.json', json_encode(['features' => []], JSON_THROW_ON_ERROR));
+        $zip->addFromString('my-theme/html/message.html.twig', '<p>Message</p>');
+        $zip->addFromString('my-theme/html/page.html.twig', '<p>Page</p>');
+        $zip->close();
+
+        try {
+            $this->themeHelper->install($zipPath);
+
+            $this->assertFileExists($themeRoot.'/'.$zipName.'/config.json');
+            $this->assertFileExists($themeRoot.'/'.$zipName.'/html/message.html.twig');
+            $this->assertFileExists($themeRoot.'/'.$zipName.'/html/page.html.twig');
+        } finally {
+            $filesystem = new Filesystem();
+            $filesystem->remove([$themeRoot, $zipPath]);
+        }
+    }
+
     public function testThemeFallbackToDefaultIfTemplateIsMissing(): void
     {
         $this->twig->expects($this->exactly(2))

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/ThemeHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/ThemeHelperTest.php
@@ -193,6 +193,109 @@ final class ThemeHelperTest extends TestCase
         }
     }
 
+    public function testThemeInstallRejectsParentDirectoryZipSlip(): void
+    {
+        $themeRoot = sys_get_temp_dir().'/theme_install_'.uniqid();
+        $this->pathsHelper->method('getSystemPath')
+            ->with('themes', true)
+            ->willReturn($themeRoot);
+
+        $zipPath = sys_get_temp_dir().'/theme_install_'.uniqid().'.zip';
+        $zipName = basename($zipPath, '.zip');
+
+        $zip = new \ZipArchive();
+        $zip->open($zipPath, \ZipArchive::CREATE);
+        $zip->addFromString('config.json', json_encode(['features' => []], JSON_THROW_ON_ERROR));
+        $zip->addFromString('html/message.html.twig', '<p>Message</p>');
+        $zip->addFromString('../outside.txt', 'zip-slip');
+        $zip->close();
+
+        $thrown = false;
+
+        try {
+            $this->themeHelper->install($zipPath);
+        } catch (\Exception $exception) {
+            $thrown = true;
+            $this->assertSame('mautic.core.update.error_extracting_package', $exception->getMessage());
+        } finally {
+            $filesystem = new Filesystem();
+            $this->assertFileDoesNotExist($themeRoot.'/outside.txt');
+            $this->assertDirectoryDoesNotExist($themeRoot.'/'.$zipName);
+            $filesystem->remove([$themeRoot, $zipPath]);
+        }
+
+        $this->assertTrue($thrown);
+    }
+
+    public function testThemeInstallRejectsAbsolutePathZipSlip(): void
+    {
+        $themeRoot = sys_get_temp_dir().'/theme_install_'.uniqid();
+        $this->pathsHelper->method('getSystemPath')
+            ->with('themes', true)
+            ->willReturn($themeRoot);
+
+        $zipPath = sys_get_temp_dir().'/theme_install_'.uniqid().'.zip';
+        $zipName = basename($zipPath, '.zip');
+
+        $zip = new \ZipArchive();
+        $zip->open($zipPath, \ZipArchive::CREATE);
+        $zip->addFromString('config.json', json_encode(['features' => []], JSON_THROW_ON_ERROR));
+        $zip->addFromString('html/message.html.twig', '<p>Message</p>');
+        $zip->addFromString('/tmp/absolute-theme-slip.txt', 'zip-slip');
+        $zip->close();
+
+        $thrown = false;
+
+        try {
+            $this->themeHelper->install($zipPath);
+        } catch (\Exception $exception) {
+            $thrown = true;
+            $this->assertSame('mautic.core.update.error_extracting_package', $exception->getMessage());
+        } finally {
+            $filesystem = new Filesystem();
+            $this->assertFileDoesNotExist('/tmp/absolute-theme-slip.txt');
+            $this->assertDirectoryDoesNotExist($themeRoot.'/'.$zipName);
+            $filesystem->remove([$themeRoot, $zipPath]);
+        }
+
+        $this->assertTrue($thrown);
+    }
+
+    public function testThemeInstallRejectsWrappedParentDirectoryZipSlip(): void
+    {
+        $themeRoot = sys_get_temp_dir().'/theme_install_'.uniqid();
+        $this->pathsHelper->method('getSystemPath')
+            ->with('themes', true)
+            ->willReturn($themeRoot);
+
+        $zipPath = sys_get_temp_dir().'/theme_install_'.uniqid().'.zip';
+        $zipName = basename($zipPath, '.zip');
+
+        $zip = new \ZipArchive();
+        $zip->open($zipPath, \ZipArchive::CREATE);
+        $zip->addFromString('my-theme/config.json', json_encode(['features' => []], JSON_THROW_ON_ERROR));
+        $zip->addFromString('my-theme/html/message.html.twig', '<p>Message</p>');
+        $zip->addFromString('my-theme/html/page.html.twig', '<p>Page</p>');
+        $zip->addFromString('my-theme/../../outside.txt', 'zip-slip');
+        $zip->close();
+
+        $thrown = false;
+
+        try {
+            $this->themeHelper->install($zipPath);
+        } catch (\Exception $exception) {
+            $thrown = true;
+            $this->assertSame('mautic.core.update.error_extracting_package', $exception->getMessage());
+        } finally {
+            $filesystem = new Filesystem();
+            $this->assertFileDoesNotExist($themeRoot.'/outside.txt');
+            $this->assertDirectoryDoesNotExist($themeRoot.'/'.$zipName);
+            $filesystem->remove([$themeRoot, $zipPath]);
+        }
+
+        $this->assertTrue($thrown);
+    }
+
     public function testThemeFallbackToDefaultIfTemplateIsMissing(): void
     {
         $this->twig->expects($this->exactly(2))


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌
| New feature/enhancement? (use the a.x branch)      | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | Fixes #16769

## Description

Theme uploads that are zipped as a single top-level folder now install successfully. The installer detects that wrapper folder, validates the required files inside it, and extracts the archive contents without leaving the extra directory level in place.

---
### 📋 Steps to test this PR:

1. Create a theme folder with `config.json`, `html/message.html.twig`, and `html/page.html.twig` inside a single top-level directory.
2. Zip the folder so the archive contains that wrapper directory.
3. Install the zip from Settings > Themes.
4. Confirm the theme installs and the extracted files land under the installed theme directory without the extra wrapper folder.

### Verification

- `git diff --check` passed.
- Added a regression test covering the wrapped-zip layout in `ThemeHelperTest`.
- Runtime PHPUnit could not be executed here because this workspace does not have `php` or `ddev` installed.

### Notes

The issue thread had maintainer pushback that a root-level zip is the expected shape. This change keeps that shape working, but also accepts the common one-folder zip layout that users get from compressing a theme directory directly.
