### PR TITLE
[di] flip event listeners to subscribers, fix ExceptionListener double registration

### DIFF
--- a/app/bundles/ApiBundle/Config/services.php
+++ b/app/bundles/ApiBundle/Config/services.php
@@ -26,8 +26,7 @@ return function (ContainerConfigurator $configurator): void {
     $services->load('Mautic\\ApiBundle\\Entity\\oAuth2\\', '../Entity/oAuth2/*Repository.php');
     $services->set('mautic.api.helper.entity_result', Mautic\ApiBundle\Helper\EntityResultHelper::class);
 
-    $services->set(Mautic\ApiBundle\EventListener\PreAuthorizationEventListener::class)
-        ->tag('kernel.event_listener', ['event' => 'fos_oauth_server.pre_authorization_process', 'method' => 'onPreAuthorizationProcess'])->tag('kernel.event_listener', ['event' => 'fos_oauth_server.post_authorization_process', 'method' => 'onPostAuthorizationProcess']);
+    $services->set(Mautic\ApiBundle\EventListener\PreAuthorizationEventListener::class);
 
     $services->set('mautic.validator.oauthcallback', Mautic\ApiBundle\Form\Validator\Constraints\OAuthCallbackValidator::class)->tag('validator.constraint_validator');
     $services->set('mautic.api.security.voter.permission', Mautic\ApiBundle\Security\Voter\ApiPermissionVoter::class)->tag('security.voter');

--- a/app/bundles/ApiBundle/EventListener/PreAuthorizationEventListener.php
+++ b/app/bundles/ApiBundle/EventListener/PreAuthorizationEventListener.php
@@ -7,10 +7,11 @@ use FOS\OAuthServerBundle\Event\OAuthEvent;
 use Mautic\ApiBundle\Entity\oAuth2\Client;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\UserBundle\Entity\UserRepository;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class PreAuthorizationEventListener
+class PreAuthorizationEventListener implements EventSubscriberInterface
 {
     public function __construct(
         private readonly EntityManagerInterface $em,
@@ -18,6 +19,17 @@ class PreAuthorizationEventListener
         private readonly CorePermissions $mauticSecurity,
         private readonly TranslatorInterface $translator,
     ) {
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            OAuthEvent::PRE_AUTHORIZATION_PROCESS  => 'onPreAuthorizationProcess',
+            OAuthEvent::POST_AUTHORIZATION_PROCESS => 'onPostAuthorizationProcess',
+        ];
     }
 
     /**

--- a/app/bundles/CoreBundle/Config/services.php
+++ b/app/bundles/CoreBundle/Config/services.php
@@ -170,8 +170,7 @@ return function (ContainerConfigurator $configurator): void {
     $services->alias(Mautic\CoreBundle\Security\Permissions\CorePermissions::class, 'mautic.security');
 
     $services->set('mautic.exception.listener', Mautic\CoreBundle\EventListener\ExceptionListener::class)
-        ->arg('$controller', 'Mautic\CoreBundle\Controller\ExceptionController::showAction')
-        ->tag('kernel.event_listener', ['event' => 'kernel.exception', 'method' => 'onKernelException', 'priority' => 253]);
+        ->arg('$controller', 'Mautic\CoreBundle\Controller\ExceptionController::showAction');
 
     $services->alias(Mautic\CoreBundle\EventListener\ExceptionListener::class, 'mautic.exception.listener');
     $services->set('mautic.helper.cookie', Mautic\CoreBundle\Helper\CookieHelper::class)

--- a/app/bundles/CoreBundle/EventListener/ExceptionListener.php
+++ b/app/bundles/CoreBundle/EventListener/ExceptionListener.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpKernel\EventListener\ErrorListener;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -25,6 +26,24 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 class ExceptionListener extends ErrorListener
 {
+    /**
+     * Mautic handles the exception well before the Symfony error listener does, so onKernelException runs
+     * at a high priority instead of the -128 the parent asks for.
+     *
+     * @return array<string, mixed>
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::CONTROLLER_ARGUMENTS => 'onControllerArguments',
+            KernelEvents::EXCEPTION            => [
+                ['logKernelException', 0],
+                ['onKernelException', 253],
+            ],
+            KernelEvents::RESPONSE             => ['removeCspHeader', -128],
+        ];
+    }
+
     /**
      * @param string|object|mixed[]|null $controller
      */

--- a/app/bundles/CoreBundle/Tests/Functional/DependencyInjection/EventSubscriberSmokeTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/DependencyInjection/EventSubscriberSmokeTest.php
@@ -51,6 +51,12 @@ final class EventSubscriberSmokeTest extends AbstractContainerSmokeTestCase
         'kernel.controller' => [
             \Mautic\IntegrationsBundle\EventListener\ControllerSubscriber::class,
         ],
+        \FOS\OAuthServerBundle\Event\OAuthEvent::PRE_AUTHORIZATION_PROCESS => [
+            \Mautic\ApiBundle\EventListener\PreAuthorizationEventListener::class,
+        ],
+        \FOS\OAuthServerBundle\Event\OAuthEvent::POST_AUTHORIZATION_PROCESS => [
+            \Mautic\ApiBundle\EventListener\PreAuthorizationEventListener::class,
+        ],
         'security.interactive_login' => [
             \Mautic\CoreBundle\EventListener\CoreSubscriber::class,
         ],

--- a/app/bundles/FormBundle/Config/services.php
+++ b/app/bundles/FormBundle/Config/services.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 use Mautic\CoreBundle\DependencyInjection\MauticCoreExtension;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
 return function (ContainerConfigurator $configurator): void {
     $services = $configurator->services()
         ->defaults()

--- a/app/bundles/FormBundle/Config/services.php
+++ b/app/bundles/FormBundle/Config/services.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 use Mautic\CoreBundle\DependencyInjection\MauticCoreExtension;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
-
 return function (ContainerConfigurator $configurator): void {
     $services = $configurator->services()
         ->defaults()


### PR DESCRIPTION
Two event listeners are wired by hand in `services.php` even though the subscriber interface can carry the same wiring. This moves the event map into the class.

## PreAuthorizationEventListener

```diff
-$services->set(PreAuthorizationEventListener::class)
-    ->tag('kernel.event_listener', ['event' => 'fos_oauth_server.pre_authorization_process', 'method' => 'onPreAuthorizationProcess'])
-    ->tag('kernel.event_listener', ['event' => 'fos_oauth_server.post_authorization_process', 'method' => 'onPostAuthorizationProcess']);
+$services->set(PreAuthorizationEventListener::class);
```

The class already implemented `EventSubscriberInterface`; it just lacked `getSubscribedEvents()`, so it was a fatal error waiting on the next container build. It now names its events through the `OAuthEvent` constants rather than repeating the raw strings in config.

## ExceptionListener — fixes a double registration

This one was registered **twice**. It extends Symfony's `ErrorListener`, which implements `EventSubscriberInterface`, so autoconfiguration already tagged it `kernel.event_subscriber` — while `services.php` added an explicit `kernel.event_listener` tag on top:

```
mautic.exception.listener -> kernel.event_subscriber
                             kernel.event_listener event="kernel.exception" method="onKernelException" priority="253"
```

`onKernelException` therefore ran twice per exception: once at priority 253 and once at the parent's -128. It now overrides `getSubscribedEvents()` with the intended priority and runs once.