### PR TITLE
[Tracker] Mark classes without children as final

### DIFF
--- a/app/bundles/ApiBundle/EventListener/PreAuthorizationEventListener.php
+++ b/app/bundles/ApiBundle/EventListener/PreAuthorizationEventListener.php
@@ -11,7 +11,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class PreAuthorizationEventListener implements EventSubscriberInterface
+final class PreAuthorizationEventListener implements EventSubscriberInterface
 {
     public function __construct(
         private readonly EntityManagerInterface $em,
@@ -68,7 +68,7 @@ class PreAuthorizationEventListener implements EventSubscriberInterface
     /**
      * @return mixed
      */
-    protected function getUser(OAuthEvent $event)
+    private function getUser(OAuthEvent $event)
     {
         return $this->userRepository->findOneByUsername($event->getUser()->getUserIdentifier());
     }

--- a/app/bundles/ApiBundle/Model/ClientModel.php
+++ b/app/bundles/ApiBundle/Model/ClientModel.php
@@ -27,7 +27,7 @@ use Symfony\Contracts\EventDispatcher\Event;
 /**
  * @extends FormModel<Client>
  */
-class ClientModel extends FormModel implements GlobalSearchInterface
+final class ClientModel extends FormModel implements GlobalSearchInterface
 {
     /**
      * @var string

--- a/app/bundles/ApiBundle/Security/Permissions/ApiPermissions.php
+++ b/app/bundles/ApiBundle/Security/Permissions/ApiPermissions.php
@@ -6,7 +6,7 @@ use Mautic\CoreBundle\Security\Permissions\AbstractPermissions;
 use Mautic\UserBundle\Form\Type\PermissionListType;
 use Symfony\Component\Form\FormBuilderInterface;
 
-class ApiPermissions extends AbstractPermissions
+final class ApiPermissions extends AbstractPermissions
 {
     /**
      * @param mixed[] $params

--- a/app/bundles/ApiBundle/Security/Voter/ApiPermissionVoter.php
+++ b/app/bundles/ApiBundle/Security/Voter/ApiPermissionVoter.php
@@ -8,7 +8,7 @@ use Symfony\Component\Security\Core\Authorization\Voter\Vote;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 use Symfony\Component\Security\Core\User\UserInterface;
 
-class ApiPermissionVoter extends Voter
+final class ApiPermissionVoter extends Voter
 {
     public function __construct(
         private readonly CorePermissions $security,

--- a/app/bundles/ApiBundle/Serializer/Exclusion/FieldInclusionStrategy.php
+++ b/app/bundles/ApiBundle/Serializer/Exclusion/FieldInclusionStrategy.php
@@ -10,7 +10,7 @@ use JMS\Serializer\Metadata\PropertyMetadata;
 /**
  * Include specific fields at a specific level.
  */
-class FieldInclusionStrategy implements ExclusionStrategyInterface
+final class FieldInclusionStrategy implements ExclusionStrategyInterface
 {
     private readonly int $level;
 

--- a/app/bundles/ApiBundle/Serializer/Exclusion/ParentChildrenExclusionStrategy.php
+++ b/app/bundles/ApiBundle/Serializer/Exclusion/ParentChildrenExclusionStrategy.php
@@ -5,7 +5,7 @@ namespace Mautic\ApiBundle\Serializer\Exclusion;
 /**
  * Only include the first level of a children/parent of an entity that relates to itself.
  */
-class ParentChildrenExclusionStrategy extends FieldExclusionStrategy
+final class ParentChildrenExclusionStrategy extends FieldExclusionStrategy
 {
     /**
      * @param int $level

--- a/app/bundles/ApiBundle/Serializer/Exclusion/PublishDetailsExclusionStrategy.php
+++ b/app/bundles/ApiBundle/Serializer/Exclusion/PublishDetailsExclusionStrategy.php
@@ -5,7 +5,7 @@ namespace Mautic\ApiBundle\Serializer\Exclusion;
 /**
  * Only include FormEntity properties for the top level entity and not the associated entities.
  */
-class PublishDetailsExclusionStrategy extends FieldExclusionStrategy
+final class PublishDetailsExclusionStrategy extends FieldExclusionStrategy
 {
     public function __construct()
     {

--- a/app/bundles/AssetBundle/DataFixtures/ORM/LoadAssetData.php
+++ b/app/bundles/AssetBundle/DataFixtures/ORM/LoadAssetData.php
@@ -7,7 +7,7 @@ use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Mautic\AssetBundle\Entity\Asset;
 
-class LoadAssetData extends AbstractFixture implements OrderedFixtureInterface
+final class LoadAssetData extends AbstractFixture implements OrderedFixtureInterface
 {
     public function load(ObjectManager $manager): void
     {

--- a/app/bundles/AssetBundle/ErrorHandler/DropzoneErrorHandler.php
+++ b/app/bundles/AssetBundle/ErrorHandler/DropzoneErrorHandler.php
@@ -5,7 +5,7 @@ namespace Mautic\AssetBundle\ErrorHandler;
 use Oneup\UploaderBundle\Uploader\ErrorHandler\ErrorHandlerInterface;
 use Oneup\UploaderBundle\Uploader\Response\AbstractResponse;
 
-class DropzoneErrorHandler implements ErrorHandlerInterface
+final class DropzoneErrorHandler implements ErrorHandlerInterface
 {
     public function addException(AbstractResponse $response, \Exception $exception): void
     {

--- a/app/bundles/AssetBundle/Security/Permissions/AssetPermissions.php
+++ b/app/bundles/AssetBundle/Security/Permissions/AssetPermissions.php
@@ -6,7 +6,7 @@ use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Security\Permissions\AbstractPermissions;
 use Symfony\Component\Form\FormBuilderInterface;
 
-class AssetPermissions extends AbstractPermissions
+final class AssetPermissions extends AbstractPermissions
 {
     public function __construct(CoreParametersHelper $coreParametersHelper)
     {

--- a/app/bundles/CacheBundle/Cache/Adapter/MemcachedTagAwareAdapter.php
+++ b/app/bundles/CacheBundle/Cache/Adapter/MemcachedTagAwareAdapter.php
@@ -8,7 +8,7 @@ use Mautic\CacheBundle\Exceptions\InvalidArgumentException;
 use Symfony\Component\Cache\Adapter\MemcachedAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapter;
 
-class MemcachedTagAwareAdapter extends TagAwareAdapter
+final class MemcachedTagAwareAdapter extends TagAwareAdapter
 {
     public function __construct(array $servers, string $namespace, int $lifetime)
     {

--- a/app/bundles/CacheBundle/Cache/Adapter/RedisAdapter.php
+++ b/app/bundles/CacheBundle/Cache/Adapter/RedisAdapter.php
@@ -7,7 +7,7 @@ namespace Mautic\CacheBundle\Cache\Adapter;
 use Symfony\Component\Cache\Adapter\RedisAdapter as SymfonyRedisAdapter;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
-class RedisAdapter extends SymfonyRedisAdapter
+final class RedisAdapter extends SymfonyRedisAdapter
 {
     use RedisAdapterTrait;
 

--- a/app/bundles/CacheBundle/Cache/Adapter/RedisTagAwareAdapter.php
+++ b/app/bundles/CacheBundle/Cache/Adapter/RedisTagAwareAdapter.php
@@ -8,7 +8,7 @@ use Symfony\Component\Cache\Adapter\RedisAdapter;
 use Symfony\Component\Cache\Adapter\TagAwareAdapter;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
-class RedisTagAwareAdapter extends TagAwareAdapter
+final class RedisTagAwareAdapter extends TagAwareAdapter
 {
     use RedisAdapterTrait;
 

--- a/app/bundles/CacheBundle/Exceptions/InvalidArgumentException.php
+++ b/app/bundles/CacheBundle/Exceptions/InvalidArgumentException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\CacheBundle\Exceptions;
 
-class InvalidArgumentException extends \Symfony\Component\Cache\Exception\InvalidArgumentException
+final class InvalidArgumentException extends \Symfony\Component\Cache\Exception\InvalidArgumentException
 {
 }

--- a/app/bundles/CampaignBundle/DataFixtures/ORM/CampaignData.php
+++ b/app/bundles/CampaignBundle/DataFixtures/ORM/CampaignData.php
@@ -7,7 +7,7 @@ use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Mautic\CampaignBundle\Entity\Campaign;
 
-class CampaignData extends AbstractFixture implements OrderedFixtureInterface
+final class CampaignData extends AbstractFixture implements OrderedFixtureInterface
 {
     public function load(ObjectManager $manager): void
     {

--- a/app/bundles/CampaignBundle/Entity/Result/CountResult.php
+++ b/app/bundles/CampaignBundle/Entity/Result/CountResult.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\CampaignBundle\Entity\Result;
 
-class CountResult
+final class CountResult
 {
     private readonly int $count;
 

--- a/app/bundles/CampaignBundle/EventCollector/Builder/ConnectionBuilder.php
+++ b/app/bundles/CampaignBundle/EventCollector/Builder/ConnectionBuilder.php
@@ -4,7 +4,7 @@ namespace Mautic\CampaignBundle\EventCollector\Builder;
 
 use Mautic\CampaignBundle\Entity\Event;
 
-class ConnectionBuilder
+final class ConnectionBuilder
 {
     private static array $eventTypes = [];
 

--- a/app/bundles/CampaignBundle/EventCollector/Builder/EventBuilder.php
+++ b/app/bundles/CampaignBundle/EventCollector/Builder/EventBuilder.php
@@ -6,7 +6,7 @@ use Mautic\CampaignBundle\EventCollector\Accessor\Event\ActionAccessor;
 use Mautic\CampaignBundle\EventCollector\Accessor\Event\ConditionAccessor;
 use Mautic\CampaignBundle\EventCollector\Accessor\Event\DecisionAccessor;
 
-class EventBuilder
+final class EventBuilder
 {
     public static function buildActions(array $actions): array
     {

--- a/app/bundles/CampaignBundle/Executioner/ContactFinder/Limiter/ContactLimiter.php
+++ b/app/bundles/CampaignBundle/Executioner/ContactFinder/Limiter/ContactLimiter.php
@@ -4,7 +4,7 @@ namespace Mautic\CampaignBundle\Executioner\ContactFinder\Limiter;
 
 use Mautic\CampaignBundle\Executioner\Exception\NoContactsFoundException;
 
-class ContactLimiter
+final class ContactLimiter
 {
     private readonly int $batchLimit;
 

--- a/app/bundles/CampaignBundle/Executioner/Dispatcher/ActionDispatcher.php
+++ b/app/bundles/CampaignBundle/Executioner/Dispatcher/ActionDispatcher.php
@@ -18,7 +18,7 @@ use Mautic\CampaignBundle\Executioner\Scheduler\EventScheduler;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-class ActionDispatcher
+final class ActionDispatcher
 {
     public function __construct(
         private readonly EventDispatcherInterface $dispatcher,

--- a/app/bundles/CampaignBundle/Executioner/Dispatcher/ConditionDispatcher.php
+++ b/app/bundles/CampaignBundle/Executioner/Dispatcher/ConditionDispatcher.php
@@ -8,7 +8,7 @@ use Mautic\CampaignBundle\Event\ConditionEvent;
 use Mautic\CampaignBundle\EventCollector\Accessor\Event\ConditionAccessor;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-class ConditionDispatcher
+final class ConditionDispatcher
 {
     public function __construct(
         private readonly EventDispatcherInterface $dispatcher,

--- a/app/bundles/CampaignBundle/Executioner/Dispatcher/DecisionDispatcher.php
+++ b/app/bundles/CampaignBundle/Executioner/Dispatcher/DecisionDispatcher.php
@@ -11,7 +11,7 @@ use Mautic\CampaignBundle\EventCollector\Accessor\Event\DecisionAccessor;
 use Mautic\CampaignBundle\Executioner\Result\EvaluatedContacts;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-class DecisionDispatcher
+final class DecisionDispatcher
 {
     public function __construct(
         private readonly EventDispatcherInterface $dispatcher,

--- a/app/bundles/CampaignBundle/Executioner/KickoffExecutioner.php
+++ b/app/bundles/CampaignBundle/Executioner/KickoffExecutioner.php
@@ -23,7 +23,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class KickoffExecutioner implements ExecutionerInterface
+final class KickoffExecutioner implements ExecutionerInterface
 {
     private ?ContactLimiter $limiter = null;
 

--- a/app/bundles/CampaignBundle/Executioner/Result/Counter.php
+++ b/app/bundles/CampaignBundle/Executioner/Result/Counter.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\CampaignBundle\Executioner\Result;
 
-class Counter
+final class Counter
 {
     private int $rescheduled = 0;
 

--- a/app/bundles/CampaignBundle/Executioner/Result/EvaluatedContacts.php
+++ b/app/bundles/CampaignBundle/Executioner/Result/EvaluatedContacts.php
@@ -5,7 +5,7 @@ namespace Mautic\CampaignBundle\Executioner\Result;
 use Doctrine\Common\Collections\ArrayCollection;
 use Mautic\LeadBundle\Entity\Lead;
 
-class EvaluatedContacts
+final class EvaluatedContacts
 {
     private readonly ArrayCollection $passed;
 

--- a/app/bundles/CampaignBundle/Executioner/Result/Responses.php
+++ b/app/bundles/CampaignBundle/Executioner/Result/Responses.php
@@ -6,7 +6,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CampaignBundle\Entity\LeadEventLog;
 
-class Responses
+final class Responses
 {
     private array $actionResponses = [];
 

--- a/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/DateTime.php
+++ b/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/DateTime.php
@@ -5,7 +5,7 @@ namespace Mautic\CampaignBundle\Executioner\Scheduler\Mode;
 use Mautic\CampaignBundle\Entity\Event;
 use Psr\Log\LoggerInterface;
 
-class DateTime implements ScheduleModeInterface
+final class DateTime implements ScheduleModeInterface
 {
     public function __construct(
         private readonly LoggerInterface $logger,

--- a/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
+++ b/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
@@ -12,7 +12,7 @@ use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\LeadBundle\Entity\Lead;
 use Psr\Log\LoggerInterface;
 
-class Interval implements ScheduleModeInterface
+final class Interval implements ScheduleModeInterface
 {
     public const LOG_DATE_FORMAT = 'Y-m-d H:i:s T';
 

--- a/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Optimized.php
+++ b/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Optimized.php
@@ -8,7 +8,7 @@ use Mautic\CampaignBundle\Entity\Event;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Services\PeakInteractionTimer;
 
-class Optimized implements ScheduleModeInterface
+final class Optimized implements ScheduleModeInterface
 {
     public const OPTIMIZED_TIME         = 0;
 

--- a/app/bundles/CampaignBundle/Executioner/TestInactiveExecutioner.php
+++ b/app/bundles/CampaignBundle/Executioner/TestInactiveExecutioner.php
@@ -9,7 +9,7 @@ use Symfony\Contracts\Service\ResetInterface;
 /**
  * @internal Used in tests
  */
-class TestInactiveExecutioner extends InactiveExecutioner implements ResetInterface
+final class TestInactiveExecutioner extends InactiveExecutioner implements ResetInterface
 {
     /**
      * @internal Used in tests

--- a/app/bundles/CampaignBundle/Executioner/TestScheduledExecutioner.php
+++ b/app/bundles/CampaignBundle/Executioner/TestScheduledExecutioner.php
@@ -7,7 +7,7 @@ namespace Mautic\CampaignBundle\Executioner;
 /**
  * @internal Used in tests
  */
-class TestScheduledExecutioner extends ScheduledExecutioner
+final class TestScheduledExecutioner extends ScheduledExecutioner
 {
     /**
      * @internal Used in tests

--- a/app/bundles/CampaignBundle/Helper/ChannelExtractor.php
+++ b/app/bundles/CampaignBundle/Helper/ChannelExtractor.php
@@ -6,7 +6,7 @@ use Mautic\CampaignBundle\Entity\ChannelInterface;
 use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CampaignBundle\EventCollector\Accessor\Event\AbstractEventAccessor;
 
-class ChannelExtractor
+final class ChannelExtractor
 {
     public static function setChannel(ChannelInterface $entity, Event $event, AbstractEventAccessor $eventConfig): void
     {

--- a/app/bundles/CampaignBundle/Model/EventLogModel.php
+++ b/app/bundles/CampaignBundle/Model/EventLogModel.php
@@ -23,7 +23,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 /**
  * @extends AbstractCommonModel<LeadEventLog>
  */
-class EventLogModel extends AbstractCommonModel
+final class EventLogModel extends AbstractCommonModel
 {
     public function __construct(
         protected EventModel $eventModel,

--- a/app/bundles/CampaignBundle/Model/Exceptions/CampaignAlreadyUnpublishedException.php
+++ b/app/bundles/CampaignBundle/Model/Exceptions/CampaignAlreadyUnpublishedException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\CampaignBundle\Model\Exceptions;
 
-class CampaignAlreadyUnpublishedException extends \Exception
+final class CampaignAlreadyUnpublishedException extends \Exception
 {
 }

--- a/app/bundles/CampaignBundle/Model/Exceptions/CampaignVersionMismatchedException.php
+++ b/app/bundles/CampaignBundle/Model/Exceptions/CampaignVersionMismatchedException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\CampaignBundle\Model\Exceptions;
 
-class CampaignVersionMismatchedException extends \Exception
+final class CampaignVersionMismatchedException extends \Exception
 {
 }

--- a/app/bundles/CampaignBundle/Security/Permissions/CampaignPermissions.php
+++ b/app/bundles/CampaignBundle/Security/Permissions/CampaignPermissions.php
@@ -5,7 +5,7 @@ namespace Mautic\CampaignBundle\Security\Permissions;
 use Mautic\CoreBundle\Security\Permissions\AbstractPermissions;
 use Symfony\Component\Form\FormBuilderInterface;
 
-class CampaignPermissions extends AbstractPermissions
+final class CampaignPermissions extends AbstractPermissions
 {
     /**
      * @param mixed[] $params

--- a/app/bundles/CategoryBundle/Model/ContactActionModel.php
+++ b/app/bundles/CategoryBundle/Model/ContactActionModel.php
@@ -4,7 +4,7 @@ namespace Mautic\CategoryBundle\Model;
 
 use Mautic\LeadBundle\Model\LeadModel;
 
-class ContactActionModel
+final class ContactActionModel
 {
     public function __construct(
         private readonly LeadModel $contactModel,

--- a/app/bundles/CategoryBundle/Security/Permissions/CategoryPermissions.php
+++ b/app/bundles/CategoryBundle/Security/Permissions/CategoryPermissions.php
@@ -5,7 +5,7 @@ namespace Mautic\CategoryBundle\Security\Permissions;
 use Mautic\CoreBundle\Security\Permissions\AbstractPermissions;
 use Symfony\Component\Form\FormBuilderInterface;
 
-class CategoryPermissions extends AbstractPermissions
+final class CategoryPermissions extends AbstractPermissions
 {
     /**
      * @param mixed[] $params

--- a/app/bundles/ChannelBundle/Model/ChannelActionModel.php
+++ b/app/bundles/ChannelBundle/Model/ChannelActionModel.php
@@ -8,7 +8,7 @@ use Mautic\LeadBundle\Model\DoNotContact;
 use Mautic\LeadBundle\Model\LeadModel;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class ChannelActionModel
+final class ChannelActionModel
 {
     public function __construct(
         private readonly LeadModel $contactModel,

--- a/app/bundles/ChannelBundle/Model/FrequencyActionModel.php
+++ b/app/bundles/ChannelBundle/Model/FrequencyActionModel.php
@@ -7,7 +7,7 @@ use Mautic\LeadBundle\Entity\FrequencyRuleRepository;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Model\LeadModel;
 
-class FrequencyActionModel
+final class FrequencyActionModel
 {
     public function __construct(
         private readonly LeadModel $contactModel,

--- a/app/bundles/ChannelBundle/PreferenceBuilder/ChannelPreferences.php
+++ b/app/bundles/ChannelBundle/PreferenceBuilder/ChannelPreferences.php
@@ -6,7 +6,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CampaignBundle\Entity\LeadEventLog;
 
-class ChannelPreferences
+final class ChannelPreferences
 {
     /**
      * @var ArrayCollection[]

--- a/app/bundles/ChannelBundle/PreferenceBuilder/PreferenceBuilder.php
+++ b/app/bundles/ChannelBundle/PreferenceBuilder/PreferenceBuilder.php
@@ -8,7 +8,7 @@ use Mautic\CampaignBundle\Entity\LeadEventLog;
 use Mautic\LeadBundle\Entity\DoNotContact;
 use Psr\Log\LoggerInterface;
 
-class PreferenceBuilder
+final class PreferenceBuilder
 {
     /**
      * @var ChannelPreferences[]

--- a/app/bundles/ChannelBundle/Security/Permissions/ChannelPermissions.php
+++ b/app/bundles/ChannelBundle/Security/Permissions/ChannelPermissions.php
@@ -5,7 +5,7 @@ namespace Mautic\ChannelBundle\Security\Permissions;
 use Mautic\CoreBundle\Security\Permissions\AbstractPermissions;
 use Symfony\Component\Form\FormBuilderInterface;
 
-class ChannelPermissions extends AbstractPermissions
+final class ChannelPermissions extends AbstractPermissions
 {
     /**
      * @param mixed[] $params

--- a/app/bundles/ConfigBundle/Form/DataTransformer/DsnTransformer.php
+++ b/app/bundles/ConfigBundle/Form/DataTransformer/DsnTransformer.php
@@ -12,7 +12,7 @@ use Symfony\Component\Form\DataTransformerInterface;
 /**
  * @implements DataTransformerInterface<string, array>
  */
-class DsnTransformer implements DataTransformerInterface
+final class DsnTransformer implements DataTransformerInterface
 {
     private const PASSWORD_MASK = '🔒';
 

--- a/app/bundles/ConfigBundle/Mapper/ConfigMapper.php
+++ b/app/bundles/ConfigBundle/Mapper/ConfigMapper.php
@@ -7,7 +7,7 @@ use Mautic\ConfigBundle\Mapper\Helper\ConfigHelper;
 use Mautic\ConfigBundle\Mapper\Helper\RestrictionHelper;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 
-class ConfigMapper
+final class ConfigMapper
 {
     /**
      * @var mixed[]

--- a/app/bundles/ConfigBundle/Model/SysinfoModel.php
+++ b/app/bundles/ConfigBundle/Model/SysinfoModel.php
@@ -10,23 +10,23 @@ use Mautic\InstallBundle\Configurator\Step\CheckStep;
 use Mautic\InstallBundle\Install\InstallService;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class SysinfoModel
+final class SysinfoModel
 {
     /**
      * @var string|null
      */
-    protected $phpInfo;
+    private $phpInfo;
 
     /**
      * @var array<string,bool>|null
      */
-    protected $folders;
+    private $folders;
 
     public function __construct(
-        protected PathsHelper $pathsHelper,
-        protected CoreParametersHelper $coreParametersHelper,
+        private PathsHelper $pathsHelper,
+        private CoreParametersHelper $coreParametersHelper,
         private readonly TranslatorInterface $translator,
-        protected Connection $connection,
+        private Connection $connection,
         private readonly InstallService $installService,
         private readonly CheckStep $checkStep,
     ) {

--- a/app/bundles/CoreBundle/Cache/MiddlewareCacheWarmer.php
+++ b/app/bundles/CoreBundle/Cache/MiddlewareCacheWarmer.php
@@ -6,7 +6,7 @@ namespace Mautic\CoreBundle\Cache;
 
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 
-class MiddlewareCacheWarmer implements CacheWarmerInterface
+final class MiddlewareCacheWarmer implements CacheWarmerInterface
 {
     private ?string $cacheFile = null;
 

--- a/app/bundles/CoreBundle/Cache/ResultCacheOptions.php
+++ b/app/bundles/CoreBundle/Cache/ResultCacheOptions.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\Cache;
 
-class ResultCacheOptions
+final class ResultCacheOptions
 {
     /**
      * @param string  $namespace mainly used for invalidation

--- a/app/bundles/CoreBundle/Console/Output/ConsoleDatetimeOutput.php
+++ b/app/bundles/CoreBundle/Console/Output/ConsoleDatetimeOutput.php
@@ -9,7 +9,7 @@ use Symfony\Component\Console\Output\ConsoleOutputInterface;
  * Custom console output to prefix all messages with the current datetime
  * Heavily inspired by https://github.com/8p/AssistBundle.
  */
-class ConsoleDatetimeOutput extends ConsoleOutput implements ConsoleOutputInterface
+final class ConsoleDatetimeOutput extends ConsoleOutput implements ConsoleOutputInterface
 {
     /**
      * Prefix message with current datetime.

--- a/app/bundles/CoreBundle/DependencyInjection/Builder/BundleMetadataBuilder.php
+++ b/app/bundles/CoreBundle/DependencyInjection/Builder/BundleMetadataBuilder.php
@@ -6,7 +6,7 @@ use Mautic\CoreBundle\DependencyInjection\Builder\Metadata\ConfigMetadata;
 use Mautic\CoreBundle\DependencyInjection\Builder\Metadata\EntityMetadata;
 use Mautic\CoreBundle\DependencyInjection\Builder\Metadata\PermissionClassMetadata;
 
-class BundleMetadataBuilder
+final class BundleMetadataBuilder
 {
     private array $ipLookupServices = [];
 

--- a/app/bundles/CoreBundle/DependencyInjection/Builder/Metadata/ConfigMetadata.php
+++ b/app/bundles/CoreBundle/DependencyInjection/Builder/Metadata/ConfigMetadata.php
@@ -5,7 +5,7 @@ namespace Mautic\CoreBundle\DependencyInjection\Builder\Metadata;
 use Illuminate\Support\Collection;
 use Mautic\CoreBundle\DependencyInjection\Builder\BundleMetadata;
 
-class ConfigMetadata
+final class ConfigMetadata
 {
     private array $ipLookupServices = [];
 

--- a/app/bundles/CoreBundle/DependencyInjection/Builder/Metadata/EntityMetadata.php
+++ b/app/bundles/CoreBundle/DependencyInjection/Builder/Metadata/EntityMetadata.php
@@ -6,7 +6,7 @@ use Mautic\CoreBundle\DependencyInjection\Builder\BundleMetadata;
 use Mautic\CoreBundle\Entity\DeprecatedInterface;
 use Symfony\Component\Finder\Finder;
 
-class EntityMetadata
+final class EntityMetadata
 {
     private array $ormConfig = [];
 

--- a/app/bundles/CoreBundle/DependencyInjection/Builder/Metadata/PermissionClassMetadata.php
+++ b/app/bundles/CoreBundle/DependencyInjection/Builder/Metadata/PermissionClassMetadata.php
@@ -10,7 +10,7 @@ use Symfony\Component\Finder\Finder;
  * This is an temporary necessity until https://github.com/mautic/mautic/pull/7312 is merged and permission classes are
  * converted to services.
  */
-class PermissionClassMetadata
+final class PermissionClassMetadata
 {
     public function __construct(
         private readonly BundleMetadata $metadata,

--- a/app/bundles/CoreBundle/DependencyInjection/EnvProcessor/IntNullableProcessor.php
+++ b/app/bundles/CoreBundle/DependencyInjection/EnvProcessor/IntNullableProcessor.php
@@ -4,7 +4,7 @@ namespace Mautic\CoreBundle\DependencyInjection\EnvProcessor;
 
 use Symfony\Component\DependencyInjection\EnvVarProcessorInterface;
 
-class IntNullableProcessor implements EnvVarProcessorInterface
+final class IntNullableProcessor implements EnvVarProcessorInterface
 {
     public function getEnv(string $prefix, string $name, \Closure $getEnv): ?int
     {

--- a/app/bundles/CoreBundle/DependencyInjection/EnvProcessor/MauticConstProcessor.php
+++ b/app/bundles/CoreBundle/DependencyInjection/EnvProcessor/MauticConstProcessor.php
@@ -4,7 +4,7 @@ namespace Mautic\CoreBundle\DependencyInjection\EnvProcessor;
 
 use Symfony\Component\DependencyInjection\EnvVarProcessorInterface;
 
-class MauticConstProcessor implements EnvVarProcessorInterface
+final class MauticConstProcessor implements EnvVarProcessorInterface
 {
     public function getEnv(string $prefix, string $name, \Closure $getEnv): ?string
     {

--- a/app/bundles/CoreBundle/DependencyInjection/EnvProcessor/NullableProcessor.php
+++ b/app/bundles/CoreBundle/DependencyInjection/EnvProcessor/NullableProcessor.php
@@ -4,7 +4,7 @@ namespace Mautic\CoreBundle\DependencyInjection\EnvProcessor;
 
 use Symfony\Component\DependencyInjection\EnvVarProcessorInterface;
 
-class NullableProcessor implements EnvVarProcessorInterface
+final class NullableProcessor implements EnvVarProcessorInterface
 {
     public function getEnv(string $prefix, string $name, \Closure $getEnv): ?string
     {

--- a/app/bundles/CoreBundle/Doctrine/Common/DataFixtures/Purger/ORMPurgerFactory.php
+++ b/app/bundles/CoreBundle/Doctrine/Common/DataFixtures/Purger/ORMPurgerFactory.php
@@ -11,7 +11,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Doctrine\Common\DataFixtures\Event\PreExecuteEvent;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
-class ORMPurgerFactory implements PurgerFactory
+final class ORMPurgerFactory implements PurgerFactory
 {
     public function __construct(
         private readonly EventDispatcherInterface $eventDispatcher,

--- a/app/bundles/CoreBundle/Doctrine/Connection/PrimaryReadReplicaConnectionWrapper.php
+++ b/app/bundles/CoreBundle/Doctrine/Connection/PrimaryReadReplicaConnectionWrapper.php
@@ -7,7 +7,7 @@ namespace Mautic\CoreBundle\Doctrine\Connection;
 use Doctrine\DBAL\Connections\PrimaryReadReplicaConnection;
 use Doctrine\DBAL\Exception;
 
-class PrimaryReadReplicaConnectionWrapper extends PrimaryReadReplicaConnection
+final class PrimaryReadReplicaConnectionWrapper extends PrimaryReadReplicaConnection
 {
     /**
      * @param array<string, string> $dbParams

--- a/app/bundles/CoreBundle/Doctrine/DatabasePlatform.php
+++ b/app/bundles/CoreBundle/Doctrine/DatabasePlatform.php
@@ -15,7 +15,7 @@ use Doctrine\DBAL\Platforms\SQLServerPlatform;
 /**
  * A workaround for deprecated \Doctrine\DBAL\Platforms\AbstractPlatform::getName.
  */
-class DatabasePlatform
+final class DatabasePlatform
 {
     public static function getDatabasePlatform(AbstractPlatform $platform): string
     {

--- a/app/bundles/CoreBundle/Doctrine/Helper/FulltextKeyword.php
+++ b/app/bundles/CoreBundle/Doctrine/Helper/FulltextKeyword.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\Doctrine\Helper;
 
-class FulltextKeyword implements \Stringable
+final class FulltextKeyword implements \Stringable
 {
     public function __construct(
         private readonly string $value,

--- a/app/bundles/CoreBundle/Doctrine/Mapping/AssociationBuilder.php
+++ b/app/bundles/CoreBundle/Doctrine/Mapping/AssociationBuilder.php
@@ -8,7 +8,7 @@ namespace Mautic\CoreBundle\Doctrine\Mapping;
  *
  * Also gives support for allowing a many-to-one to be the primary key
  */
-class AssociationBuilder extends \Doctrine\ORM\Mapping\Builder\AssociationBuilder
+final class AssociationBuilder extends \Doctrine\ORM\Mapping\Builder\AssociationBuilder
 {
     /**
      * Set orphanRemoval.

--- a/app/bundles/CoreBundle/Doctrine/Mapping/ClassMetadataBuilder.php
+++ b/app/bundles/CoreBundle/Doctrine/Mapping/ClassMetadataBuilder.php
@@ -15,7 +15,7 @@ use Mautic\LeadBundle\Entity\Lead;
  * Override Doctrine's builder classes to add support to orphanRemoval until the fix is incorporated into Doctrine release
  * See @see https://github.com/doctrine/doctrine2/pull/1326/.
  */
-class ClassMetadataBuilder extends OrmClassMetadataBuilder
+final class ClassMetadataBuilder extends OrmClassMetadataBuilder
 {
     /**
      * Max length of indexed VARCHAR fields for UTF8MB4 encoding.

--- a/app/bundles/CoreBundle/Doctrine/Mapping/ManyToManyAssociationBuilder.php
+++ b/app/bundles/CoreBundle/Doctrine/Mapping/ManyToManyAssociationBuilder.php
@@ -8,7 +8,7 @@ namespace Mautic\CoreBundle\Doctrine\Mapping;
  * Override Doctrine's builder classes to add support to orphanRemoval until the fix is incorporated into Doctrine release
  * See @see https://github.com/doctrine/doctrine2/pull/1326/
  */
-class ManyToManyAssociationBuilder extends \Doctrine\ORM\Mapping\Builder\ManyToManyAssociationBuilder
+final class ManyToManyAssociationBuilder extends \Doctrine\ORM\Mapping\Builder\ManyToManyAssociationBuilder
 {
     /**
      * Set orphanRemoval.

--- a/app/bundles/CoreBundle/Doctrine/Mapping/OneToManyAssociationBuilder.php
+++ b/app/bundles/CoreBundle/Doctrine/Mapping/OneToManyAssociationBuilder.php
@@ -8,7 +8,7 @@ namespace Mautic\CoreBundle\Doctrine\Mapping;
  * Override Doctrine's builder classes to add support to orphanRemoval until the fix is incorporated into Doctrine release
  * See @see https://github.com/doctrine/doctrine2/pull/1326/
  */
-class OneToManyAssociationBuilder extends \Doctrine\ORM\Mapping\Builder\OneToManyAssociationBuilder
+final class OneToManyAssociationBuilder extends \Doctrine\ORM\Mapping\Builder\OneToManyAssociationBuilder
 {
     /**
      * Set orphanRemoval.

--- a/app/bundles/CoreBundle/Doctrine/Paginator/SimplePaginator.php
+++ b/app/bundles/CoreBundle/Doctrine/Paginator/SimplePaginator.php
@@ -15,7 +15,7 @@ use Doctrine\ORM\Tools\Pagination\CountWalker;
  *
  * @implements \IteratorAggregate<mixed>
  */
-class SimplePaginator implements \IteratorAggregate, \Countable
+final class SimplePaginator implements \IteratorAggregate, \Countable
 {
     private ?int $count = null;
 

--- a/app/bundles/CoreBundle/Doctrine/QueryFormatter/MysqlFormatter.php
+++ b/app/bundles/CoreBundle/Doctrine/QueryFormatter/MysqlFormatter.php
@@ -5,7 +5,7 @@ namespace Mautic\CoreBundle\Doctrine\QueryFormatter;
 /**
  * Help generate SQL statements to format column data.
  */
-class MysqlFormatter extends AbstractFormatter
+final class MysqlFormatter extends AbstractFormatter
 {
     /**
      * Format field to datetime.

--- a/app/bundles/CoreBundle/Doctrine/Type/ArrayType.php
+++ b/app/bundles/CoreBundle/Doctrine/Type/ArrayType.php
@@ -10,7 +10,7 @@ use Doctrine\DBAL\Types\ConversionException;
  *
  * @since 2.0
  */
-class ArrayType extends \Doctrine\DBAL\Types\ArrayType
+final class ArrayType extends \Doctrine\DBAL\Types\ArrayType
 {
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {

--- a/app/bundles/CoreBundle/Doctrine/Type/GeneratedType.php
+++ b/app/bundles/CoreBundle/Doctrine/Type/GeneratedType.php
@@ -10,7 +10,7 @@ use Doctrine\DBAL\Types\Type;
 /**
  * Type that creates a read-only generated (virtual) column.
  */
-class GeneratedType extends Type
+final class GeneratedType extends Type
 {
     /**
      * @var string

--- a/app/bundles/CoreBundle/Doctrine/Type/UTCDateTimeImmutableType.php
+++ b/app/bundles/CoreBundle/Doctrine/Type/UTCDateTimeImmutableType.php
@@ -7,7 +7,7 @@ namespace Mautic\CoreBundle\Doctrine\Type;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\DateTimeImmutableType;
 
-class UTCDateTimeImmutableType extends DateTimeImmutableType
+final class UTCDateTimeImmutableType extends DateTimeImmutableType
 {
     /**
      * Persist the date in UTC.

--- a/app/bundles/CoreBundle/Doctrine/Type/UTCDateTimeType.php
+++ b/app/bundles/CoreBundle/Doctrine/Type/UTCDateTimeType.php
@@ -7,7 +7,7 @@ use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\DateTimeType;
 use Mautic\CoreBundle\Helper\DateTimeHelper;
 
-class UTCDateTimeType extends DateTimeType
+final class UTCDateTimeType extends DateTimeType
 {
     private static ?\DateTimeZone $utc = null;
 

--- a/app/bundles/CoreBundle/Entity/Transformer/NotificationArrayTransformer.php
+++ b/app/bundles/CoreBundle/Entity/Transformer/NotificationArrayTransformer.php
@@ -6,7 +6,7 @@ use Mautic\CoreBundle\Entity\Notification;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 
-class NotificationArrayTransformer implements DataTransformerInterface
+final class NotificationArrayTransformer implements DataTransformerInterface
 {
     public function transform(mixed $value): mixed
     {

--- a/app/bundles/CoreBundle/ErrorHandler/ErrorHandler.php
+++ b/app/bundles/CoreBundle/ErrorHandler/ErrorHandler.php
@@ -11,7 +11,7 @@ namespace Mautic\CoreBundle\ErrorHandler {
     use Symfony\Component\ErrorHandler\Error\OutOfMemoryError;
     use Symfony\Component\ErrorHandler\Exception\FlattenException;
 
-    class ErrorHandler
+    final class ErrorHandler
     {
         public static $handler;
 
@@ -373,7 +373,7 @@ namespace Mautic\CoreBundle\ErrorHandler {
         /**
          * @param mixed[] $context
          */
-        protected function log($logLevel, $message, array $context = [], $debugTrace = null): void
+        private function log($logLevel, $message, array $context = [], $debugTrace = null): void
         {
             $message = strip_tags($message);
             if ($this->logger) {

--- a/app/bundles/CoreBundle/EventListener/ConsoleErrorListener.php
+++ b/app/bundles/CoreBundle/EventListener/ConsoleErrorListener.php
@@ -7,7 +7,7 @@ namespace Mautic\CoreBundle\EventListener;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Event\ConsoleErrorEvent;
 
-class ConsoleErrorListener
+final class ConsoleErrorListener
 {
     public function __construct(
         private readonly LoggerInterface $logger,

--- a/app/bundles/CoreBundle/EventListener/ConsoleTerminateListener.php
+++ b/app/bundles/CoreBundle/EventListener/ConsoleTerminateListener.php
@@ -5,7 +5,7 @@ namespace Mautic\CoreBundle\EventListener;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Event\ConsoleTerminateEvent;
 
-class ConsoleTerminateListener
+final class ConsoleTerminateListener
 {
     public function __construct(
         private readonly LoggerInterface $logger,

--- a/app/bundles/CoreBundle/EventListener/DoctrineGeneratedColumnsListener.php
+++ b/app/bundles/CoreBundle/EventListener/DoctrineGeneratedColumnsListener.php
@@ -9,11 +9,11 @@ use Mautic\CoreBundle\Doctrine\Provider\GeneratedColumnsProviderInterface;
 use Mautic\CoreBundle\Doctrine\Type\GeneratedType;
 use Psr\Log\LoggerInterface;
 
-class DoctrineGeneratedColumnsListener
+final class DoctrineGeneratedColumnsListener
 {
     public function __construct(
-        protected GeneratedColumnsProviderInterface $generatedColumnsProvider,
-        protected LoggerInterface $logger,
+        private GeneratedColumnsProviderInterface $generatedColumnsProvider,
+        private LoggerInterface $logger,
     ) {
     }
 

--- a/app/bundles/CoreBundle/EventListener/ErrorHandlingListener.php
+++ b/app/bundles/CoreBundle/EventListener/ErrorHandlingListener.php
@@ -8,7 +8,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
-class ErrorHandlingListener implements EventSubscriberInterface
+final class ErrorHandlingListener implements EventSubscriberInterface
 {
     public static function getSubscribedEvents(): array
     {

--- a/app/bundles/CoreBundle/EventListener/ExceptionListener.php
+++ b/app/bundles/CoreBundle/EventListener/ExceptionListener.php
@@ -24,7 +24,7 @@ use Symfony\Component\Security\Core\Exception\LogoutException;
 use Symfony\Component\Security\Http\SecurityRequestAttributes;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
-class ExceptionListener extends ErrorListener
+final class ExceptionListener extends ErrorListener
 {
     /**
      * Mautic handles the exception well before the Symfony error listener does, so onKernelException runs

--- a/app/bundles/CoreBundle/EventListener/UUIDListener.php
+++ b/app/bundles/CoreBundle/EventListener/UUIDListener.php
@@ -12,7 +12,7 @@ use Mautic\CoreBundle\Entity\UuidInterface;
 use Ramsey\Uuid\Uuid;
 
 #[AsDoctrineListener(Events::prePersist)]
-class UUIDListener
+final class UUIDListener
 {
     public function __construct(
         private readonly EntityManagerInterface $em,

--- a/app/bundles/CoreBundle/Factory/TransifexFactory.php
+++ b/app/bundles/CoreBundle/Factory/TransifexFactory.php
@@ -14,7 +14,7 @@ use Mautic\Transifex\Transifex;
 use Mautic\Transifex\TransifexInterface;
 use Psr\Http\Client\ClientInterface;
 
-class TransifexFactory
+final class TransifexFactory
 {
     private ?TransifexInterface $transifex = null;
 

--- a/app/bundles/CoreBundle/Helper/Chart/BarChart.php
+++ b/app/bundles/CoreBundle/Helper/Chart/BarChart.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\CoreBundle\Helper\Chart;
 
-class BarChart extends AbstractChart implements ChartInterface
+final class BarChart extends AbstractChart implements ChartInterface
 {
     /**
      * Defines the basic chart values, generates the time axe labels from it.

--- a/app/bundles/CoreBundle/Helper/Chart/LineChart.php
+++ b/app/bundles/CoreBundle/Helper/Chart/LineChart.php
@@ -5,7 +5,7 @@ namespace Mautic\CoreBundle\Helper\Chart;
 /**
  * Line chart requires the same data as Bar chart.
  */
-class LineChart extends AbstractChart implements ChartInterface
+final class LineChart extends AbstractChart implements ChartInterface
 {
     /**
      * Match date/time unit to a humanly readable label

--- a/app/bundles/CoreBundle/Helper/Chart/PieChart.php
+++ b/app/bundles/CoreBundle/Helper/Chart/PieChart.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\CoreBundle\Helper\Chart;
 
-class PieChart extends AbstractChart implements ChartInterface
+final class PieChart extends AbstractChart implements ChartInterface
 {
     /**
      * Holds the suma of the all dataset values.

--- a/app/bundles/CoreBundle/Helper/Chart/SeriesPieChart.php
+++ b/app/bundles/CoreBundle/Helper/Chart/SeriesPieChart.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\Helper\Chart;
 
-class SeriesPieChart extends AbstractChart implements ChartInterface
+final class SeriesPieChart extends AbstractChart implements ChartInterface
 {
     protected int|float $totalCount = 0;
 

--- a/app/bundles/CoreBundle/Helper/DateTime/DateTimeToken.php
+++ b/app/bundles/CoreBundle/Helper/DateTime/DateTimeToken.php
@@ -4,7 +4,7 @@ namespace Mautic\CoreBundle\Helper\DateTime;
 
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 
-class DateTimeToken
+final class DateTimeToken
 {
     public function __construct(
         private readonly CoreParametersHelper $coreParametersHelper,

--- a/app/bundles/CoreBundle/Helper/EmojiMap/HtmlToUnicodeEmojiMap.php
+++ b/app/bundles/CoreBundle/Helper/EmojiMap/HtmlToUnicodeEmojiMap.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\CoreBundle\Helper\EmojiMap;
 
-class HtmlToUnicodeEmojiMap
+final class HtmlToUnicodeEmojiMap
 {
     public static $map = [
         "<span class=\x22emoji-outer emoji-sizer\x22><span class=\x22emoji-inner emojia9\x22></span></span>"                                  => "\xc2\xa9",

--- a/app/bundles/CoreBundle/Helper/EmojiMap/ShortToUnicodeEmojiMap.php
+++ b/app/bundles/CoreBundle/Helper/EmojiMap/ShortToUnicodeEmojiMap.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\CoreBundle\Helper\EmojiMap;
 
-class ShortToUnicodeEmojiMap
+final class ShortToUnicodeEmojiMap
 {
     public static $map = [
         ':copyright:'                                              => "\xc2\xa9",

--- a/app/bundles/CoreBundle/Helper/EmojiMap/UnicodeToHtmlEmojiMap.php
+++ b/app/bundles/CoreBundle/Helper/EmojiMap/UnicodeToHtmlEmojiMap.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\CoreBundle\Helper\EmojiMap;
 
-class UnicodeToHtmlEmojiMap
+final class UnicodeToHtmlEmojiMap
 {
     public static $map = [
         "\xc2\xa9"                                                                                                       => "<span class=\x22emoji-outer emoji-sizer\x22><span class=\x22emoji-inner emojia9\x22></span></span>",

--- a/app/bundles/CoreBundle/Helper/EmojiMap/UnicodeToShortEmojiMap.php
+++ b/app/bundles/CoreBundle/Helper/EmojiMap/UnicodeToShortEmojiMap.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\CoreBundle\Helper\EmojiMap;
 
-class UnicodeToShortEmojiMap
+final class UnicodeToShortEmojiMap
 {
     public static $map = [
         "\xc2\xa9"                                                                                                     => ':copyright:',

--- a/app/bundles/CoreBundle/Helper/Language/Installer.php
+++ b/app/bundles/CoreBundle/Helper/Language/Installer.php
@@ -5,7 +5,7 @@ namespace Mautic\CoreBundle\Helper\Language;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 
-class Installer
+final class Installer
 {
     private ?string $sourceDirectory = null;
 

--- a/app/bundles/CoreBundle/Helper/ListParser/ArrayListParser.php
+++ b/app/bundles/CoreBundle/Helper/ListParser/ArrayListParser.php
@@ -4,7 +4,7 @@ namespace Mautic\CoreBundle\Helper\ListParser;
 
 use Mautic\CoreBundle\Helper\ListParser\Exception\FormatNotSupportedException;
 
-class ArrayListParser implements ListParserInterface
+final class ArrayListParser implements ListParserInterface
 {
     public function parse($list): array
     {

--- a/app/bundles/CoreBundle/Helper/ListParser/BarListParser.php
+++ b/app/bundles/CoreBundle/Helper/ListParser/BarListParser.php
@@ -4,7 +4,7 @@ namespace Mautic\CoreBundle\Helper\ListParser;
 
 use Mautic\CoreBundle\Helper\ListParser\Exception\FormatNotSupportedException;
 
-class BarListParser implements ListParserInterface
+final class BarListParser implements ListParserInterface
 {
     public function parse($list): array
     {

--- a/app/bundles/CoreBundle/Helper/ListParser/JsonListParser.php
+++ b/app/bundles/CoreBundle/Helper/ListParser/JsonListParser.php
@@ -4,7 +4,7 @@ namespace Mautic\CoreBundle\Helper\ListParser;
 
 use Mautic\CoreBundle\Helper\ListParser\Exception\FormatNotSupportedException;
 
-class JsonListParser implements ListParserInterface
+final class JsonListParser implements ListParserInterface
 {
     public function parse($list): array
     {

--- a/app/bundles/CoreBundle/Helper/ListParser/ValueListParser.php
+++ b/app/bundles/CoreBundle/Helper/ListParser/ValueListParser.php
@@ -4,7 +4,7 @@ namespace Mautic\CoreBundle\Helper\ListParser;
 
 use Mautic\CoreBundle\Helper\ListParser\Exception\FormatNotSupportedException;
 
-class ValueListParser implements ListParserInterface
+final class ValueListParser implements ListParserInterface
 {
     public function parse($list): array
     {

--- a/app/bundles/CoreBundle/Helper/PrivateAddressChecker.php
+++ b/app/bundles/CoreBundle/Helper/PrivateAddressChecker.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\Helper;
 
-class PrivateAddressChecker
+final class PrivateAddressChecker
 {
     private const PRIVATE_IP_RANGES = [
         '10.0.0.0/8',      // RFC1918

--- a/app/bundles/CoreBundle/Helper/Serializer.php
+++ b/app/bundles/CoreBundle/Helper/Serializer.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\CoreBundle\Helper;
 
-class Serializer
+final class Serializer
 {
     /**
      * Unserializing a string can be a security vulnerability as it can contain classes that can execute a PHP code.

--- a/app/bundles/CoreBundle/Helper/Tree/IntNode.php
+++ b/app/bundles/CoreBundle/Helper/Tree/IntNode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\Helper\Tree;
 
-class IntNode implements NodeInterface
+final class IntNode implements NodeInterface
 {
     /**
      * @var NodeInterface[]

--- a/app/bundles/CoreBundle/Helper/Tree/JsPlumbFormatter.php
+++ b/app/bundles/CoreBundle/Helper/Tree/JsPlumbFormatter.php
@@ -19,7 +19,7 @@ namespace Mautic\CoreBundle\Helper\Tree;
  *  ]
  *];
  */
-class JsPlumbFormatter implements NodeFormatterInterface
+final class JsPlumbFormatter implements NodeFormatterInterface
 {
     /**
      * @return mixed[]

--- a/app/bundles/CoreBundle/Helper/Update/Github/Release.php
+++ b/app/bundles/CoreBundle/Helper/Update/Github/Release.php
@@ -5,7 +5,7 @@ namespace Mautic\CoreBundle\Helper\Update\Github;
 use Mautic\CoreBundle\Helper\Update\Exception\UpdatePackageNotFoundException;
 use Mautic\CoreBundle\Release\Metadata;
 
-class Release
+final class Release
 {
     /**
      * @var string

--- a/app/bundles/CoreBundle/Helper/Update/PreUpdateChecks/CheckDatabaseDriverAndVersion.php
+++ b/app/bundles/CoreBundle/Helper/Update/PreUpdateChecks/CheckDatabaseDriverAndVersion.php
@@ -7,7 +7,7 @@ namespace Mautic\CoreBundle\Helper\Update\PreUpdateChecks;
 use Doctrine\ORM\EntityManagerInterface;
 use Mautic\InstallBundle\Configurator\Step\DoctrineStep;
 
-class CheckDatabaseDriverAndVersion extends AbstractPreUpdateCheck
+final class CheckDatabaseDriverAndVersion extends AbstractPreUpdateCheck
 {
     public function __construct(
         private readonly EntityManagerInterface $em,

--- a/app/bundles/CoreBundle/Helper/Update/PreUpdateChecks/CheckPhpVersion.php
+++ b/app/bundles/CoreBundle/Helper/Update/PreUpdateChecks/CheckPhpVersion.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\Helper\Update\PreUpdateChecks;
 
-class CheckPhpVersion extends AbstractPreUpdateCheck
+final class CheckPhpVersion extends AbstractPreUpdateCheck
 {
     public function runCheck(): PreUpdateCheckResult
     {

--- a/app/bundles/CoreBundle/Helper/Update/PreUpdateChecks/PreUpdateCheckError.php
+++ b/app/bundles/CoreBundle/Helper/Update/PreUpdateChecks/PreUpdateCheckError.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\Helper\Update\PreUpdateChecks;
 
-class PreUpdateCheckError
+final class PreUpdateCheckError
 {
     /**
      * Create a new error. Errors are supposed to be translatable, so please provide proper translation keys. If that's not possible, please provide a clear error message in English.

--- a/app/bundles/CoreBundle/Helper/Update/PreUpdateChecks/PreUpdateCheckResult.php
+++ b/app/bundles/CoreBundle/Helper/Update/PreUpdateChecks/PreUpdateCheckResult.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\Helper\Update\PreUpdateChecks;
 
-class PreUpdateCheckResult
+final class PreUpdateCheckResult
 {
     /**
      * @var PreUpdateCheckError[]

--- a/app/bundles/CoreBundle/IpLookup/ExtremeIpLookup.php
+++ b/app/bundles/CoreBundle/IpLookup/ExtremeIpLookup.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\CoreBundle\IpLookup;
 
-class ExtremeIpLookup extends AbstractRemoteDataLookup
+final class ExtremeIpLookup extends AbstractRemoteDataLookup
 {
     public string $businessWebsite = '';
 

--- a/app/bundles/CoreBundle/IpLookup/GeobytesLookup.php
+++ b/app/bundles/CoreBundle/IpLookup/GeobytesLookup.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\CoreBundle\IpLookup;
 
-class GeobytesLookup extends AbstractRemoteDataLookup
+final class GeobytesLookup extends AbstractRemoteDataLookup
 {
     public string $forwarderfor        = '';
 

--- a/app/bundles/CoreBundle/IpLookup/GeoipsLookup.php
+++ b/app/bundles/CoreBundle/IpLookup/GeoipsLookup.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\CoreBundle\IpLookup;
 
-class GeoipsLookup extends AbstractRemoteDataLookup
+final class GeoipsLookup extends AbstractRemoteDataLookup
 {
     public string $continent_name = '';
 

--- a/app/bundles/CoreBundle/IpLookup/IP2LocationAPILookup.php
+++ b/app/bundles/CoreBundle/IpLookup/IP2LocationAPILookup.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\CoreBundle\IpLookup;
 
-class IP2LocationAPILookup extends AbstractRemoteDataLookup
+final class IP2LocationAPILookup extends AbstractRemoteDataLookup
 {
     public function getAttribution(): string
     {

--- a/app/bundles/CoreBundle/IpLookup/IP2LocationBinLookup.php
+++ b/app/bundles/CoreBundle/IpLookup/IP2LocationBinLookup.php
@@ -4,7 +4,7 @@ namespace Mautic\CoreBundle\IpLookup;
 
 use IP2Location\Database;
 
-class IP2LocationBinLookup extends AbstractLocalDataLookup
+final class IP2LocationBinLookup extends AbstractLocalDataLookup
 {
     public function getAttribution(): string
     {

--- a/app/bundles/CoreBundle/IpLookup/IpinfodbLookup.php
+++ b/app/bundles/CoreBundle/IpLookup/IpinfodbLookup.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\CoreBundle\IpLookup;
 
-class IpinfodbLookup extends AbstractRemoteDataLookup
+final class IpinfodbLookup extends AbstractRemoteDataLookup
 {
     public string $statusCode    = '';
 

--- a/app/bundles/CoreBundle/IpLookup/IpstackLookup.php
+++ b/app/bundles/CoreBundle/IpLookup/IpstackLookup.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\CoreBundle\IpLookup;
 
-class IpstackLookup extends AbstractRemoteDataLookup
+final class IpstackLookup extends AbstractRemoteDataLookup
 {
     public string $country_code = '';
 

--- a/app/bundles/CoreBundle/IpLookup/MaxmindDownloadLookup.php
+++ b/app/bundles/CoreBundle/IpLookup/MaxmindDownloadLookup.php
@@ -4,7 +4,7 @@ namespace Mautic\CoreBundle\IpLookup;
 
 use GeoIp2\Database\Reader;
 
-class MaxmindDownloadLookup extends AbstractLocalDataLookup
+final class MaxmindDownloadLookup extends AbstractLocalDataLookup
 {
     public function getAttribution(): string
     {

--- a/app/bundles/CoreBundle/IpLookup/TelizeLookup.php
+++ b/app/bundles/CoreBundle/IpLookup/TelizeLookup.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\CoreBundle\IpLookup;
 
-class TelizeLookup extends AbstractRemoteDataLookup
+final class TelizeLookup extends AbstractRemoteDataLookup
 {
     public string $offset         = '';
 

--- a/app/bundles/CoreBundle/Loader/EnvVars/ApiEnvVars.php
+++ b/app/bundles/CoreBundle/Loader/EnvVars/ApiEnvVars.php
@@ -4,7 +4,7 @@ namespace Mautic\CoreBundle\Loader\EnvVars;
 
 use Symfony\Component\HttpFoundation\ParameterBag;
 
-class ApiEnvVars implements EnvVarsInterface
+final class ApiEnvVars implements EnvVarsInterface
 {
     public static function load(ParameterBag $config, ParameterBag $defaultConfig, ParameterBag $envVars): void
     {

--- a/app/bundles/CoreBundle/Loader/EnvVars/ConfigEnvVars.php
+++ b/app/bundles/CoreBundle/Loader/EnvVars/ConfigEnvVars.php
@@ -4,7 +4,7 @@ namespace Mautic\CoreBundle\Loader\EnvVars;
 
 use Symfony\Component\HttpFoundation\ParameterBag;
 
-class ConfigEnvVars implements EnvVarsInterface
+final class ConfigEnvVars implements EnvVarsInterface
 {
     public static function load(ParameterBag $config, ParameterBag $defaultConfig, ParameterBag $envVars): void
     {

--- a/app/bundles/CoreBundle/Loader/EnvVars/ElFinderEnvVars.php
+++ b/app/bundles/CoreBundle/Loader/EnvVars/ElFinderEnvVars.php
@@ -4,7 +4,7 @@ namespace Mautic\CoreBundle\Loader\EnvVars;
 
 use Symfony\Component\HttpFoundation\ParameterBag;
 
-class ElFinderEnvVars implements EnvVarsInterface
+final class ElFinderEnvVars implements EnvVarsInterface
 {
     public static function load(ParameterBag $config, ParameterBag $defaultConfig, ParameterBag $envVars): void
     {

--- a/app/bundles/CoreBundle/Loader/EnvVars/MigrationsEnvVars.php
+++ b/app/bundles/CoreBundle/Loader/EnvVars/MigrationsEnvVars.php
@@ -4,7 +4,7 @@ namespace Mautic\CoreBundle\Loader\EnvVars;
 
 use Symfony\Component\HttpFoundation\ParameterBag;
 
-class MigrationsEnvVars implements EnvVarsInterface
+final class MigrationsEnvVars implements EnvVarsInterface
 {
     public static function load(ParameterBag $config, ParameterBag $defaultConfig, ParameterBag $envVars): void
     {

--- a/app/bundles/CoreBundle/Loader/EnvVars/SAMLEnvVars.php
+++ b/app/bundles/CoreBundle/Loader/EnvVars/SAMLEnvVars.php
@@ -4,7 +4,7 @@ namespace Mautic\CoreBundle\Loader\EnvVars;
 
 use Symfony\Component\HttpFoundation\ParameterBag;
 
-class SAMLEnvVars implements EnvVarsInterface
+final class SAMLEnvVars implements EnvVarsInterface
 {
     public static function load(ParameterBag $config, ParameterBag $defaultConfig, ParameterBag $envVars): void
     {

--- a/app/bundles/CoreBundle/Loader/EnvVars/SessionEnvVars.php
+++ b/app/bundles/CoreBundle/Loader/EnvVars/SessionEnvVars.php
@@ -4,7 +4,7 @@ namespace Mautic\CoreBundle\Loader\EnvVars;
 
 use Symfony\Component\HttpFoundation\ParameterBag;
 
-class SessionEnvVars implements EnvVarsInterface
+final class SessionEnvVars implements EnvVarsInterface
 {
     public static function load(ParameterBag $config, ParameterBag $defaultConfig, ParameterBag $envVars): void
     {

--- a/app/bundles/CoreBundle/Loader/EnvVars/SiteUrlEnvVars.php
+++ b/app/bundles/CoreBundle/Loader/EnvVars/SiteUrlEnvVars.php
@@ -4,7 +4,7 @@ namespace Mautic\CoreBundle\Loader\EnvVars;
 
 use Symfony\Component\HttpFoundation\ParameterBag;
 
-class SiteUrlEnvVars implements EnvVarsInterface
+final class SiteUrlEnvVars implements EnvVarsInterface
 {
     public static function load(ParameterBag $config, ParameterBag $defaultConfig, ParameterBag $envVars): void
     {

--- a/app/bundles/CoreBundle/Loader/EnvVars/TwigEnvVars.php
+++ b/app/bundles/CoreBundle/Loader/EnvVars/TwigEnvVars.php
@@ -4,7 +4,7 @@ namespace Mautic\CoreBundle\Loader\EnvVars;
 
 use Symfony\Component\HttpFoundation\ParameterBag;
 
-class TwigEnvVars implements EnvVarsInterface
+final class TwigEnvVars implements EnvVarsInterface
 {
     public static function load(ParameterBag $config, ParameterBag $defaultConfig, ParameterBag $envVars): void
     {

--- a/app/bundles/CoreBundle/Loader/ParameterLoader.php
+++ b/app/bundles/CoreBundle/Loader/ParameterLoader.php
@@ -7,7 +7,7 @@ use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpFoundation\ParameterBag;
 
-class ParameterLoader
+final class ParameterLoader
 {
     private readonly string $configBaseDir;
 

--- a/app/bundles/CoreBundle/Loader/RouteLoader.php
+++ b/app/bundles/CoreBundle/Loader/RouteLoader.php
@@ -9,7 +9,7 @@ use Symfony\Component\Config\Loader\Loader;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Routing\RouteCollection;
 
-class RouteLoader extends Loader
+final class RouteLoader extends Loader
 {
     public function __construct(
         private readonly EventDispatcherInterface $dispatcher,

--- a/app/bundles/CoreBundle/Loader/TranslationLoader.php
+++ b/app/bundles/CoreBundle/Loader/TranslationLoader.php
@@ -10,7 +10,7 @@ use Symfony\Component\Translation\Loader\ArrayLoader;
 use Symfony\Component\Translation\Loader\LoaderInterface;
 use Symfony\Component\Translation\MessageCatalogue;
 
-class TranslationLoader extends ArrayLoader implements LoaderInterface
+final class TranslationLoader extends ArrayLoader implements LoaderInterface
 {
     public function __construct(
         private readonly BundleHelper $bundleHelper,

--- a/app/bundles/CoreBundle/Menu/MenuBuilder.php
+++ b/app/bundles/CoreBundle/Menu/MenuBuilder.php
@@ -9,7 +9,7 @@ use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Event\MenuEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-class MenuBuilder
+final class MenuBuilder
 {
     public function __construct(
         private readonly FactoryInterface $factory,

--- a/app/bundles/CoreBundle/Menu/MenuRenderer.php
+++ b/app/bundles/CoreBundle/Menu/MenuRenderer.php
@@ -7,7 +7,7 @@ use Knp\Menu\Matcher\MatcherInterface;
 use Knp\Menu\Renderer\RendererInterface;
 use Twig\Environment;
 
-class MenuRenderer implements RendererInterface
+final class MenuRenderer implements RendererInterface
 {
     private readonly array $defaultOptions;
 

--- a/app/bundles/CoreBundle/Monolog/Handler/FileLogHandler.php
+++ b/app/bundles/CoreBundle/Monolog/Handler/FileLogHandler.php
@@ -7,7 +7,7 @@ use Monolog\Formatter\FormatterInterface;
 use Monolog\Handler\RotatingFileHandler;
 use Monolog\Level;
 
-class FileLogHandler extends RotatingFileHandler
+final class FileLogHandler extends RotatingFileHandler
 {
     public function __construct(CoreParametersHelper $coreParametersHelper, FormatterInterface $exceptionFormatter)
     {

--- a/app/bundles/CoreBundle/Monolog/LogProcessor.php
+++ b/app/bundles/CoreBundle/Monolog/LogProcessor.php
@@ -6,7 +6,7 @@ namespace Mautic\CoreBundle\Monolog;
 
 use Monolog\LogRecord;
 
-class LogProcessor
+final class LogProcessor
 {
     public function __invoke(LogRecord $record): LogRecord
     {

--- a/app/bundles/CoreBundle/Predis/Command/Unlink.php
+++ b/app/bundles/CoreBundle/Predis/Command/Unlink.php
@@ -7,7 +7,7 @@ namespace Mautic\CoreBundle\Predis\Command;
 use Predis\Command\Command;
 use Predis\Command\PrefixableCommandInterface;
 
-class Unlink extends Command implements PrefixableCommandInterface
+final class Unlink extends Command implements PrefixableCommandInterface
 {
     public const ID = 'UNLINK';
 

--- a/app/bundles/CoreBundle/Predis/Replication/MasterOnlyStrategy.php
+++ b/app/bundles/CoreBundle/Predis/Replication/MasterOnlyStrategy.php
@@ -6,7 +6,7 @@ namespace Mautic\CoreBundle\Predis\Replication;
 
 use Predis\Replication\ReplicationStrategy;
 
-class MasterOnlyStrategy extends ReplicationStrategy
+final class MasterOnlyStrategy extends ReplicationStrategy
 {
     public function __construct(
         private readonly StrategyConfig $config,

--- a/app/bundles/CoreBundle/ProcessSignal/ProcessSignalState.php
+++ b/app/bundles/CoreBundle/ProcessSignal/ProcessSignalState.php
@@ -6,7 +6,7 @@ namespace Mautic\CoreBundle\ProcessSignal;
 
 use Mautic\CoreBundle\ProcessSignal\Exception\InvalidStateException;
 
-class ProcessSignalState implements \Stringable
+final class ProcessSignalState implements \Stringable
 {
     private const START_TAG = '<<<StartOfState>>>';
 

--- a/app/bundles/CoreBundle/Release/ThisRelease.php
+++ b/app/bundles/CoreBundle/Release/ThisRelease.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\CoreBundle\Release;
 
-class ThisRelease
+final class ThisRelease
 {
     public static function getMetadata(): Metadata
     {

--- a/app/bundles/CoreBundle/Security/Permissions/SystemPermissions.php
+++ b/app/bundles/CoreBundle/Security/Permissions/SystemPermissions.php
@@ -4,7 +4,7 @@ namespace Mautic\CoreBundle\Security\Permissions;
 
 use Symfony\Component\Form\FormBuilderInterface;
 
-class SystemPermissions extends AbstractPermissions
+final class SystemPermissions extends AbstractPermissions
 {
     /**
      * @param mixed[] $params

--- a/app/bundles/CoreBundle/Service/LocalFileAdapterService.php
+++ b/app/bundles/CoreBundle/Service/LocalFileAdapterService.php
@@ -9,7 +9,7 @@ use League\Flysystem\Local\LocalFilesystemAdapter;
 use League\Flysystem\UnixVisibility\PortableVisibilityConverter;
 use League\Flysystem\Visibility;
 
-class LocalFileAdapterService extends LocalFilesystemAdapter
+final class LocalFileAdapterService extends LocalFilesystemAdapter
 {
     public function __construct(string $root)
     {

--- a/app/bundles/CoreBundle/Session/Storage/Handler/RedisSentinelSessionHandler.php
+++ b/app/bundles/CoreBundle/Session/Storage/Handler/RedisSentinelSessionHandler.php
@@ -13,7 +13,7 @@ use Symfony\Component\HttpFoundation\Session\Storage\Handler\AbstractSessionHand
 /**
  * @deprecated since Mautic 5.0, to be removed in 6.0 with no replacement.
  */
-class RedisSentinelSessionHandler extends AbstractSessionHandler
+final class RedisSentinelSessionHandler extends AbstractSessionHandler
 {
     /**
      * @var Client Redis client

--- a/app/bundles/CoreBundle/Test/Container/TestContainer.php
+++ b/app/bundles/CoreBundle/Test/Container/TestContainer.php
@@ -7,7 +7,7 @@ namespace Mautic\CoreBundle\Test\Container;
 use Symfony\Bundle\FrameworkBundle\Test\TestContainer as BaseTestContainer;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-class TestContainer extends BaseTestContainer
+final class TestContainer extends BaseTestContainer
 {
     private ContainerInterface $publicContainer;
 

--- a/app/bundles/CoreBundle/Test/Doctrine/DBALMocker.php
+++ b/app/bundles/CoreBundle/Test/Doctrine/DBALMocker.php
@@ -12,21 +12,21 @@ use PHPUnit\Framework\MockObject\MockBuilder;
 use PHPUnit\Framework\MockObject\Rule\AnyInvokedCount;
 use PHPUnit\Framework\TestCase;
 
-class DBALMocker
+final class DBALMocker
 {
-    protected $mockEm;
+    private $mockEm;
 
-    protected $mockConnection;
+    private $mockConnection;
 
-    protected $mockQueryBuilder;
+    private $mockQueryBuilder;
 
-    protected $queryResponse;
+    private $queryResponse;
 
-    protected $connectionUpdated;
+    private $connectionUpdated;
 
-    protected $connectionInserted;
+    private $connectionInserted;
 
-    protected $queryParts = [
+    private $queryParts = [
         'select'     => [],
         'from'       => [],
         'where'      => [],
@@ -34,7 +34,7 @@ class DBALMocker
     ];
 
     public function __construct(
-        protected TestCase $testCase,
+        private TestCase $testCase,
     ) {
     }
 

--- a/app/bundles/CoreBundle/Test/DoctrineExtensions/TablePrefix.php
+++ b/app/bundles/CoreBundle/Test/DoctrineExtensions/TablePrefix.php
@@ -5,9 +5,9 @@ namespace Mautic\CoreBundle\Test\DoctrineExtensions;
 use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 
-class TablePrefix
+final class TablePrefix
 {
-    protected string $prefix;
+    private string $prefix;
 
     /**
      * @param string $prefix

--- a/app/bundles/CoreBundle/Test/Extensions/DbPrefix/DbPrefix.php
+++ b/app/bundles/CoreBundle/Test/Extensions/DbPrefix/DbPrefix.php
@@ -11,7 +11,7 @@ use PHPUnit\Runner\Extension\Facade;
 use PHPUnit\Runner\Extension\ParameterCollection;
 use PHPUnit\TextUI\Configuration\Configuration;
 
-class DbPrefix implements Extension
+final class DbPrefix implements Extension
 {
     public function bootstrap(Configuration $configuration, Facade $facade, ParameterCollection $parameters): void
     {

--- a/app/bundles/CoreBundle/Test/Extensions/SeparateProcess/SeparateProcess.php
+++ b/app/bundles/CoreBundle/Test/Extensions/SeparateProcess/SeparateProcess.php
@@ -15,7 +15,7 @@ use PHPUnit\Runner\Extension\Facade;
 use PHPUnit\Runner\Extension\ParameterCollection;
 use PHPUnit\TextUI\Configuration\Configuration;
 
-class SeparateProcess implements Extension
+final class SeparateProcess implements Extension
 {
     private bool $prepared          = false;
 

--- a/app/bundles/CoreBundle/Test/Extensions/SlowTest/SlowTest.php
+++ b/app/bundles/CoreBundle/Test/Extensions/SlowTest/SlowTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Runner\Extension\Facade;
 use PHPUnit\Runner\Extension\ParameterCollection;
 use PHPUnit\TextUI\Configuration\Configuration;
 
-class SlowTest implements Extension
+final class SlowTest implements Extension
 {
     private bool $prepared          = false;
 

--- a/app/bundles/CoreBundle/Test/Guzzle/ClientFactory.php
+++ b/app/bundles/CoreBundle/Test/Guzzle/ClientFactory.php
@@ -9,7 +9,7 @@ use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 
-class ClientFactory
+final class ClientFactory
 {
     public static function stub(MockHandler $handler): ClientInterface
     {

--- a/app/bundles/CoreBundle/Test/Session/InMemoryTokenStorage.php
+++ b/app/bundles/CoreBundle/Test/Session/InMemoryTokenStorage.php
@@ -14,7 +14,7 @@ use Symfony\Component\Security\Csrf\TokenStorage\SessionTokenStorage;
  * The issue was mostly that the session was not started in the test environment.
  * And when started it was different in each request.
  */
-class InMemoryTokenStorage implements ClearableTokenStorageInterface
+final class InMemoryTokenStorage implements ClearableTokenStorageInterface
 {
     /**
      * @var array<string,string[]>

--- a/app/bundles/CoreBundle/Translation/TranslatorLoader.php
+++ b/app/bundles/CoreBundle/Translation/TranslatorLoader.php
@@ -9,7 +9,7 @@ namespace Mautic\CoreBundle\Translation;
  *
  * @phpstan-ignore-next-line class.extendsFinalByPhpDoc
  */
-class TranslatorLoader extends \Symfony\Bundle\FrameworkBundle\Translation\Translator
+final class TranslatorLoader extends \Symfony\Bundle\FrameworkBundle\Translation\Translator
 {
     protected function loadCatalogue(string $locale): void
     {

--- a/app/bundles/CoreBundle/Update/StepProvider.php
+++ b/app/bundles/CoreBundle/Update/StepProvider.php
@@ -5,7 +5,7 @@ namespace Mautic\CoreBundle\Update;
 use Mautic\CoreBundle\Update\Step\StepInterface;
 use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 
-class StepProvider
+final class StepProvider
 {
     /**
      * @var StepInterface[]

--- a/app/bundles/DynamicContentBundle/Security/Permissions/DynamicContentPermissions.php
+++ b/app/bundles/DynamicContentBundle/Security/Permissions/DynamicContentPermissions.php
@@ -5,7 +5,7 @@ namespace Mautic\DynamicContentBundle\Security\Permissions;
 use Mautic\CoreBundle\Security\Permissions\AbstractPermissions;
 use Symfony\Component\Form\FormBuilderInterface;
 
-class DynamicContentPermissions extends AbstractPermissions
+final class DynamicContentPermissions extends AbstractPermissions
 {
     /**
      * @param mixed[] $params

--- a/app/bundles/EmailBundle/DataFixtures/ORM/LoadEmailData.php
+++ b/app/bundles/EmailBundle/DataFixtures/ORM/LoadEmailData.php
@@ -10,7 +10,7 @@ use Mautic\CoreBundle\Helper\Serializer;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Model\EmailModel;
 
-class LoadEmailData extends AbstractFixture implements OrderedFixtureInterface
+final class LoadEmailData extends AbstractFixture implements OrderedFixtureInterface
 {
     public function __construct(
         private readonly EmailModel $emailModel,

--- a/app/bundles/EmailBundle/DependencyInjection/EnvProcessor/MailerDsnEnvVarProcessor.php
+++ b/app/bundles/EmailBundle/DependencyInjection/EnvProcessor/MailerDsnEnvVarProcessor.php
@@ -7,7 +7,7 @@ namespace Mautic\EmailBundle\DependencyInjection\EnvProcessor;
 use Mautic\CoreBundle\Helper\Dsn\Dsn;
 use Symfony\Component\DependencyInjection\EnvVarProcessorInterface;
 
-class MailerDsnEnvVarProcessor implements EnvVarProcessorInterface
+final class MailerDsnEnvVarProcessor implements EnvVarProcessorInterface
 {
     public function getEnv(string $prefix, string $name, \Closure $getEnv): string
     {

--- a/app/bundles/EmailBundle/Helper/UrlMatcher.php
+++ b/app/bundles/EmailBundle/Helper/UrlMatcher.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\EmailBundle\Helper;
 
-class UrlMatcher
+final class UrlMatcher
 {
     /**
      * @param string[] $urlsToCheckAgainst

--- a/app/bundles/EmailBundle/Mailer/Transport/InvalidTransport.php
+++ b/app/bundles/EmailBundle/Mailer/Transport/InvalidTransport.php
@@ -10,7 +10,7 @@ use Symfony\Component\Mailer\SentMessage;
 use Symfony\Component\Mailer\Transport\TransportInterface;
 use Symfony\Component\Mime\RawMessage;
 
-class InvalidTransport implements TransportInterface
+final class InvalidTransport implements TransportInterface
 {
     public function send(RawMessage $message, ?Envelope $envelope = null): ?SentMessage
     {

--- a/app/bundles/EmailBundle/Model/EmailActionModel.php
+++ b/app/bundles/EmailBundle/Model/EmailActionModel.php
@@ -9,7 +9,7 @@ use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Entity\EmailRepository;
 
-class EmailActionModel
+final class EmailActionModel
 {
     public function __construct(
         private readonly EmailModel $emailModel,

--- a/app/bundles/EmailBundle/Model/TransportCallback.php
+++ b/app/bundles/EmailBundle/Model/TransportCallback.php
@@ -8,7 +8,7 @@ use Mautic\EmailBundle\MonitoredEmail\Search\ContactFinder;
 use Mautic\LeadBundle\Entity\DoNotContact as DNC;
 use Mautic\LeadBundle\Model\DoNotContact;
 
-class TransportCallback
+final class TransportCallback
 {
     public function __construct(
         private readonly DoNotContact $dncModel,

--- a/app/bundles/EmailBundle/MonitoredEmail/Accessor/ConfigAccessor.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Accessor/ConfigAccessor.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\EmailBundle\MonitoredEmail\Accessor;
 
-class ConfigAccessor
+final class ConfigAccessor
 {
     /**
      * @param mixed[] $config
@@ -57,7 +57,7 @@ class ConfigAccessor
     /**
      * @return string|null
      */
-    protected function getProperty($property)
+    private function getProperty($property)
     {
         return $this->config[$property] ?? null;
     }

--- a/app/bundles/EmailBundle/MonitoredEmail/Attachment.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Attachment.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\EmailBundle\MonitoredEmail;
 
-class Attachment
+final class Attachment
 {
     public $id;
 

--- a/app/bundles/EmailBundle/MonitoredEmail/Fetcher.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Fetcher.php
@@ -9,7 +9,7 @@ use Mautic\EmailBundle\MonitoredEmail\Organizer\MailboxOrganizer;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class Fetcher
+final class Fetcher
 {
     private ?array $mailboxes = null;
 

--- a/app/bundles/EmailBundle/MonitoredEmail/Message.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Message.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\EmailBundle\MonitoredEmail;
 
-class Message
+final class Message
 {
     public $id;
 
@@ -45,7 +45,7 @@ class Message
     /**
      * @var Attachment[]
      */
-    protected $attachments = [];
+    private $attachments = [];
 
     public function addAttachment(Attachment $attachment): void
     {

--- a/app/bundles/EmailBundle/MonitoredEmail/Organizer/MailboxOrganizer.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Organizer/MailboxOrganizer.php
@@ -6,16 +6,16 @@ use Mautic\EmailBundle\Event\ParseEmailEvent;
 use Mautic\EmailBundle\MonitoredEmail\Accessor\ConfigAccessor;
 use Mautic\EmailBundle\MonitoredEmail\Mailbox;
 
-class MailboxOrganizer
+final class MailboxOrganizer
 {
     /**
      * @var MailboxContainer[]
      */
-    protected $containers = [];
+    private $containers = [];
 
     public function __construct(
-        protected ParseEmailEvent $event,
-        protected array $mailboxes,
+        private ParseEmailEvent $event,
+        private array $mailboxes,
     ) {
     }
 
@@ -62,7 +62,7 @@ class MailboxOrganizer
     /**
      * @return MailboxContainer
      */
-    protected function getContainer(ConfigAccessor $config)
+    private function getContainer(ConfigAccessor $config)
     {
         $key = $config->getKey();
         if (!isset($this->containers[$key])) {

--- a/app/bundles/EmailBundle/MonitoredEmail/Processor/Address.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Processor/Address.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\EmailBundle\MonitoredEmail\Processor;
 
-class Address
+final class Address
 {
     /**
      * @param string $addresses String of email address from an email header

--- a/app/bundles/EmailBundle/MonitoredEmail/Processor/Bounce/BodyParser.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Processor/Bounce/BodyParser.php
@@ -8,7 +8,7 @@ use Mautic\EmailBundle\MonitoredEmail\Processor\Bounce\Definition\Category;
 use Mautic\EmailBundle\MonitoredEmail\Processor\Bounce\Definition\Type;
 use Mautic\EmailBundle\MonitoredEmail\Processor\Bounce\Mapper\CategoryMapper;
 
-class BodyParser
+final class BodyParser
 {
     /**
      * @throws BounceNotFound

--- a/app/bundles/EmailBundle/MonitoredEmail/Processor/Bounce/BouncedEmail.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Processor/Bounce/BouncedEmail.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\EmailBundle\MonitoredEmail\Processor\Bounce;
 
-class BouncedEmail
+final class BouncedEmail
 {
     /**
      * @var string|null

--- a/app/bundles/EmailBundle/MonitoredEmail/Processor/Bounce/DsnParser.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Processor/Bounce/DsnParser.php
@@ -8,7 +8,7 @@ use Mautic\EmailBundle\MonitoredEmail\Processor\Address;
 use Mautic\EmailBundle\MonitoredEmail\Processor\Bounce\Definition\Category;
 use Mautic\EmailBundle\MonitoredEmail\Processor\Bounce\Mapper\CategoryMapper;
 
-class DsnParser
+final class DsnParser
 {
     /**
      * @throws BounceNotFound

--- a/app/bundles/EmailBundle/MonitoredEmail/Processor/Bounce/Mapper/Category.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Processor/Bounce/Mapper/Category.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\EmailBundle\MonitoredEmail\Processor\Bounce\Mapper;
 
-class Category
+final class Category
 {
     /**
      * @param string $category

--- a/app/bundles/EmailBundle/MonitoredEmail/Processor/Bounce/Mapper/CategoryMapper.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Processor/Bounce/Mapper/CategoryMapper.php
@@ -7,12 +7,12 @@ use Mautic\EmailBundle\MonitoredEmail\Processor\Bounce\Definition\Category;
 use Mautic\EmailBundle\MonitoredEmail\Processor\Bounce\Definition\Type;
 use Mautic\EmailBundle\MonitoredEmail\Processor\Bounce\Mapper\Category as CategoryObject;
 
-class CategoryMapper
+final class CategoryMapper
 {
     /**
      * @var array
      */
-    protected static $mappings = [
+    private static $mappings = [
         Category::ANTISPAM       => ['permanent' => false, 'bounce_type' => Type::BLOCKED],
         Category::AUTOREPLY      => ['permanent' => false, 'bounce_type' => Type::AUTOREPLY],
         Category::CONCURRENT     => ['permanent' => false, 'bounce_type' => Type::SOFT],

--- a/app/bundles/EmailBundle/MonitoredEmail/Processor/Bounce/Parser.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Processor/Bounce/Parser.php
@@ -5,7 +5,7 @@ namespace Mautic\EmailBundle\MonitoredEmail\Processor\Bounce;
 use Mautic\EmailBundle\MonitoredEmail\Exception\BounceNotFound;
 use Mautic\EmailBundle\MonitoredEmail\Message;
 
-class Parser
+final class Parser
 {
     public function __construct(
         private readonly Message $message,

--- a/app/bundles/EmailBundle/MonitoredEmail/Processor/FeedbackLoop/Parser.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Processor/FeedbackLoop/Parser.php
@@ -6,7 +6,7 @@ use Mautic\EmailBundle\MonitoredEmail\Exception\FeedbackLoopNotFound;
 use Mautic\EmailBundle\MonitoredEmail\Message;
 use Mautic\EmailBundle\MonitoredEmail\Processor\Address;
 
-class Parser
+final class Parser
 {
     public function __construct(
         private readonly Message $message,
@@ -33,7 +33,7 @@ class Parser
         throw new FeedbackLoopNotFound();
     }
 
-    protected function searchMessage(string $pattern, string $content): ?string
+    private function searchMessage(string $pattern, string $content): ?string
     {
         if (preg_match('/'.$pattern.'/i', $content, $match)) {
             if ($parsedAddressList = Address::parseList($match[1])) {

--- a/app/bundles/EmailBundle/MonitoredEmail/Processor/Reply.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Processor/Reply.php
@@ -18,7 +18,7 @@ use Mautic\LeadBundle\Tracker\ContactTracker;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-class Reply implements ProcessorInterface
+final class Reply implements ProcessorInterface
 {
     public function __construct(
         private readonly EmailStatModel $emailStatModel,
@@ -105,7 +105,7 @@ class Reply implements ProcessorInterface
     /**
      * @param string $messageId
      */
-    protected function createReply(Stat $stat, $messageId): void
+    private function createReply(Stat $stat, $messageId): void
     {
         $replies = $stat->getReplies()->filter(
             fn (EmailReply $reply): bool => $reply->getMessageId() === $messageId

--- a/app/bundles/EmailBundle/MonitoredEmail/Processor/Reply/Parser.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Processor/Reply/Parser.php
@@ -5,7 +5,7 @@ namespace Mautic\EmailBundle\MonitoredEmail\Processor\Reply;
 use Mautic\EmailBundle\MonitoredEmail\Exception\ReplyNotFound;
 use Mautic\EmailBundle\MonitoredEmail\Message;
 
-class Parser
+final class Parser
 {
     public function __construct(
         private readonly Message $message,

--- a/app/bundles/EmailBundle/MonitoredEmail/Processor/Reply/RepliedEmail.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Processor/Reply/RepliedEmail.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\EmailBundle\MonitoredEmail\Processor\Reply;
 
-class RepliedEmail
+final class RepliedEmail
 {
     /**
      * @param string $fromAddress

--- a/app/bundles/EmailBundle/MonitoredEmail/Processor/Unsubscription/Parser.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Processor/Unsubscription/Parser.php
@@ -5,10 +5,10 @@ namespace Mautic\EmailBundle\MonitoredEmail\Processor\Unsubscription;
 use Mautic\EmailBundle\MonitoredEmail\Exception\UnsubscriptionNotFound;
 use Mautic\EmailBundle\MonitoredEmail\Message;
 
-class Parser
+final class Parser
 {
     public function __construct(
-        protected Message $message,
+        private Message $message,
     ) {
     }
 

--- a/app/bundles/EmailBundle/MonitoredEmail/Processor/Unsubscription/UnsubscribedEmail.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Processor/Unsubscription/UnsubscribedEmail.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\EmailBundle\MonitoredEmail\Processor\Unsubscription;
 
-class UnsubscribedEmail
+final class UnsubscribedEmail
 {
     /**
      * @param string $contactEmail

--- a/app/bundles/EmailBundle/MonitoredEmail/Search/Result.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Search/Result.php
@@ -5,7 +5,7 @@ namespace Mautic\EmailBundle\MonitoredEmail\Search;
 use Mautic\EmailBundle\Entity\Stat;
 use Mautic\LeadBundle\Entity\Lead;
 
-class Result
+final class Result
 {
     private ?Stat $stat = null;
 

--- a/app/bundles/EmailBundle/OptionsAccessor/EmailToUserAccessor.php
+++ b/app/bundles/EmailBundle/OptionsAccessor/EmailToUserAccessor.php
@@ -5,7 +5,7 @@ namespace Mautic\EmailBundle\OptionsAccessor;
 use Mautic\CoreBundle\Form\DataTransformer\ArrayStringTransformer;
 use Mautic\UserBundle\Entity\User;
 
-class EmailToUserAccessor
+final class EmailToUserAccessor
 {
     private readonly ArrayStringTransformer $transformer;
 

--- a/app/bundles/EmailBundle/Security/Permissions/EmailPermissions.php
+++ b/app/bundles/EmailBundle/Security/Permissions/EmailPermissions.php
@@ -6,7 +6,7 @@ use Mautic\CoreBundle\Security\Permissions\AbstractPermissions;
 use Mautic\UserBundle\Form\Type\PermissionListType;
 use Symfony\Component\Form\FormBuilderInterface;
 
-class EmailPermissions extends AbstractPermissions
+final class EmailPermissions extends AbstractPermissions
 {
     /**
      * @param mixed[] $params

--- a/app/bundles/EmailBundle/Stat/Reference.php
+++ b/app/bundles/EmailBundle/Stat/Reference.php
@@ -4,7 +4,7 @@ namespace Mautic\EmailBundle\Stat;
 
 use Mautic\EmailBundle\Entity\Stat;
 
-class Reference
+final class Reference
 {
     private readonly ?int $emailId;
 

--- a/app/bundles/EmailBundle/Stats/EmailDependencies.php
+++ b/app/bundles/EmailBundle/Stats/EmailDependencies.php
@@ -11,7 +11,7 @@ use Mautic\PointBundle\Model\PointModel;
 use Mautic\PointBundle\Model\TriggerEventModel;
 use Mautic\ReportBundle\Model\ReportModel;
 
-class EmailDependencies
+final class EmailDependencies
 {
     public function __construct(
         private readonly CampaignModel $campaignModel,

--- a/app/bundles/EmailBundle/Stats/EmailPeriodMetrics.php
+++ b/app/bundles/EmailBundle/Stats/EmailPeriodMetrics.php
@@ -9,7 +9,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Mautic\CoreBundle\Helper\DateTimeHelper;
 
-class EmailPeriodMetrics
+final class EmailPeriodMetrics
 {
     private const CAMPAIGN_EVENT_SOURCE = 'campaign.event';
 

--- a/app/bundles/EmailBundle/Stats/FetchOptions/EmailStatOptions.php
+++ b/app/bundles/EmailBundle/Stats/FetchOptions/EmailStatOptions.php
@@ -4,7 +4,7 @@ namespace Mautic\EmailBundle\Stats\FetchOptions;
 
 use Mautic\StatsBundle\Event\Options\FetchOptions;
 
-class EmailStatOptions extends FetchOptions
+final class EmailStatOptions extends FetchOptions
 {
     private array $ids = [];
 

--- a/app/bundles/EmailBundle/Stats/StatHelperContainer.php
+++ b/app/bundles/EmailBundle/Stats/StatHelperContainer.php
@@ -6,7 +6,7 @@ use Mautic\EmailBundle\Stats\Exception\InvalidStatHelperException;
 use Mautic\EmailBundle\Stats\Helper\StatHelperInterface;
 use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 
-class StatHelperContainer
+final class StatHelperContainer
 {
     /**
      * @var array<string, StatHelperInterface>

--- a/app/bundles/FormBundle/Crate/FileFieldCrate.php
+++ b/app/bundles/FormBundle/Crate/FileFieldCrate.php
@@ -5,7 +5,7 @@ namespace Mautic\FormBundle\Crate;
 use Mautic\FormBundle\Entity\Field;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
-class FileFieldCrate
+final class FileFieldCrate
 {
     public function __construct(
         private readonly UploadedFile $uploadedFile,

--- a/app/bundles/FormBundle/Crate/UploadFileCrate.php
+++ b/app/bundles/FormBundle/Crate/UploadFileCrate.php
@@ -5,7 +5,7 @@ namespace Mautic\FormBundle\Crate;
 use Mautic\FormBundle\Entity\Field;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
-class UploadFileCrate implements \Iterator
+final class UploadFileCrate implements \Iterator
 {
     /**
      * @var array|FileFieldCrate[]

--- a/app/bundles/FormBundle/DataFixtures/ORM/LoadFormData.php
+++ b/app/bundles/FormBundle/DataFixtures/ORM/LoadFormData.php
@@ -16,7 +16,7 @@ use Mautic\FormBundle\Model\FieldModel;
 use Mautic\FormBundle\Model\FormModel;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-class LoadFormData extends AbstractFixture implements OrderedFixtureInterface
+final class LoadFormData extends AbstractFixture implements OrderedFixtureInterface
 {
     public const FORM_PREFIX = 'form-';
 

--- a/app/bundles/FormBundle/DataFixtures/ORM/LoadFormResultData.php
+++ b/app/bundles/FormBundle/DataFixtures/ORM/LoadFormResultData.php
@@ -10,7 +10,7 @@ use Mautic\FormBundle\Entity\Submission;
 use Mautic\FormBundle\Model\SubmissionModel;
 use Mautic\PageBundle\Model\PageModel;
 
-class LoadFormResultData extends AbstractFixture implements OrderedFixtureInterface
+final class LoadFormResultData extends AbstractFixture implements OrderedFixtureInterface
 {
     public function __construct(
         private readonly PageModel $pageModel,

--- a/app/bundles/FormBundle/Enum/ConditionalFieldEnum.php
+++ b/app/bundles/FormBundle/Enum/ConditionalFieldEnum.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\FormBundle\Enum;
 
-class ConditionalFieldEnum
+final class ConditionalFieldEnum
 {
     /**
      * @var string[]

--- a/app/bundles/FormBundle/Model/SubmissionModel.php
+++ b/app/bundles/FormBundle/Model/SubmissionModel.php
@@ -71,7 +71,7 @@ use Twig\Environment;
 /**
  * @extends CommonFormModel<Submission>
  */
-class SubmissionModel extends CommonFormModel
+final class SubmissionModel extends CommonFormModel
 {
     public function __construct(
         protected IpLookupHelper $ipLookupHelper,

--- a/app/bundles/FormBundle/Model/SubmissionResultLoader.php
+++ b/app/bundles/FormBundle/Model/SubmissionResultLoader.php
@@ -6,7 +6,7 @@ use Mautic\CoreBundle\Model\MauticModelInterface;
 use Mautic\FormBundle\Entity\Submission;
 use Mautic\FormBundle\Entity\SubmissionRepository;
 
-class SubmissionResultLoader implements MauticModelInterface
+final class SubmissionResultLoader implements MauticModelInterface
 {
     public function __construct(
         private readonly SubmissionRepository $submissionRepository,

--- a/app/bundles/FormBundle/ProgressiveProfiling/DisplayCounter.php
+++ b/app/bundles/FormBundle/ProgressiveProfiling/DisplayCounter.php
@@ -5,7 +5,7 @@ namespace Mautic\FormBundle\ProgressiveProfiling;
 use Mautic\FormBundle\Entity\Field;
 use Mautic\FormBundle\Entity\Form;
 
-class DisplayCounter
+final class DisplayCounter
 {
     private int $displayedFields = 0;
 

--- a/app/bundles/FormBundle/ProgressiveProfiling/DisplayManager.php
+++ b/app/bundles/FormBundle/ProgressiveProfiling/DisplayManager.php
@@ -5,7 +5,7 @@ namespace Mautic\FormBundle\ProgressiveProfiling;
 use Mautic\FormBundle\Entity\Field;
 use Mautic\FormBundle\Entity\Form;
 
-class DisplayManager
+final class DisplayManager
 {
     private readonly DisplayCounter $displayCounter;
 

--- a/app/bundles/FormBundle/Security/Permissions/FormPermissions.php
+++ b/app/bundles/FormBundle/Security/Permissions/FormPermissions.php
@@ -5,7 +5,7 @@ namespace Mautic\FormBundle\Security\Permissions;
 use Mautic\CoreBundle\Security\Permissions\AbstractPermissions;
 use Symfony\Component\Form\FormBuilderInterface;
 
-class FormPermissions extends AbstractPermissions
+final class FormPermissions extends AbstractPermissions
 {
     /**
      * @param mixed[] $params

--- a/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
+++ b/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
@@ -9,7 +9,7 @@ use Mautic\CoreBundle\Security\Cryptography\Cipher\Symmetric\OpenSSLCipher;
 use Mautic\InstallBundle\Configurator\Form\CheckStepType;
 use Symfony\Component\HttpFoundation\RequestStack;
 
-class CheckStep implements StepInterface
+final class CheckStep implements StepInterface
 {
     /**
      * Flag if the configuration file is writable.

--- a/app/bundles/InstallBundle/Configurator/Step/DoctrineStep.php
+++ b/app/bundles/InstallBundle/Configurator/Step/DoctrineStep.php
@@ -9,7 +9,7 @@ use Mautic\InstallBundle\Configurator\Form\DoctrineStepType;
 /**
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class DoctrineStep implements StepInterface
+final class DoctrineStep implements StepInterface
 {
     /**
      * Database driver.

--- a/app/bundles/InstallBundle/Configurator/Step/UserStep.php
+++ b/app/bundles/InstallBundle/Configurator/Step/UserStep.php
@@ -5,7 +5,7 @@ namespace Mautic\InstallBundle\Configurator\Step;
 use Mautic\CoreBundle\Configurator\Step\StepInterface;
 use Mautic\InstallBundle\Configurator\Form\UserStepType;
 
-class UserStep implements StepInterface
+final class UserStep implements StepInterface
 {
     /**
      * User's first name.

--- a/app/bundles/InstallBundle/InstallFixtures/ORM/LeadFieldData.php
+++ b/app/bundles/InstallBundle/InstallFixtures/ORM/LeadFieldData.php
@@ -10,7 +10,7 @@ use Mautic\LeadBundle\Entity\LeadField;
 use Mautic\LeadBundle\Model\FieldModel;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class LeadFieldData extends AbstractFixture implements OrderedFixtureInterface, FixtureGroupInterface
+final class LeadFieldData extends AbstractFixture implements OrderedFixtureInterface, FixtureGroupInterface
 {
     public function __construct(
         private readonly TranslatorInterface $translator,

--- a/app/bundles/InstallBundle/InstallFixtures/ORM/LoadReportData.php
+++ b/app/bundles/InstallBundle/InstallFixtures/ORM/LoadReportData.php
@@ -10,7 +10,7 @@ use Mautic\CoreBundle\Helper\CsvHelper;
 use Mautic\CoreBundle\Helper\Serializer;
 use Mautic\ReportBundle\Entity\Report;
 
-class LoadReportData extends AbstractFixture implements OrderedFixtureInterface, FixtureGroupInterface
+final class LoadReportData extends AbstractFixture implements OrderedFixtureInterface, FixtureGroupInterface
 {
     public static function getGroups(): array
     {

--- a/app/bundles/InstallBundle/InstallFixtures/ORM/RoleData.php
+++ b/app/bundles/InstallBundle/InstallFixtures/ORM/RoleData.php
@@ -9,7 +9,7 @@ use Doctrine\Persistence\ObjectManager;
 use Mautic\UserBundle\Entity\Role;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class RoleData extends AbstractFixture implements OrderedFixtureInterface, FixtureGroupInterface
+final class RoleData extends AbstractFixture implements OrderedFixtureInterface, FixtureGroupInterface
 {
     public function __construct(
         private readonly TranslatorInterface $translator,

--- a/app/bundles/IntegrationsBundle/Auth/Provider/ApiKey/HttpFactory.php
+++ b/app/bundles/IntegrationsBundle/Auth/Provider/ApiKey/HttpFactory.php
@@ -22,7 +22,7 @@ use Mautic\IntegrationsBundle\Exception\PluginNotConfiguredException;
 /**
  * Factory for building HTTP clients using basic auth.
  */
-class HttpFactory implements AuthProviderInterface
+final class HttpFactory implements AuthProviderInterface
 {
     public const NAME = 'api_key';
 

--- a/app/bundles/IntegrationsBundle/Auth/Provider/BasicAuth/HttpFactory.php
+++ b/app/bundles/IntegrationsBundle/Auth/Provider/BasicAuth/HttpFactory.php
@@ -14,7 +14,7 @@ use Mautic\IntegrationsBundle\Exception\PluginNotConfiguredException;
 /**
  * Factory for building HTTP clients using basic auth.
  */
-class HttpFactory implements AuthProviderInterface
+final class HttpFactory implements AuthProviderInterface
 {
     public const NAME = 'basic_auth';
 
@@ -56,7 +56,7 @@ class HttpFactory implements AuthProviderInterface
         return $this->initializedClients[$credentials->getUsername()];
     }
 
-    protected function credentialsAreConfigured(CredentialsInterface $credentials): bool
+    private function credentialsAreConfigured(CredentialsInterface $credentials): bool
     {
         return $credentials->getUsername() && $credentials->getPassword();
     }

--- a/app/bundles/IntegrationsBundle/Auth/Provider/Oauth1aTwoLegged/HttpFactory.php
+++ b/app/bundles/IntegrationsBundle/Auth/Provider/Oauth1aTwoLegged/HttpFactory.php
@@ -16,7 +16,7 @@ use Mautic\IntegrationsBundle\Exception\PluginNotConfiguredException;
 /**
  * Factory for building HTTP clients that will sign the requests with Oauth1a headers.
  */
-class HttpFactory implements AuthProviderInterface
+final class HttpFactory implements AuthProviderInterface
 {
     public const NAME = 'oauth1a_two_legged';
 

--- a/app/bundles/IntegrationsBundle/Auth/Provider/Oauth2TwoLegged/HttpFactory.php
+++ b/app/bundles/IntegrationsBundle/Auth/Provider/Oauth2TwoLegged/HttpFactory.php
@@ -32,7 +32,7 @@ use Mautic\IntegrationsBundle\Exception\PluginNotConfiguredException;
  *
  * @see https://github.com/kamermans/guzzle-oauth2-subscriber
  */
-class HttpFactory implements AuthProviderInterface
+final class HttpFactory implements AuthProviderInterface
 {
     public const NAME = 'oauth2_two_legged';
 

--- a/app/bundles/IntegrationsBundle/Auth/Support/Oauth2/Token/IntegrationToken.php
+++ b/app/bundles/IntegrationsBundle/Auth/Support/Oauth2/Token/IntegrationToken.php
@@ -7,7 +7,7 @@ namespace Mautic\IntegrationsBundle\Auth\Support\Oauth2\Token;
 use kamermans\OAuth2\Token\TokenInterface;
 use kamermans\OAuth2\Token\TokenSerializer;
 
-class IntegrationToken implements TokenInterface
+final class IntegrationToken implements TokenInterface
 {
     // Pull in serialize() and unserialize() methods
     use TokenSerializer;

--- a/app/bundles/IntegrationsBundle/Auth/Support/Oauth2/Token/IntegrationTokenFactory.php
+++ b/app/bundles/IntegrationsBundle/Auth/Support/Oauth2/Token/IntegrationTokenFactory.php
@@ -6,7 +6,7 @@ namespace Mautic\IntegrationsBundle\Auth\Support\Oauth2\Token;
 
 use kamermans\OAuth2\Token\TokenInterface;
 
-class IntegrationTokenFactory implements TokenFactoryInterface
+final class IntegrationTokenFactory implements TokenFactoryInterface
 {
     /**
      * @param mixed[]  $extraKeysToStore Extra keys returned by the service during the token process that needs to be captured

--- a/app/bundles/IntegrationsBundle/Auth/Support/Oauth2/Token/TokenPersistence.php
+++ b/app/bundles/IntegrationsBundle/Auth/Support/Oauth2/Token/TokenPersistence.php
@@ -10,7 +10,7 @@ use Mautic\IntegrationsBundle\Exception\IntegrationNotSetException;
 use Mautic\IntegrationsBundle\Helper\IntegrationsHelper;
 use Mautic\PluginBundle\Entity\Integration;
 
-class TokenPersistence implements TokenPersistenceInterface
+final class TokenPersistence implements TokenPersistenceInterface
 {
     private ?Integration $integration = null;
 

--- a/app/bundles/IntegrationsBundle/Auth/Support/Oauth2/Token/TokenPersistenceFactory.php
+++ b/app/bundles/IntegrationsBundle/Auth/Support/Oauth2/Token/TokenPersistenceFactory.php
@@ -8,7 +8,7 @@ use kamermans\OAuth2\Token\RawToken;
 use Mautic\IntegrationsBundle\Helper\IntegrationsHelper;
 use Mautic\PluginBundle\Entity\Integration;
 
-class TokenPersistenceFactory
+final class TokenPersistenceFactory
 {
     public function __construct(
         private readonly IntegrationsHelper $integrationsHelper,

--- a/app/bundles/IntegrationsBundle/Facade/EncryptionService.php
+++ b/app/bundles/IntegrationsBundle/Facade/EncryptionService.php
@@ -6,7 +6,7 @@ namespace Mautic\IntegrationsBundle\Facade;
 
 use Mautic\CoreBundle\Helper\EncryptionHelper;
 
-class EncryptionService
+final class EncryptionService
 {
     public function __construct(
         private readonly EncryptionHelper $encryptionHelper,

--- a/app/bundles/IntegrationsBundle/Helper/TokenParser.php
+++ b/app/bundles/IntegrationsBundle/Helper/TokenParser.php
@@ -7,7 +7,7 @@ namespace Mautic\IntegrationsBundle\Helper;
 use Doctrine\Common\Collections\ArrayCollection;
 use Mautic\IntegrationsBundle\DTO\IntegrationObjectToken as Token;
 
-class TokenParser
+final class TokenParser
 {
     public const TOKEN = '{mapped-integration-object=(.*?)}';
 

--- a/app/bundles/IntegrationsBundle/Migration/Engine.php
+++ b/app/bundles/IntegrationsBundle/Migration/Engine.php
@@ -7,7 +7,7 @@ namespace Mautic\IntegrationsBundle\Migration;
 use Doctrine\ORM\EntityManagerInterface;
 use Mautic\IntegrationsBundle\Exception\PathNotFoundException;
 
-class Engine
+final class Engine
 {
     private readonly string $migrationsPath;
 

--- a/app/bundles/IntegrationsBundle/Migrations/Version_0_0_1.php
+++ b/app/bundles/IntegrationsBundle/Migrations/Version_0_0_1.php
@@ -8,7 +8,7 @@ use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaException;
 use Mautic\IntegrationsBundle\Migration\AbstractMigration;
 
-class Version_0_0_1 extends AbstractMigration
+final class Version_0_0_1 extends AbstractMigration
 {
     private string $table = 'sync_object_mapping';
 

--- a/app/bundles/IntegrationsBundle/Sync/Logger/DebugLogger.php
+++ b/app/bundles/IntegrationsBundle/Sync/Logger/DebugLogger.php
@@ -7,7 +7,7 @@ namespace Mautic\IntegrationsBundle\Sync\Logger;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 
-class DebugLogger
+final class DebugLogger
 {
     private static ?LoggerInterface $logger = null;
 

--- a/app/bundles/IntegrationsBundle/Sync/Notification/Handler/CompanyNotificationHandler.php
+++ b/app/bundles/IntegrationsBundle/Sync/Notification/Handler/CompanyNotificationHandler.php
@@ -10,7 +10,7 @@ use Mautic\IntegrationsBundle\Sync\Notification\Helper\UserNotificationHelper;
 use Mautic\IntegrationsBundle\Sync\Notification\Writer;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\MauticSyncDataExchange;
 
-class CompanyNotificationHandler implements HandlerInterface
+final class CompanyNotificationHandler implements HandlerInterface
 {
     public function __construct(
         private readonly Writer $writer,

--- a/app/bundles/IntegrationsBundle/Sync/Notification/Handler/ContactNotificationHandler.php
+++ b/app/bundles/IntegrationsBundle/Sync/Notification/Handler/ContactNotificationHandler.php
@@ -14,7 +14,7 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadEventLog;
 use Mautic\LeadBundle\Entity\LeadEventLogRepository;
 
-class ContactNotificationHandler implements HandlerInterface
+final class ContactNotificationHandler implements HandlerInterface
 {
     private ?string $integrationDisplayName = null;
 

--- a/app/bundles/IntegrationsBundle/Sync/Notification/Handler/HandlerContainer.php
+++ b/app/bundles/IntegrationsBundle/Sync/Notification/Handler/HandlerContainer.php
@@ -7,7 +7,7 @@ namespace Mautic\IntegrationsBundle\Sync\Notification\Handler;
 use Mautic\IntegrationsBundle\Sync\Exception\HandlerNotSupportedException;
 use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 
-class HandlerContainer
+final class HandlerContainer
 {
     private array $handlers = [];
 

--- a/app/bundles/IntegrationsBundle/Sync/Notification/Helper/UserNotificationBuilder.php
+++ b/app/bundles/IntegrationsBundle/Sync/Notification/Helper/UserNotificationBuilder.php
@@ -7,7 +7,7 @@ namespace Mautic\IntegrationsBundle\Sync\Notification\Helper;
 use Mautic\IntegrationsBundle\Sync\Exception\ObjectNotSupportedException;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class UserNotificationBuilder
+final class UserNotificationBuilder
 {
     public function __construct(
         private readonly UserHelper $userHelper,

--- a/app/bundles/IntegrationsBundle/Sync/SyncJudge/Modes/BestEvidence.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncJudge/Modes/BestEvidence.php
@@ -8,7 +8,7 @@ use Mautic\IntegrationsBundle\Sync\DAO\Sync\InformationChangeRequestDAO;
 use Mautic\IntegrationsBundle\Sync\Exception\ConflictUnresolvedException;
 use Mautic\IntegrationsBundle\Sync\SyncJudge\SyncJudgeInterface;
 
-class BestEvidence implements JudgementModeInterface
+final class BestEvidence implements JudgementModeInterface
 {
     use DateComparisonTrait;
 

--- a/app/bundles/IntegrationsBundle/Sync/SyncJudge/Modes/FuzzyEvidence.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncJudge/Modes/FuzzyEvidence.php
@@ -7,7 +7,7 @@ namespace Mautic\IntegrationsBundle\Sync\SyncJudge\Modes;
 use Mautic\IntegrationsBundle\Sync\DAO\Sync\InformationChangeRequestDAO;
 use Mautic\IntegrationsBundle\Sync\Exception\ConflictUnresolvedException;
 
-class FuzzyEvidence implements JudgementModeInterface
+final class FuzzyEvidence implements JudgementModeInterface
 {
     /**
      * @throws ConflictUnresolvedException

--- a/app/bundles/IntegrationsBundle/Sync/SyncJudge/Modes/HardEvidence.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncJudge/Modes/HardEvidence.php
@@ -8,7 +8,7 @@ use Mautic\IntegrationsBundle\Sync\DAO\Sync\InformationChangeRequestDAO;
 use Mautic\IntegrationsBundle\Sync\Exception\ConflictUnresolvedException;
 use Mautic\IntegrationsBundle\Sync\SyncJudge\SyncJudgeInterface;
 
-class HardEvidence implements JudgementModeInterface
+final class HardEvidence implements JudgementModeInterface
 {
     use DateComparisonTrait;
 

--- a/app/bundles/IntegrationsBundle/Sync/SyncProcess/SyncProcess.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncProcess/SyncProcess.php
@@ -28,7 +28,7 @@ use Mautic\IntegrationsBundle\Sync\SyncProcess\Direction\Internal\MauticSyncProc
 use Mautic\IntegrationsBundle\Sync\SyncService\SyncServiceInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-class SyncProcess
+final class SyncProcess
 {
     private ?int $syncIteration = null;
 

--- a/app/bundles/LeadBundle/DataFixtures/ORM/LoadCategorizedLeadListData.php
+++ b/app/bundles/LeadBundle/DataFixtures/ORM/LoadCategorizedLeadListData.php
@@ -10,7 +10,7 @@ use Mautic\CoreBundle\Helper\CsvHelper;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\LeadListRepository;
 
-class LoadCategorizedLeadListData extends AbstractFixture implements OrderedFixtureInterface
+final class LoadCategorizedLeadListData extends AbstractFixture implements OrderedFixtureInterface
 {
     public function __construct(
         private readonly LeadListRepository $leadListRepository,

--- a/app/bundles/LeadBundle/DataFixtures/ORM/LoadCategoryData.php
+++ b/app/bundles/LeadBundle/DataFixtures/ORM/LoadCategoryData.php
@@ -9,7 +9,7 @@ use Mautic\CategoryBundle\Entity\Category;
 use Mautic\CategoryBundle\Entity\CategoryRepository;
 use Mautic\CoreBundle\Helper\CsvHelper;
 
-class LoadCategoryData extends AbstractFixture implements OrderedFixtureInterface
+final class LoadCategoryData extends AbstractFixture implements OrderedFixtureInterface
 {
     public function __construct(
         private readonly CategoryRepository $categoryRepository,

--- a/app/bundles/LeadBundle/DataFixtures/ORM/LoadCompanyData.php
+++ b/app/bundles/LeadBundle/DataFixtures/ORM/LoadCompanyData.php
@@ -9,7 +9,7 @@ use Mautic\CoreBundle\Helper\CsvHelper;
 use Mautic\LeadBundle\Entity\Company;
 use Mautic\LeadBundle\Model\CompanyModel;
 
-class LoadCompanyData extends AbstractFixture implements OrderedFixtureInterface
+final class LoadCompanyData extends AbstractFixture implements OrderedFixtureInterface
 {
     public function __construct(
         private readonly CompanyModel $companyModel,

--- a/app/bundles/LeadBundle/DataFixtures/ORM/LoadLeadData.php
+++ b/app/bundles/LeadBundle/DataFixtures/ORM/LoadLeadData.php
@@ -12,7 +12,7 @@ use Mautic\LeadBundle\Entity\CompanyLeadRepository;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadRepository;
 
-class LoadLeadData extends AbstractFixture implements OrderedFixtureInterface
+final class LoadLeadData extends AbstractFixture implements OrderedFixtureInterface
 {
     public function __construct(
         private readonly LeadRepository $leadRepository,

--- a/app/bundles/LeadBundle/DataFixtures/ORM/LoadLeadListData.php
+++ b/app/bundles/LeadBundle/DataFixtures/ORM/LoadLeadListData.php
@@ -8,7 +8,7 @@ use Doctrine\Persistence\ObjectManager;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Model\ListModel;
 
-class LoadLeadListData extends AbstractFixture implements OrderedFixtureInterface
+final class LoadLeadListData extends AbstractFixture implements OrderedFixtureInterface
 {
     public function __construct(
         private readonly ListModel $segmentModel,

--- a/app/bundles/LeadBundle/DataObject/ContactFieldToken.php
+++ b/app/bundles/LeadBundle/DataObject/ContactFieldToken.php
@@ -10,7 +10,7 @@ use Mautic\LeadBundle\Exception\InvalidContactFieldTokenException;
 /**
  * A value object representation of a contact field token.
  */
-class ContactFieldToken
+final class ContactFieldToken
 {
     private string $fieldAlias;
 

--- a/app/bundles/LeadBundle/DataObject/LeadManipulator.php
+++ b/app/bundles/LeadBundle/DataObject/LeadManipulator.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\LeadBundle\DataObject;
 
-class LeadManipulator
+final class LeadManipulator
 {
     /**
      * If true then the manipulator was logged and should not be logged for the second time.

--- a/app/bundles/LeadBundle/Deduplicate/ContactDeduper.php
+++ b/app/bundles/LeadBundle/Deduplicate/ContactDeduper.php
@@ -10,7 +10,7 @@ use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Field\FieldsWithUniqueIdentifier;
 use Mautic\LeadBundle\Model\FieldModel;
 
-class ContactDeduper
+final class ContactDeduper
 {
     use DeduperTrait;
 

--- a/app/bundles/LeadBundle/Event/LeadFieldEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadFieldEvent.php
@@ -7,7 +7,7 @@ use Mautic\CoreBundle\Event\DependencyErrorEventInterface;
 use Mautic\CoreBundle\Event\DependencyErrorEventTrait;
 use Mautic\LeadBundle\Entity\LeadField;
 
-class LeadFieldEvent extends CommonEvent implements DependencyErrorEventInterface
+final class LeadFieldEvent extends CommonEvent implements DependencyErrorEventInterface
 {
     use DependencyErrorEventTrait;
 

--- a/app/bundles/LeadBundle/Field/IdentifierFields.php
+++ b/app/bundles/LeadBundle/Field/IdentifierFields.php
@@ -8,7 +8,7 @@ use Mautic\LeadBundle\Entity\Company;
 use Mautic\LeadBundle\Entity\IdentifierFieldEntityInterface;
 use Mautic\LeadBundle\Entity\Lead;
 
-class IdentifierFields
+final class IdentifierFields
 {
     public function __construct(
         private readonly FieldsWithUniqueIdentifier $fieldsWithUniqueIdentifier,

--- a/app/bundles/LeadBundle/Helper/Progress.php
+++ b/app/bundles/LeadBundle/Helper/Progress.php
@@ -6,29 +6,29 @@ use Mautic\CoreBundle\Helper\ProgressBarHelper;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class Progress
+final class Progress
 {
     /**
      * Total number of items representing 100%.
      *
      * @var int
      */
-    protected $total = 0;
+    private $total = 0;
 
     /**
      * Currently proccessed items.
      *
      * @var int
      */
-    protected $done = 0;
+    private $done = 0;
 
     /**
      * @var ProgressBar|null
      */
-    protected $bar;
+    private $bar;
 
     public function __construct(
-        protected ?OutputInterface $output = null,
+        private ?OutputInterface $output = null,
     ) {
     }
 

--- a/app/bundles/LeadBundle/Model/ContactExportSchedulerModel.php
+++ b/app/bundles/LeadBundle/Model/ContactExportSchedulerModel.php
@@ -28,7 +28,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 /**
  * @extends AbstractCommonModel<ContactExportScheduler>
  */
-class ContactExportSchedulerModel extends AbstractCommonModel
+final class ContactExportSchedulerModel extends AbstractCommonModel
 {
     private const EXPORT_FILE_NAME_DATE_FORMAT = 'Y_m_d_H_i_s';
 

--- a/app/bundles/LeadBundle/Model/DeviceModel.php
+++ b/app/bundles/LeadBundle/Model/DeviceModel.php
@@ -24,7 +24,7 @@ use Symfony\Contracts\EventDispatcher\Event;
 /**
  * @extends FormModel<LeadDevice>
  */
-class DeviceModel extends FormModel
+final class DeviceModel extends FormModel
 {
     public function __construct(
         private readonly LeadDeviceRepository $leadDeviceRepository,

--- a/app/bundles/LeadBundle/Model/NoteModel.php
+++ b/app/bundles/LeadBundle/Model/NoteModel.php
@@ -26,7 +26,7 @@ use Symfony\Contracts\EventDispatcher\Event;
 /**
  * @extends FormModel<LeadNote>
  */
-class NoteModel extends FormModel
+final class NoteModel extends FormModel
 {
     public function __construct(
         EntityManagerInterface $em,

--- a/app/bundles/LeadBundle/Model/SegmentActionModel.php
+++ b/app/bundles/LeadBundle/Model/SegmentActionModel.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\LeadBundle\Model;
 
-class SegmentActionModel
+final class SegmentActionModel
 {
     public function __construct(
         private readonly LeadModel $contactModel,

--- a/app/bundles/LeadBundle/Security/Permissions/LeadPermissions.php
+++ b/app/bundles/LeadBundle/Security/Permissions/LeadPermissions.php
@@ -6,7 +6,7 @@ use Mautic\CoreBundle\Security\Permissions\AbstractPermissions;
 use Mautic\UserBundle\Form\Type\PermissionListType;
 use Symfony\Component\Form\FormBuilderInterface;
 
-class LeadPermissions extends AbstractPermissions
+final class LeadPermissions extends AbstractPermissions
 {
     public const LISTS_VIEW         = 'lead:lists:view';
 

--- a/app/bundles/LeadBundle/Segment/ContactSegmentFilterFactory.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentFilterFactory.php
@@ -11,7 +11,7 @@ use Mautic\LeadBundle\Segment\Query\Filter\FilterQueryBuilderInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-class ContactSegmentFilterFactory
+final class ContactSegmentFilterFactory
 {
     public const CUSTOM_OPERATOR = 'custom_operator';
 

--- a/app/bundles/LeadBundle/Segment/ContactSegmentFilters.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentFilters.php
@@ -5,7 +5,7 @@ namespace Mautic\LeadBundle\Segment;
 /**
  * Array object containing filters.
  */
-class ContactSegmentFilters implements \Iterator, \Countable
+final class ContactSegmentFilters implements \Iterator, \Countable
 {
     private int $position = 0;
 

--- a/app/bundles/LeadBundle/Segment/Decorator/Date/DateOptionParameters.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/DateOptionParameters.php
@@ -5,7 +5,7 @@ namespace Mautic\LeadBundle\Segment\Decorator\Date;
 use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\LeadBundle\Segment\ContactSegmentFilterCrate;
 
-class DateOptionParameters
+final class DateOptionParameters
 {
     private readonly bool $hasTimePart;
 

--- a/app/bundles/LeadBundle/Segment/Decorator/Date/Day/DateDayToday.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/Day/DateDayToday.php
@@ -4,7 +4,7 @@ namespace Mautic\LeadBundle\Segment\Decorator\Date\Day;
 
 use Mautic\CoreBundle\Helper\DateTimeHelper;
 
-class DateDayToday extends DateDayAbstract
+final class DateDayToday extends DateDayAbstract
 {
     protected function modifyBaseDate(DateTimeHelper $dateTimeHelper): void
     {

--- a/app/bundles/LeadBundle/Segment/Decorator/Date/Day/DateDayTomorrow.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/Day/DateDayTomorrow.php
@@ -4,7 +4,7 @@ namespace Mautic\LeadBundle\Segment\Decorator\Date\Day;
 
 use Mautic\CoreBundle\Helper\DateTimeHelper;
 
-class DateDayTomorrow extends DateDayAbstract
+final class DateDayTomorrow extends DateDayAbstract
 {
     protected function modifyBaseDate(DateTimeHelper $dateTimeHelper): void
     {

--- a/app/bundles/LeadBundle/Segment/Decorator/Date/Day/DateDayYesterday.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/Day/DateDayYesterday.php
@@ -4,7 +4,7 @@ namespace Mautic\LeadBundle\Segment\Decorator\Date\Day;
 
 use Mautic\CoreBundle\Helper\DateTimeHelper;
 
-class DateDayYesterday extends DateDayAbstract
+final class DateDayYesterday extends DateDayAbstract
 {
     protected function modifyBaseDate(DateTimeHelper $dateTimeHelper): void
     {

--- a/app/bundles/LeadBundle/Segment/Decorator/Date/Month/DateMonthLast.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/Month/DateMonthLast.php
@@ -4,7 +4,7 @@ namespace Mautic\LeadBundle\Segment\Decorator\Date\Month;
 
 use Mautic\CoreBundle\Helper\DateTimeHelper;
 
-class DateMonthLast extends DateMonthAbstract
+final class DateMonthLast extends DateMonthAbstract
 {
     protected function modifyBaseDate(DateTimeHelper $dateTimeHelper): void
     {

--- a/app/bundles/LeadBundle/Segment/Decorator/Date/Month/DateMonthNext.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/Month/DateMonthNext.php
@@ -4,7 +4,7 @@ namespace Mautic\LeadBundle\Segment\Decorator\Date\Month;
 
 use Mautic\CoreBundle\Helper\DateTimeHelper;
 
-class DateMonthNext extends DateMonthAbstract
+final class DateMonthNext extends DateMonthAbstract
 {
     protected function modifyBaseDate(DateTimeHelper $dateTimeHelper): void
     {

--- a/app/bundles/LeadBundle/Segment/Decorator/Date/Month/DateMonthThis.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/Month/DateMonthThis.php
@@ -4,7 +4,7 @@ namespace Mautic\LeadBundle\Segment\Decorator\Date\Month;
 
 use Mautic\CoreBundle\Helper\DateTimeHelper;
 
-class DateMonthThis extends DateMonthAbstract
+final class DateMonthThis extends DateMonthAbstract
 {
     protected function modifyBaseDate(DateTimeHelper $dateTimeHelper): void
     {

--- a/app/bundles/LeadBundle/Segment/Decorator/Date/Week/DateWeekLast.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/Week/DateWeekLast.php
@@ -4,7 +4,7 @@ namespace Mautic\LeadBundle\Segment\Decorator\Date\Week;
 
 use Mautic\CoreBundle\Helper\DateTimeHelper;
 
-class DateWeekLast extends DateWeekAbstract
+final class DateWeekLast extends DateWeekAbstract
 {
     protected function modifyBaseDate(DateTimeHelper $dateTimeHelper): void
     {

--- a/app/bundles/LeadBundle/Segment/Decorator/Date/Week/DateWeekNext.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/Week/DateWeekNext.php
@@ -4,7 +4,7 @@ namespace Mautic\LeadBundle\Segment\Decorator\Date\Week;
 
 use Mautic\CoreBundle\Helper\DateTimeHelper;
 
-class DateWeekNext extends DateWeekAbstract
+final class DateWeekNext extends DateWeekAbstract
 {
     protected function modifyBaseDate(DateTimeHelper $dateTimeHelper): void
     {

--- a/app/bundles/LeadBundle/Segment/Decorator/Date/Week/DateWeekThis.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/Week/DateWeekThis.php
@@ -4,7 +4,7 @@ namespace Mautic\LeadBundle\Segment\Decorator\Date\Week;
 
 use Mautic\CoreBundle\Helper\DateTimeHelper;
 
-class DateWeekThis extends DateWeekAbstract
+final class DateWeekThis extends DateWeekAbstract
 {
     protected function modifyBaseDate(DateTimeHelper $dateTimeHelper): void
     {

--- a/app/bundles/LeadBundle/Segment/Decorator/Date/Year/DateYearLast.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/Year/DateYearLast.php
@@ -4,7 +4,7 @@ namespace Mautic\LeadBundle\Segment\Decorator\Date\Year;
 
 use Mautic\CoreBundle\Helper\DateTimeHelper;
 
-class DateYearLast extends DateYearAbstract
+final class DateYearLast extends DateYearAbstract
 {
     protected function modifyBaseDate(DateTimeHelper $dateTimeHelper): void
     {

--- a/app/bundles/LeadBundle/Segment/Decorator/Date/Year/DateYearNext.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/Year/DateYearNext.php
@@ -4,7 +4,7 @@ namespace Mautic\LeadBundle\Segment\Decorator\Date\Year;
 
 use Mautic\CoreBundle\Helper\DateTimeHelper;
 
-class DateYearNext extends DateYearAbstract
+final class DateYearNext extends DateYearAbstract
 {
     protected function modifyBaseDate(DateTimeHelper $dateTimeHelper): void
     {

--- a/app/bundles/LeadBundle/Segment/Decorator/Date/Year/DateYearThis.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/Date/Year/DateYearThis.php
@@ -4,7 +4,7 @@ namespace Mautic\LeadBundle\Segment\Decorator\Date\Year;
 
 use Mautic\CoreBundle\Helper\DateTimeHelper;
 
-class DateYearThis extends DateYearAbstract
+final class DateYearThis extends DateYearAbstract
 {
     protected function modifyBaseDate(DateTimeHelper $dateTimeHelper): void
     {

--- a/app/bundles/LeadBundle/Segment/Decorator/DateCompanyDecorator.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/DateCompanyDecorator.php
@@ -5,7 +5,7 @@ namespace Mautic\LeadBundle\Segment\Decorator;
 use Mautic\LeadBundle\Segment\ContactSegmentFilterCrate;
 use Mautic\LeadBundle\Segment\Query\Filter\ComplexRelationValueFilterQueryBuilder;
 
-class DateCompanyDecorator implements FilterDecoratorInterface
+final class DateCompanyDecorator implements FilterDecoratorInterface
 {
     public function __construct(
         private readonly FilterDecoratorInterface $dateDecorator,

--- a/app/bundles/LeadBundle/Segment/DoNotContact/DoNotContactParts.php
+++ b/app/bundles/LeadBundle/Segment/DoNotContact/DoNotContactParts.php
@@ -4,7 +4,7 @@ namespace Mautic\LeadBundle\Segment\DoNotContact;
 
 use Mautic\LeadBundle\Entity\DoNotContact;
 
-class DoNotContactParts
+final class DoNotContactParts
 {
     private string $channel = 'email';
 

--- a/app/bundles/LeadBundle/Segment/IntegrationCampaign/IntegrationCampaignParts.php
+++ b/app/bundles/LeadBundle/Segment/IntegrationCampaign/IntegrationCampaignParts.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\LeadBundle\Segment\IntegrationCampaign;
 
-class IntegrationCampaignParts
+final class IntegrationCampaignParts
 {
     private readonly string $integrationName;
 

--- a/app/bundles/LeadBundle/Segment/OperatorOptions.php
+++ b/app/bundles/LeadBundle/Segment/OperatorOptions.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\LeadBundle\Segment;
 
-class OperatorOptions
+final class OperatorOptions
 {
     public const EQUAL_TO              = '=';
 

--- a/app/bundles/LeadBundle/Segment/Query/ContactSegmentQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/ContactSegmentQueryBuilder.php
@@ -20,7 +20,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 /**
  * Responsible for building queries for segments.
  */
-class ContactSegmentQueryBuilder
+final class ContactSegmentQueryBuilder
 {
     use LeadBatchLimiterTrait;
 

--- a/app/bundles/LeadBundle/Segment/Query/Filter/ChannelClickQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/ChannelClickQueryBuilder.php
@@ -8,7 +8,7 @@ use Mautic\LeadBundle\Segment\ContactSegmentFilter;
 use Mautic\LeadBundle\Segment\Query\LeadBatchLimiterTrait;
 use Mautic\LeadBundle\Segment\Query\QueryBuilder;
 
-class ChannelClickQueryBuilder extends BaseFilterQueryBuilder
+final class ChannelClickQueryBuilder extends BaseFilterQueryBuilder
 {
     use LeadBatchLimiterTrait;
 

--- a/app/bundles/LeadBundle/Segment/Query/Filter/ComplexRelationValueFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/ComplexRelationValueFilterQueryBuilder.php
@@ -18,7 +18,7 @@ use Mautic\LeadBundle\Segment\Query\QueryBuilder;
  *
  * @see \Mautic\LeadBundle\Segment\Decorator\CompanyDecorator
  */
-class ComplexRelationValueFilterQueryBuilder extends BaseFilterQueryBuilder
+final class ComplexRelationValueFilterQueryBuilder extends BaseFilterQueryBuilder
 {
     public static function getServiceId(): string
     {

--- a/app/bundles/LeadBundle/Segment/Query/Filter/DoNotContactFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/DoNotContactFilterQueryBuilder.php
@@ -7,7 +7,7 @@ use Mautic\LeadBundle\Segment\Query\LeadBatchLimiterTrait;
 use Mautic\LeadBundle\Segment\Query\QueryBuilder;
 use Mautic\LeadBundle\Segment\Query\QueryException;
 
-class DoNotContactFilterQueryBuilder extends BaseFilterQueryBuilder
+final class DoNotContactFilterQueryBuilder extends BaseFilterQueryBuilder
 {
     use LeadBatchLimiterTrait;
 

--- a/app/bundles/LeadBundle/Segment/Query/Filter/ForeignFuncFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/ForeignFuncFilterQueryBuilder.php
@@ -7,7 +7,7 @@ use Mautic\LeadBundle\Segment\Exception\FieldNotFoundException;
 use Mautic\LeadBundle\Segment\Query\QueryBuilder;
 use Mautic\LeadBundle\Segment\Query\QueryException;
 
-class ForeignFuncFilterQueryBuilder extends BaseFilterQueryBuilder
+final class ForeignFuncFilterQueryBuilder extends BaseFilterQueryBuilder
 {
     public static function getServiceId(): string
     {

--- a/app/bundles/LeadBundle/Segment/Query/Filter/ForeignValueFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/ForeignValueFilterQueryBuilder.php
@@ -7,7 +7,7 @@ use Mautic\LeadBundle\Segment\OperatorOptions;
 use Mautic\LeadBundle\Segment\Query\LeadBatchLimiterTrait;
 use Mautic\LeadBundle\Segment\Query\QueryBuilder;
 
-class ForeignValueFilterQueryBuilder extends BaseFilterQueryBuilder
+final class ForeignValueFilterQueryBuilder extends BaseFilterQueryBuilder
 {
     use LeadBatchLimiterTrait;
 

--- a/app/bundles/LeadBundle/Segment/Query/Filter/IntegrationCampaignFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/IntegrationCampaignFilterQueryBuilder.php
@@ -6,7 +6,7 @@ use Mautic\LeadBundle\Segment\ContactSegmentFilter;
 use Mautic\LeadBundle\Segment\Query\QueryBuilder;
 use Mautic\LeadBundle\Segment\Query\QueryException;
 
-class IntegrationCampaignFilterQueryBuilder extends BaseFilterQueryBuilder
+final class IntegrationCampaignFilterQueryBuilder extends BaseFilterQueryBuilder
 {
     public static function getServiceId(): string
     {

--- a/app/bundles/LeadBundle/Segment/Query/Filter/SessionsFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/SessionsFilterQueryBuilder.php
@@ -5,7 +5,7 @@ namespace Mautic\LeadBundle\Segment\Query\Filter;
 use Mautic\LeadBundle\Segment\ContactSegmentFilter;
 use Mautic\LeadBundle\Segment\Query\QueryBuilder;
 
-class SessionsFilterQueryBuilder extends BaseFilterQueryBuilder
+final class SessionsFilterQueryBuilder extends BaseFilterQueryBuilder
 {
     public static function getServiceId(): string
     {

--- a/app/bundles/LeadBundle/Segment/Query/QueryException.php
+++ b/app/bundles/LeadBundle/Segment/Query/QueryException.php
@@ -5,7 +5,7 @@ namespace Mautic\LeadBundle\Segment\Query;
 /**
  * @since 2.1.4
  */
-class QueryException extends \Doctrine\DBAL\Exception
+final class QueryException extends \Doctrine\DBAL\Exception
 {
     public static function unknownAlias($alias, $registeredAliases): self
     {

--- a/app/bundles/LeadBundle/Segment/Stat/ChartQuery/SegmentContactsLineChartQuery.php
+++ b/app/bundles/LeadBundle/Segment/Stat/ChartQuery/SegmentContactsLineChartQuery.php
@@ -9,7 +9,7 @@ use Mautic\CoreBundle\Helper\Chart\ChartQuery;
 use Mautic\LeadBundle\Entity\LeadEventLog;
 use Mautic\LeadBundle\Segment\Exception\SegmentNotFoundException;
 
-class SegmentContactsLineChartQuery extends ChartQuery
+final class SegmentContactsLineChartQuery extends ChartQuery
 {
     /**
      * @var int

--- a/app/bundles/LeadBundle/Segment/Stat/SegmentCampaignShare.php
+++ b/app/bundles/LeadBundle/Segment/Stat/SegmentCampaignShare.php
@@ -6,7 +6,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CampaignBundle\Model\CampaignModel;
 use Mautic\CoreBundle\Helper\CacheStorageHelper;
 
-class SegmentCampaignShare
+final class SegmentCampaignShare
 {
     public function __construct(
         private readonly CampaignModel $campaignModel,

--- a/app/bundles/LeadBundle/Segment/Stat/SegmentDependencies.php
+++ b/app/bundles/LeadBundle/Segment/Stat/SegmentDependencies.php
@@ -9,7 +9,7 @@ use Mautic\LeadBundle\Model\ListModel;
 use Mautic\PointBundle\Model\TriggerEventModel;
 use Mautic\ReportBundle\Model\ReportModel;
 
-class SegmentDependencies
+final class SegmentDependencies
 {
     public function __construct(
         private readonly EmailModel $emailModel,

--- a/app/bundles/LeadBundle/Services/ContactColumnsDictionary.php
+++ b/app/bundles/LeadBundle/Services/ContactColumnsDictionary.php
@@ -6,7 +6,7 @@ use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\LeadBundle\Model\FieldModel;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class ContactColumnsDictionary
+final class ContactColumnsDictionary
 {
     /**
      * @var mixed[]
@@ -14,7 +14,7 @@ class ContactColumnsDictionary
     private array $fieldList = [];
 
     public function __construct(
-        protected FieldModel $fieldModel,
+        private FieldModel $fieldModel,
         private readonly TranslatorInterface $translator,
         private readonly CoreParametersHelper $coreParametersHelper,
     ) {

--- a/app/bundles/LeadBundle/Services/SegmentDependencyTreeFactory.php
+++ b/app/bundles/LeadBundle/Services/SegmentDependencyTreeFactory.php
@@ -10,7 +10,7 @@ use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Model\ListModel;
 use Symfony\Component\Routing\RouterInterface;
 
-class SegmentDependencyTreeFactory
+final class SegmentDependencyTreeFactory
 {
     /**
      * @var int[]

--- a/app/bundles/MarketplaceBundle/Collection/MaintainerCollection.php
+++ b/app/bundles/MarketplaceBundle/Collection/MaintainerCollection.php
@@ -7,7 +7,7 @@ namespace Mautic\MarketplaceBundle\Collection;
 use Mautic\MarketplaceBundle\DTO\Maintainer;
 use Mautic\MarketplaceBundle\Exception\RecordNotFoundException;
 
-class MaintainerCollection implements \Iterator, \Countable, \ArrayAccess
+final class MaintainerCollection implements \Iterator, \Countable, \ArrayAccess
 {
     /**
      * @var Maintainer[]

--- a/app/bundles/MarketplaceBundle/Collection/PackageCollection.php
+++ b/app/bundles/MarketplaceBundle/Collection/PackageCollection.php
@@ -7,7 +7,7 @@ namespace Mautic\MarketplaceBundle\Collection;
 use Mautic\MarketplaceBundle\DTO\PackageBase;
 use Mautic\MarketplaceBundle\Exception\RecordNotFoundException;
 
-class PackageCollection implements \Iterator, \Countable, \ArrayAccess
+final class PackageCollection implements \Iterator, \Countable, \ArrayAccess
 {
     /**
      * @var PackageBase[]

--- a/app/bundles/MarketplaceBundle/Collection/VersionCollection.php
+++ b/app/bundles/MarketplaceBundle/Collection/VersionCollection.php
@@ -7,7 +7,7 @@ namespace Mautic\MarketplaceBundle\Collection;
 use Mautic\MarketplaceBundle\DTO\Version;
 use Mautic\MarketplaceBundle\Exception\RecordNotFoundException;
 
-class VersionCollection implements \Iterator, \Countable, \ArrayAccess
+final class VersionCollection implements \Iterator, \Countable, \ArrayAccess
 {
     /**
      * @var Version[]

--- a/app/bundles/MarketplaceBundle/Security/Permissions/MarketplacePermissions.php
+++ b/app/bundles/MarketplaceBundle/Security/Permissions/MarketplacePermissions.php
@@ -9,7 +9,7 @@ use Mautic\CoreBundle\Security\Permissions\AbstractPermissions;
 use Mautic\MarketplaceBundle\Service\Config;
 use Symfony\Component\Form\FormBuilderInterface;
 
-class MarketplacePermissions extends AbstractPermissions
+final class MarketplacePermissions extends AbstractPermissions
 {
     public const BASE                 = 'marketplace';
 

--- a/app/bundles/MarketplaceBundle/Service/PluginCollector.php
+++ b/app/bundles/MarketplaceBundle/Service/PluginCollector.php
@@ -9,7 +9,7 @@ use Mautic\MarketplaceBundle\Api\Connection;
 use Mautic\MarketplaceBundle\Collection\PackageCollection;
 use Mautic\MarketplaceBundle\DTO\AllowlistEntry;
 
-class PluginCollector
+final class PluginCollector
 {
     /**
      * @var AllowlistEntry[]

--- a/app/bundles/MarketplaceBundle/Service/RouteProvider.php
+++ b/app/bundles/MarketplaceBundle/Service/RouteProvider.php
@@ -6,7 +6,7 @@ namespace Mautic\MarketplaceBundle\Service;
 
 use Symfony\Component\Routing\RouterInterface;
 
-class RouteProvider
+final class RouteProvider
 {
     public const ROUTE_LIST = 'mautic_marketplace_list';
 

--- a/app/bundles/MessengerBundle/DependencyInjection/EnvProcessor/MessengerNullableEnvVarProcessor.php
+++ b/app/bundles/MessengerBundle/DependencyInjection/EnvProcessor/MessengerNullableEnvVarProcessor.php
@@ -6,7 +6,7 @@ namespace Mautic\MessengerBundle\DependencyInjection\EnvProcessor;
 
 use Symfony\Component\DependencyInjection\EnvVarProcessorInterface;
 
-class MessengerNullableEnvVarProcessor implements EnvVarProcessorInterface
+final class MessengerNullableEnvVarProcessor implements EnvVarProcessorInterface
 {
     public function getEnv(string $prefix, string $name, \Closure $getEnv): string
     {

--- a/app/bundles/MessengerBundle/Exceptions/InvalidPayloadException.php
+++ b/app/bundles/MessengerBundle/Exceptions/InvalidPayloadException.php
@@ -6,7 +6,7 @@ namespace Mautic\MessengerBundle\Exceptions;
 
 use Symfony\Component\Messenger\Exception\UnrecoverableExceptionInterface;
 
-class InvalidPayloadException extends MauticMessengerException implements UnrecoverableExceptionInterface
+final class InvalidPayloadException extends MauticMessengerException implements UnrecoverableExceptionInterface
 {
     /**
      * @param array<mixed> $payload

--- a/app/bundles/MessengerBundle/Message/EmailHitNotification.php
+++ b/app/bundles/MessengerBundle/Message/EmailHitNotification.php
@@ -7,7 +7,7 @@ namespace Mautic\MessengerBundle\Message;
 use Mautic\MessengerBundle\Message\Traits\MessageRequestTrait;
 use Symfony\Component\HttpFoundation\Request;
 
-class EmailHitNotification
+final class EmailHitNotification
 {
     use MessageRequestTrait;
 

--- a/app/bundles/MessengerBundle/Message/TestEmail.php
+++ b/app/bundles/MessengerBundle/Message/TestEmail.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\MessengerBundle\Message;
 
-class TestEmail
+final class TestEmail
 {
     public function __construct(
         public int $userId,

--- a/app/bundles/MessengerBundle/Message/TestFailed.php
+++ b/app/bundles/MessengerBundle/Message/TestFailed.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\MessengerBundle\Message;
 
-class TestFailed
+final class TestFailed
 {
     public function __construct(
         public int $userId,

--- a/app/bundles/MessengerBundle/Message/TestHit.php
+++ b/app/bundles/MessengerBundle/Message/TestHit.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\MessengerBundle\Message;
 
-class TestHit
+final class TestHit
 {
     public function __construct(
         public int $userId,

--- a/app/bundles/MessengerBundle/MessageHandler/EmailHitNotificationHandler.php
+++ b/app/bundles/MessengerBundle/MessageHandler/EmailHitNotificationHandler.php
@@ -13,7 +13,7 @@ use Symfony\Component\Messenger\Exception\RecoverableMessageHandlingException;
 use Symfony\Component\Messenger\Handler\Acknowledger;
 
 #[AsMessageHandler]
-class EmailHitNotificationHandler
+final class EmailHitNotificationHandler
 {
     private readonly bool $isSyncTransport;
 

--- a/app/bundles/MessengerBundle/MessageHandler/PageHitNotificationHandler.php
+++ b/app/bundles/MessengerBundle/MessageHandler/PageHitNotificationHandler.php
@@ -17,7 +17,7 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\Handler\Acknowledger;
 
 #[AsMessageHandler]
-class PageHitNotificationHandler
+final class PageHitNotificationHandler
 {
     public function __construct(
         private readonly PageRepository $pageRepository,

--- a/app/bundles/MessengerBundle/MessageHandler/RemoveReportAttachmentHandler.php
+++ b/app/bundles/MessengerBundle/MessageHandler/RemoveReportAttachmentHandler.php
@@ -11,7 +11,7 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Mime\Email;
 
 #[AsMessageHandler(priority: -1000)]
-class RemoveReportAttachmentHandler
+final class RemoveReportAttachmentHandler
 {
     public function __construct(
         private readonly ExportHandler $exportHandler,

--- a/app/bundles/MessengerBundle/Retry/RetryStrategy.php
+++ b/app/bundles/MessengerBundle/Retry/RetryStrategy.php
@@ -9,7 +9,7 @@ use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Retry\MultiplierRetryStrategy;
 use Symfony\Component\Messenger\Retry\RetryStrategyInterface;
 
-class RetryStrategy implements RetryStrategyInterface
+final class RetryStrategy implements RetryStrategyInterface
 {
     private RetryStrategyInterface $retryStrategy;
 

--- a/app/bundles/MessengerBundle/Service/TestMessageFactory.php
+++ b/app/bundles/MessengerBundle/Service/TestMessageFactory.php
@@ -9,7 +9,7 @@ use Mautic\MessengerBundle\Message\TestEmail;
 use Mautic\MessengerBundle\Message\TestFailed;
 use Mautic\MessengerBundle\Message\TestHit;
 
-class TestMessageFactory
+final class TestMessageFactory
 {
     public function __construct(
         private readonly UserHelper $userHelper,

--- a/app/bundles/MessengerBundle/Transport/NullTransport.php
+++ b/app/bundles/MessengerBundle/Transport/NullTransport.php
@@ -7,7 +7,7 @@ namespace Mautic\MessengerBundle\Transport;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Transport\TransportInterface;
 
-class NullTransport implements TransportInterface
+final class NullTransport implements TransportInterface
 {
     public function get(): iterable
     {

--- a/app/bundles/MessengerBundle/Transport/NullTransportFactory.php
+++ b/app/bundles/MessengerBundle/Transport/NullTransportFactory.php
@@ -11,7 +11,7 @@ use Symfony\Component\Messenger\Transport\TransportInterface;
 /**
  * Needed for the E2E tests.
  */
-class NullTransportFactory implements TransportFactoryInterface
+final class NullTransportFactory implements TransportFactoryInterface
 {
     /**
      * @param mixed[] $options

--- a/app/bundles/NotificationBundle/Integration/OneSignalIntegration.php
+++ b/app/bundles/NotificationBundle/Integration/OneSignalIntegration.php
@@ -8,7 +8,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilder;
 
-class OneSignalIntegration extends AbstractIntegration
+final class OneSignalIntegration extends AbstractIntegration
 {
     protected bool $coreIntegration = true;
 

--- a/app/bundles/NotificationBundle/Model/NotificationModel.php
+++ b/app/bundles/NotificationBundle/Model/NotificationModel.php
@@ -37,7 +37,7 @@ use Symfony\Contracts\EventDispatcher\Event;
  *
  * @implements AjaxLookupModelInterface<Notification>
  */
-class NotificationModel extends FormModel implements AjaxLookupModelInterface, GlobalSearchInterface
+final class NotificationModel extends FormModel implements AjaxLookupModelInterface, GlobalSearchInterface
 {
     use TranslationModelTrait;
 

--- a/app/bundles/NotificationBundle/Security/Permissions/NotificationPermissions.php
+++ b/app/bundles/NotificationBundle/Security/Permissions/NotificationPermissions.php
@@ -5,7 +5,7 @@ namespace Mautic\NotificationBundle\Security\Permissions;
 use Mautic\CoreBundle\Security\Permissions\AbstractPermissions;
 use Symfony\Component\Form\FormBuilderInterface;
 
-class NotificationPermissions extends AbstractPermissions
+final class NotificationPermissions extends AbstractPermissions
 {
     /**
      * @param mixed[] $params

--- a/app/bundles/PageBundle/DataFixtures/ORM/LoadPageCategoryData.php
+++ b/app/bundles/PageBundle/DataFixtures/ORM/LoadPageCategoryData.php
@@ -8,7 +8,7 @@ use Doctrine\Persistence\ObjectManager;
 use Mautic\CategoryBundle\Entity\Category;
 use Mautic\CategoryBundle\Model\CategoryModel;
 
-class LoadPageCategoryData extends AbstractFixture implements OrderedFixtureInterface
+final class LoadPageCategoryData extends AbstractFixture implements OrderedFixtureInterface
 {
     public function __construct(
         private readonly CategoryModel $categoryModel,

--- a/app/bundles/PageBundle/DataFixtures/ORM/LoadPageData.php
+++ b/app/bundles/PageBundle/DataFixtures/ORM/LoadPageData.php
@@ -10,7 +10,7 @@ use Mautic\CoreBundle\Helper\Serializer;
 use Mautic\PageBundle\Entity\Page;
 use Mautic\PageBundle\Model\PageModel;
 
-class LoadPageData extends AbstractFixture implements OrderedFixtureInterface
+final class LoadPageData extends AbstractFixture implements OrderedFixtureInterface
 {
     public function __construct(
         private readonly PageModel $pageModel,

--- a/app/bundles/PageBundle/DataFixtures/ORM/LoadPageHitData.php
+++ b/app/bundles/PageBundle/DataFixtures/ORM/LoadPageHitData.php
@@ -10,7 +10,7 @@ use Mautic\CoreBundle\Helper\Serializer;
 use Mautic\PageBundle\Entity\Hit;
 use Mautic\PageBundle\Model\PageModel;
 
-class LoadPageHitData extends AbstractFixture implements OrderedFixtureInterface
+final class LoadPageHitData extends AbstractFixture implements OrderedFixtureInterface
 {
     public function __construct(
         private readonly PageModel $pageModel,

--- a/app/bundles/PageBundle/EventListener/TokenSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/TokenSubscriber.php
@@ -6,7 +6,7 @@ use Mautic\PageBundle\Event\PageDisplayEvent;
 use Mautic\PageBundle\PageEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class TokenSubscriber implements EventSubscriberInterface
+final class TokenSubscriber implements EventSubscriberInterface
 {
     public static function getSubscribedEvents(): array
     {

--- a/app/bundles/PageBundle/Model/VideoModel.php
+++ b/app/bundles/PageBundle/Model/VideoModel.php
@@ -23,7 +23,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 /**
  * @extends FormModel<VideoHit>
  */
-class VideoModel extends FormModel
+final class VideoModel extends FormModel
 {
     public function __construct(
         protected IpLookupHelper $ipLookupHelper,

--- a/app/bundles/PageBundle/Security/Permissions/PagePermissions.php
+++ b/app/bundles/PageBundle/Security/Permissions/PagePermissions.php
@@ -5,7 +5,7 @@ namespace Mautic\PageBundle\Security\Permissions;
 use Mautic\CoreBundle\Security\Permissions\AbstractPermissions;
 use Symfony\Component\Form\FormBuilderInterface;
 
-class PagePermissions extends AbstractPermissions
+final class PagePermissions extends AbstractPermissions
 {
     /**
      * @param mixed[] $params

--- a/app/bundles/PluginBundle/Bundle/PluginDatabase.php
+++ b/app/bundles/PluginBundle/Bundle/PluginDatabase.php
@@ -12,7 +12,7 @@ use Mautic\IntegrationsBundle\Migration\Engine;
 use Mautic\PluginBundle\Entity\Plugin;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
-class PluginDatabase
+final class PluginDatabase
 {
     private readonly string $mauticDbPrefix;
 

--- a/app/bundles/PluginBundle/Facade/ReloadFacade.php
+++ b/app/bundles/PluginBundle/Facade/ReloadFacade.php
@@ -6,7 +6,7 @@ use Mautic\PluginBundle\Helper\ReloadHelper;
 use Mautic\PluginBundle\Model\PluginModel;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class ReloadFacade
+final class ReloadFacade
 {
     public function __construct(
         private readonly PluginModel $pluginModel,

--- a/app/bundles/PluginBundle/Helper/Cleaner.php
+++ b/app/bundles/PluginBundle/Helper/Cleaner.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\PluginBundle\Helper;
 
-class Cleaner
+final class Cleaner
 {
     public const FIELD_TYPE_STRING   = 'string';
 

--- a/app/bundles/PluginBundle/Integration/IntegrationObject.php
+++ b/app/bundles/PluginBundle/Integration/IntegrationObject.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\PluginBundle\Integration;
 
-class IntegrationObject
+final class IntegrationObject
 {
     /**
      * @param string $type

--- a/app/bundles/PluginBundle/Security/Permissions/PluginPermissions.php
+++ b/app/bundles/PluginBundle/Security/Permissions/PluginPermissions.php
@@ -5,7 +5,7 @@ namespace Mautic\PluginBundle\Security\Permissions;
 use Mautic\CoreBundle\Security\Permissions\AbstractPermissions;
 use Symfony\Component\Form\FormBuilderInterface;
 
-class PluginPermissions extends AbstractPermissions
+final class PluginPermissions extends AbstractPermissions
 {
     /**
      * @param mixed[] $params

--- a/app/bundles/PointBundle/Model/InsightModel.php
+++ b/app/bundles/PointBundle/Model/InsightModel.php
@@ -27,7 +27,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 /**
  * @extends CommonFormModel<PointInsight>
  */
-class InsightModel extends CommonFormModel
+final class InsightModel extends CommonFormModel
 {
     public function __construct(
         protected LeadModel $leadModel,

--- a/app/bundles/PointBundle/Security/Permissions/PointPermissions.php
+++ b/app/bundles/PointBundle/Security/Permissions/PointPermissions.php
@@ -5,7 +5,7 @@ namespace Mautic\PointBundle\Security\Permissions;
 use Mautic\CoreBundle\Security\Permissions\AbstractPermissions;
 use Symfony\Component\Form\FormBuilderInterface;
 
-class PointPermissions extends AbstractPermissions
+final class PointPermissions extends AbstractPermissions
 {
     /**
      * @param mixed[] $params

--- a/app/bundles/ReportBundle/Builder/InvalidReportQueryException.php
+++ b/app/bundles/ReportBundle/Builder/InvalidReportQueryException.php
@@ -2,6 +2,6 @@
 
 namespace Mautic\ReportBundle\Builder;
 
-class InvalidReportQueryException extends \Exception
+final class InvalidReportQueryException extends \Exception
 {
 }

--- a/app/bundles/ReportBundle/Crate/ReportDataResult.php
+++ b/app/bundles/ReportBundle/Crate/ReportDataResult.php
@@ -4,7 +4,7 @@ namespace Mautic\ReportBundle\Crate;
 
 use Mautic\CoreBundle\Twig\Helper\FormatterHelper;
 
-class ReportDataResult
+final class ReportDataResult
 {
     private readonly int $totalResults;
 

--- a/app/bundles/ReportBundle/Generator/ReportGenerator.php
+++ b/app/bundles/ReportBundle/Generator/ReportGenerator.php
@@ -13,7 +13,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 
-class ReportGenerator
+final class ReportGenerator
 {
     private string $validInterface = ReportBuilderInterface::class;
 
@@ -65,7 +65,7 @@ class ReportGenerator
     /**
      * @throws RuntimeException
      */
-    protected function getBuilder(): MauticReportBuilder
+    private function getBuilder(): MauticReportBuilder
     {
         $className = MauticReportBuilder::class;
 

--- a/app/bundles/ReportBundle/Model/ExportResponse.php
+++ b/app/bundles/ReportBundle/Model/ExportResponse.php
@@ -4,7 +4,7 @@ namespace Mautic\ReportBundle\Model;
 
 use Symfony\Component\HttpFoundation\Response;
 
-class ExportResponse
+final class ExportResponse
 {
     /**
      * @param string $fileName

--- a/app/bundles/ReportBundle/Model/ReportCleanup.php
+++ b/app/bundles/ReportBundle/Model/ReportCleanup.php
@@ -4,7 +4,7 @@ namespace Mautic\ReportBundle\Model;
 
 use Mautic\ReportBundle\Scheduler\Model\FileHandler;
 
-class ReportCleanup
+final class ReportCleanup
 {
     public const KEEP_FILE_DAYS = 7;
 

--- a/app/bundles/ReportBundle/Model/ReportExporter.php
+++ b/app/bundles/ReportBundle/Model/ReportExporter.php
@@ -12,7 +12,7 @@ use Mautic\ReportBundle\Scheduler\Enum\SchedulerEnum;
 use Mautic\ReportBundle\Scheduler\Option\ExportOption;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-class ReportExporter
+final class ReportExporter
 {
     public function __construct(
         private readonly ScheduleModel $schedulerModel,

--- a/app/bundles/ReportBundle/Scheduler/Builder/SchedulerDailyBuilder.php
+++ b/app/bundles/ReportBundle/Scheduler/Builder/SchedulerDailyBuilder.php
@@ -8,7 +8,7 @@ use Mautic\ReportBundle\Scheduler\SchedulerInterface;
 use Recurr\Exception\InvalidArgument;
 use Recurr\Rule;
 
-class SchedulerDailyBuilder implements BuilderInterface
+final class SchedulerDailyBuilder implements BuilderInterface
 {
     /**
      * @throws InvalidSchedulerException

--- a/app/bundles/ReportBundle/Scheduler/Builder/SchedulerMonthBuilder.php
+++ b/app/bundles/ReportBundle/Scheduler/Builder/SchedulerMonthBuilder.php
@@ -10,7 +10,7 @@ use Recurr\Exception\InvalidArgument;
 use Recurr\Exception\InvalidRRule;
 use Recurr\Rule;
 
-class SchedulerMonthBuilder implements BuilderInterface
+final class SchedulerMonthBuilder implements BuilderInterface
 {
     /**
      * @throws InvalidSchedulerException

--- a/app/bundles/ReportBundle/Scheduler/Builder/SchedulerNowBuilder.php
+++ b/app/bundles/ReportBundle/Scheduler/Builder/SchedulerNowBuilder.php
@@ -10,7 +10,7 @@ use Mautic\ReportBundle\Scheduler\SchedulerInterface;
 use Recurr\Exception\InvalidArgument;
 use Recurr\Rule;
 
-class SchedulerNowBuilder implements BuilderInterface
+final class SchedulerNowBuilder implements BuilderInterface
 {
     /**
      * @throws InvalidSchedulerException

--- a/app/bundles/ReportBundle/Scheduler/Builder/SchedulerWeeklyBuilder.php
+++ b/app/bundles/ReportBundle/Scheduler/Builder/SchedulerWeeklyBuilder.php
@@ -10,7 +10,7 @@ use Recurr\Exception\InvalidArgument;
 use Recurr\Exception\InvalidRRule;
 use Recurr\Rule;
 
-class SchedulerWeeklyBuilder implements BuilderInterface
+final class SchedulerWeeklyBuilder implements BuilderInterface
 {
     /**
      * @throws InvalidSchedulerException

--- a/app/bundles/ReportBundle/Scheduler/Entity/SchedulerEntity.php
+++ b/app/bundles/ReportBundle/Scheduler/Entity/SchedulerEntity.php
@@ -5,7 +5,7 @@ namespace Mautic\ReportBundle\Scheduler\Entity;
 use Mautic\ReportBundle\Scheduler\Enum\SchedulerEnum;
 use Mautic\ReportBundle\Scheduler\SchedulerInterface;
 
-class SchedulerEntity implements SchedulerInterface
+final class SchedulerEntity implements SchedulerInterface
 {
     /**
      * @param bool        $isScheduled

--- a/app/bundles/ReportBundle/Scheduler/Enum/SchedulerEnum.php
+++ b/app/bundles/ReportBundle/Scheduler/Enum/SchedulerEnum.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\ReportBundle\Scheduler\Enum;
 
-class SchedulerEnum
+final class SchedulerEnum
 {
     public const UNIT_NOW     = 'NOW';
 

--- a/app/bundles/ReportBundle/Scheduler/Factory/SchedulerTemplateFactory.php
+++ b/app/bundles/ReportBundle/Scheduler/Factory/SchedulerTemplateFactory.php
@@ -10,7 +10,7 @@ use Mautic\ReportBundle\Scheduler\BuilderInterface;
 use Mautic\ReportBundle\Scheduler\Exception\NotSupportedScheduleTypeException;
 use Mautic\ReportBundle\Scheduler\SchedulerInterface;
 
-class SchedulerTemplateFactory
+final class SchedulerTemplateFactory
 {
     /**
      * @throws NotSupportedScheduleTypeException

--- a/app/bundles/ReportBundle/Security/Permissions/ReportPermissions.php
+++ b/app/bundles/ReportBundle/Security/Permissions/ReportPermissions.php
@@ -5,7 +5,7 @@ namespace Mautic\ReportBundle\Security\Permissions;
 use Mautic\CoreBundle\Security\Permissions\AbstractPermissions;
 use Symfony\Component\Form\FormBuilderInterface;
 
-class ReportPermissions extends AbstractPermissions
+final class ReportPermissions extends AbstractPermissions
 {
     /**
      * @param mixed[] $params

--- a/app/bundles/SmsBundle/Broadcast/BroadcastExecutioner.php
+++ b/app/bundles/SmsBundle/Broadcast/BroadcastExecutioner.php
@@ -9,7 +9,7 @@ use Mautic\SmsBundle\Entity\Sms;
 use Mautic\SmsBundle\Model\SmsModel;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class BroadcastExecutioner
+final class BroadcastExecutioner
 {
     private ?ContactLimiter $contactLimiter = null;
 

--- a/app/bundles/SmsBundle/Broadcast/BroadcastQuery.php
+++ b/app/bundles/SmsBundle/Broadcast/BroadcastQuery.php
@@ -10,7 +10,7 @@ use Mautic\ChannelBundle\Entity\MessageQueue;
 use Mautic\SmsBundle\Entity\Sms;
 use Mautic\SmsBundle\Model\SmsModel;
 
-class BroadcastQuery
+final class BroadcastQuery
 {
     use ContactLimiterTrait;
 

--- a/app/bundles/SmsBundle/Broadcast/BroadcastResult.php
+++ b/app/bundles/SmsBundle/Broadcast/BroadcastResult.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\SmsBundle\Broadcast;
 
-class BroadcastResult
+final class BroadcastResult
 {
     private int $sentCount = 0;
 

--- a/app/bundles/SmsBundle/Callback/HandlerContainer.php
+++ b/app/bundles/SmsBundle/Callback/HandlerContainer.php
@@ -5,7 +5,7 @@ namespace Mautic\SmsBundle\Callback;
 use Mautic\SmsBundle\Exception\CallbackHandlerNotFound;
 use Symfony\Component\DependencyInjection\Attribute\AutowireIterator;
 
-class HandlerContainer
+final class HandlerContainer
 {
     /**
      * @var CallbackInterface[]

--- a/app/bundles/SmsBundle/Integration/Twilio/TwilioCallback.php
+++ b/app/bundles/SmsBundle/Integration/Twilio/TwilioCallback.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Twilio\Exceptions\ConfigurationException;
 
-class TwilioCallback implements CallbackInterface
+final class TwilioCallback implements CallbackInterface
 {
     public function __construct(
         private readonly ContactHelper $contactHelper,

--- a/app/bundles/SmsBundle/Integration/TwilioIntegration.php
+++ b/app/bundles/SmsBundle/Integration/TwilioIntegration.php
@@ -9,7 +9,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilder;
 
-class TwilioIntegration extends AbstractIntegration
+final class TwilioIntegration extends AbstractIntegration
 {
     protected bool $coreIntegration = true;
 

--- a/app/bundles/SmsBundle/Security/Permissions/SmsPermissions.php
+++ b/app/bundles/SmsBundle/Security/Permissions/SmsPermissions.php
@@ -5,7 +5,7 @@ namespace Mautic\SmsBundle\Security\Permissions;
 use Mautic\CoreBundle\Security\Permissions\AbstractPermissions;
 use Symfony\Component\Form\FormBuilderInterface;
 
-class SmsPermissions extends AbstractPermissions
+final class SmsPermissions extends AbstractPermissions
 {
     /**
      * @param mixed[] $params

--- a/app/bundles/StageBundle/Security/Permissions/StagePermissions.php
+++ b/app/bundles/StageBundle/Security/Permissions/StagePermissions.php
@@ -5,7 +5,7 @@ namespace Mautic\StageBundle\Security\Permissions;
 use Mautic\CoreBundle\Security\Permissions\AbstractPermissions;
 use Symfony\Component\Form\FormBuilderInterface;
 
-class StagePermissions extends AbstractPermissions
+final class StagePermissions extends AbstractPermissions
 {
     public const PERMISSION_VIEW    = 'stage:stages:view';
 

--- a/app/bundles/StatsBundle/Aggregate/Calculator.php
+++ b/app/bundles/StatsBundle/Aggregate/Calculator.php
@@ -6,7 +6,7 @@ use Mautic\StatsBundle\Aggregate\Collection\DAO\StatDAO;
 use Mautic\StatsBundle\Aggregate\Collection\DAO\StatsDAO;
 use Mautic\StatsBundle\Aggregate\Helper\CalculatorHelper;
 
-class Calculator
+final class Calculator
 {
     public function __construct(
         private readonly StatsDAO $statsDAO,

--- a/app/bundles/StatsBundle/Aggregate/Collection/StatCollection.php
+++ b/app/bundles/StatsBundle/Aggregate/Collection/StatCollection.php
@@ -6,7 +6,7 @@ use Mautic\StatsBundle\Aggregate\Calculator;
 use Mautic\StatsBundle\Aggregate\Collection\DAO\StatsDAO;
 use Mautic\StatsBundle\Aggregate\Helper\CalculatorHelper;
 
-class StatCollection
+final class StatCollection
 {
     private readonly StatsDAO $stats;
 

--- a/app/bundles/StatsBundle/Aggregate/Collection/Stats/HourStat.php
+++ b/app/bundles/StatsBundle/Aggregate/Collection/Stats/HourStat.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\StatsBundle\Aggregate\Collection\Stats;
 
-class HourStat
+final class HourStat
 {
     private int $count = 0;
 

--- a/app/bundles/StatsBundle/Aggregate/Collection/Stats/MonthStat.php
+++ b/app/bundles/StatsBundle/Aggregate/Collection/Stats/MonthStat.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\StatsBundle\Aggregate\Collection\Stats;
 
-class MonthStat implements StatInterface
+final class MonthStat implements StatInterface
 {
     /**
      * @var DayStat[]

--- a/app/bundles/StatsBundle/Aggregate/Collection/Stats/WeekStat.php
+++ b/app/bundles/StatsBundle/Aggregate/Collection/Stats/WeekStat.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\StatsBundle\Aggregate\Collection\Stats;
 
-class WeekStat
+final class WeekStat
 {
     private int $count = 0;
 

--- a/app/bundles/StatsBundle/Aggregate/Collection/Stats/YearStat.php
+++ b/app/bundles/StatsBundle/Aggregate/Collection/Stats/YearStat.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\StatsBundle\Aggregate\Collection\Stats;
 
-class YearStat implements StatInterface
+final class YearStat implements StatInterface
 {
     /**
      * @var MonthStat[]

--- a/app/bundles/StatsBundle/Aggregate/Collector.php
+++ b/app/bundles/StatsBundle/Aggregate/Collector.php
@@ -8,7 +8,7 @@ use Mautic\StatsBundle\Event\Options\FetchOptions;
 use Mautic\StatsBundle\StatEvents;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-class Collector
+final class Collector
 {
     public function __construct(
         private readonly EventDispatcherInterface $eventDispatcher,

--- a/app/bundles/UserBundle/DataFixtures/ORM/LoadRoleData.php
+++ b/app/bundles/UserBundle/DataFixtures/ORM/LoadRoleData.php
@@ -9,7 +9,7 @@ use Doctrine\Persistence\ObjectManager;
 use Mautic\UserBundle\Entity\Role;
 use Mautic\UserBundle\Model\RoleModel;
 
-class LoadRoleData extends AbstractFixture implements OrderedFixtureInterface, FixtureGroupInterface
+final class LoadRoleData extends AbstractFixture implements OrderedFixtureInterface, FixtureGroupInterface
 {
     public static function getGroups(): array
     {

--- a/app/bundles/UserBundle/DataFixtures/ORM/LoadUserData.php
+++ b/app/bundles/UserBundle/DataFixtures/ORM/LoadUserData.php
@@ -9,7 +9,7 @@ use Doctrine\Persistence\ObjectManager;
 use Mautic\UserBundle\Entity\User;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 
-class LoadUserData extends AbstractFixture implements OrderedFixtureInterface, FixtureGroupInterface
+final class LoadUserData extends AbstractFixture implements OrderedFixtureInterface, FixtureGroupInterface
 {
     public static function getGroups(): array
     {

--- a/app/bundles/UserBundle/DependencyInjection/Firewall/Factory/PluginFactory.php
+++ b/app/bundles/UserBundle/DependencyInjection/Firewall/Factory/PluginFactory.php
@@ -8,7 +8,7 @@ use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-class PluginFactory implements AuthenticatorFactoryInterface
+final class PluginFactory implements AuthenticatorFactoryInterface
 {
     public const PRIORITY = -30;
 

--- a/app/bundles/UserBundle/Hash/UserHash.php
+++ b/app/bundles/UserBundle/Hash/UserHash.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\UserBundle\Hash;
 
-class UserHash
+final class UserHash
 {
     public const FAKE_USER_HASH = 'xxxxxxxxxxxxxx';
 

--- a/app/bundles/UserBundle/Model/PasswordStrengthEstimatorModel.php
+++ b/app/bundles/UserBundle/Model/PasswordStrengthEstimatorModel.php
@@ -9,7 +9,7 @@ use Mautic\UserBundle\UserEvents;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use ZxcvbnPhp\Zxcvbn as PasswordStrengthEstimator;
 
-class PasswordStrengthEstimatorModel
+final class PasswordStrengthEstimatorModel
 {
     public const MINIMUM_PASSWORD_STRENGTH_ALLOWED = 3;
 

--- a/app/bundles/UserBundle/Model/RoleModel.php
+++ b/app/bundles/UserBundle/Model/RoleModel.php
@@ -21,7 +21,7 @@ use Symfony\Contracts\Service\Attribute\Required;
 /**
  * @extends FormModel<Role>
  */
-class RoleModel extends FormModel implements GlobalSearchInterface
+final class RoleModel extends FormModel implements GlobalSearchInterface
 {
     private UserRepository $userRepository;
 

--- a/app/bundles/UserBundle/Security/Authenticator/Passport/Badge/PasswordStrengthBadge.php
+++ b/app/bundles/UserBundle/Security/Authenticator/Passport/Badge/PasswordStrengthBadge.php
@@ -6,7 +6,7 @@ namespace Mautic\UserBundle\Security\Authenticator\Passport\Badge;
 
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\BadgeInterface;
 
-class PasswordStrengthBadge implements BadgeInterface
+final class PasswordStrengthBadge implements BadgeInterface
 {
     private bool $resolved = false;
 

--- a/app/bundles/UserBundle/Security/Authenticator/Passport/Badge/PluginBadge.php
+++ b/app/bundles/UserBundle/Security/Authenticator/Passport/Badge/PluginBadge.php
@@ -8,7 +8,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\BadgeInterface;
 
-class PluginBadge implements BadgeInterface
+final class PluginBadge implements BadgeInterface
 {
     public function __construct(
         private readonly ?TokenInterface $preAuthenticatedToken,

--- a/app/bundles/UserBundle/Security/EntryPoint/MainEntryPoint.php
+++ b/app/bundles/UserBundle/Security/EntryPoint/MainEntryPoint.php
@@ -11,7 +11,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
 
-class MainEntryPoint implements AuthenticationEntryPointInterface
+final class MainEntryPoint implements AuthenticationEntryPointInterface
 {
     public function __construct(
         private readonly UrlGeneratorInterface $urlGenerator,

--- a/app/bundles/UserBundle/Security/Permissions/UserPermissions.php
+++ b/app/bundles/UserBundle/Security/Permissions/UserPermissions.php
@@ -6,7 +6,7 @@ use Mautic\CoreBundle\Security\Permissions\AbstractPermissions;
 use Mautic\UserBundle\Form\Type\PermissionListType;
 use Symfony\Component\Form\FormBuilderInterface;
 
-class UserPermissions extends AbstractPermissions
+final class UserPermissions extends AbstractPermissions
 {
     /**
      * @param mixed[] $params

--- a/app/bundles/UserBundle/Security/SAML/EntityDescriptorProviderFactory.php
+++ b/app/bundles/UserBundle/Security/SAML/EntityDescriptorProviderFactory.php
@@ -9,7 +9,7 @@ use LightSaml\Credential\X509Credential;
 use LightSaml\Store\Credential\CredentialStoreInterface;
 use Symfony\Component\Routing\RouterInterface;
 
-class EntityDescriptorProviderFactory
+final class EntityDescriptorProviderFactory
 {
     public static function build(
         string $ownEntityId,

--- a/app/bundles/UserBundle/Security/SAML/Store/CredentialsStore.php
+++ b/app/bundles/UserBundle/Security/SAML/Store/CredentialsStore.php
@@ -9,7 +9,7 @@ use LightSaml\Store\Credential\CredentialStoreInterface;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use RobRichards\XMLSecLibs\XMLSecurityKey;
 
-class CredentialsStore implements CredentialStoreInterface
+final class CredentialsStore implements CredentialStoreInterface
 {
     private ?X509Credential $credentials = null;
 

--- a/app/bundles/UserBundle/Security/SAML/Store/EntityDescriptorStore.php
+++ b/app/bundles/UserBundle/Security/SAML/Store/EntityDescriptorStore.php
@@ -6,7 +6,7 @@ use LightSaml\Model\Metadata\EntityDescriptor;
 use LightSaml\Store\EntityDescriptor\EntityDescriptorStoreInterface;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 
-class EntityDescriptorStore implements EntityDescriptorStoreInterface
+final class EntityDescriptorStore implements EntityDescriptorStoreInterface
 {
     private ?EntityDescriptor $entityDescriptor = null;
 

--- a/app/bundles/UserBundle/Security/SAML/Store/IdStore.php
+++ b/app/bundles/UserBundle/Security/SAML/Store/IdStore.php
@@ -7,7 +7,7 @@ use LightSaml\Provider\TimeProvider\TimeProviderInterface;
 use LightSaml\Store\Id\IdStoreInterface;
 use Mautic\UserBundle\Entity\IdEntry;
 
-class IdStore implements IdStoreInterface
+final class IdStore implements IdStoreInterface
 {
     public function __construct(
         private readonly EntityManagerInterface $manager,

--- a/app/bundles/UserBundle/Security/SAML/Store/Request/RequestStateStore.php
+++ b/app/bundles/UserBundle/Security/SAML/Store/Request/RequestStateStore.php
@@ -8,7 +8,7 @@ use LightSaml\State\Request\RequestState;
 use LightSaml\Store\Request\AbstractRequestStateArrayStore;
 use Mautic\CacheBundle\Cache\CacheProviderInterface;
 
-class RequestStateStore extends AbstractRequestStateArrayStore
+final class RequestStateStore extends AbstractRequestStateArrayStore
 {
     private readonly string $prefix;
 

--- a/app/bundles/UserBundle/Security/SAML/Store/TrustOptionsStore.php
+++ b/app/bundles/UserBundle/Security/SAML/Store/TrustOptionsStore.php
@@ -6,7 +6,7 @@ use LightSaml\Meta\TrustOptions\TrustOptions;
 use LightSaml\Store\TrustOptions\TrustOptionsStoreInterface;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 
-class TrustOptionsStore implements TrustOptionsStoreInterface
+final class TrustOptionsStore implements TrustOptionsStoreInterface
 {
     private ?TrustOptions $trustOptions = null;
 

--- a/app/bundles/UserBundle/Security/SAML/User/UserCreator.php
+++ b/app/bundles/UserBundle/Security/SAML/User/UserCreator.php
@@ -12,7 +12,7 @@ use Mautic\UserBundle\Model\UserModel;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 
-class UserCreator implements UserCreatorInterface
+final class UserCreator implements UserCreatorInterface
 {
     private readonly int $defaultRole;
 

--- a/app/bundles/WebhookBundle/Notificator/WebhookFailureNotificator.php
+++ b/app/bundles/WebhookBundle/Notificator/WebhookFailureNotificator.php
@@ -8,7 +8,7 @@ use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\WebhookBundle\Entity\Webhook;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class WebhookFailureNotificator
+final class WebhookFailureNotificator
 {
     public function __construct(
         private readonly WebhookNotificationSender $sender,

--- a/app/bundles/WebhookBundle/Notificator/WebhookNotificationSender.php
+++ b/app/bundles/WebhookBundle/Notificator/WebhookNotificationSender.php
@@ -16,7 +16,7 @@ use Mautic\WebhookBundle\Event\WebhookNotificationEvent;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Twig\Environment;
 
-class WebhookNotificationSender
+final class WebhookNotificationSender
 {
     public function __construct(
         private readonly Environment $twig,

--- a/app/bundles/WebhookBundle/Security/Permissions/WebhookPermissions.php
+++ b/app/bundles/WebhookBundle/Security/Permissions/WebhookPermissions.php
@@ -5,7 +5,7 @@ namespace Mautic\WebhookBundle\Security\Permissions;
 use Mautic\CoreBundle\Security\Permissions\AbstractPermissions;
 use Symfony\Component\Form\FormBuilderInterface;
 
-class WebhookPermissions extends AbstractPermissions
+final class WebhookPermissions extends AbstractPermissions
 {
     /**
      * @param mixed[] $params

--- a/app/middlewares/CORSMiddleware.php
+++ b/app/middlewares/CORSMiddleware.php
@@ -6,7 +6,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
-class CORSMiddleware implements HttpKernelInterface, PrioritizedMiddlewareInterface
+final class CORSMiddleware implements HttpKernelInterface, PrioritizedMiddlewareInterface
 {
     use ConfigAwareTrait;
 

--- a/app/middlewares/CatchExceptionMiddleware.php
+++ b/app/middlewares/CatchExceptionMiddleware.php
@@ -7,14 +7,14 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
-class CatchExceptionMiddleware implements HttpKernelInterface, PrioritizedMiddlewareInterface
+final class CatchExceptionMiddleware implements HttpKernelInterface, PrioritizedMiddlewareInterface
 {
     public const PRIORITY = 100;
 
     /**
      * @var HttpKernelInterface
      */
-    protected $app;
+    private $app;
 
     public function __construct(HttpKernelInterface $app)
     {

--- a/app/middlewares/Dev/IpRestrictMiddleware.php
+++ b/app/middlewares/Dev/IpRestrictMiddleware.php
@@ -8,7 +8,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
-class IpRestrictMiddleware implements HttpKernelInterface, PrioritizedMiddlewareInterface
+final class IpRestrictMiddleware implements HttpKernelInterface, PrioritizedMiddlewareInterface
 {
     use ConfigAwareTrait;
 

--- a/app/middlewares/HSTSMiddleware.php
+++ b/app/middlewares/HSTSMiddleware.php
@@ -8,7 +8,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
-class HSTSMiddleware implements HttpKernelInterface, PrioritizedMiddlewareInterface
+final class HSTSMiddleware implements HttpKernelInterface, PrioritizedMiddlewareInterface
 {
     use ConfigAwareTrait;
 

--- a/app/middlewares/MiddlewareBuilder.php
+++ b/app/middlewares/MiddlewareBuilder.php
@@ -4,7 +4,7 @@ namespace Mautic\Middleware;
 
 use Mautic\CoreBundle\Cache\MiddlewareCacheWarmer;
 
-class MiddlewareBuilder
+final class MiddlewareBuilder
 {
     private \AppKernel $app;
 

--- a/app/middlewares/StackedHttpKernel.php
+++ b/app/middlewares/StackedHttpKernel.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpKernel\TerminableInterface;
  * @see https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21StackMiddleware%21StackedHttpKernel.php/class/StackedHttpKernel/11.x
  * @see \Drupal\Core\DependencyInjection\Compiler\StackedKernelPass
  */
-class StackedHttpKernel implements HttpKernelInterface, TerminableInterface
+final class StackedHttpKernel implements HttpKernelInterface, TerminableInterface
 {
     /**
      * The decorated kernel.

--- a/app/middlewares/TrustMiddleware.php
+++ b/app/middlewares/TrustMiddleware.php
@@ -6,7 +6,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
-class TrustMiddleware implements HttpKernelInterface, PrioritizedMiddlewareInterface
+final class TrustMiddleware implements HttpKernelInterface, PrioritizedMiddlewareInterface
 {
     use ConfigAwareTrait;
 

--- a/app/middlewares/VersionCheckMiddleware.php
+++ b/app/middlewares/VersionCheckMiddleware.php
@@ -6,14 +6,14 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
-class VersionCheckMiddleware implements HttpKernelInterface, PrioritizedMiddlewareInterface
+final class VersionCheckMiddleware implements HttpKernelInterface, PrioritizedMiddlewareInterface
 {
     public const PRIORITY = 10;
 
     /**
      * @var HttpKernelInterface
      */
-    protected $app;
+    private $app;
 
     /**
      * @var string

--- a/app/migrations/Version20190326190241.php
+++ b/app/migrations/Version20190326190241.php
@@ -9,7 +9,7 @@ use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
 /**
  * Auto-generated Migration: Please modify to your needs!
  */
-class Version20190326190241 extends AbstractMauticMigration
+final class Version20190326190241 extends AbstractMauticMigration
 {
     /**
      * @throws SkipMigration

--- a/app/migrations/Version20190410143658.php
+++ b/app/migrations/Version20190410143658.php
@@ -6,7 +6,7 @@ use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\Exception\SkipMigration;
 use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
 
-class Version20190410143658 extends AbstractMauticMigration
+final class Version20190410143658 extends AbstractMauticMigration
 {
     /**
      * @throws \Doctrine\DBAL\Schema\SchemaException

--- a/app/migrations/Version20190524124819.php
+++ b/app/migrations/Version20190524124819.php
@@ -9,7 +9,7 @@ use Mautic\LeadBundle\Field\Helper\IndexHelper;
 /**
  * Auto-generated Migration: Please modify to your needs!
  */
-class Version20190524124819 extends PreUpAssertionMigration
+final class Version20190524124819 extends PreUpAssertionMigration
 {
     protected function preUpAssertions(): void
     {

--- a/app/migrations/Version20191106152509.php
+++ b/app/migrations/Version20191106152509.php
@@ -7,7 +7,7 @@ namespace Mautic\Migrations;
 use Doctrine\DBAL\Schema\Schema;
 use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
 
-class Version20191106152509 extends AbstractMauticMigration
+final class Version20191106152509 extends AbstractMauticMigration
 {
     public function up(Schema $schema): void
     {

--- a/app/migrations/Version20200513162918.php
+++ b/app/migrations/Version20200513162918.php
@@ -12,7 +12,7 @@ use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
 /**
  * Migration for removing online status.
  */
-class Version20200513162918 extends AbstractMauticMigration
+final class Version20200513162918 extends AbstractMauticMigration
 {
     /**
      * @throws SkipMigration

--- a/app/migrations/Version20220429091934.php
+++ b/app/migrations/Version20220429091934.php
@@ -8,7 +8,7 @@ use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\Table;
 use Mautic\CoreBundle\Doctrine\PreUpAssertionMigration;
 
-class Version20220429091934 extends PreUpAssertionMigration
+final class Version20220429091934 extends PreUpAssertionMigration
 {
     private const SIGNED   = 'SIGNED';
 

--- a/app/migrations/Version20231207235400.php
+++ b/app/migrations/Version20231207235400.php
@@ -6,7 +6,7 @@ use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\Exception\SkipMigration;
 use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
 
-class Version20231207235400 extends AbstractMauticMigration
+final class Version20231207235400 extends AbstractMauticMigration
 {
     public function preUp(Schema $schema): void
     {

--- a/app/migrations/Version20250804003400.php
+++ b/app/migrations/Version20250804003400.php
@@ -8,7 +8,7 @@ use Doctrine\DBAL\Schema\Schema;
 use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
 use Mautic\LeadBundle\Segment\OperatorOptions;
 
-class Version20250804003400 extends AbstractMauticMigration
+final class Version20250804003400 extends AbstractMauticMigration
 {
     private string $leadListsTable;
 

--- a/plugins/GrapesJsBuilderBundle/Helper/FileManager.php
+++ b/plugins/GrapesJsBuilderBundle/Helper/FileManager.php
@@ -13,7 +13,7 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 
-class FileManager
+final class FileManager
 {
     public const GRAPESJS_IMAGES_DIRECTORY = '';
 

--- a/plugins/GrapesJsBuilderBundle/InstallFixtures/ORM/GrapesJsData.php
+++ b/plugins/GrapesJsBuilderBundle/InstallFixtures/ORM/GrapesJsData.php
@@ -12,7 +12,7 @@ use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\PluginBundle\Entity\Integration;
 use Mautic\PluginBundle\Entity\Plugin;
 
-class GrapesJsData extends AbstractFixture implements OrderedFixtureInterface, FixtureGroupInterface
+final class GrapesJsData extends AbstractFixture implements OrderedFixtureInterface, FixtureGroupInterface
 {
     public function __construct(
         private readonly CoreParametersHelper $coreParametersHelper,

--- a/plugins/GrapesJsBuilderBundle/Integration/Support/BuilderSupport.php
+++ b/plugins/GrapesJsBuilderBundle/Integration/Support/BuilderSupport.php
@@ -7,7 +7,7 @@ namespace MauticPlugin\GrapesJsBuilderBundle\Integration\Support;
 use Mautic\IntegrationsBundle\Integration\Interfaces\BuilderInterface;
 use MauticPlugin\GrapesJsBuilderBundle\Integration\GrapesJsBuilderIntegration;
 
-class BuilderSupport extends GrapesJsBuilderIntegration implements BuilderInterface
+final class BuilderSupport extends GrapesJsBuilderIntegration implements BuilderInterface
 {
     /**
      * @var string[]

--- a/plugins/GrapesJsBuilderBundle/Integration/Support/ConfigSupport.php
+++ b/plugins/GrapesJsBuilderBundle/Integration/Support/ConfigSupport.php
@@ -8,7 +8,7 @@ use Mautic\IntegrationsBundle\Integration\DefaultConfigFormTrait;
 use Mautic\IntegrationsBundle\Integration\Interfaces\ConfigFormInterface;
 use MauticPlugin\GrapesJsBuilderBundle\Integration\GrapesJsBuilderIntegration;
 
-class ConfigSupport extends GrapesJsBuilderIntegration implements ConfigFormInterface
+final class ConfigSupport extends GrapesJsBuilderIntegration implements ConfigFormInterface
 {
     use DefaultConfigFormTrait;
 }

--- a/plugins/MauticClearbitBundle/Services/Clearbit_Company.php
+++ b/plugins/MauticClearbitBundle/Services/Clearbit_Company.php
@@ -5,7 +5,7 @@ namespace MauticPlugin\MauticClearbitBundle\Services;
 /**
  * This class handles everything related to the Company lookup API.
  */
-class Clearbit_Company extends Clearbit_Base
+final class Clearbit_Company extends Clearbit_Base
 {
     public function __construct($api_key)
     {

--- a/plugins/MauticClearbitBundle/Services/Clearbit_Person.php
+++ b/plugins/MauticClearbitBundle/Services/Clearbit_Person.php
@@ -5,7 +5,7 @@ namespace MauticPlugin\MauticClearbitBundle\Services;
 /**
  * This class handles everything related to the Person lookup API.
  */
-class Clearbit_Person extends Clearbit_Base
+final class Clearbit_Person extends Clearbit_Base
 {
     protected $_resourceUri = '/people/find';
 

--- a/plugins/MauticCloudStorageBundle/Integration/AmazonS3Integration.php
+++ b/plugins/MauticCloudStorageBundle/Integration/AmazonS3Integration.php
@@ -13,7 +13,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilder;
 
-class AmazonS3Integration extends CloudStorageIntegration
+final class AmazonS3Integration extends CloudStorageIntegration
 {
     private ?ResolvableFilesystem $fileSystem = null;
 

--- a/plugins/MauticCrmBundle/Api/DynamicsApi.php
+++ b/plugins/MauticCrmBundle/Api/DynamicsApi.php
@@ -6,7 +6,7 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\PluginBundle\Exception\ApiErrorException;
 use Psr\Http\Message\ResponseInterface;
 
-class DynamicsApi extends CrmApi
+final class DynamicsApi extends CrmApi
 {
     private function getUrl(): string
     {

--- a/plugins/MauticCrmBundle/Api/HubspotApi.php
+++ b/plugins/MauticCrmBundle/Api/HubspotApi.php
@@ -9,7 +9,7 @@ use MauticPlugin\MauticCrmBundle\Integration\HubspotIntegration;
 /**
  * @property HubspotIntegration $integration
  */
-class HubspotApi extends CrmApi
+final class HubspotApi extends CrmApi
 {
     protected $requestSettings = [
         'encode_parameters' => 'json',

--- a/plugins/MauticCrmBundle/Api/Salesforce/Helper/RequestUrl.php
+++ b/plugins/MauticCrmBundle/Api/Salesforce/Helper/RequestUrl.php
@@ -2,7 +2,7 @@
 
 namespace MauticPlugin\MauticCrmBundle\Api\Salesforce\Helper;
 
-class RequestUrl
+final class RequestUrl
 {
     /**
      * Correctly generate the URL based on given URL parts.

--- a/plugins/MauticCrmBundle/Api/SalesforceApi.php
+++ b/plugins/MauticCrmBundle/Api/SalesforceApi.php
@@ -13,7 +13,7 @@ use MauticPlugin\MauticCrmBundle\Integration\SalesforceIntegration;
 /**
  * @property SalesforceIntegration $integration
  */
-class SalesforceApi extends CrmApi
+final class SalesforceApi extends CrmApi
 {
     /**
      * This regular expression parses missing field's name from the error message.

--- a/plugins/MauticCrmBundle/Api/SugarcrmApi.php
+++ b/plugins/MauticCrmBundle/Api/SugarcrmApi.php
@@ -8,7 +8,7 @@ use MauticPlugin\MauticCrmBundle\Integration\SugarcrmIntegration;
 /**
  * @property SugarcrmIntegration $integration
  */
-class SugarcrmApi extends CrmApi
+final class SugarcrmApi extends CrmApi
 {
     protected $object = 'Leads';
 

--- a/plugins/MauticCrmBundle/Api/VtigerApi.php
+++ b/plugins/MauticCrmBundle/Api/VtigerApi.php
@@ -4,7 +4,7 @@ namespace MauticPlugin\MauticCrmBundle\Api;
 
 use Mautic\PluginBundle\Exception\ApiErrorException;
 
-class VtigerApi extends CrmApi
+final class VtigerApi extends CrmApi
 {
     protected $element = 'Leads';
 

--- a/plugins/MauticCrmBundle/Api/Zoho/Mapper.php
+++ b/plugins/MauticCrmBundle/Api/Zoho/Mapper.php
@@ -4,7 +4,7 @@ namespace MauticPlugin\MauticCrmBundle\Api\Zoho;
 
 use MauticPlugin\MauticCrmBundle\Api\Zoho\Exception\MatchingKeyNotFoundException;
 
-class Mapper
+final class Mapper
 {
     private array $contact = [];
 

--- a/plugins/MauticCrmBundle/Api/ZohoApi.php
+++ b/plugins/MauticCrmBundle/Api/ZohoApi.php
@@ -4,7 +4,7 @@ namespace MauticPlugin\MauticCrmBundle\Api;
 
 use Mautic\PluginBundle\Exception\ApiErrorException;
 
-class ZohoApi extends CrmApi
+final class ZohoApi extends CrmApi
 {
     /**
      * @param string $operation

--- a/plugins/MauticCrmBundle/Integration/Salesforce/CampaignMember/Fetcher.php
+++ b/plugins/MauticCrmBundle/Integration/Salesforce/CampaignMember/Fetcher.php
@@ -10,7 +10,7 @@ use MauticPlugin\MauticCrmBundle\Integration\Salesforce\Object\Contact;
 use MauticPlugin\MauticCrmBundle\Integration\Salesforce\Object\Lead;
 use MauticPlugin\MauticCrmBundle\Integration\Salesforce\QueryBuilder;
 
-class Fetcher
+final class Fetcher
 {
     private array $leads = [];
 

--- a/plugins/MauticCrmBundle/Integration/Salesforce/CampaignMember/Organizer.php
+++ b/plugins/MauticCrmBundle/Integration/Salesforce/CampaignMember/Organizer.php
@@ -5,7 +5,7 @@ namespace MauticPlugin\MauticCrmBundle\Integration\Salesforce\CampaignMember;
 use MauticPlugin\MauticCrmBundle\Integration\Salesforce\Object\Contact;
 use MauticPlugin\MauticCrmBundle\Integration\Salesforce\Object\Lead;
 
-class Organizer
+final class Organizer
 {
     /**
      * @var array<string, Lead>

--- a/plugins/MauticCrmBundle/Integration/Salesforce/Object/CampaignMember.php
+++ b/plugins/MauticCrmBundle/Integration/Salesforce/Object/CampaignMember.php
@@ -2,7 +2,7 @@
 
 namespace MauticPlugin\MauticCrmBundle\Integration\Salesforce\Object;
 
-class CampaignMember
+final class CampaignMember
 {
     public const OBJECT = 'CampaignMember';
 }

--- a/plugins/MauticCrmBundle/Integration/Salesforce/Object/Contact.php
+++ b/plugins/MauticCrmBundle/Integration/Salesforce/Object/Contact.php
@@ -2,7 +2,7 @@
 
 namespace MauticPlugin\MauticCrmBundle\Integration\Salesforce\Object;
 
-class Contact
+final class Contact
 {
     public const OBJECT = 'Contact';
 

--- a/plugins/MauticCrmBundle/Integration/Salesforce/Object/Lead.php
+++ b/plugins/MauticCrmBundle/Integration/Salesforce/Object/Lead.php
@@ -2,7 +2,7 @@
 
 namespace MauticPlugin\MauticCrmBundle\Integration\Salesforce\Object;
 
-class Lead
+final class Lead
 {
     public const OBJECT = 'Lead';
 

--- a/plugins/MauticCrmBundle/Integration/Salesforce/QueryBuilder.php
+++ b/plugins/MauticCrmBundle/Integration/Salesforce/QueryBuilder.php
@@ -4,7 +4,7 @@ namespace MauticPlugin\MauticCrmBundle\Integration\Salesforce;
 
 use MauticPlugin\MauticCrmBundle\Integration\Salesforce\Exception\NoObjectsToFetchException;
 
-class QueryBuilder
+final class QueryBuilder
 {
     /**
      * @throws NoObjectsToFetchException

--- a/plugins/MauticCrmBundle/Integration/Salesforce/ResultsPaginator.php
+++ b/plugins/MauticCrmBundle/Integration/Salesforce/ResultsPaginator.php
@@ -5,7 +5,7 @@ namespace MauticPlugin\MauticCrmBundle\Integration\Salesforce;
 use Mautic\PluginBundle\Exception\ApiErrorException;
 use Psr\Log\LoggerInterface;
 
-class ResultsPaginator
+final class ResultsPaginator
 {
     /**
      * @var array

--- a/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
@@ -36,7 +36,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 /**
  * @extends CrmAbstractIntegration<SugarcrmApi>
  */
-class SugarcrmIntegration extends CrmAbstractIntegration
+final class SugarcrmIntegration extends CrmAbstractIntegration
 {
     private CompanyRepository $companyRepository;
 

--- a/plugins/MauticCrmBundle/Integration/ZohoIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/ZohoIntegration.php
@@ -19,7 +19,7 @@ use Symfony\Component\Form\FormBuilder;
 /**
  * @extends CrmAbstractIntegration<ZohoApi>
  */
-class ZohoIntegration extends CrmAbstractIntegration
+final class ZohoIntegration extends CrmAbstractIntegration
 {
     /**
      * Returns the name of the social integration that must match the name of the file.

--- a/plugins/MauticCrmBundle/Services/Transport.php
+++ b/plugins/MauticCrmBundle/Services/Transport.php
@@ -5,7 +5,7 @@ namespace MauticPlugin\MauticCrmBundle\Services;
 use GuzzleHttp\Client;
 use Psr\Http\Message\ResponseInterface;
 
-class Transport implements TransportInterface
+final class Transport implements TransportInterface
 {
     public function __construct(
         private readonly Client $client,

--- a/plugins/MauticEmailMarketingBundle/Api/ConstantContactApi.php
+++ b/plugins/MauticEmailMarketingBundle/Api/ConstantContactApi.php
@@ -4,7 +4,7 @@ namespace MauticPlugin\MauticEmailMarketingBundle\Api;
 
 use Mautic\PluginBundle\Exception\ApiErrorException;
 
-class ConstantContactApi extends EmailMarketingApi
+final class ConstantContactApi extends EmailMarketingApi
 {
     private string $version = 'v2';
 

--- a/plugins/MauticEmailMarketingBundle/Api/IcontactApi.php
+++ b/plugins/MauticEmailMarketingBundle/Api/IcontactApi.php
@@ -4,7 +4,7 @@ namespace MauticPlugin\MauticEmailMarketingBundle\Api;
 
 use Mautic\PluginBundle\Exception\ApiErrorException;
 
-class IcontactApi extends EmailMarketingApi
+final class IcontactApi extends EmailMarketingApi
 {
     protected function request($endpoint, $parameters = [], $method = 'GET')
     {

--- a/plugins/MauticEmailMarketingBundle/Api/MailchimpApi.php
+++ b/plugins/MauticEmailMarketingBundle/Api/MailchimpApi.php
@@ -4,7 +4,7 @@ namespace MauticPlugin\MauticEmailMarketingBundle\Api;
 
 use Mautic\PluginBundle\Exception\ApiErrorException;
 
-class MailchimpApi extends EmailMarketingApi
+final class MailchimpApi extends EmailMarketingApi
 {
     private string $version = '3.0';
 

--- a/plugins/MauticEmailMarketingBundle/Integration/ConstantContactIntegration.php
+++ b/plugins/MauticEmailMarketingBundle/Integration/ConstantContactIntegration.php
@@ -4,7 +4,7 @@ namespace MauticPlugin\MauticEmailMarketingBundle\Integration;
 
 use MauticPlugin\MauticEmailMarketingBundle\Form\Type\ConstantContactType;
 
-class ConstantContactIntegration extends EmailAbstractIntegration
+final class ConstantContactIntegration extends EmailAbstractIntegration
 {
     public function getName(): string
     {

--- a/plugins/MauticEmailMarketingBundle/Integration/IcontactIntegration.php
+++ b/plugins/MauticEmailMarketingBundle/Integration/IcontactIntegration.php
@@ -4,7 +4,7 @@ namespace MauticPlugin\MauticEmailMarketingBundle\Integration;
 
 use MauticPlugin\MauticEmailMarketingBundle\Form\Type\IcontactType;
 
-class IcontactIntegration extends EmailAbstractIntegration
+final class IcontactIntegration extends EmailAbstractIntegration
 {
     public function getName(): string
     {

--- a/plugins/MauticEmailMarketingBundle/Integration/MailchimpIntegration.php
+++ b/plugins/MauticEmailMarketingBundle/Integration/MailchimpIntegration.php
@@ -4,7 +4,7 @@ namespace MauticPlugin\MauticEmailMarketingBundle\Integration;
 
 use MauticPlugin\MauticEmailMarketingBundle\Form\Type\MailchimpType;
 
-class MailchimpIntegration extends EmailAbstractIntegration
+final class MailchimpIntegration extends EmailAbstractIntegration
 {
     public function getName(): string
     {

--- a/plugins/MauticFocusBundle/FocusEventTypes.php
+++ b/plugins/MauticFocusBundle/FocusEventTypes.php
@@ -2,7 +2,7 @@
 
 namespace MauticPlugin\MauticFocusBundle;
 
-class FocusEventTypes
+final class FocusEventTypes
 {
     /**
      * The focus.on_open event type is used for event dispatched when an focus is opened.

--- a/plugins/MauticFocusBundle/Security/Permissions/FocusPermissions.php
+++ b/plugins/MauticFocusBundle/Security/Permissions/FocusPermissions.php
@@ -5,7 +5,7 @@ namespace MauticPlugin\MauticFocusBundle\Security\Permissions;
 use Mautic\CoreBundle\Security\Permissions\AbstractPermissions;
 use Symfony\Component\Form\FormBuilderInterface;
 
-class FocusPermissions extends AbstractPermissions
+final class FocusPermissions extends AbstractPermissions
 {
     /**
      * @param mixed[] $params

--- a/plugins/MauticFullContactBundle/Services/FullContact_Batch.php
+++ b/plugins/MauticFullContactBundle/Services/FullContact_Batch.php
@@ -11,7 +11,7 @@ use MauticPlugin\MauticFullContactBundle\Exception\NotImplementedException;
  * @author   Adam Curtis <me@alc.im>
  * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache
  */
-class FullContact_Batch extends FullContact_Base
+final class FullContact_Batch extends FullContact_Base
 {
     protected $_resourceUri = '/batch.json';
 

--- a/plugins/MauticFullContactBundle/Services/FullContact_Company.php
+++ b/plugins/MauticFullContactBundle/Services/FullContact_Company.php
@@ -8,7 +8,7 @@ namespace MauticPlugin\MauticFullContactBundle\Services;
  * @author   Adam Curtis <me@alc.im>
  * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache
  */
-class FullContact_Company extends FullContact_Base
+final class FullContact_Company extends FullContact_Base
 {
     /**
      * Supported lookup methods.

--- a/plugins/MauticFullContactBundle/Services/FullContact_Icon.php
+++ b/plugins/MauticFullContactBundle/Services/FullContact_Icon.php
@@ -8,7 +8,7 @@ namespace MauticPlugin\MauticFullContactBundle\Services;
  * @author   Keith Casey <contrib@caseysoftware.com>
  * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache
  */
-class FullContact_Icon extends FullContact_Base
+final class FullContact_Icon extends FullContact_Base
 {
     protected $_supportedMethods = ['available'];
 

--- a/plugins/MauticFullContactBundle/Services/FullContact_Location.php
+++ b/plugins/MauticFullContactBundle/Services/FullContact_Location.php
@@ -8,7 +8,7 @@ namespace MauticPlugin\MauticFullContactBundle\Services;
  * @author   Keith Casey <contrib@caseysoftware.com>
  * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache
  */
-class FullContact_Location extends FullContact_Base
+final class FullContact_Location extends FullContact_Base
 {
     /**
      * Supported lookup methods.

--- a/plugins/MauticFullContactBundle/Services/FullContact_Name.php
+++ b/plugins/MauticFullContactBundle/Services/FullContact_Name.php
@@ -8,7 +8,7 @@ namespace MauticPlugin\MauticFullContactBundle\Services;
  * @author   Keith Casey <contrib@caseysoftware.com>
  * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache
  */
-class FullContact_Name extends FullContact_Base
+final class FullContact_Name extends FullContact_Base
 {
     /**
      * Supported lookup methods.

--- a/plugins/MauticFullContactBundle/Services/FullContact_Person.php
+++ b/plugins/MauticFullContactBundle/Services/FullContact_Person.php
@@ -8,7 +8,7 @@ namespace MauticPlugin\MauticFullContactBundle\Services;
  * @author   Keith Casey <contrib@caseysoftware.com>
  * @license  http://www.apache.org/licenses/LICENSE-2.0 Apache
  */
-class FullContact_Person extends FullContact_Base
+final class FullContact_Person extends FullContact_Base
 {
     /**
      * Supported lookup methods.

--- a/plugins/MauticGmailBundle/Integration/GmailIntegration.php
+++ b/plugins/MauticGmailBundle/Integration/GmailIntegration.php
@@ -4,7 +4,7 @@ namespace MauticPlugin\MauticGmailBundle\Integration;
 
 use Mautic\PluginBundle\Integration\AbstractIntegration;
 
-class GmailIntegration extends AbstractIntegration
+final class GmailIntegration extends AbstractIntegration
 {
     public function getName(): string
     {

--- a/plugins/MauticOutlookBundle/Integration/OutlookIntegration.php
+++ b/plugins/MauticOutlookBundle/Integration/OutlookIntegration.php
@@ -5,7 +5,7 @@ namespace MauticPlugin\MauticOutlookBundle\Integration;
 use Mautic\CoreBundle\Helper\UrlHelper;
 use Mautic\PluginBundle\Integration\AbstractIntegration;
 
-class OutlookIntegration extends AbstractIntegration
+final class OutlookIntegration extends AbstractIntegration
 {
     public function getName(): string
     {

--- a/plugins/MauticSocialBundle/Integration/FacebookIntegration.php
+++ b/plugins/MauticSocialBundle/Integration/FacebookIntegration.php
@@ -4,7 +4,7 @@ namespace MauticPlugin\MauticSocialBundle\Integration;
 
 use MauticPlugin\MauticSocialBundle\Form\Type\FacebookType;
 
-class FacebookIntegration extends SocialIntegration
+final class FacebookIntegration extends SocialIntegration
 {
     public function getName(): string
     {

--- a/plugins/MauticSocialBundle/Integration/FoursquareIntegration.php
+++ b/plugins/MauticSocialBundle/Integration/FoursquareIntegration.php
@@ -2,7 +2,7 @@
 
 namespace MauticPlugin\MauticSocialBundle\Integration;
 
-class FoursquareIntegration extends SocialIntegration
+final class FoursquareIntegration extends SocialIntegration
 {
     public function getName(): string
     {

--- a/plugins/MauticSocialBundle/Integration/InstagramIntegration.php
+++ b/plugins/MauticSocialBundle/Integration/InstagramIntegration.php
@@ -2,7 +2,7 @@
 
 namespace MauticPlugin\MauticSocialBundle\Integration;
 
-class InstagramIntegration extends SocialIntegration
+final class InstagramIntegration extends SocialIntegration
 {
     public function getName(): string
     {

--- a/plugins/MauticSocialBundle/Integration/TwitterIntegration.php
+++ b/plugins/MauticSocialBundle/Integration/TwitterIntegration.php
@@ -4,7 +4,7 @@ namespace MauticPlugin\MauticSocialBundle\Integration;
 
 use MauticPlugin\MauticSocialBundle\Form\Type\TwitterType;
 
-class TwitterIntegration extends SocialIntegration
+final class TwitterIntegration extends SocialIntegration
 {
     public const NAME = 'Twitter';
 

--- a/plugins/MauticSocialBundle/Model/MonitoringModel.php
+++ b/plugins/MauticSocialBundle/Model/MonitoringModel.php
@@ -19,7 +19,7 @@ use Symfony\Contracts\Service\Attribute\Required;
 /**
  * @extends FormModel<Monitoring>
  */
-class MonitoringModel extends FormModel
+final class MonitoringModel extends FormModel
 {
     private MonitoringRepository $monitoringRepository;
 

--- a/plugins/MauticSocialBundle/Model/PostCountModel.php
+++ b/plugins/MauticSocialBundle/Model/PostCountModel.php
@@ -10,7 +10,7 @@ use Symfony\Contracts\Service\Attribute\Required;
 /**
  * @extends AbstractCommonModel<PostCount>
  */
-class PostCountModel extends AbstractCommonModel
+final class PostCountModel extends AbstractCommonModel
 {
     private PostCountRepository $postCountRepository;
 

--- a/plugins/MauticSocialBundle/Model/TweetModel.php
+++ b/plugins/MauticSocialBundle/Model/TweetModel.php
@@ -23,7 +23,7 @@ use Symfony\Contracts\Service\Attribute\Required;
  *
  * @implements AjaxLookupModelInterface<Tweet>
  */
-class TweetModel extends FormModel implements AjaxLookupModelInterface
+final class TweetModel extends FormModel implements AjaxLookupModelInterface
 {
     private TweetStatRepository $tweetStatRepository;
 

--- a/plugins/MauticSocialBundle/Security/Permissions/MauticSocialPermissions.php
+++ b/plugins/MauticSocialBundle/Security/Permissions/MauticSocialPermissions.php
@@ -5,7 +5,7 @@ namespace MauticPlugin\MauticSocialBundle\Security\Permissions;
 use Mautic\CoreBundle\Security\Permissions\AbstractPermissions;
 use Symfony\Component\Form\FormBuilderInterface;
 
-class MauticSocialPermissions extends AbstractPermissions
+final class MauticSocialPermissions extends AbstractPermissions
 {
     /**
      * @param mixed[] $params

--- a/plugins/MauticTagManagerBundle/Model/TagModel.php
+++ b/plugins/MauticTagManagerBundle/Model/TagModel.php
@@ -12,7 +12,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Contracts\Service\Attribute\Required;
 
-class TagModel extends BaseTagModel implements GlobalSearchInterface
+final class TagModel extends BaseTagModel implements GlobalSearchInterface
 {
     private TagRepository $tagRepository;
 

--- a/plugins/MauticTagManagerBundle/Stats/TagDependencies.php
+++ b/plugins/MauticTagManagerBundle/Stats/TagDependencies.php
@@ -11,7 +11,7 @@ use Mautic\LeadBundle\Model\ListModel;
 use Mautic\PointBundle\Model\TriggerEventModel;
 use Mautic\ReportBundle\Model\ReportModel;
 
-class TagDependencies
+final class TagDependencies
 {
     public function __construct(
         private readonly CampaignModel $campaignModel,


### PR DESCRIPTION
## Description

Adds `final` to 744 classes in `app/` and `plugins/` that have no subclass anywhere in the repository.

**This PR is being split by class kind so each piece is reviewable on its own.** It stays open as a tracker; please review the slices below rather than this diff.

| PR | Scope | Files |
| --- | --- | --- |
| #16881 | Controllers | 37 |
| #16882 | Repositories | 30 |
| #16883 | Helpers | 73 |
| #16884 | DI extensions | 74 |
| #16885 | Console commands | 52 |
| #16886 | Test support classes | 23 |
| #16887 | Validators and constraints | 20 |
| #16888 | DAO and DTO classes | 23 |

That accounts for 332 classes. The remainder (models, event listeners, integrations, form types, and so on) will follow as further slices.

## Rationale

Making the absence of inheritance explicit prevents accidental extension, and lets PHPStan reason precisely about these types — it can narrow return types and spot dead members once it knows a class cannot be extended.

The change is mechanical:

```diff
-class RequestHelper
+final class RequestHelper
 {
     public static function hasBasicAuth(Request $request): bool
```

Where a class became final, `php-cs-fixer`'s `protected_to_private` rule then narrowed members a subclass could no longer reach. That is the only non-`final` edit in the series.

## Scope

Abstract classes are never candidates, and the `Common*` base classes are excluded because they do have children.

## Safety

- **Doctrine**: no mapped entity is finalized — only repositories and plain data holders under `Entity/`. Proxy generation is unaffected.
- **PHPUnit**: no class mocked anywhere in the test suite is finalized, so no `createMock()` call breaks.
- **DI**: the only `lazy: true` services are firewall listeners in `app/config/security.php`; none are among the finalized classes.

21 classes were left non-final because finalizing them let PHPStan prove pre-existing dead code that inheritance had been masking — unused return types, write-only properties, an unused method. Those findings look genuine, but fixing them means semantic edits, so they are left for a follow-up.

## Notes

Found with [recongo](https://github.com/TomasVotruba/recongo), a PHP parser and refactoring tool written in Go, via its `finalize-classes-without-children` rule. `app/` and `plugins/` were scanned together so that a plugin extending a core class keeps that class open. `themes/` was not scanned.
