### PR TITLE
[phpstan] add rule against parent constructor forwarding, convert 8 classes to autowire*()

### DIFF
--- a/app/bundles/ApiBundle/Controller/ClientController.php
+++ b/app/bundles/ApiBundle/Controller/ClientController.php
@@ -2,45 +2,27 @@
 
 namespace Mautic\ApiBundle\Controller;
 
-use Doctrine\Persistence\ManagerRegistry;
 use Mautic\ApiBundle\Model\ClientModel;
 use Mautic\CoreBundle\Controller\AbstractStandardFormController;
-use Mautic\CoreBundle\Factory\ModelFactory;
 use Mautic\CoreBundle\Factory\PageHelperFactoryInterface;
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
-use Mautic\CoreBundle\Helper\UserHelper;
-use Mautic\CoreBundle\Security\Permissions\CorePermissions;
-use Mautic\CoreBundle\Service\FlashBag;
-use Mautic\CoreBundle\Translation\Translator;
-use Mautic\FormBundle\Helper\FormFieldHelper;
 use Mautic\UserBundle\Entity\User;
 use OAuth2\OAuth2;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Contracts\Service\Attribute\Required;
 
 final class ClientController extends AbstractStandardFormController
 {
-    public function __construct(
-        private readonly ClientModel $clientModel,
-        FormFactoryInterface $formFactory,
-        FormFieldHelper $fieldHelper,
-        ManagerRegistry $doctrine,
-        ModelFactory $modelFactory,
-        UserHelper $userHelper,
-        CoreParametersHelper $coreParametersHelper,
-        EventDispatcherInterface $dispatcher,
-        Translator $translator,
-        FlashBag $flashBag,
-        RequestStack $requestStack,
-        CorePermissions $security,
-    ) {
-        parent::__construct($formFactory, $fieldHelper, $doctrine, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security);
+    private ClientModel $clientModel;
+
+    #[Required]
+    public function autowireClientController(
+        ClientModel $clientModel,
+    ): void {
+        $this->clientModel = $clientModel;
     }
 
     /**

--- a/app/bundles/ApiBundle/Model/ClientModel.php
+++ b/app/bundles/ApiBundle/Model/ClientModel.php
@@ -2,27 +2,20 @@
 
 namespace Mautic\ApiBundle\Model;
 
-use Doctrine\ORM\EntityManagerInterface;
 use Mautic\ApiBundle\ApiEvents;
 use Mautic\ApiBundle\Entity\oAuth2\Client;
 use Mautic\ApiBundle\Entity\oAuth2\ClientRepository;
 use Mautic\ApiBundle\Event\ClientEvent;
 use Mautic\ApiBundle\Form\Type\ClientType;
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
-use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\CoreBundle\Model\FormModel;
 use Mautic\CoreBundle\Model\GlobalSearchInterface;
-use Mautic\CoreBundle\Security\Permissions\CorePermissions;
-use Mautic\CoreBundle\Translation\Translator;
 use Mautic\UserBundle\Entity\User;
-use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\EventDispatcher\Event;
+use Symfony\Contracts\Service\Attribute\Required;
 
 /**
  * @extends FormModel<Client>
@@ -38,19 +31,17 @@ class ClientModel extends FormModel implements GlobalSearchInterface
 
     private const DEFAULT_API_MODE = 'oauth2';
 
-    public function __construct(
-        private readonly RequestStack $requestStack,
-        EntityManagerInterface $em,
-        CorePermissions $security,
-        EventDispatcherInterface $dispatcher,
-        UrlGeneratorInterface $router,
-        Translator $translator,
-        UserHelper $userHelper,
-        LoggerInterface $mauticLogger,
-        CoreParametersHelper $coreParametersHelper,
-        private readonly ClientRepository $clientRepository,
-    ) {
-        parent::__construct($em, $security, $dispatcher, $router, $translator, $userHelper, $mauticLogger, $coreParametersHelper);
+    private RequestStack $requestStack;
+
+    private ClientRepository $clientRepository;
+
+    #[Required]
+    public function autowireClientModel(
+        RequestStack $requestStack,
+        ClientRepository $clientRepository,
+    ): void {
+        $this->requestStack     = $requestStack;
+        $this->clientRepository = $clientRepository;
     }
 
     private function getApiMode(): string

--- a/app/bundles/CampaignBundle/Controller/AjaxController.php
+++ b/app/bundles/CampaignBundle/Controller/AjaxController.php
@@ -15,44 +15,25 @@ use Symfony\Contracts\Service\Attribute\Required;
 
 final class AjaxController extends CommonAjaxController
 {
-<<<<<<< HEAD
-    public function __construct(
-        private readonly DateHelper $dateHelper,
-        private readonly EventLogModel $eventLogModel,
-        private readonly LeadModel $leadModel,
-        ManagerRegistry $doctrine,
-        ModelFactory $modelFactory,
-        UserHelper $userHelper,
-        CoreParametersHelper $coreParametersHelper,
-        EventDispatcherInterface $dispatcher,
-        Translator $translator,
-        FlashBag $flashBag,
-        RequestStack $requestStack,
-        CorePermissions $security,
-        private readonly LeadEventLogRepository $leadEventLogRepository,
-    ) {
-        parent::__construct($doctrine, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security);
-=======
     private DateHelper $dateHelper;
 
     private EventLogModel $eventLogModel;
 
     private LeadModel $leadModel;
 
-    private \Mautic\CampaignBundle\Entity\LeadEventLogRepository $leadEventLogRepository;
+    private LeadEventLogRepository $leadEventLogRepository;
 
     #[Required]
     public function autowireCampaignAjaxController(
         DateHelper $dateHelper,
         EventLogModel $eventLogModel,
         LeadModel $leadModel,
-        \Mautic\CampaignBundle\Entity\LeadEventLogRepository $leadEventLogRepository,
+        LeadEventLogRepository $leadEventLogRepository,
     ): void {
         $this->dateHelper             = $dateHelper;
         $this->eventLogModel          = $eventLogModel;
         $this->leadModel              = $leadModel;
         $this->leadEventLogRepository = $leadEventLogRepository;
->>>>>>> e346b540a8 ([phpstan] add rule to avoid ctor forwarding)
     }
 
     public function updateConnectionsAction(Request $request): JsonResponse

--- a/app/bundles/CampaignBundle/Controller/AjaxController.php
+++ b/app/bundles/CampaignBundle/Controller/AjaxController.php
@@ -2,27 +2,20 @@
 
 namespace Mautic\CampaignBundle\Controller;
 
-use Doctrine\Persistence\ManagerRegistry;
 use Mautic\CampaignBundle\Entity\LeadEventLog;
 use Mautic\CampaignBundle\Entity\LeadEventLogRepository;
 use Mautic\CampaignBundle\Model\EventLogModel;
 use Mautic\CoreBundle\Controller\AjaxController as CommonAjaxController;
-use Mautic\CoreBundle\Factory\ModelFactory;
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\InputHelper;
-use Mautic\CoreBundle\Helper\UserHelper;
-use Mautic\CoreBundle\Security\Permissions\CorePermissions;
-use Mautic\CoreBundle\Service\FlashBag;
-use Mautic\CoreBundle\Translation\Translator;
 use Mautic\CoreBundle\Twig\Helper\DateHelper;
 use Mautic\LeadBundle\Model\LeadModel;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Contracts\Service\Attribute\Required;
 
 final class AjaxController extends CommonAjaxController
 {
+<<<<<<< HEAD
     public function __construct(
         private readonly DateHelper $dateHelper,
         private readonly EventLogModel $eventLogModel,
@@ -39,6 +32,27 @@ final class AjaxController extends CommonAjaxController
         private readonly LeadEventLogRepository $leadEventLogRepository,
     ) {
         parent::__construct($doctrine, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security);
+=======
+    private DateHelper $dateHelper;
+
+    private EventLogModel $eventLogModel;
+
+    private LeadModel $leadModel;
+
+    private \Mautic\CampaignBundle\Entity\LeadEventLogRepository $leadEventLogRepository;
+
+    #[Required]
+    public function autowireCampaignAjaxController(
+        DateHelper $dateHelper,
+        EventLogModel $eventLogModel,
+        LeadModel $leadModel,
+        \Mautic\CampaignBundle\Entity\LeadEventLogRepository $leadEventLogRepository,
+    ): void {
+        $this->dateHelper             = $dateHelper;
+        $this->eventLogModel          = $eventLogModel;
+        $this->leadModel              = $leadModel;
+        $this->leadEventLogRepository = $leadEventLogRepository;
+>>>>>>> e346b540a8 ([phpstan] add rule to avoid ctor forwarding)
     }
 
     public function updateConnectionsAction(Request $request): JsonResponse

--- a/app/bundles/CampaignBundle/Controller/EventController.php
+++ b/app/bundles/CampaignBundle/Controller/EventController.php
@@ -2,28 +2,18 @@
 
 namespace Mautic\CampaignBundle\Controller;
 
-use Doctrine\Persistence\ManagerRegistry;
 use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CampaignBundle\EventCollector\EventCollector;
 use Mautic\CampaignBundle\Form\Type\EventType;
 use Mautic\CampaignBundle\Model\CampaignModel;
 use Mautic\CampaignBundle\Model\EventModel;
 use Mautic\CoreBundle\Controller\FormController as CommonFormController;
-use Mautic\CoreBundle\Factory\ModelFactory;
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\DateTimeHelper;
-use Mautic\CoreBundle\Helper\UserHelper;
-use Mautic\CoreBundle\Security\Permissions\CorePermissions;
-use Mautic\CoreBundle\Service\FlashBag;
-use Mautic\CoreBundle\Translation\Translator;
 use Mautic\CoreBundle\Twig\Helper\DateHelper;
-use Mautic\FormBundle\Helper\FormFieldHelper;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Contracts\Service\Attribute\Required;
 
 final class EventController extends CommonFormController
 {
@@ -36,24 +26,25 @@ final class EventController extends CommonFormController
         Event::TYPE_CONDITION,
     ];
 
-    public function __construct(
-        FormFactoryInterface $formFactory,
-        FormFieldHelper $fieldHelper,
-        private readonly EventCollector $eventCollector,
-        private readonly DateHelper $dateHelper,
-        ManagerRegistry $doctrine,
-        ModelFactory $modelFactory,
-        UserHelper $userHelper,
-        CoreParametersHelper $coreParametersHelper,
-        EventDispatcherInterface $dispatcher,
-        Translator $translator,
-        FlashBag $flashBag,
-        RequestStack $requestStack,
-        CorePermissions $security,
-        private readonly CampaignModel $campaignModel,
-        private readonly EventModel $eventModel,
-    ) {
-        parent::__construct($formFactory, $fieldHelper, $doctrine, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security);
+    private EventCollector $eventCollector;
+
+    private DateHelper $dateHelper;
+
+    private CampaignModel $campaignModel;
+
+    private EventModel $eventModel;
+
+    #[Required]
+    public function autowireEventController(
+        EventCollector $eventCollector,
+        DateHelper $dateHelper,
+        CampaignModel $campaignModel,
+        EventModel $eventModel,
+    ): void {
+        $this->eventCollector = $eventCollector;
+        $this->dateHelper = $dateHelper;
+        $this->campaignModel = $campaignModel;
+        $this->eventModel = $eventModel;
     }
 
     /**

--- a/app/bundles/CampaignBundle/Controller/ImportController.php
+++ b/app/bundles/CampaignBundle/Controller/ImportController.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\CampaignBundle\Controller;
 
-use Doctrine\Persistence\ManagerRegistry;
 use Mautic\CampaignBundle\Entity\Campaign;
 use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CampaignBundle\Form\Type\CampaignImportType;
@@ -12,21 +11,16 @@ use Mautic\CoreBundle\Controller\AbstractFormController;
 use Mautic\CoreBundle\Event\EntityImportAnalyzeEvent;
 use Mautic\CoreBundle\Event\EntityImportEvent;
 use Mautic\CoreBundle\Event\EntityImportUndoEvent;
-use Mautic\CoreBundle\Factory\ModelFactory;
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\CoreBundle\Helper\ImportHelper;
 use Mautic\CoreBundle\Helper\PathsHelper;
 use Mautic\CoreBundle\Helper\UserHelper;
-use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\CoreBundle\Service\FlashBag;
-use Mautic\CoreBundle\Translation\Translator;
 use Mautic\FormBundle\Entity\Action;
 use Mautic\FormBundle\Entity\Field;
 use Mautic\FormBundle\Entity\Form;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormFactoryInterface;
@@ -36,6 +30,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\Service\Attribute\Required;
 
 final class ImportController extends AbstractFormController
 {
@@ -46,21 +41,29 @@ final class ImportController extends AbstractFormController
 
     public const STEP_IMPORT_FROM_ZIP = 3;
 
-    public function __construct(
-        ManagerRegistry $doctrine,
-        CoreParametersHelper $coreParametersHelper,
-        ModelFactory $modelFactory,
-        private readonly UserHelper $userHelper,
-        EventDispatcherInterface $dispatcher,
-        Translator $translator,
-        FlashBag $flashBag,
-        private readonly RequestStack $requestStack,
-        CorePermissions $security,
-        private readonly LoggerInterface $logger,
-        private readonly PathsHelper $pathsHelper,
-        private readonly FormFactoryInterface $formFactory,
-    ) {
-        parent::__construct($doctrine, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security);
+    private UserHelper $userHelper;
+
+    private RequestStack $requestStack;
+
+    private LoggerInterface $logger;
+
+    private PathsHelper $pathsHelper;
+
+    private FormFactoryInterface $formFactory;
+
+    #[Required]
+    public function autowireImportController(
+        UserHelper $userHelper,
+        RequestStack $requestStack,
+        LoggerInterface $logger,
+        PathsHelper $pathsHelper,
+        FormFactoryInterface $formFactory,
+    ): void {
+        $this->userHelper   = $userHelper;
+        $this->requestStack = $requestStack;
+        $this->logger       = $logger;
+        $this->pathsHelper  = $pathsHelper;
+        $this->formFactory  = $formFactory;
     }
 
     public function newAction(): Response

--- a/app/bundles/CategoryBundle/Controller/BatchContactController.php
+++ b/app/bundles/CategoryBundle/Controller/BatchContactController.php
@@ -2,39 +2,28 @@
 
 namespace Mautic\CategoryBundle\Controller;
 
-use Doctrine\Persistence\ManagerRegistry;
 use Mautic\CategoryBundle\Model\CategoryModel;
 use Mautic\CategoryBundle\Model\ContactActionModel;
 use Mautic\CoreBundle\Controller\AbstractFormController;
-use Mautic\CoreBundle\Factory\ModelFactory;
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
-use Mautic\CoreBundle\Helper\UserHelper;
-use Mautic\CoreBundle\Security\Permissions\CorePermissions;
-use Mautic\CoreBundle\Service\FlashBag;
-use Mautic\CoreBundle\Translation\Translator;
 use Mautic\LeadBundle\Form\Type\BatchType;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\Service\Attribute\Required;
 
 final class BatchContactController extends AbstractFormController
 {
-    public function __construct(
-        private readonly ContactActionModel $actionModel,
-        private readonly CategoryModel $categoryModel,
-        ManagerRegistry $doctrine,
-        ModelFactory $modelFactory,
-        UserHelper $userHelper,
-        CoreParametersHelper $coreParametersHelper,
-        EventDispatcherInterface $dispatcher,
-        Translator $translator,
-        FlashBag $flashBag,
-        RequestStack $requestStack,
-        CorePermissions $security,
-    ) {
-        parent::__construct($doctrine, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security);
+    private ContactActionModel $actionModel;
+
+    private CategoryModel $categoryModel;
+
+    #[Required]
+    public function autowireBatchContactController(
+        ContactActionModel $actionModel,
+        CategoryModel $categoryModel,
+    ): void {
+        $this->actionModel   = $actionModel;
+        $this->categoryModel = $categoryModel;
     }
 
     /**

--- a/app/bundles/CategoryBundle/Controller/CategoryController.php
+++ b/app/bundles/CategoryBundle/Controller/CategoryController.php
@@ -2,41 +2,31 @@
 
 namespace Mautic\CategoryBundle\Controller;
 
-use Doctrine\Persistence\ManagerRegistry;
 use Mautic\CategoryBundle\CategoryEvents;
 use Mautic\CategoryBundle\Event\CategoryTypesEvent;
 use Mautic\CategoryBundle\Model\CategoryModel;
 use Mautic\CoreBundle\Controller\AbstractFormController;
 use Mautic\CoreBundle\Exception\DeleteEntityDependencyException;
-use Mautic\CoreBundle\Factory\ModelFactory;
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
-use Mautic\CoreBundle\Helper\UserHelper;
-use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\CoreBundle\Service\FlashBag;
-use Mautic\CoreBundle\Translation\Translator;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\Service\Attribute\Required;
 
 final class CategoryController extends AbstractFormController
 {
-    public function __construct(
-        private readonly FormFactoryInterface $formFactory,
-        ManagerRegistry $doctrine,
-        ModelFactory $modelFactory,
-        UserHelper $userHelper,
-        CoreParametersHelper $coreParametersHelper,
-        EventDispatcherInterface $dispatcher,
-        Translator $translator,
-        FlashBag $flashBag,
-        RequestStack $requestStack,
-        CorePermissions $security,
-        private readonly CategoryModel $categoryModel,
-    ) {
-        parent::__construct($doctrine, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security);
+    private FormFactoryInterface $formFactory;
+
+    private CategoryModel $categoryModel;
+
+    #[Required]
+    public function autowireCategoryController(
+        FormFactoryInterface $formFactory,
+        CategoryModel $categoryModel,
+    ): void {
+        $this->formFactory   = $formFactory;
+        $this->categoryModel = $categoryModel;
     }
 
     /**

--- a/app/bundles/CategoryBundle/Model/CategoryModel.php
+++ b/app/bundles/CategoryBundle/Model/CategoryModel.php
@@ -2,27 +2,20 @@
 
 namespace Mautic\CategoryBundle\Model;
 
-use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CategoryBundle\CategoryEvents;
 use Mautic\CategoryBundle\Entity\Category;
 use Mautic\CategoryBundle\Entity\CategoryRepository;
 use Mautic\CategoryBundle\Event\CategoryEvent;
 use Mautic\CategoryBundle\Event\CategoryTypeEntityEvent;
 use Mautic\CategoryBundle\Form\Type\CategoryType;
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
-use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\CoreBundle\Model\AjaxLookupModelInterface;
 use Mautic\CoreBundle\Model\FormModel;
-use Mautic\CoreBundle\Security\Permissions\CorePermissions;
-use Mautic\CoreBundle\Translation\Translator;
-use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\EventDispatcher\Event;
+use Symfony\Contracts\Service\Attribute\Required;
 
 /**
  * @extends FormModel<Category>
@@ -34,19 +27,17 @@ class CategoryModel extends FormModel implements AjaxLookupModelInterface
      */
     private array $categoriesByBundleCache = [];
 
-    public function __construct(
-        protected RequestStack $requestStack,
-        EntityManagerInterface $em,
-        CorePermissions $security,
-        EventDispatcherInterface $dispatcher,
-        UrlGeneratorInterface $router,
-        Translator $translator,
-        UserHelper $userHelper,
-        LoggerInterface $mauticLogger,
-        CoreParametersHelper $coreParametersHelper,
-        private readonly CategoryRepository $categoryRepository,
-    ) {
-        parent::__construct($em, $security, $dispatcher, $router, $translator, $userHelper, $mauticLogger, $coreParametersHelper);
+    protected RequestStack $requestStack;
+
+    private CategoryRepository $categoryRepository;
+
+    #[Required]
+    public function autowireCategoryModel(
+        RequestStack $requestStack,
+        CategoryRepository $categoryRepository,
+    ): void {
+        $this->requestStack       = $requestStack;
+        $this->categoryRepository = $categoryRepository;
     }
 
     // @phpstan-ignore-next-line method.childReturnType

--- a/app/bundles/ChannelBundle/Controller/BatchContactController.php
+++ b/app/bundles/ChannelBundle/Controller/BatchContactController.php
@@ -2,41 +2,33 @@
 
 namespace Mautic\ChannelBundle\Controller;
 
-use Doctrine\Persistence\ManagerRegistry;
 use Mautic\ChannelBundle\Model\ChannelActionModel;
 use Mautic\ChannelBundle\Model\FrequencyActionModel;
 use Mautic\CoreBundle\Controller\AbstractFormController;
-use Mautic\CoreBundle\Factory\ModelFactory;
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
-use Mautic\CoreBundle\Helper\UserHelper;
-use Mautic\CoreBundle\Security\Permissions\CorePermissions;
-use Mautic\CoreBundle\Service\FlashBag;
-use Mautic\CoreBundle\Translation\Translator;
 use Mautic\LeadBundle\Form\Type\ContactChannelsType;
 use Mautic\LeadBundle\Model\LeadModel;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\Service\Attribute\Required;
 
 final class BatchContactController extends AbstractFormController
 {
-    public function __construct(
-        private readonly ChannelActionModel $channelActionModel,
-        private readonly FrequencyActionModel $frequencyActionModel,
-        private readonly LeadModel $contactModel,
-        ManagerRegistry $doctrine,
-        ModelFactory $modelFactory,
-        UserHelper $userHelper,
-        CoreParametersHelper $coreParametersHelper,
-        EventDispatcherInterface $dispatcher,
-        Translator $translator,
-        FlashBag $flashBag,
-        RequestStack $requestStack,
-        CorePermissions $security,
-    ) {
-        parent::__construct($doctrine, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security);
+    private ChannelActionModel $channelActionModel;
+
+    private FrequencyActionModel $frequencyActionModel;
+
+    private LeadModel $contactModel;
+
+    #[Required]
+    public function autowireBatchContactController(
+        ChannelActionModel $channelActionModel,
+        FrequencyActionModel $frequencyActionModel,
+        LeadModel $contactModel,
+    ): void {
+        $this->channelActionModel   = $channelActionModel;
+        $this->frequencyActionModel = $frequencyActionModel;
+        $this->contactModel         = $contactModel;
     }
 
     /**

--- a/app/bundles/ChannelBundle/Controller/MessageController.php
+++ b/app/bundles/ChannelBundle/Controller/MessageController.php
@@ -2,22 +2,12 @@
 
 namespace Mautic\ChannelBundle\Controller;
 
-use Doctrine\Persistence\ManagerRegistry;
 use Mautic\ChannelBundle\Entity\Channel;
 use Mautic\ChannelBundle\Model\MessageModel;
 use Mautic\CoreBundle\Controller\AbstractStandardFormController;
-use Mautic\CoreBundle\Factory\ModelFactory;
 use Mautic\CoreBundle\Factory\PageHelperFactoryInterface;
 use Mautic\CoreBundle\Helper\Chart\LineChart;
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
-use Mautic\CoreBundle\Helper\UserHelper;
-use Mautic\CoreBundle\Security\Permissions\CorePermissions;
-use Mautic\CoreBundle\Service\FlashBag;
-use Mautic\CoreBundle\Translation\Translator;
-use Mautic\FormBundle\Helper\FormFieldHelper;
 use Mautic\LeadBundle\Controller\EntityContactsTrait;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -25,26 +15,23 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\Service\Attribute\Required;
 
 final class MessageController extends AbstractStandardFormController
 {
     use EntityContactsTrait;
 
-    public function __construct(
-        FormFactoryInterface $formFactory,
-        FormFieldHelper $fieldHelper,
-        ManagerRegistry $doctrine,
-        ModelFactory $modelFactory,
-        UserHelper $userHelper,
-        CoreParametersHelper $coreParametersHelper,
-        EventDispatcherInterface $dispatcher,
-        Translator $translator,
-        FlashBag $flashBag,
-        private RequestStack $requestStack,
-        CorePermissions $security,
-        private MessageModel $messageModel,
-    ) {
-        parent::__construct($formFactory, $fieldHelper, $doctrine, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security);
+    private RequestStack $requestStack;
+
+    private MessageModel $messageModel;
+
+    #[Required]
+    public function autowireMessageController(
+        RequestStack $requestStack,
+        MessageModel $messageModel,
+    ): void {
+        $this->requestStack = $requestStack;
+        $this->messageModel = $messageModel;
     }
 
     /**

--- a/app/bundles/ChannelBundle/Model/MessageModel.php
+++ b/app/bundles/ChannelBundle/Model/MessageModel.php
@@ -2,7 +2,6 @@
 
 namespace Mautic\ChannelBundle\Model;
 
-use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CampaignBundle\Model\CampaignModel;
 use Mautic\ChannelBundle\ChannelEvents;
 use Mautic\ChannelBundle\Entity\Message;
@@ -10,20 +9,14 @@ use Mautic\ChannelBundle\Entity\MessageRepository;
 use Mautic\ChannelBundle\Event\MessageEvent;
 use Mautic\ChannelBundle\Form\Type\MessageType;
 use Mautic\ChannelBundle\Helper\ChannelListHelper;
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
-use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\CoreBundle\Model\AjaxLookupModelInterface;
 use Mautic\CoreBundle\Model\FormModel;
 use Mautic\CoreBundle\Model\GlobalSearchInterface;
-use Mautic\CoreBundle\Security\Permissions\CorePermissions;
-use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\EventDispatcher\Event;
-use Symfony\Contracts\Translation\TranslatorInterface;
+use Symfony\Contracts\Service\Attribute\Required;
 
 /**
  * @extends FormModel<Message>
@@ -36,20 +29,21 @@ class MessageModel extends FormModel implements AjaxLookupModelInterface, Global
 
     protected static $channels;
 
-    public function __construct(
-        protected ChannelListHelper $channelListHelper,
-        protected CampaignModel $campaignModel,
-        EntityManagerInterface $em,
-        CorePermissions $security,
-        EventDispatcherInterface $dispatcher,
-        UrlGeneratorInterface $router,
-        TranslatorInterface $translator,
-        UserHelper $userHelper,
-        LoggerInterface $mauticLogger,
-        CoreParametersHelper $coreParametersHelper,
-        private readonly MessageRepository $messageRepository,
-    ) {
-        parent::__construct($em, $security, $dispatcher, $router, $translator, $userHelper, $mauticLogger, $coreParametersHelper);
+    protected ChannelListHelper $channelListHelper;
+
+    protected CampaignModel $campaignModel;
+
+    private MessageRepository $messageRepository;
+
+    #[Required]
+    public function autowireMessageModel(
+        ChannelListHelper $channelListHelper,
+        CampaignModel $campaignModel,
+        MessageRepository $messageRepository,
+    ): void {
+        $this->channelListHelper = $channelListHelper;
+        $this->campaignModel     = $campaignModel;
+        $this->messageRepository = $messageRepository;
     }
 
     /**

--- a/app/bundles/ChannelBundle/Model/MessageQueueModel.php
+++ b/app/bundles/ChannelBundle/Model/MessageQueueModel.php
@@ -2,26 +2,19 @@
 
 namespace Mautic\ChannelBundle\Model;
 
-use Doctrine\ORM\EntityManagerInterface;
 use Mautic\ChannelBundle\ChannelEvents;
 use Mautic\ChannelBundle\Entity\MessageQueue;
 use Mautic\ChannelBundle\Entity\MessageQueueRepository;
 use Mautic\ChannelBundle\Event\MessageQueueBatchProcessEvent;
 use Mautic\ChannelBundle\Event\MessageQueueEvent;
 use Mautic\ChannelBundle\Event\MessageQueueProcessEvent;
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
-use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\CoreBundle\Model\FormModel;
-use Mautic\CoreBundle\Security\Permissions\CorePermissions;
-use Mautic\CoreBundle\Translation\Translator;
 use Mautic\LeadBundle\Entity\FrequencyRuleRepository;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Model\CompanyModel;
 use Mautic\LeadBundle\Model\LeadModel;
-use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\EventDispatcher\Event;
+use Symfony\Contracts\Service\Attribute\Required;
 
 /**
  * @extends FormModel<MessageQueue>
@@ -33,21 +26,25 @@ class MessageQueueModel extends FormModel
      */
     public const DEFAULT_RESCHEDULE_INTERVAL = 'PT15M';
 
-    public function __construct(
-        protected LeadModel $leadModel,
-        protected CompanyModel $companyModel,
-        CoreParametersHelper $coreParametersHelper,
-        EntityManagerInterface $em,
-        CorePermissions $security,
-        EventDispatcherInterface $dispatcher,
-        UrlGeneratorInterface $router,
-        Translator $translator,
-        UserHelper $userHelper,
-        LoggerInterface $mauticLogger,
-        private readonly MessageQueueRepository $messageQueueRepository,
-        private readonly FrequencyRuleRepository $frequencyRuleRepository,
-    ) {
-        parent::__construct($em, $security, $dispatcher, $router, $translator, $userHelper, $mauticLogger, $coreParametersHelper);
+    protected LeadModel $leadModel;
+
+    protected CompanyModel $companyModel;
+
+    private MessageQueueRepository $messageQueueRepository;
+
+    private FrequencyRuleRepository $frequencyRuleRepository;
+
+    #[Required]
+    public function autowireMessageQueueModel(
+        LeadModel $leadModel,
+        CompanyModel $companyModel,
+        MessageQueueRepository $messageQueueRepository,
+        FrequencyRuleRepository $frequencyRuleRepository,
+    ): void {
+        $this->leadModel               = $leadModel;
+        $this->companyModel            = $companyModel;
+        $this->messageQueueRepository  = $messageQueueRepository;
+        $this->frequencyRuleRepository = $frequencyRuleRepository;
     }
 
     public function getRepository(): MessageQueueRepository

--- a/app/bundles/ChannelBundle/Tests/Model/MessageQueueModelTest.php
+++ b/app/bundles/ChannelBundle/Tests/Model/MessageQueueModelTest.php
@@ -55,9 +55,6 @@ final class MessageQueueModelTest extends \PHPUnit\Framework\TestCase
         $this->messageQueueRepository = $this->createMock(MessageQueueRepository::class);
 
         $this->messageQueue = new MessageQueueModel(
-            $this->leadModel,
-            $this->createStub(CompanyModel::class),
-            $this->createStub(CoreParametersHelper::class),
             $this->entityManager,
             $this->createStub(CorePermissions::class),
             $this->createStub(EventDispatcherInterface::class),
@@ -65,8 +62,13 @@ final class MessageQueueModelTest extends \PHPUnit\Framework\TestCase
             $this->createStub(Translator::class),
             $this->createStub(UserHelper::class),
             $this->createStub(LoggerInterface::class),
+            $this->createStub(CoreParametersHelper::class),
+        );
+        $this->messageQueue->autowireMessageQueueModel(
+            $this->leadModel,
+            $this->createStub(CompanyModel::class),
             $this->messageQueueRepository,
-            $this->createStub(FrequencyRuleRepository::class) // $frequencyRuleRepository
+            $this->createStub(FrequencyRuleRepository::class)
         );
 
         $message      = new MessageQueue();

--- a/app/bundles/ConfigBundle/Controller/SysinfoController.php
+++ b/app/bundles/ConfigBundle/Controller/SysinfoController.php
@@ -2,38 +2,20 @@
 
 namespace Mautic\ConfigBundle\Controller;
 
-use Doctrine\Persistence\ManagerRegistry;
 use Mautic\ConfigBundle\Model\SysinfoModel;
 use Mautic\CoreBundle\Controller\FormController;
-use Mautic\CoreBundle\Factory\ModelFactory;
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
-use Mautic\CoreBundle\Helper\UserHelper;
-use Mautic\CoreBundle\Security\Permissions\CorePermissions;
-use Mautic\CoreBundle\Service\FlashBag;
-use Mautic\CoreBundle\Translation\Translator;
-use Mautic\FormBundle\Helper\FormFieldHelper;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\Form\FormFactoryInterface;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\Service\Attribute\Required;
 
 final class SysinfoController extends FormController
 {
-    public function __construct(
-        FormFactoryInterface $formFactory,
-        FormFieldHelper $fieldHelper,
-        private readonly SysinfoModel $sysinfoModel,
-        ManagerRegistry $doctrine,
-        ModelFactory $modelFactory,
-        UserHelper $userHelper,
-        CoreParametersHelper $coreParametersHelper,
-        EventDispatcherInterface $dispatcher,
-        Translator $translator,
-        FlashBag $flashBag,
-        RequestStack $requestStack,
-        CorePermissions $security,
-    ) {
-        parent::__construct($formFactory, $fieldHelper, $doctrine, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security);
+    private SysinfoModel $sysinfoModel;
+
+    #[Required]
+    public function autowireSysinfoController(
+        SysinfoModel $sysinfoModel,
+    ): void {
+        $this->sysinfoModel = $sysinfoModel;
     }
 
     public function indexAction(): Response

--- a/app/bundles/CoreBundle/Controller/Api/ThemeApiController.php
+++ b/app/bundles/CoreBundle/Controller/Api/ThemeApiController.php
@@ -17,31 +17,13 @@ use Symfony\Contracts\Service\Attribute\Required;
  */
 final class ThemeApiController extends CommonApiController
 {
-<<<<<<< HEAD
-    public function __construct(
-        CorePermissions $security,
-        Translator $translator,
-        EntityResultHelper $entityResultHelper,
-        RouterInterface $router,
-        FormFactoryInterface $formFactory,
-        AppVersion $appVersion,
-        private readonly ThemeHelper $themeHelper,
-        RequestStack $requestStack,
-        ManagerRegistry $doctrine,
-        ModelFactory $modelFactory,
-        EventDispatcherInterface $dispatcher,
-        CoreParametersHelper $coreParametersHelper,
-    ) {
-        parent::__construct($security, $translator, $entityResultHelper, $router, $formFactory, $appVersion, $requestStack, $doctrine, $modelFactory, $dispatcher, $coreParametersHelper);
-=======
-    protected ThemeHelper $themeHelper;
+    private readonly ThemeHelper $themeHelper;
 
     #[Required]
     public function autowireThemeApiController(
         ThemeHelper $themeHelper,
     ): void {
         $this->themeHelper = $themeHelper;
->>>>>>> e346b540a8 ([phpstan] add rule to avoid ctor forwarding)
     }
 
     /**

--- a/app/bundles/CoreBundle/Controller/Api/ThemeApiController.php
+++ b/app/bundles/CoreBundle/Controller/Api/ThemeApiController.php
@@ -2,31 +2,22 @@
 
 namespace Mautic\CoreBundle\Controller\Api;
 
-use Doctrine\Persistence\ManagerRegistry;
 use Mautic\ApiBundle\Controller\CommonApiController;
-use Mautic\ApiBundle\Helper\EntityResultHelper;
-use Mautic\CoreBundle\Factory\ModelFactory;
-use Mautic\CoreBundle\Helper\AppVersion;
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\CoreBundle\Helper\PathsHelper;
 use Mautic\CoreBundle\Helper\ThemeHelper;
-use Mautic\CoreBundle\Security\Permissions\CorePermissions;
-use Mautic\CoreBundle\Translation\Translator;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
-use Symfony\Component\Routing\RouterInterface;
+use Symfony\Contracts\Service\Attribute\Required;
 
 /**
  * @extends CommonApiController<object>
  */
 final class ThemeApiController extends CommonApiController
 {
+<<<<<<< HEAD
     public function __construct(
         CorePermissions $security,
         Translator $translator,
@@ -42,6 +33,15 @@ final class ThemeApiController extends CommonApiController
         CoreParametersHelper $coreParametersHelper,
     ) {
         parent::__construct($security, $translator, $entityResultHelper, $router, $formFactory, $appVersion, $requestStack, $doctrine, $modelFactory, $dispatcher, $coreParametersHelper);
+=======
+    protected ThemeHelper $themeHelper;
+
+    #[Required]
+    public function autowireThemeApiController(
+        ThemeHelper $themeHelper,
+    ): void {
+        $this->themeHelper = $themeHelper;
+>>>>>>> e346b540a8 ([phpstan] add rule to avoid ctor forwarding)
     }
 
     /**

--- a/app/bundles/CoreBundle/Model/NotificationModel.php
+++ b/app/bundles/CoreBundle/Model/NotificationModel.php
@@ -2,23 +2,16 @@
 
 namespace Mautic\CoreBundle\Model;
 
-use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Entity\Notification;
 use Mautic\CoreBundle\Entity\NotificationRepository;
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\EmojiHelper;
 use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\CoreBundle\Helper\PathsHelper;
 use Mautic\CoreBundle\Helper\UpdateHelper;
-use Mautic\CoreBundle\Helper\UserHelper;
-use Mautic\CoreBundle\Security\Permissions\CorePermissions;
-use Mautic\CoreBundle\Translation\Translator;
 use Mautic\UserBundle\Entity\User;
-use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Contracts\Service\Attribute\Required;
 
 /**
  * @extends FormModel<Notification>
@@ -30,21 +23,25 @@ class NotificationModel extends FormModel
      */
     protected $disableUpdates;
 
-    public function __construct(
-        protected PathsHelper $pathsHelper,
-        protected UpdateHelper $updateHelper,
-        CoreParametersHelper $coreParametersHelper,
-        EntityManagerInterface $em,
-        CorePermissions $security,
-        EventDispatcherInterface $dispatcher,
-        UrlGeneratorInterface $router,
-        Translator $translator,
-        UserHelper $userHelper,
-        LoggerInterface $mauticLogger,
-        private readonly RequestStack $requestStack,
-        private readonly NotificationRepository $notificationRepository,
-    ) {
-        parent::__construct($em, $security, $dispatcher, $router, $translator, $userHelper, $mauticLogger, $coreParametersHelper);
+    protected PathsHelper $pathsHelper;
+
+    protected UpdateHelper $updateHelper;
+
+    private RequestStack $requestStack;
+
+    private NotificationRepository $notificationRepository;
+
+    #[Required]
+    public function autowireNotificationModel(
+        PathsHelper $pathsHelper,
+        UpdateHelper $updateHelper,
+        RequestStack $requestStack,
+        NotificationRepository $notificationRepository,
+    ): void {
+        $this->pathsHelper             = $pathsHelper;
+        $this->updateHelper            = $updateHelper;
+        $this->requestStack            = $requestStack;
+        $this->notificationRepository  = $notificationRepository;
     }
 
     private function getSession(): SessionInterface

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
@@ -727,9 +727,6 @@ final class EmailModelTest extends \PHPUnit\Framework\TestCase
         $coreParametersHelper = $this->createStub(CoreParametersHelper::class);
 
         $messageModel = new MessageQueueModel(
-            $this->leadModel,
-            $this->companyModel,
-            $coreParametersHelper,
             $this->entityManager,
             $this->createStub(CorePermissions::class),
             $this->eventDispatcher,
@@ -737,8 +734,13 @@ final class EmailModelTest extends \PHPUnit\Framework\TestCase
             $this->translator,
             $this->userHelper,
             $this->createStub(LoggerInterface::class),
-            $this->createStub(MessageQueueRepository::class), // $messageQueueRepository
-            $this->frequencyRepository // $frequencyRuleRepository
+            $coreParametersHelper,
+        );
+        $messageModel->autowireMessageQueueModel(
+            $this->leadModel,
+            $this->companyModel,
+            $this->createStub(MessageQueueRepository::class),
+            $this->frequencyRepository
         );
 
         $emailModel = new EmailModel(

--- a/app/bundles/FormBundle/Controller/AjaxController.php
+++ b/app/bundles/FormBundle/Controller/AjaxController.php
@@ -2,41 +2,33 @@
 
 namespace Mautic\FormBundle\Controller;
 
-use Doctrine\Persistence\ManagerRegistry;
 use Mautic\CoreBundle\Controller\AjaxController as CommonAjaxController;
-use Mautic\CoreBundle\Factory\ModelFactory;
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\InputHelper;
-use Mautic\CoreBundle\Helper\UserHelper;
-use Mautic\CoreBundle\Security\Permissions\CorePermissions;
-use Mautic\CoreBundle\Service\FlashBag;
-use Mautic\CoreBundle\Translation\Translator;
 use Mautic\FormBundle\Collector\AlreadyMappedFieldCollectorInterface;
 use Mautic\FormBundle\Collector\FieldCollectorInterface;
 use Mautic\FormBundle\Crate\FieldCrate;
 use Mautic\FormBundle\Model\FormModel;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Contracts\Service\Attribute\Required;
 
 final class AjaxController extends CommonAjaxController
 {
-    public function __construct(
-        private readonly FieldCollectorInterface $fieldCollector,
-        private readonly AlreadyMappedFieldCollectorInterface $mappedFieldCollector,
-        ManagerRegistry $doctrine,
-        ModelFactory $modelFactory,
-        UserHelper $userHelper,
-        CoreParametersHelper $coreParametersHelper,
-        EventDispatcherInterface $dispatcher,
-        Translator $translator,
-        FlashBag $flashBag,
-        RequestStack $requestStack,
-        CorePermissions $security,
-        private readonly FormModel $formModel,
-    ) {
-        parent::__construct($doctrine, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security);
+    private FieldCollectorInterface $fieldCollector;
+
+    private AlreadyMappedFieldCollectorInterface $mappedFieldCollector;
+
+    private FormModel $formModel;
+
+    #[Required]
+    public function autowireFormAjaxController(
+        FieldCollectorInterface $fieldCollector,
+        AlreadyMappedFieldCollectorInterface $mappedFieldCollector,
+        FormModel $formModel,
+    ): void {
+        $this->fieldCollector       = $fieldCollector;
+        $this->mappedFieldCollector = $mappedFieldCollector;
+        $this->formModel            = $formModel;
     }
 
     public function reorderFieldsAction(Request $request, string $name = 'fields'): JsonResponse

--- a/app/bundles/FormBundle/Model/FieldModel.php
+++ b/app/bundles/FormBundle/Model/FieldModel.php
@@ -2,49 +2,46 @@
 
 namespace Mautic\FormBundle\Model;
 
-use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Doctrine\Helper\ColumnSchemaHelper;
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
-use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\CoreBundle\Model\FormModel as CommonFormModel;
-use Mautic\CoreBundle\Security\Permissions\CorePermissions;
-use Mautic\CoreBundle\Translation\Translator;
 use Mautic\FormBundle\Entity\Field;
 use Mautic\FormBundle\Entity\FieldRepository;
 use Mautic\FormBundle\Event\FormFieldEvent;
 use Mautic\FormBundle\Form\Type\FieldType;
 use Mautic\FormBundle\FormEvents;
 use Mautic\LeadBundle\Model\FieldModel as LeadFieldModel;
-use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\EventDispatcher\Event;
+use Symfony\Contracts\Service\Attribute\Required;
 
 /**
  * @extends CommonFormModel<Field>
  */
 class FieldModel extends CommonFormModel
 {
-    public function __construct(
-        protected LeadFieldModel $leadFieldModel,
-        EntityManagerInterface $em,
-        CorePermissions $security,
-        EventDispatcherInterface $dispatcher,
-        UrlGeneratorInterface $router,
-        Translator $translator,
-        UserHelper $userHelper,
-        LoggerInterface $mauticLogger,
-        CoreParametersHelper $coreParametersHelper,
-        private readonly RequestStack $requestStack,
-        private readonly ColumnSchemaHelper $columnSchemaHelper,
-        private readonly FieldRepository $fieldRepository,
-    ) {
-        parent::__construct($em, $security, $dispatcher, $router, $translator, $userHelper, $mauticLogger, $coreParametersHelper);
+    protected LeadFieldModel $leadFieldModel;
+
+    private RequestStack $requestStack;
+
+    private ColumnSchemaHelper $columnSchemaHelper;
+
+    private FieldRepository $fieldRepository;
+
+    #[Required]
+    public function autowireFieldModel(
+        LeadFieldModel $leadFieldModel,
+        RequestStack $requestStack,
+        ColumnSchemaHelper $columnSchemaHelper,
+        FieldRepository $fieldRepository,
+    ): void {
+        $this->leadFieldModel     = $leadFieldModel;
+        $this->requestStack       = $requestStack;
+        $this->columnSchemaHelper = $columnSchemaHelper;
+        $this->fieldRepository    = $fieldRepository;
     }
 
     private function getSession(): SessionInterface

--- a/app/bundles/FormBundle/Tests/Model/FieldModelTest.php
+++ b/app/bundles/FormBundle/Tests/Model/FieldModelTest.php
@@ -49,7 +49,6 @@ final class FieldModelTest extends TestCase
         $entityManager  = $this->createMock(EntityManager::class);
         $schemaHelper   = $this->createStub(ColumnSchemaHelper::class);
         $fieldModel     = new FieldModel(
-            $leadFieldModel,
             $entityManager,
             $this->createStub(CorePermissions::class),
             $this->createStub(EventDispatcherInterface::class),
@@ -58,9 +57,12 @@ final class FieldModelTest extends TestCase
             $this->createStub(UserHelper::class),
             $this->createStub(LoggerInterface::class),
             $this->createStub(CoreParametersHelper::class),
+        );
+        $fieldModel->autowireFieldModel(
+            $leadFieldModel,
             $this->createStub(RequestStack::class),
             $schemaHelper,
-            $this->createStub(FieldRepository::class) // $fieldRepository
+            $this->createStub(FieldRepository::class)
         );
 
         $entityManager

--- a/app/bundles/InstallBundle/Controller/InstallController.php
+++ b/app/bundles/InstallBundle/Controller/InstallController.php
@@ -3,41 +3,30 @@
 namespace Mautic\InstallBundle\Controller;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\Persistence\ManagerRegistry;
 use Mautic\CoreBundle\Configurator\Configurator;
 use Mautic\CoreBundle\Controller\CommonController;
-use Mautic\CoreBundle\Factory\ModelFactory;
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\PathsHelper;
-use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\CoreBundle\Loader\ParameterLoader;
-use Mautic\CoreBundle\Security\Permissions\CorePermissions;
-use Mautic\CoreBundle\Service\FlashBag;
-use Mautic\CoreBundle\Translation\Translator;
 use Mautic\InstallBundle\Install\InstallService;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\Service\Attribute\Required;
 
 final class InstallController extends CommonController
 {
-    public function __construct(
-        private readonly Configurator $configurator,
-        private readonly InstallService $installer,
-        ManagerRegistry $doctrine,
-        ModelFactory $modelFactory,
-        UserHelper $userHelper,
-        CoreParametersHelper $coreParametersHelper,
-        EventDispatcherInterface $dispatcher,
-        Translator $translator,
-        FlashBag $flashBag,
-        RequestStack $requestStack,
-        CorePermissions $security,
-    ) {
-        parent::__construct($doctrine, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security);
+    private Configurator $configurator;
+
+    private InstallService $installer;
+
+    #[Required]
+    public function autowireInstallController(
+        Configurator $configurator,
+        InstallService $installer,
+    ): void {
+        $this->configurator = $configurator;
+        $this->installer    = $installer;
     }
 
     /**

--- a/app/bundles/InstallBundle/Tests/Controller/InstallControllerTest.php
+++ b/app/bundles/InstallBundle/Tests/Controller/InstallControllerTest.php
@@ -50,8 +50,6 @@ final class InstallControllerTest extends \PHPUnit\Framework\TestCase
         $requestStack         = new RequestStack();
 
         $this->controller = new InstallController(
-            $this->createStub(Configurator::class),
-            $this->installer,
             $this->createStub(ManagerRegistry::class),
             $this->createStub(ModelFactory::class),
             $this->createStub(UserHelper::class),
@@ -61,6 +59,10 @@ final class InstallControllerTest extends \PHPUnit\Framework\TestCase
             $this->createStub(FlashBag::class),
             $requestStack,
             $this->createStub(CorePermissions::class)
+        );
+        $this->controller->autowireInstallController(
+            $this->createStub(Configurator::class),
+            $this->installer
         );
         $this->controller->setContainer($containerMock);
         $sessionMock->method('getFlashBag')->willReturn($this->createStub(FlashBagInterface::class));

--- a/app/bundles/LeadBundle/Controller/BatchSegmentController.php
+++ b/app/bundles/LeadBundle/Controller/BatchSegmentController.php
@@ -2,39 +2,28 @@
 
 namespace Mautic\LeadBundle\Controller;
 
-use Doctrine\Persistence\ManagerRegistry;
 use Mautic\CoreBundle\Controller\AbstractFormController;
-use Mautic\CoreBundle\Factory\ModelFactory;
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
-use Mautic\CoreBundle\Helper\UserHelper;
-use Mautic\CoreBundle\Security\Permissions\CorePermissions;
-use Mautic\CoreBundle\Service\FlashBag;
-use Mautic\CoreBundle\Translation\Translator;
 use Mautic\LeadBundle\Form\Type\BatchType;
 use Mautic\LeadBundle\Model\ListModel;
 use Mautic\LeadBundle\Model\SegmentActionModel;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\Service\Attribute\Required;
 
 final class BatchSegmentController extends AbstractFormController
 {
-    public function __construct(
-        private readonly SegmentActionModel $segmentActionModel,
-        private readonly ListModel $segmentModel,
-        ManagerRegistry $doctrine,
-        ModelFactory $modelFactory,
-        UserHelper $userHelper,
-        CoreParametersHelper $coreParametersHelper,
-        EventDispatcherInterface $dispatcher,
-        Translator $translator,
-        FlashBag $flashBag,
-        RequestStack $requestStack,
-        CorePermissions $security,
-    ) {
-        parent::__construct($doctrine, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security);
+    private SegmentActionModel $segmentActionModel;
+
+    private ListModel $segmentModel;
+
+    #[Required]
+    public function autowireBatchSegmentController(
+        SegmentActionModel $segmentActionModel,
+        ListModel $segmentModel,
+    ): void {
+        $this->segmentActionModel = $segmentActionModel;
+        $this->segmentModel       = $segmentModel;
     }
 
     /**

--- a/app/bundles/LeadBundle/Controller/ImportController.php
+++ b/app/bundles/LeadBundle/Controller/ImportController.php
@@ -45,45 +45,25 @@ final class ImportController extends FormController
 
     public const STEP_IMPORT_FROM_CSV = 4;
 
-<<<<<<< HEAD
-    public function __construct(
-        FormFactoryInterface $formFactory,
-        FormFieldHelper $fieldHelper,
-        private readonly LoggerInterface $logger,
-        ManagerRegistry $doctrine,
-        ModelFactory $modelFactory,
-        UserHelper $userHelper,
-        CoreParametersHelper $coreParametersHelper,
-        EventDispatcherInterface $dispatcher,
-        Translator $translator,
-        FlashBag $flashBag,
-        private readonly RequestStack $requestStack,
-        CorePermissions $security,
-        private readonly ImportModel $importModel,
-        private readonly ImportRepository $importRepository,
-    ) {
-        parent::__construct($formFactory, $fieldHelper, $doctrine, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security);
-=======
     private LoggerInterface $logger;
 
     private RequestStack $requestStack;
 
     private ImportModel $importModel;
 
-    private \Mautic\LeadBundle\Entity\ImportRepository $importRepository;
+    private ImportRepository $importRepository;
 
     #[Required]
     public function autowireImportController(
         LoggerInterface $logger,
         RequestStack $requestStack,
         ImportModel $importModel,
-        \Mautic\LeadBundle\Entity\ImportRepository $importRepository,
+        ImportRepository $importRepository,
     ): void {
         $this->logger = $logger;
         $this->requestStack = $requestStack;
         $this->importModel = $importModel;
         $this->importRepository = $importRepository;
->>>>>>> e346b540a8 ([phpstan] add rule to avoid ctor forwarding)
     }
 
     /**

--- a/app/bundles/LeadBundle/Controller/ImportController.php
+++ b/app/bundles/LeadBundle/Controller/ImportController.php
@@ -2,17 +2,10 @@
 
 namespace Mautic\LeadBundle\Controller;
 
-use Doctrine\Persistence\ManagerRegistry;
 use Mautic\CoreBundle\Controller\FormController;
-use Mautic\CoreBundle\Factory\ModelFactory;
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\CsvHelper;
-use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\CoreBundle\Model\NotificationModel;
-use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\CoreBundle\Service\FlashBag;
-use Mautic\CoreBundle\Translation\Translator;
-use Mautic\FormBundle\Helper\FormFieldHelper;
 use Mautic\LeadBundle\Entity\Import;
 use Mautic\LeadBundle\Entity\ImportRepository;
 use Mautic\LeadBundle\Event\ImportInitEvent;
@@ -27,11 +20,9 @@ use Mautic\UserBundle\Entity\User;
 use Mautic\UserBundle\Entity\UserRepository;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Form\Exception\LogicException;
 use Symfony\Component\Form\FormError;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\File\Exception\FileException;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -41,6 +32,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Contracts\Service\Attribute\Required;
 
 final class ImportController extends FormController
 {
@@ -53,6 +45,7 @@ final class ImportController extends FormController
 
     public const STEP_IMPORT_FROM_CSV = 4;
 
+<<<<<<< HEAD
     public function __construct(
         FormFactoryInterface $formFactory,
         FormFieldHelper $fieldHelper,
@@ -70,6 +63,27 @@ final class ImportController extends FormController
         private readonly ImportRepository $importRepository,
     ) {
         parent::__construct($formFactory, $fieldHelper, $doctrine, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security);
+=======
+    private LoggerInterface $logger;
+
+    private RequestStack $requestStack;
+
+    private ImportModel $importModel;
+
+    private \Mautic\LeadBundle\Entity\ImportRepository $importRepository;
+
+    #[Required]
+    public function autowireImportController(
+        LoggerInterface $logger,
+        RequestStack $requestStack,
+        ImportModel $importModel,
+        \Mautic\LeadBundle\Entity\ImportRepository $importRepository,
+    ): void {
+        $this->logger = $logger;
+        $this->requestStack = $requestStack;
+        $this->importModel = $importModel;
+        $this->importRepository = $importRepository;
+>>>>>>> e346b540a8 ([phpstan] add rule to avoid ctor forwarding)
     }
 
     /**

--- a/app/bundles/LeadBundle/Model/DeviceModel.php
+++ b/app/bundles/LeadBundle/Model/DeviceModel.php
@@ -2,42 +2,30 @@
 
 namespace Mautic\LeadBundle\Model;
 
-use Doctrine\ORM\EntityManagerInterface;
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
-use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\CoreBundle\Model\FormModel;
-use Mautic\CoreBundle\Security\Permissions\CorePermissions;
-use Mautic\CoreBundle\Translation\Translator;
 use Mautic\LeadBundle\Entity\LeadDevice;
 use Mautic\LeadBundle\Entity\LeadDeviceRepository;
 use Mautic\LeadBundle\Event\LeadDeviceEvent;
 use Mautic\LeadBundle\Form\Type\DeviceType;
 use Mautic\LeadBundle\LeadEvents;
-use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\EventDispatcher\Event;
+use Symfony\Contracts\Service\Attribute\Required;
 
 /**
  * @extends FormModel<LeadDevice>
  */
 class DeviceModel extends FormModel
 {
-    public function __construct(
-        private readonly LeadDeviceRepository $leadDeviceRepository,
-        EntityManagerInterface $em,
-        CorePermissions $security,
-        EventDispatcherInterface $dispatcher,
-        UrlGeneratorInterface $router,
-        Translator $translator,
-        UserHelper $userHelper,
-        LoggerInterface $mauticLogger,
-        CoreParametersHelper $coreParametersHelper,
-    ) {
-        parent::__construct($em, $security, $dispatcher, $router, $translator, $userHelper, $mauticLogger, $coreParametersHelper);
+    private LeadDeviceRepository $leadDeviceRepository;
+
+    #[Required]
+    public function autowireDeviceModel(
+        LeadDeviceRepository $leadDeviceRepository,
+    ): void {
+        $this->leadDeviceRepository = $leadDeviceRepository;
     }
 
     public function getRepository(): LeadDeviceRepository

--- a/app/bundles/LeadBundle/Model/NoteModel.php
+++ b/app/bundles/LeadBundle/Model/NoteModel.php
@@ -2,45 +2,36 @@
 
 namespace Mautic\LeadBundle\Model;
 
-use Doctrine\ORM\EntityManagerInterface;
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
-use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\CoreBundle\Model\FormModel;
-use Mautic\CoreBundle\Security\Permissions\CorePermissions;
-use Mautic\CoreBundle\Translation\Translator;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadNote;
 use Mautic\LeadBundle\Entity\LeadNoteRepository;
 use Mautic\LeadBundle\Event\LeadNoteEvent;
 use Mautic\LeadBundle\Form\Type\NoteType;
 use Mautic\LeadBundle\LeadEvents;
-use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\EventDispatcher\Event;
+use Symfony\Contracts\Service\Attribute\Required;
 
 /**
  * @extends FormModel<LeadNote>
  */
 class NoteModel extends FormModel
 {
-    public function __construct(
-        EntityManagerInterface $em,
-        CorePermissions $security,
-        EventDispatcherInterface $dispatcher,
-        UrlGeneratorInterface $router,
-        Translator $translator,
-        UserHelper $userHelper,
-        LoggerInterface $mauticLogger,
-        CoreParametersHelper $coreParametersHelper,
-        private readonly RequestStack $requestStack,
-        private readonly LeadNoteRepository $leadNoteRepository,
-    ) {
-        parent::__construct($em, $security, $dispatcher, $router, $translator, $userHelper, $mauticLogger, $coreParametersHelper);
+    private RequestStack $requestStack;
+
+    private LeadNoteRepository $leadNoteRepository;
+
+    #[Required]
+    public function autowireNoteModel(
+        RequestStack $requestStack,
+        LeadNoteRepository $leadNoteRepository,
+    ): void {
+        $this->requestStack       = $requestStack;
+        $this->leadNoteRepository = $leadNoteRepository;
     }
 
     public function getRepository(): LeadNoteRepository

--- a/app/bundles/MarketplaceBundle/Controller/AjaxController.php
+++ b/app/bundles/MarketplaceBundle/Controller/AjaxController.php
@@ -4,44 +4,39 @@ declare(strict_types=1);
 
 namespace Mautic\MarketplaceBundle\Controller;
 
-use Doctrine\Persistence\ManagerRegistry;
 use Mautic\CoreBundle\Controller\AjaxController as CommonAjaxController;
-use Mautic\CoreBundle\Factory\ModelFactory;
 use Mautic\CoreBundle\Helper\CacheHelper;
 use Mautic\CoreBundle\Helper\ComposerHelper;
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
-use Mautic\CoreBundle\Helper\UserHelper;
-use Mautic\CoreBundle\Security\Permissions\CorePermissions;
-use Mautic\CoreBundle\Service\FlashBag;
-use Mautic\CoreBundle\Translation\Translator;
 use Mautic\MarketplaceBundle\Security\Permissions\MarketplacePermissions;
 use Mautic\MarketplaceBundle\Service\Config;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\Service\Attribute\Required;
 
 final class AjaxController extends CommonAjaxController
 {
-    public function __construct(
-        private readonly ComposerHelper $composer,
-        private readonly CacheHelper $cacheHelper,
-        private readonly LoggerInterface $logger,
-        private readonly Config $config,
-        ManagerRegistry $doctrine,
-        ModelFactory $modelFactory,
-        UserHelper $userHelper,
-        CoreParametersHelper $coreParametersHelper,
-        EventDispatcherInterface $dispatcher,
-        Translator $translator,
-        FlashBag $flashBag,
-        RequestStack $requestStack,
-        CorePermissions $security,
-    ) {
-        parent::__construct($doctrine, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security);
+    private ComposerHelper $composer;
+
+    private CacheHelper $cacheHelper;
+
+    private LoggerInterface $logger;
+
+    private Config $config;
+
+    #[Required]
+    public function autowireMarketplaceAjaxController(
+        ComposerHelper $composer,
+        CacheHelper $cacheHelper,
+        LoggerInterface $logger,
+        Config $config,
+    ): void {
+        $this->composer    = $composer;
+        $this->cacheHelper = $cacheHelper;
+        $this->logger      = $logger;
+        $this->config      = $config;
     }
 
     public function installPackageAction(Request $request): JsonResponse

--- a/app/bundles/MarketplaceBundle/Controller/CacheController.php
+++ b/app/bundles/MarketplaceBundle/Controller/CacheController.php
@@ -4,37 +4,26 @@ declare(strict_types=1);
 
 namespace Mautic\MarketplaceBundle\Controller;
 
-use Doctrine\Persistence\ManagerRegistry;
 use Mautic\CoreBundle\Controller\CommonController;
-use Mautic\CoreBundle\Factory\ModelFactory;
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
-use Mautic\CoreBundle\Helper\UserHelper;
-use Mautic\CoreBundle\Security\Permissions\CorePermissions;
-use Mautic\CoreBundle\Service\FlashBag;
-use Mautic\CoreBundle\Translation\Translator;
 use Mautic\MarketplaceBundle\Security\Permissions\MarketplacePermissions;
 use Mautic\MarketplaceBundle\Service\Allowlist;
 use Mautic\MarketplaceBundle\Service\Config;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\Service\Attribute\Required;
 
 final class CacheController extends CommonController
 {
-    public function __construct(
-        private readonly Config $config,
-        private readonly Allowlist $allowlist,
-        ManagerRegistry $doctrine,
-        ModelFactory $modelFactory,
-        UserHelper $userHelper,
-        CoreParametersHelper $coreParametersHelper,
-        EventDispatcherInterface $dispatcher,
-        Translator $translator,
-        FlashBag $flashBag,
-        RequestStack $requestStack,
-        CorePermissions $security,
-    ) {
-        parent::__construct($doctrine, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security);
+    private Config $config;
+
+    private Allowlist $allowlist;
+
+    #[Required]
+    public function autowireCacheController(
+        Config $config,
+        Allowlist $allowlist,
+    ): void {
+        $this->config    = $config;
+        $this->allowlist = $allowlist;
     }
 
     public function clearAction(): Response

--- a/app/bundles/MarketplaceBundle/Controller/Package/DetailController.php
+++ b/app/bundles/MarketplaceBundle/Controller/Package/DetailController.php
@@ -4,42 +4,37 @@ declare(strict_types=1);
 
 namespace Mautic\MarketplaceBundle\Controller\Package;
 
-use Doctrine\Persistence\ManagerRegistry;
 use Mautic\CoreBundle\Controller\CommonController;
-use Mautic\CoreBundle\Factory\ModelFactory;
 use Mautic\CoreBundle\Helper\ComposerHelper;
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
-use Mautic\CoreBundle\Helper\UserHelper;
-use Mautic\CoreBundle\Security\Permissions\CorePermissions;
-use Mautic\CoreBundle\Service\FlashBag;
-use Mautic\CoreBundle\Translation\Translator;
 use Mautic\MarketplaceBundle\Exception\RecordNotFoundException;
 use Mautic\MarketplaceBundle\Model\PackageModel;
 use Mautic\MarketplaceBundle\Security\Permissions\MarketplacePermissions;
 use Mautic\MarketplaceBundle\Service\Config;
 use Mautic\MarketplaceBundle\Service\RouteProvider;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\Service\Attribute\Required;
 
 final class DetailController extends CommonController
 {
-    public function __construct(
-        private readonly PackageModel $packageModel,
-        private readonly RouteProvider $routeProvider,
-        private readonly Config $config,
-        private readonly ComposerHelper $composer,
-        ManagerRegistry $doctrine,
-        ModelFactory $modelFactory,
-        UserHelper $userHelper,
-        CoreParametersHelper $coreParametersHelper,
-        EventDispatcherInterface $dispatcher,
-        Translator $translator,
-        FlashBag $flashBag,
-        RequestStack $requestStack,
-        CorePermissions $security,
-    ) {
-        parent::__construct($doctrine, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security);
+    private PackageModel $packageModel;
+
+    private RouteProvider $routeProvider;
+
+    private Config $config;
+
+    private ComposerHelper $composer;
+
+    #[Required]
+    public function autowireDetailController(
+        PackageModel $packageModel,
+        RouteProvider $routeProvider,
+        Config $config,
+        ComposerHelper $composer,
+    ): void {
+        $this->packageModel  = $packageModel;
+        $this->routeProvider = $routeProvider;
+        $this->config        = $config;
+        $this->composer      = $composer;
     }
 
     public function viewAction(string $vendor, string $package): Response

--- a/app/bundles/MarketplaceBundle/Controller/Package/InstallController.php
+++ b/app/bundles/MarketplaceBundle/Controller/Package/InstallController.php
@@ -4,39 +4,31 @@ declare(strict_types=1);
 
 namespace Mautic\MarketplaceBundle\Controller\Package;
 
-use Doctrine\Persistence\ManagerRegistry;
 use Mautic\CoreBundle\Controller\CommonController;
-use Mautic\CoreBundle\Factory\ModelFactory;
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
-use Mautic\CoreBundle\Helper\UserHelper;
-use Mautic\CoreBundle\Security\Permissions\CorePermissions;
-use Mautic\CoreBundle\Service\FlashBag;
-use Mautic\CoreBundle\Translation\Translator;
 use Mautic\MarketplaceBundle\Model\PackageModel;
 use Mautic\MarketplaceBundle\Security\Permissions\MarketplacePermissions;
 use Mautic\MarketplaceBundle\Service\Config;
 use Mautic\MarketplaceBundle\Service\RouteProvider;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\Service\Attribute\Required;
 
 final class InstallController extends CommonController
 {
-    public function __construct(
-        private readonly PackageModel $packageModel,
-        private readonly RouteProvider $routeProvider,
-        private readonly Config $config,
-        ManagerRegistry $doctrine,
-        ModelFactory $modelFactory,
-        UserHelper $userHelper,
-        CoreParametersHelper $coreParametersHelper,
-        EventDispatcherInterface $dispatcher,
-        Translator $translator,
-        FlashBag $flashBag,
-        RequestStack $requestStack,
-        CorePermissions $security,
-    ) {
-        parent::__construct($doctrine, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security);
+    private PackageModel $packageModel;
+
+    private RouteProvider $routeProvider;
+
+    private Config $config;
+
+    #[Required]
+    public function autowireInstallController(
+        PackageModel $packageModel,
+        RouteProvider $routeProvider,
+        Config $config,
+    ): void {
+        $this->packageModel  = $packageModel;
+        $this->routeProvider = $routeProvider;
+        $this->config        = $config;
     }
 
     public function viewAction(string $vendor, string $package): Response

--- a/app/bundles/MarketplaceBundle/Controller/Package/ListController.php
+++ b/app/bundles/MarketplaceBundle/Controller/Package/ListController.php
@@ -4,40 +4,32 @@ declare(strict_types=1);
 
 namespace Mautic\MarketplaceBundle\Controller\Package;
 
-use Doctrine\Persistence\ManagerRegistry;
 use Mautic\CoreBundle\Controller\CommonController;
-use Mautic\CoreBundle\Factory\ModelFactory;
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\InputHelper;
-use Mautic\CoreBundle\Helper\UserHelper;
-use Mautic\CoreBundle\Security\Permissions\CorePermissions;
-use Mautic\CoreBundle\Service\FlashBag;
-use Mautic\CoreBundle\Translation\Translator;
 use Mautic\MarketplaceBundle\Security\Permissions\MarketplacePermissions;
 use Mautic\MarketplaceBundle\Service\Config;
 use Mautic\MarketplaceBundle\Service\PluginCollector;
 use Mautic\MarketplaceBundle\Service\RouteProvider;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\Service\Attribute\Required;
 
 final class ListController extends CommonController
 {
-    public function __construct(
-        private readonly PluginCollector $pluginCollector,
-        private readonly RouteProvider $routeProvider,
-        ManagerRegistry $doctrine,
-        private readonly Config $config,
-        ModelFactory $modelFactory,
-        UserHelper $userHelper,
-        CoreParametersHelper $coreParametersHelper,
-        EventDispatcherInterface $dispatcher,
-        Translator $translator,
-        FlashBag $flashBag,
-        RequestStack $requestStack,
-        CorePermissions $security,
-    ) {
-        parent::__construct($doctrine, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security);
+    private PluginCollector $pluginCollector;
+
+    private RouteProvider $routeProvider;
+
+    private Config $config;
+
+    #[Required]
+    public function autowireListController(
+        PluginCollector $pluginCollector,
+        RouteProvider $routeProvider,
+        Config $config,
+    ): void {
+        $this->pluginCollector = $pluginCollector;
+        $this->routeProvider   = $routeProvider;
+        $this->config          = $config;
     }
 
     public function listAction(int $page = 1): Response

--- a/app/bundles/MarketplaceBundle/Controller/Package/RemoveController.php
+++ b/app/bundles/MarketplaceBundle/Controller/Package/RemoveController.php
@@ -4,39 +4,31 @@ declare(strict_types=1);
 
 namespace Mautic\MarketplaceBundle\Controller\Package;
 
-use Doctrine\Persistence\ManagerRegistry;
 use Mautic\CoreBundle\Controller\CommonController;
-use Mautic\CoreBundle\Factory\ModelFactory;
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
-use Mautic\CoreBundle\Helper\UserHelper;
-use Mautic\CoreBundle\Security\Permissions\CorePermissions;
-use Mautic\CoreBundle\Service\FlashBag;
-use Mautic\CoreBundle\Translation\Translator;
 use Mautic\MarketplaceBundle\Model\PackageModel;
 use Mautic\MarketplaceBundle\Security\Permissions\MarketplacePermissions;
 use Mautic\MarketplaceBundle\Service\Config;
 use Mautic\MarketplaceBundle\Service\RouteProvider;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\Service\Attribute\Required;
 
 final class RemoveController extends CommonController
 {
-    public function __construct(
-        private readonly PackageModel $packageModel,
-        private readonly RouteProvider $routeProvider,
-        private readonly Config $config,
-        ManagerRegistry $doctrine,
-        ModelFactory $modelFactory,
-        UserHelper $userHelper,
-        CoreParametersHelper $coreParametersHelper,
-        EventDispatcherInterface $dispatcher,
-        Translator $translator,
-        FlashBag $flashBag,
-        RequestStack $requestStack,
-        CorePermissions $security,
-    ) {
-        parent::__construct($doctrine, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security);
+    private PackageModel $packageModel;
+
+    private RouteProvider $routeProvider;
+
+    private Config $config;
+
+    #[Required]
+    public function autowireRemoveController(
+        PackageModel $packageModel,
+        RouteProvider $routeProvider,
+        Config $config,
+    ): void {
+        $this->packageModel  = $packageModel;
+        $this->routeProvider = $routeProvider;
+        $this->config        = $config;
     }
 
     public function viewAction(string $vendor, string $package): Response

--- a/app/bundles/MarketplaceBundle/Tests/Functional/Controller/AjaxControllerTest.php
+++ b/app/bundles/MarketplaceBundle/Tests/Functional/Controller/AjaxControllerTest.php
@@ -91,10 +91,6 @@ final class AjaxControllerTest extends AbstractMauticTestCase
         $this->marketplaceConfig = $this->createMock(Config::class);
 
         $controller = new AjaxController(
-            $composer,
-            $cacheHelper,
-            $this->createStub(LoggerInterface::class),
-            $this->marketplaceConfig,
             $this->createStub(ManagerRegistry::class),
             $this->createStub(ModelFactory::class),
             $this->createStub(UserHelper::class),
@@ -104,6 +100,12 @@ final class AjaxControllerTest extends AbstractMauticTestCase
             $this->createStub(FlashBag::class),
             $this->requestStack,
             $this->security
+        );
+        $controller->autowireMarketplaceAjaxController(
+            $composer,
+            $cacheHelper,
+            $this->createStub(LoggerInterface::class),
+            $this->marketplaceConfig
         );
         $controller->setContainer(static::getContainer());
 

--- a/app/bundles/NotificationBundle/Model/NotificationModel.php
+++ b/app/bundles/NotificationBundle/Model/NotificationModel.php
@@ -3,17 +3,12 @@
 namespace Mautic\NotificationBundle\Model;
 
 use Doctrine\DBAL\Query\QueryBuilder;
-use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Helper\Chart\ChartQuery;
 use Mautic\CoreBundle\Helper\Chart\LineChart;
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
-use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\CoreBundle\Model\AjaxLookupModelInterface;
 use Mautic\CoreBundle\Model\FormModel;
 use Mautic\CoreBundle\Model\GlobalSearchInterface;
 use Mautic\CoreBundle\Model\TranslationModelTrait;
-use Mautic\CoreBundle\Security\Permissions\CorePermissions;
-use Mautic\CoreBundle\Translation\Translator;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\NotificationBundle\Entity\Notification;
 use Mautic\NotificationBundle\Entity\NotificationRepository;
@@ -24,13 +19,11 @@ use Mautic\NotificationBundle\Form\Type\MobileNotificationType;
 use Mautic\NotificationBundle\Form\Type\NotificationType;
 use Mautic\NotificationBundle\NotificationEvents;
 use Mautic\PageBundle\Model\TrackableModel;
-use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\EventDispatcher\Event;
+use Symfony\Contracts\Service\Attribute\Required;
 
 /**
  * @extends FormModel<Notification>
@@ -41,20 +34,21 @@ class NotificationModel extends FormModel implements AjaxLookupModelInterface, G
 {
     use TranslationModelTrait;
 
-    public function __construct(
-        protected TrackableModel $pageTrackableModel,
-        EntityManagerInterface $em,
-        CorePermissions $security,
-        EventDispatcherInterface $dispatcher,
-        UrlGeneratorInterface $router,
-        Translator $translator,
-        UserHelper $userHelper,
-        LoggerInterface $mauticLogger,
-        CoreParametersHelper $coreParametersHelper,
-        private readonly NotificationRepository $notificationRepository,
-        private readonly StatRepository $statRepository,
-    ) {
-        parent::__construct($em, $security, $dispatcher, $router, $translator, $userHelper, $mauticLogger, $coreParametersHelper);
+    protected TrackableModel $pageTrackableModel;
+
+    private NotificationRepository $notificationRepository;
+
+    private StatRepository $statRepository;
+
+    #[Required]
+    public function autowireNotificationModel(
+        TrackableModel $pageTrackableModel,
+        NotificationRepository $notificationRepository,
+        StatRepository $statRepository,
+    ): void {
+        $this->pageTrackableModel     = $pageTrackableModel;
+        $this->notificationRepository = $notificationRepository;
+        $this->statRepository         = $statRepository;
     }
 
     public function getRepository(): NotificationRepository

--- a/app/bundles/PageBundle/Model/RedirectModel.php
+++ b/app/bundles/PageBundle/Model/RedirectModel.php
@@ -2,40 +2,31 @@
 
 namespace Mautic\PageBundle\Model;
 
-use Doctrine\ORM\EntityManagerInterface;
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\UrlHelper;
-use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\CoreBundle\Model\FormModel;
-use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\CoreBundle\Shortener\Shortener;
-use Mautic\CoreBundle\Translation\Translator;
 use Mautic\PageBundle\Entity\Redirect;
 use Mautic\PageBundle\Entity\RedirectRepository;
 use Mautic\PageBundle\Event\RedirectGenerationEvent;
 use Mautic\PageBundle\PageEvents;
-use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Contracts\Service\Attribute\Required;
 
 /**
  * @extends FormModel<Redirect>
  */
 class RedirectModel extends FormModel
 {
-    public function __construct(
-        EntityManagerInterface $em,
-        CorePermissions $security,
-        EventDispatcherInterface $dispatcher,
-        UrlGeneratorInterface $router,
-        Translator $translator,
-        UserHelper $userHelper,
-        LoggerInterface $mauticLogger,
-        CoreParametersHelper $coreParametersHelper,
-        private readonly Shortener $shortener,
-        private readonly RedirectRepository $redirectRepository,
-    ) {
-        parent::__construct($em, $security, $dispatcher, $router, $translator, $userHelper, $mauticLogger, $coreParametersHelper);
+    private Shortener $shortener;
+
+    private RedirectRepository $redirectRepository;
+
+    #[Required]
+    public function autowireRedirectModel(
+        Shortener $shortener,
+        RedirectRepository $redirectRepository,
+    ): void {
+        $this->shortener          = $shortener;
+        $this->redirectRepository = $redirectRepository;
     }
 
     public function getRepository(): RedirectRepository

--- a/app/bundles/PageBundle/Model/TrackableModel.php
+++ b/app/bundles/PageBundle/Model/TrackableModel.php
@@ -2,14 +2,9 @@
 
 namespace Mautic\PageBundle\Model;
 
-use Doctrine\ORM\EntityManagerInterface;
 use GuzzleHttp\Psr7\Uri;
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\UrlHelper;
-use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\CoreBundle\Model\AbstractCommonModel;
-use Mautic\CoreBundle\Security\Permissions\CorePermissions;
-use Mautic\CoreBundle\Translation\Translator;
 use Mautic\LeadBundle\Entity\LeadFieldRepository;
 use Mautic\LeadBundle\Helper\TokenHelper;
 use Mautic\PageBundle\Entity\Redirect;
@@ -17,9 +12,7 @@ use Mautic\PageBundle\Entity\Trackable;
 use Mautic\PageBundle\Entity\TrackableRepository;
 use Mautic\PageBundle\Event\UntrackableUrlsEvent;
 use Mautic\PageBundle\PageEvents;
-use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Contracts\Service\Attribute\Required;
 
 /**
  * @extends AbstractCommonModel<Trackable>
@@ -61,20 +54,21 @@ class TrackableModel extends AbstractCommonModel
 
     private ?array $contactFieldUrlTokens = null;
 
-    public function __construct(
-        protected RedirectModel $redirectModel,
-        private readonly LeadFieldRepository $leadFieldRepository,
-        EntityManagerInterface $em,
-        CorePermissions $security,
-        EventDispatcherInterface $dispatcher,
-        UrlGeneratorInterface $router,
-        Translator $translator,
-        UserHelper $userHelper,
-        LoggerInterface $mauticLogger,
-        CoreParametersHelper $coreParametersHelper,
-        private readonly TrackableRepository $trackableRepository,
-    ) {
-        parent::__construct($em, $security, $dispatcher, $router, $translator, $userHelper, $mauticLogger, $coreParametersHelper);
+    protected RedirectModel $redirectModel;
+
+    private LeadFieldRepository $leadFieldRepository;
+
+    private TrackableRepository $trackableRepository;
+
+    #[Required]
+    public function autowireTrackableModel(
+        RedirectModel $redirectModel,
+        LeadFieldRepository $leadFieldRepository,
+        TrackableRepository $trackableRepository,
+    ): void {
+        $this->redirectModel        = $redirectModel;
+        $this->leadFieldRepository  = $leadFieldRepository;
+        $this->trackableRepository  = $trackableRepository;
     }
 
     public function getRepository(): TrackableRepository

--- a/app/bundles/PageBundle/Model/VideoModel.php
+++ b/app/bundles/PageBundle/Model/VideoModel.php
@@ -2,43 +2,37 @@
 
 namespace Mautic\PageBundle\Model;
 
-use Doctrine\ORM\EntityManagerInterface;
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\IpLookupHelper;
-use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\CoreBundle\Model\FormModel;
-use Mautic\CoreBundle\Security\Permissions\CorePermissions;
-use Mautic\CoreBundle\Translation\Translator;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Tracker\ContactTracker;
 use Mautic\PageBundle\Entity\VideoHit;
 use Mautic\PageBundle\Entity\VideoHitRepository;
 use Mautic\PageBundle\Event\VideoHitEvent;
 use Mautic\PageBundle\PageEvents;
-use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Contracts\Service\Attribute\Required;
 
 /**
  * @extends FormModel<VideoHit>
  */
 class VideoModel extends FormModel
 {
-    public function __construct(
-        protected IpLookupHelper $ipLookupHelper,
-        protected ContactTracker $contactTracker,
-        EntityManagerInterface $em,
-        CorePermissions $security,
-        EventDispatcherInterface $dispatcher,
-        UrlGeneratorInterface $router,
-        Translator $translator,
-        UserHelper $userHelper,
-        LoggerInterface $mauticLogger,
-        CoreParametersHelper $coreParametersHelper,
-        private readonly VideoHitRepository $videoHitRepository,
-    ) {
-        parent::__construct($em, $security, $dispatcher, $router, $translator, $userHelper, $mauticLogger, $coreParametersHelper);
+    protected IpLookupHelper $ipLookupHelper;
+
+    protected ContactTracker $contactTracker;
+
+    private VideoHitRepository $videoHitRepository;
+
+    #[Required]
+    public function autowireVideoModel(
+        IpLookupHelper $ipLookupHelper,
+        ContactTracker $contactTracker,
+        VideoHitRepository $videoHitRepository,
+    ): void {
+        $this->ipLookupHelper     = $ipLookupHelper;
+        $this->contactTracker     = $contactTracker;
+        $this->videoHitRepository = $videoHitRepository;
     }
 
     public function getHitRepository(): VideoHitRepository

--- a/app/bundles/PageBundle/Tests/Model/RedirectModelTest.php
+++ b/app/bundles/PageBundle/Tests/Model/RedirectModelTest.php
@@ -65,8 +65,10 @@ final class RedirectModelTest extends PageTestAbstract
             $this->createStub(UserHelper::class),
             $this->createStub(LoggerInterface::class),
             $this->createStub(CoreParametersHelper::class),
+        );
+        $model->autowireRedirectModel(
             $shortener,
-            $this->createStub(RedirectRepository::class), // $redirectRepository
+            $this->createStub(RedirectRepository::class)
         );
 
         $redirect = new Redirect();

--- a/app/bundles/PageBundle/Tests/Model/TrackableModelTest.php
+++ b/app/bundles/PageBundle/Tests/Model/TrackableModelTest.php
@@ -36,8 +36,6 @@ final class TrackableModelTest extends TestCase
 
         $mockModel = $this->getMockBuilder(TrackableModel::class)
             ->setConstructorArgs([
-                $mockRedirectModel,
-                $mockLeadFieldRepository,
                 $this->createStub(EntityManagerInterface::class),
                 $this->createStub(CorePermissions::class),
                 $this->createStub(EventDispatcherInterface::class),
@@ -46,10 +44,11 @@ final class TrackableModelTest extends TestCase
                 $this->createStub(UserHelper::class),
                 $this->createStub(LoggerInterface::class),
                 $this->createStub(CoreParametersHelper::class),
-                $this->createStub(TrackableRepository::class),
             ])
             ->onlyMethods(['getDoNotTrackList', 'getEntitiesFromUrls', 'createTrackingTokens',  'extractTrackablesFromHtml'])
             ->getMock();
+
+        $mockModel->autowireTrackableModel($mockRedirectModel, $mockLeadFieldRepository, $this->createStub(TrackableRepository::class));
 
         $mockModel->expects($this->once())
             ->method('getEntitiesFromUrls')
@@ -88,8 +87,6 @@ final class TrackableModelTest extends TestCase
 
         $mockModel = $this->getMockBuilder(TrackableModel::class)
             ->setConstructorArgs([
-                $mockRedirectModel,
-                $mockLeadFieldRepository,
                 $this->createStub(EntityManagerInterface::class),
                 $this->createStub(CorePermissions::class),
                 $this->createStub(EventDispatcherInterface::class),
@@ -98,10 +95,11 @@ final class TrackableModelTest extends TestCase
                 $this->createStub(UserHelper::class),
                 $this->createStub(LoggerInterface::class),
                 $this->createStub(CoreParametersHelper::class),
-                $this->createStub(TrackableRepository::class),
             ])
             ->onlyMethods(['getDoNotTrackList', 'getEntitiesFromUrls', 'createTrackingTokens',  'extractTrackablesFromText'])
             ->getMock();
+
+        $mockModel->autowireTrackableModel($mockRedirectModel, $mockLeadFieldRepository, $this->createStub(TrackableRepository::class));
 
         $mockModel->expects($this->once())
             ->method('getDoNotTrackList')
@@ -627,8 +625,6 @@ TEXT;
 
         $mockModel = $this->getMockBuilder(TrackableModel::class)
             ->setConstructorArgs([
-                $mockRedirectModel,
-                $mockLeadFieldRepository,
                 $this->createStub(EntityManagerInterface::class),
                 $this->createStub(CorePermissions::class),
                 $this->createStub(EventDispatcherInterface::class),
@@ -637,10 +633,11 @@ TEXT;
                 $this->createStub(UserHelper::class),
                 $this->createStub(LoggerInterface::class),
                 $this->createStub(CoreParametersHelper::class),
-                $this->createStub(TrackableRepository::class),
             ])
             ->onlyMethods(['getDoNotTrackList', 'getEntitiesFromUrls', 'getContactFieldUrlTokens'])
             ->getMock();
+
+        $mockModel->autowireTrackableModel($mockRedirectModel, $mockLeadFieldRepository, $this->createStub(TrackableRepository::class));
 
         $mockModel->expects($this->once())
             ->method('getDoNotTrackList')

--- a/app/bundles/PageBundle/Tests/Model/TrackableModelTest.php
+++ b/app/bundles/PageBundle/Tests/Model/TrackableModelTest.php
@@ -620,9 +620,6 @@ TEXT;
             ]
         );
 
-        $mockRedirectModel       = $this->createMock(RedirectModel::class);
-        $mockLeadFieldRepository = $this->createMock(LeadFieldRepository::class);
-
         $mockModel = $this->getMockBuilder(TrackableModel::class)
             ->setConstructorArgs([
                 $this->createStub(EntityManagerInterface::class),
@@ -637,7 +634,7 @@ TEXT;
             ->onlyMethods(['getDoNotTrackList', 'getEntitiesFromUrls', 'getContactFieldUrlTokens'])
             ->getMock();
 
-        $mockModel->autowireTrackableModel($mockRedirectModel, $mockLeadFieldRepository, $this->createStub(TrackableRepository::class));
+        $mockModel->autowireTrackableModel($this->createMock(RedirectModel::class), $this->createMock(LeadFieldRepository::class), $this->createStub(TrackableRepository::class));
 
         $mockModel->expects($this->once())
             ->method('getDoNotTrackList')

--- a/app/bundles/PageBundle/Tests/PageTestAbstract.php
+++ b/app/bundles/PageBundle/Tests/PageTestAbstract.php
@@ -164,8 +164,6 @@ abstract class PageTestAbstract extends TestCase
      */
     protected function getRedirectModel(): MockObject
     {
-        $shortener = $this->createMock(Shortener::class);
-
         $mockRedirectModel = $this->getMockBuilder(RedirectModel::class)
             ->setConstructorArgs([
                 $this->createStub(EntityManagerInterface::class),
@@ -180,7 +178,7 @@ abstract class PageTestAbstract extends TestCase
             ->onlyMethods(['createRedirectEntity', 'generateRedirectUrl'])
             ->getMock();
 
-        $mockRedirectModel->autowireRedirectModel($shortener, $this->createStub(RedirectRepository::class));
+        $mockRedirectModel->autowireRedirectModel($this->createMock(Shortener::class), $this->createStub(RedirectRepository::class));
 
         $mockRedirectModel
             ->method('createRedirectEntity')

--- a/app/bundles/PageBundle/Tests/PageTestAbstract.php
+++ b/app/bundles/PageBundle/Tests/PageTestAbstract.php
@@ -176,11 +176,11 @@ abstract class PageTestAbstract extends TestCase
                 $this->createStub(UserHelper::class),
                 $this->createStub(LoggerInterface::class),
                 $this->createStub(CoreParametersHelper::class),
-                $shortener,
-                $this->createStub(RedirectRepository::class),
             ])
             ->onlyMethods(['createRedirectEntity', 'generateRedirectUrl'])
             ->getMock();
+
+        $mockRedirectModel->autowireRedirectModel($shortener, $this->createStub(RedirectRepository::class));
 
         $mockRedirectModel
             ->method('createRedirectEntity')

--- a/app/bundles/PointBundle/Model/InsightModel.php
+++ b/app/bundles/PointBundle/Model/InsightModel.php
@@ -4,12 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\PointBundle\Model;
 
-use Doctrine\ORM\EntityManagerInterface;
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
-use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\CoreBundle\Model\FormModel as CommonFormModel;
-use Mautic\CoreBundle\Security\Permissions\CorePermissions;
-use Mautic\CoreBundle\Translation\Translator;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\PointBundle\Entity\Group;
@@ -17,31 +12,27 @@ use Mautic\PointBundle\Entity\GroupContactScore;
 use Mautic\PointBundle\Entity\PointInsight;
 use Mautic\PointBundle\Entity\PointInsightRepository;
 use Mautic\PointBundle\Form\Type\PointInsightType;
-use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Contracts\Service\Attribute\Required;
 
 /**
  * @extends CommonFormModel<PointInsight>
  */
 class InsightModel extends CommonFormModel
 {
-    public function __construct(
-        protected LeadModel $leadModel,
-        EntityManagerInterface $em,
-        CorePermissions $security,
-        EventDispatcherInterface $dispatcher,
-        UrlGeneratorInterface $router,
-        Translator $translator,
-        UserHelper $userHelper,
-        LoggerInterface $mauticLogger,
-        CoreParametersHelper $coreParametersHelper,
-        private readonly PointInsightRepository $pointInsightRepository,
-    ) {
-        parent::__construct($em, $security, $dispatcher, $router, $translator, $userHelper, $mauticLogger, $coreParametersHelper);
+    protected LeadModel $leadModel;
+
+    private PointInsightRepository $pointInsightRepository;
+
+    #[Required]
+    public function autowireInsightModel(
+        LeadModel $leadModel,
+        PointInsightRepository $pointInsightRepository,
+    ): void {
+        $this->leadModel              = $leadModel;
+        $this->pointInsightRepository = $pointInsightRepository;
     }
 
     public function getRepository(): PointInsightRepository

--- a/app/bundles/ProjectBundle/Model/ProjectModel.php
+++ b/app/bundles/ProjectBundle/Model/ProjectModel.php
@@ -4,34 +4,25 @@ declare(strict_types=1);
 
 namespace Mautic\ProjectBundle\Model;
 
-use Doctrine\ORM\EntityManagerInterface;
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
-use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\CoreBundle\Model\AjaxLookupModelInterface;
 use Mautic\CoreBundle\Model\FormModel;
-use Mautic\CoreBundle\Security\Permissions\CorePermissions;
-use Mautic\CoreBundle\Translation\Translator;
 use Mautic\ProjectBundle\Entity\ProjectRepository;
 use Mautic\ProjectBundle\Service\ProjectEntityLoaderService;
-use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Contracts\Service\Attribute\Required;
 
 final class ProjectModel extends FormModel implements AjaxLookupModelInterface
 {
-    public function __construct(
-        EntityManagerInterface $em,
-        CorePermissions $security,
-        EventDispatcherInterface $dispatcher,
-        UrlGeneratorInterface $router,
-        Translator $translator,
-        UserHelper $userHelper,
-        LoggerInterface $logger,
-        CoreParametersHelper $coreParametersHelper,
-        private readonly ProjectEntityLoaderService $entityLoaderService,
-        private readonly ProjectRepository $projectRepository,
-    ) {
-        parent::__construct($em, $security, $dispatcher, $router, $translator, $userHelper, $logger, $coreParametersHelper);
+    private ProjectEntityLoaderService $entityLoaderService;
+
+    private ProjectRepository $projectRepository;
+
+    #[Required]
+    public function autowireProjectModel(
+        ProjectEntityLoaderService $entityLoaderService,
+        ProjectRepository $projectRepository,
+    ): void {
+        $this->entityLoaderService = $entityLoaderService;
+        $this->projectRepository   = $projectRepository;
     }
 
     public function getRepository(): ProjectRepository

--- a/app/bundles/StageBundle/Model/StageModel.php
+++ b/app/bundles/StageBundle/Model/StageModel.php
@@ -3,15 +3,10 @@
 namespace Mautic\StageBundle\Model;
 
 use Doctrine\DBAL\ParameterType;
-use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Helper\Chart\ChartQuery;
 use Mautic\CoreBundle\Helper\Chart\LineChart;
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
-use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\CoreBundle\Model\FormModel as CommonFormModel;
 use Mautic\CoreBundle\Model\GlobalSearchInterface;
-use Mautic\CoreBundle\Security\Permissions\CorePermissions;
-use Mautic\CoreBundle\Translation\Translator;
 use Mautic\LeadBundle\Entity\StagesChangeLogRepository;
 use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\StageBundle\Entity\LeadStageLogRepository;
@@ -21,34 +16,36 @@ use Mautic\StageBundle\Event\StageBuilderEvent;
 use Mautic\StageBundle\Event\StageEvent;
 use Mautic\StageBundle\Form\Type\StageType;
 use Mautic\StageBundle\StageEvents;
-use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\EventDispatcher\Event;
+use Symfony\Contracts\Service\Attribute\Required;
 
 /**
  * @extends CommonFormModel<Stage>
  */
 class StageModel extends CommonFormModel implements GlobalSearchInterface
 {
-    public function __construct(
-        protected LeadModel $leadModel,
-        UserHelper $userHelper,
-        EntityManagerInterface $em,
-        CorePermissions $security,
-        EventDispatcherInterface $dispatcher,
-        UrlGeneratorInterface $router,
-        Translator $translator,
-        LoggerInterface $mauticLogger,
-        CoreParametersHelper $coreParametersHelper,
-        private readonly StageRepository $stageRepository,
-        private readonly StagesChangeLogRepository $stagesChangeLogRepository,
-        private readonly LeadStageLogRepository $leadStageLogRepository,
-    ) {
-        parent::__construct($em, $security, $dispatcher, $router, $translator, $userHelper, $mauticLogger, $coreParametersHelper);
+    protected LeadModel $leadModel;
+
+    private StageRepository $stageRepository;
+
+    private StagesChangeLogRepository $stagesChangeLogRepository;
+
+    private LeadStageLogRepository $leadStageLogRepository;
+
+    #[Required]
+    public function autowireStageModel(
+        LeadModel $leadModel,
+        StageRepository $stageRepository,
+        StagesChangeLogRepository $stagesChangeLogRepository,
+        LeadStageLogRepository $leadStageLogRepository,
+    ): void {
+        $this->leadModel                 = $leadModel;
+        $this->stageRepository           = $stageRepository;
+        $this->stagesChangeLogRepository = $stagesChangeLogRepository;
+        $this->leadStageLogRepository    = $leadStageLogRepository;
     }
 
     public function getRepository(): StageRepository

--- a/app/bundles/UserBundle/Controller/SecurityController.php
+++ b/app/bundles/UserBundle/Controller/SecurityController.php
@@ -4,22 +4,14 @@ declare(strict_types=1);
 
 namespace Mautic\UserBundle\Controller;
 
-use Doctrine\Persistence\ManagerRegistry;
 use Mautic\CoreBundle\Controller\CommonController;
-use Mautic\CoreBundle\Factory\ModelFactory;
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
-use Mautic\CoreBundle\Helper\UserHelper;
-use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\CoreBundle\Service\FlashBag;
-use Mautic\CoreBundle\Translation\Translator;
 use Mautic\PluginBundle\Helper\IntegrationHelper;
 use Mautic\UserBundle\Exception\WeakPasswordException;
 use Mautic\UserBundle\Security\SAML\Helper as SAMLHelper;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
@@ -27,23 +19,18 @@ use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
+use Symfony\Contracts\Service\Attribute\Required;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class SecurityController extends CommonController implements EventSubscriberInterface
 {
-    public function __construct(
-        ManagerRegistry $doctrine,
-        ModelFactory $modelFactory,
-        UserHelper $userHelper,
-        CoreParametersHelper $coreParametersHelper,
-        EventDispatcherInterface $dispatcher,
-        Translator $translator,
-        FlashBag $flashBag,
-        RequestStack $requestStack,
-        CorePermissions $security,
-        private readonly AuthorizationCheckerInterface $authorizationChecker,
-    ) {
-        parent::__construct($doctrine, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security);
+    private AuthorizationCheckerInterface $authorizationChecker;
+
+    #[Required]
+    public function autowireSecurityController(
+        AuthorizationCheckerInterface $authorizationChecker,
+    ): void {
+        $this->authorizationChecker = $authorizationChecker;
     }
 
     public function onRequest(RequestEvent $event): void

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -252,6 +252,7 @@ rules:
 
 	- Utils\PHPStan\Rule\NoServicesInBundleConfigRule
 	#- Utils\PHPStan\Rule\NoUnusedServiceAliasRule
+	- Utils\PHPStan\Rule\NoParentConstructorForwardingRule
 
 #services:
 #	-

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -224,6 +224,7 @@ parameters:
 	scanDirectories:
 		# the kernel boot reflects these classes, so PHPStan can no longer locate them by autoloading
 		- vendor/javer/sp-bundle/src
+		- vendor/javer/symfony-bridge/src
 	scanFiles:
 		# This is here because a few functions in the global namespace are defined in this file
 		- vendor/twig/twig/src/Extension/EscaperExtension.php

--- a/plugins/GrapesJsBuilderBundle/Model/GrapesJsBuilderModel.php
+++ b/plugins/GrapesJsBuilderBundle/Model/GrapesJsBuilderModel.php
@@ -4,29 +4,23 @@ declare(strict_types=1);
 
 namespace MauticPlugin\GrapesJsBuilderBundle\Model;
 
-use Doctrine\ORM\EntityManagerInterface;
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
-use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\CoreBundle\Model\AbstractCommonModel;
-use Mautic\CoreBundle\Security\Permissions\CorePermissions;
-use Mautic\CoreBundle\Translation\Translator;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Entity\EmailRepository;
 use Mautic\EmailBundle\Model\EmailModel;
 use Mautic\PageBundle\Entity\Page;
 use MauticPlugin\GrapesJsBuilderBundle\Entity\GrapesJsBuilder;
 use MauticPlugin\GrapesJsBuilderBundle\Entity\GrapesJsBuilderRepository;
-use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Contracts\Service\Attribute\Required;
 
 /**
  * @extends AbstractCommonModel<GrapesJsBuilder>
  */
 class GrapesJsBuilderModel extends AbstractCommonModel
 {
+<<<<<<< HEAD
     public function __construct(
         private readonly RequestStack $requestStack,
         private readonly EmailModel $emailModel,
@@ -42,6 +36,27 @@ class GrapesJsBuilderModel extends AbstractCommonModel
         private readonly EmailRepository $emailRepository,
     ) {
         parent::__construct($em, $security, $dispatcher, $router, $translator, $userHelper, $mauticLogger, $coreParametersHelper);
+=======
+    private RequestStack $requestStack;
+
+    private EmailModel $emailModel;
+
+    private GrapesJsBuilderRepository $grapesJsBuilderRepository;
+
+    private \Mautic\EmailBundle\Entity\EmailRepository $emailRepository;
+
+    #[Required]
+    public function autowireGrapesJsBuilderModel(
+        RequestStack $requestStack,
+        EmailModel $emailModel,
+        GrapesJsBuilderRepository $grapesJsBuilderRepository,
+        \Mautic\EmailBundle\Entity\EmailRepository $emailRepository,
+    ): void {
+        $this->requestStack              = $requestStack;
+        $this->emailModel                = $emailModel;
+        $this->grapesJsBuilderRepository = $grapesJsBuilderRepository;
+        $this->emailRepository           = $emailRepository;
+>>>>>>> e346b540a8 ([phpstan] add rule to avoid ctor forwarding)
     }
 
     public function getRepository(): GrapesJsBuilderRepository

--- a/plugins/GrapesJsBuilderBundle/Model/GrapesJsBuilderModel.php
+++ b/plugins/GrapesJsBuilderBundle/Model/GrapesJsBuilderModel.php
@@ -20,43 +20,25 @@ use Symfony\Contracts\Service\Attribute\Required;
  */
 class GrapesJsBuilderModel extends AbstractCommonModel
 {
-<<<<<<< HEAD
-    public function __construct(
-        private readonly RequestStack $requestStack,
-        private readonly EmailModel $emailModel,
-        EntityManagerInterface $em,
-        CorePermissions $security,
-        EventDispatcherInterface $dispatcher,
-        UrlGeneratorInterface $router,
-        Translator $translator,
-        UserHelper $userHelper,
-        LoggerInterface $mauticLogger,
-        CoreParametersHelper $coreParametersHelper,
-        private readonly GrapesJsBuilderRepository $grapesJsBuilderRepository,
-        private readonly EmailRepository $emailRepository,
-    ) {
-        parent::__construct($em, $security, $dispatcher, $router, $translator, $userHelper, $mauticLogger, $coreParametersHelper);
-=======
     private RequestStack $requestStack;
 
     private EmailModel $emailModel;
 
     private GrapesJsBuilderRepository $grapesJsBuilderRepository;
 
-    private \Mautic\EmailBundle\Entity\EmailRepository $emailRepository;
+    private EmailRepository $emailRepository;
 
     #[Required]
     public function autowireGrapesJsBuilderModel(
         RequestStack $requestStack,
         EmailModel $emailModel,
         GrapesJsBuilderRepository $grapesJsBuilderRepository,
-        \Mautic\EmailBundle\Entity\EmailRepository $emailRepository,
+        EmailRepository $emailRepository,
     ): void {
         $this->requestStack              = $requestStack;
         $this->emailModel                = $emailModel;
         $this->grapesJsBuilderRepository = $grapesJsBuilderRepository;
         $this->emailRepository           = $emailRepository;
->>>>>>> e346b540a8 ([phpstan] add rule to avoid ctor forwarding)
     }
 
     public function getRepository(): GrapesJsBuilderRepository

--- a/plugins/GrapesJsBuilderBundle/Tests/Unit/Model/GrapesJsBuilderModelEditorStateTest.php
+++ b/plugins/GrapesJsBuilderBundle/Tests/Unit/Model/GrapesJsBuilderModelEditorStateTest.php
@@ -149,9 +149,7 @@ final class GrapesJsBuilderModelEditorStateTest extends TestCase
         ?GrapesJsBuilderRepository $grapesJsBuilderRepository = null,
         ?EmailRepository $emailRepository = null,
     ): GrapesJsBuilderModel {
-        return new GrapesJsBuilderModel(
-            $requestStack,
-            $emailModel,
+        $grapesJsBuilderModel = new GrapesJsBuilderModel(
             $entityManager,
             $this->createStub(CorePermissions::class),
             $this->createStub(EventDispatcherInterface::class),
@@ -160,8 +158,14 @@ final class GrapesJsBuilderModelEditorStateTest extends TestCase
             $this->createStub(UserHelper::class),
             $this->createStub(LoggerInterface::class),
             $this->createStub(CoreParametersHelper::class),
-            $grapesJsBuilderRepository ?? $this->createStub(GrapesJsBuilderRepository::class), // $grapesJsBuilderRepository
-            $emailRepository ?? $this->createStub(EmailRepository::class), // $emailRepository
         );
+        $grapesJsBuilderModel->autowireGrapesJsBuilderModel(
+            $requestStack,
+            $emailModel,
+            $grapesJsBuilderRepository ?? $this->createStub(GrapesJsBuilderRepository::class),
+            $emailRepository ?? $this->createStub(EmailRepository::class),
+        );
+
+        return $grapesJsBuilderModel;
     }
 }

--- a/plugins/GrapesJsBuilderBundle/Tests/Unit/Model/GrapesJsBuilderModelTest.php
+++ b/plugins/GrapesJsBuilderBundle/Tests/Unit/Model/GrapesJsBuilderModelTest.php
@@ -96,8 +96,6 @@ final class GrapesJsBuilderModelTest extends \PHPUnit\Framework\TestCase
         $email = new Email();
 
         $grapeJsBuilderModel = new GrapesJsBuilderModel(
-            $requestStack,
-            $emailModel,
             $entityManager,
             $this->createStub(CorePermissions::class),
             $this->createStub(EventDispatcherInterface::class),
@@ -106,8 +104,12 @@ final class GrapesJsBuilderModelTest extends \PHPUnit\Framework\TestCase
             $this->createStub(UserHelper::class),
             $this->createStub(LoggerInterface::class),
             $this->createStub(CoreParametersHelper::class),
-            $grapesJsBuilderRepository, // $grapesJsBuilderRepository
-            $emailRepository, // $emailRepository
+        );
+        $grapeJsBuilderModel->autowireGrapesJsBuilderModel(
+            $requestStack,
+            $emailModel,
+            $grapesJsBuilderRepository,
+            $emailRepository,
         );
 
         $grapeJsBuilderModel->addOrEditEntity($email);
@@ -201,8 +203,6 @@ final class GrapesJsBuilderModelTest extends \PHPUnit\Framework\TestCase
         $email = new Email();
 
         $grapeJsBuilderModel = new GrapesJsBuilderModel(
-            $requestStack,
-            $emailModel,
             $entityManager,
             $this->createStub(CorePermissions::class),
             $this->createStub(EventDispatcherInterface::class),
@@ -211,8 +211,12 @@ final class GrapesJsBuilderModelTest extends \PHPUnit\Framework\TestCase
             $this->createStub(UserHelper::class),
             $this->createStub(LoggerInterface::class),
             $this->createStub(CoreParametersHelper::class),
-            $grapesJsBuilderRepository, // $grapesJsBuilderRepository
-            $emailRepository, // $emailRepository
+        );
+        $grapeJsBuilderModel->autowireGrapesJsBuilderModel(
+            $requestStack,
+            $emailModel,
+            $grapesJsBuilderRepository,
+            $emailRepository,
         );
 
         $grapeJsBuilderModel->addOrEditEntity($email);

--- a/plugins/MauticCrmBundle/Integration/HubspotIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/HubspotIntegration.php
@@ -2,34 +2,18 @@
 
 namespace MauticPlugin\MauticCrmBundle\Integration;
 
-use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Helper\ArrayHelper;
-use Mautic\CoreBundle\Helper\CacheStorageHelper;
-use Mautic\CoreBundle\Helper\EncryptionHelper;
-use Mautic\CoreBundle\Helper\PathsHelper;
 use Mautic\CoreBundle\Helper\UserHelper;
-use Mautic\CoreBundle\Model\NotificationModel;
 use Mautic\LeadBundle\DataObject\LeadManipulator;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\StagesChangeLog;
-use Mautic\LeadBundle\Field\FieldsWithUniqueIdentifier;
-use Mautic\LeadBundle\Model\CompanyModel;
-use Mautic\LeadBundle\Model\DoNotContact;
-use Mautic\LeadBundle\Model\FieldModel;
-use Mautic\LeadBundle\Model\LeadModel;
-use Mautic\PluginBundle\Model\IntegrationEntityModel;
 use Mautic\StageBundle\Entity\Stage;
 use Mautic\StageBundle\Entity\StageRepository;
 use MauticPlugin\MauticCrmBundle\Api\HubspotApi;
-use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Service\Attribute\Required;
-use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * @method HubspotApi getApiHelper()
@@ -40,53 +24,18 @@ class HubspotIntegration extends CrmAbstractIntegration
 {
     private StageRepository $stageRepository;
 
+    protected UserHelper $userHelper;
+
     #[Required]
     public function autowireHubspotIntegration(
         StageRepository $stageRepository,
+        UserHelper $userHelper,
     ): void {
         $this->stageRepository = $stageRepository;
+        $this->userHelper = $userHelper;
     }
 
     public const ACCESS_KEY = 'accessKey';
-
-    public function __construct(
-        EventDispatcherInterface $eventDispatcher,
-        CacheStorageHelper $cacheStorageHelper,
-        EntityManagerInterface $entityManager,
-        RequestStack $requestStack,
-        RouterInterface $router,
-        TranslatorInterface $translator,
-        LoggerInterface $logger,
-        EncryptionHelper $encryptionHelper,
-        LeadModel $leadModel,
-        CompanyModel $companyModel,
-        PathsHelper $pathsHelper,
-        NotificationModel $notificationModel,
-        FieldModel $fieldModel,
-        IntegrationEntityModel $integrationEntityModel,
-        DoNotContact $doNotContact,
-        FieldsWithUniqueIdentifier $fieldsWithUniqueIdentifier,
-        protected UserHelper $userHelper,
-    ) {
-        parent::__construct(
-            $eventDispatcher,
-            $cacheStorageHelper,
-            $entityManager,
-            $requestStack,
-            $router,
-            $translator,
-            $logger,
-            $encryptionHelper,
-            $leadModel,
-            $companyModel,
-            $pathsHelper,
-            $notificationModel,
-            $fieldModel,
-            $integrationEntityModel,
-            $doNotContact,
-            $fieldsWithUniqueIdentifier
-        );
-    }
 
     public function getName(): string
     {

--- a/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
@@ -2,36 +2,21 @@
 
 namespace MauticPlugin\MauticCrmBundle\Integration;
 
-use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Form\Type\ButtonGroupType;
-use Mautic\CoreBundle\Helper\CacheStorageHelper;
-use Mautic\CoreBundle\Helper\EncryptionHelper;
-use Mautic\CoreBundle\Helper\PathsHelper;
-use Mautic\CoreBundle\Model\NotificationModel;
 use Mautic\LeadBundle\Entity\Company;
 use Mautic\LeadBundle\Entity\CompanyRepository;
 use Mautic\LeadBundle\Entity\Lead;
-use Mautic\LeadBundle\Field\FieldsWithUniqueIdentifier;
-use Mautic\LeadBundle\Model\CompanyModel;
 use Mautic\LeadBundle\Model\DoNotContact;
-use Mautic\LeadBundle\Model\FieldModel;
-use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\PluginBundle\Entity\IntegrationEntity;
 use Mautic\PluginBundle\Exception\ApiErrorException;
-use Mautic\PluginBundle\Model\IntegrationEntityModel;
 use Mautic\UserBundle\Model\UserModel;
 use MauticPlugin\MauticCrmBundle\Api\SugarcrmApi;
-use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilder;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Contracts\Service\Attribute\Required;
-use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * @extends CrmAbstractIntegration<SugarcrmApi>
@@ -43,8 +28,12 @@ class SugarcrmIntegration extends CrmAbstractIntegration
     #[Required]
     public function autowireSugarcrmIntegration(
         CompanyRepository $companyRepository,
+        DoNotContact $doNotContactModel,
+        UserModel $userModel,
     ): void {
         $this->companyRepository = $companyRepository;
+        $this->doNotContactModel = $doNotContactModel;
+        $this->userModel = $userModel;
     }
 
     /**
@@ -63,44 +52,9 @@ class SugarcrmIntegration extends CrmAbstractIntegration
 
     private $authorizationError;
 
-    public function __construct(
-        EventDispatcherInterface $eventDispatcher,
-        CacheStorageHelper $cacheStorageHelper,
-        EntityManagerInterface $entityManager,
-        RequestStack $requestStack,
-        RouterInterface $router,
-        TranslatorInterface $translator,
-        LoggerInterface $logger,
-        EncryptionHelper $encryptionHelper,
-        LeadModel $leadModel,
-        CompanyModel $companyModel,
-        PathsHelper $pathsHelper,
-        NotificationModel $notificationModel,
-        FieldModel $fieldModel,
-        IntegrationEntityModel $integrationEntityModel,
-        FieldsWithUniqueIdentifier $fieldsWithUniqueIdentifier,
-        protected DoNotContact $doNotContactModel,
-        private readonly UserModel $userModel,
-    ) {
-        parent::__construct(
-            $eventDispatcher,
-            $cacheStorageHelper,
-            $entityManager,
-            $requestStack,
-            $router,
-            $translator,
-            $logger,
-            $encryptionHelper,
-            $leadModel,
-            $companyModel,
-            $pathsHelper,
-            $notificationModel,
-            $fieldModel,
-            $integrationEntityModel,
-            $doNotContactModel,
-            $fieldsWithUniqueIdentifier
-        );
-    }
+    protected DoNotContact $doNotContactModel;
+
+    private UserModel $userModel;
 
     /**
      * Returns the name of the social integration that must match the name of the file.

--- a/plugins/MauticCrmBundle/Tests/Integration/HubspotIntegrationTest.php
+++ b/plugins/MauticCrmBundle/Tests/Integration/HubspotIntegrationTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace MauticPlugin\MauticCrmBundle\Tests\Integration;
 
-use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\PluginBundle\Entity\Integration;
 use Mautic\PluginBundle\Event\PluginIntegrationKeyEvent;
 use Mautic\PluginBundle\PluginEvents;
@@ -38,7 +37,6 @@ final class HubspotIntegrationTest extends AbstractIntegrationTestCase
             $this->integrationEntityModel,
             $this->doNotContact,
             $this->fieldsWithUniqueIdentifier,
-            $this->createStub(UserHelper::class)
         );
     }
 

--- a/plugins/MauticFocusBundle/Controller/FocusController.php
+++ b/plugins/MauticFocusBundle/Controller/FocusController.php
@@ -2,47 +2,35 @@
 
 namespace MauticPlugin\MauticFocusBundle\Controller;
 
-use Doctrine\Persistence\ManagerRegistry;
 use Mautic\CacheBundle\Cache\CacheProviderTagAwareInterface;
 use Mautic\CoreBundle\Controller\AbstractStandardFormController;
-use Mautic\CoreBundle\Factory\ModelFactory;
 use Mautic\CoreBundle\Form\Type\DateRangeType;
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
-use Mautic\CoreBundle\Helper\UserHelper;
-use Mautic\CoreBundle\Security\Permissions\CorePermissions;
-use Mautic\CoreBundle\Service\FlashBag;
-use Mautic\CoreBundle\Translation\Translator;
-use Mautic\FormBundle\Helper\FormFieldHelper;
 use Mautic\PageBundle\Model\TrackableModel;
 use MauticPlugin\MauticFocusBundle\Entity\Focus;
 use MauticPlugin\MauticFocusBundle\Model\FocusModel;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\Service\Attribute\Required;
 
 final class FocusController extends AbstractStandardFormController
 {
-    public function __construct(
-        private readonly CacheProviderTagAwareInterface $cacheProvider,
-        FormFactoryInterface $formFactory,
-        FormFieldHelper $fieldHelper,
-        ManagerRegistry $doctrine,
-        ModelFactory $modelFactory,
-        UserHelper $userHelper,
-        CoreParametersHelper $coreParametersHelper,
-        EventDispatcherInterface $dispatcher,
-        Translator $translator,
-        FlashBag $flashBag,
-        RequestStack $requestStack,
-        CorePermissions $security,
-        private readonly FocusModel $focusModel,
-        private readonly TrackableModel $trackableModel,
-    ) {
-        parent::__construct($formFactory, $fieldHelper, $doctrine, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security);
+    private CacheProviderTagAwareInterface $cacheProvider;
+
+    private FocusModel $focusModel;
+
+    private TrackableModel $trackableModel;
+
+    #[Required]
+    public function autowireFocusController(
+        CacheProviderTagAwareInterface $cacheProvider,
+        FocusModel $focusModel,
+        TrackableModel $trackableModel,
+    ): void {
+        $this->cacheProvider = $cacheProvider;
+        $this->focusModel = $focusModel;
+        $this->trackableModel = $trackableModel;
     }
 
     protected function getTemplateBase(): string

--- a/plugins/MauticSocialBundle/Config/services.php
+++ b/plugins/MauticSocialBundle/Config/services.php
@@ -10,8 +10,7 @@ return function (ContainerConfigurator $configurator): void {
         ->defaults()
         ->autowire()
         ->autoconfigure()
-        ->public()
-        ->bind(Monolog\Logger::class, \Symfony\Component\DependencyInjection\Loader\Configurator\service('monolog.logger.mautic'));
+        ->public();
 
     $excludes = [
     ];

--- a/plugins/MauticSocialBundle/Integration/SocialIntegration.php
+++ b/plugins/MauticSocialBundle/Integration/SocialIntegration.php
@@ -2,26 +2,12 @@
 
 namespace MauticPlugin\MauticSocialBundle\Integration;
 
-use Doctrine\ORM\EntityManagerInterface;
-use Mautic\CoreBundle\Helper\CacheStorageHelper;
-use Mautic\CoreBundle\Helper\EncryptionHelper;
-use Mautic\CoreBundle\Helper\PathsHelper;
-use Mautic\CoreBundle\Model\NotificationModel;
 use Mautic\CoreBundle\Translation\Translator;
-use Mautic\LeadBundle\Field\FieldsWithUniqueIdentifier;
-use Mautic\LeadBundle\Model\CompanyModel;
-use Mautic\LeadBundle\Model\DoNotContact;
-use Mautic\LeadBundle\Model\FieldModel;
-use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\PluginBundle\Helper\IntegrationHelper;
 use Mautic\PluginBundle\Integration\AbstractIntegration;
-use Mautic\PluginBundle\Model\IntegrationEntityModel;
-use Monolog\Logger;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilder;
-use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\Routing\RouterInterface;
+use Symfony\Contracts\Service\Attribute\Required;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 abstract class SocialIntegration extends AbstractIntegration
@@ -33,43 +19,13 @@ abstract class SocialIntegration extends AbstractIntegration
      */
     protected TranslatorInterface $translator;
 
-    public function __construct(
-        EventDispatcherInterface $eventDispatcher,
-        CacheStorageHelper $cacheStorageHelper,
-        EntityManagerInterface $entityManager,
-        RequestStack $requestStack,
-        RouterInterface $router,
-        Translator $translator,
-        Logger $logger,
-        EncryptionHelper $encryptionHelper,
-        LeadModel $leadModel,
-        CompanyModel $companyModel,
-        PathsHelper $pathsHelper,
-        NotificationModel $notificationModel,
-        FieldModel $fieldModel,
-        FieldsWithUniqueIdentifier $fieldsWithUniqueIdentifier,
-        IntegrationEntityModel $integrationEntityModel,
-        DoNotContact $doNotContact,
-        protected IntegrationHelper $integrationHelper,
-    ) {
-        parent::__construct(
-            $eventDispatcher,
-            $cacheStorageHelper,
-            $entityManager,
-            $requestStack,
-            $router,
-            $translator,
-            $logger,
-            $encryptionHelper,
-            $leadModel,
-            $companyModel,
-            $pathsHelper,
-            $notificationModel,
-            $fieldModel,
-            $integrationEntityModel,
-            $doNotContact,
-            $fieldsWithUniqueIdentifier
-        );
+    protected IntegrationHelper $integrationHelper;
+
+    #[Required]
+    public function autowireSocialIntegration(
+        IntegrationHelper $integrationHelper,
+    ): void {
+        $this->integrationHelper = $integrationHelper;
     }
 
     /**

--- a/plugins/MauticSocialBundle/Tests/Integration/FoursquareIntegrationTest.php
+++ b/plugins/MauticSocialBundle/Tests/Integration/FoursquareIntegrationTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace MauticPlugin\MauticSocialBundle\Tests\Integration;
 
 use Mautic\CoreBundle\Translation\Translator;
-use Mautic\PluginBundle\Helper\IntegrationHelper;
 use Mautic\PluginBundle\Tests\Integration\AbstractIntegrationTestCase;
 use MauticPlugin\MauticSocialBundle\Integration\FoursquareIntegration;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -33,10 +32,9 @@ final class FoursquareIntegrationTest extends AbstractIntegrationTestCase
             $this->pathsHelper,
             $this->notificationModel,
             $this->fieldModel,
-            $this->fieldsWithUniqueIdentifier,
             $this->integrationEntityModel,
             $this->doNotContact,
-            $this->createStub(IntegrationHelper::class),
+            $this->fieldsWithUniqueIdentifier,
         );
     }
 

--- a/plugins/MauticSocialBundle/Tests/Integration/InstagramIntegrationTest.php
+++ b/plugins/MauticSocialBundle/Tests/Integration/InstagramIntegrationTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace MauticPlugin\MauticSocialBundle\Tests\Integration;
 
 use Mautic\CoreBundle\Translation\Translator;
-use Mautic\PluginBundle\Helper\IntegrationHelper;
 use Mautic\PluginBundle\Tests\Integration\AbstractIntegrationTestCase;
 use MauticPlugin\MauticSocialBundle\Integration\InstagramIntegration;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -33,10 +32,9 @@ final class InstagramIntegrationTest extends AbstractIntegrationTestCase
             $this->pathsHelper,
             $this->notificationModel,
             $this->fieldModel,
-            $this->fieldsWithUniqueIdentifier,
             $this->integrationEntityModel,
             $this->doNotContact,
-            $this->createStub(IntegrationHelper::class),
+            $this->fieldsWithUniqueIdentifier,
         );
     }
 

--- a/utils/phpstan/src/Rule/NoParentConstructorForwardingRule.php
+++ b/utils/phpstan/src/Rule/NoParentConstructorForwardingRule.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Rule;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Param;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Expression;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * A constructor must not repeat the parameters of its parent only to hand them straight over.
+ *
+ * A child that adds one dependency of its own ends up spelling out every parent parameter again:
+ *
+ *     public function __construct(
+ *         ManagerRegistry $doctrine,
+ *         ModelFactory $modelFactory,
+ *         // ... every other parent parameter
+ *         private readonly AuthorizationCheckerInterface $authorizationChecker,
+ *     ) {
+ *         parent::__construct($doctrine, $modelFactory, ...);
+ *     }
+ *
+ * Every parameter the parent adds later has to be added here as well, in the right order, in every child.
+ * Only a long list counts, from 10 parameters up - handing one or two over is no bother. A constructor
+ * that takes about as many dependencies of its own is a constructor in its own right, so the own ones
+ * must be at most half of the handed over ones.
+ * An autowire*() method takes the new dependency alone and leaves the parent constructor untouched:
+ *
+ *     #[Required]
+ *     public function autowireSomeController(AuthorizationCheckerInterface $authorizationChecker): void
+ *     {
+ *         $this->authorizationChecker = $authorizationChecker;
+ *     }
+ *
+ * @implements Rule<ClassMethod>
+ */
+final class NoParentConstructorForwardingRule implements Rule
+{
+    /**
+     * @var string
+     */
+    private const CONSTRUCTOR_NAME = '__construct';
+
+    /**
+     * A parameter or two handed over is no bother, a long list repeated in every child is.
+     *
+     * @var int
+     */
+    private const MINIMAL_PASSED_THROUGH_PARAM_COUNT = 6;
+
+    /**
+     * Classes 3rd-party code extends, so their constructor contract must stay as it is.
+     *
+     * @var string[]
+     */
+    private const SKIPPED_CLASSES = [
+        'Mautic\ApiBundle\Controller\CommonApiController',
+    ];
+
+    public function getNodeType(): string
+    {
+        return ClassMethod::class;
+    }
+
+    /**
+     * @return list<\PHPStan\Rules\IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (self::CONSTRUCTOR_NAME !== $node->name->toLowerString()) {
+            return [];
+        }
+
+        $classReflection = $scope->getClassReflection();
+        if ($classReflection instanceof ClassReflection && in_array($classReflection->getName(), self::SKIPPED_CLASSES, true)) {
+            return [];
+        }
+
+        $forwardedVariableNames = $this->resolveForwardedVariableNames($node);
+        if ([] === $forwardedVariableNames) {
+            return [];
+        }
+
+        $passedThroughParams = $this->resolvePassedThroughParams($node, $forwardedVariableNames);
+        if (count($passedThroughParams) < self::MINIMAL_PASSED_THROUGH_PARAM_COUNT) {
+            return [];
+        }
+
+        if ((2 * count($this->resolveOwnParams($node, $forwardedVariableNames))) > count($passedThroughParams)) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(sprintf(
+                'Constructor hands %d parameter(s) straight over to parent::__construct(), drop them and take the dependency of its own in an autowire*() method instead.',
+                count($passedThroughParams)
+            ))
+                ->identifier('mautic.noParentConstructorForwarding')
+                ->line($node->getStartLine())
+                ->build(),
+        ];
+    }
+
+    /**
+     * The variables a sole parent::__construct() call hands over, e.g. "doctrine" of parent::__construct($doctrine).
+     *
+     * @return array<string, true>
+     */
+    private function resolveForwardedVariableNames(ClassMethod $classMethod): array
+    {
+        $stmts = $classMethod->stmts ?? [];
+        if (1 !== count($stmts)) {
+            return [];
+        }
+
+        $onlyStmt = $stmts[0];
+        if (!$onlyStmt instanceof Expression || !$onlyStmt->expr instanceof StaticCall) {
+            return [];
+        }
+
+        $staticCall = $onlyStmt->expr;
+        if (!$staticCall->class instanceof Name || 'parent' !== $staticCall->class->toLowerString()) {
+            return [];
+        }
+
+        if (!$staticCall->name instanceof Identifier || self::CONSTRUCTOR_NAME !== $staticCall->name->toLowerString()) {
+            return [];
+        }
+
+        $forwardedVariableNames = [];
+        foreach ($staticCall->getArgs() as $arg) {
+            if ($arg->value instanceof Variable && is_string($arg->value->name)) {
+                $forwardedVariableNames[$arg->value->name] = true;
+            }
+        }
+
+        return $forwardedVariableNames;
+    }
+
+    /**
+     * A parameter the class keeps for itself, e.g. the promoted property of a child that adds one dependency.
+     *
+     * @param array<string, true> $forwardedVariableNames
+     *
+     * @return list<Param>
+     */
+    private function resolveOwnParams(ClassMethod $classMethod, array $forwardedVariableNames): array
+    {
+        $ownParams = [];
+
+        foreach ($classMethod->params as $param) {
+            if (!$param->var instanceof Variable || !is_string($param->var->name)) {
+                continue;
+            }
+
+            if (isset($forwardedVariableNames[$param->var->name])) {
+                continue;
+            }
+
+            $ownParams[] = $param;
+        }
+
+        return $ownParams;
+    }
+
+    /**
+     * A parameter is passed through when it is handed to the parent and kept nowhere else, so a promoted
+     * property, the very dependency of the class itself, is left out.
+     *
+     * @param array<string, true> $forwardedVariableNames
+     *
+     * @return list<Param>
+     */
+    private function resolvePassedThroughParams(ClassMethod $classMethod, array $forwardedVariableNames): array
+    {
+        $passedThroughParams = [];
+
+        foreach ($classMethod->params as $param) {
+            if (0 !== $param->flags) {
+                continue;
+            }
+
+            if (!$param->var instanceof Variable || !is_string($param->var->name)) {
+                continue;
+            }
+
+            if (!isset($forwardedVariableNames[$param->var->name])) {
+                continue;
+            }
+
+            $passedThroughParams[] = $param;
+        }
+
+        return $passedThroughParams;
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/ParentConstructor/ForwardingChildService.php
+++ b/utils/phpstan/tests/Rule/Fixture/ParentConstructor/ForwardingChildService.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture\ParentConstructor;
+
+final class ForwardingChildService extends ParentService
+{
+    public function __construct(
+        \stdClass $first,
+        \ArrayObject $second,
+        \SplStack $third,
+        \SplQueue $fourth,
+        \SplFixedArray $fifth,
+        \ArrayIterator $sixth,
+        \SplObjectStorage $seventh,
+        \DateTime $eighth,
+        \DateInterval $ninth,
+        \DateTimeZone $tenth,
+        private readonly \SplDoublyLinkedList $own,
+    ) {
+        parent::__construct($first, $second, $third, $fourth, $fifth, $sixth, $seventh, $eighth, $ninth, $tenth);
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/ParentConstructor/HalfOwnChildService.php
+++ b/utils/phpstan/tests/Rule/Fixture/ParentConstructor/HalfOwnChildService.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture\ParentConstructor;
+
+final class HalfOwnChildService extends ParentService
+{
+    public function __construct(
+        \stdClass $first,
+        \ArrayObject $second,
+        \SplStack $third,
+        \SplQueue $fourth,
+        \SplFixedArray $fifth,
+        \ArrayIterator $sixth,
+        \SplObjectStorage $seventh,
+        \DateTime $eighth,
+        \DateInterval $ninth,
+        \DateTimeZone $tenth,
+        private readonly \SplDoublyLinkedList $firstOwn,
+        private readonly \SplMinHeap $secondOwn,
+        private readonly \SplMaxHeap $thirdOwn,
+        private readonly \SplPriorityQueue $fourthOwn,
+        private readonly \SplTempFileObject $fifthOwn,
+    ) {
+        parent::__construct($first, $second, $third, $fourth, $fifth, $sixth, $seventh, $eighth, $ninth, $tenth);
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/ParentConstructor/ManyOwnChildService.php
+++ b/utils/phpstan/tests/Rule/Fixture/ParentConstructor/ManyOwnChildService.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture\ParentConstructor;
+
+final class ManyOwnChildService extends ParentService
+{
+    public function __construct(
+        \stdClass $first,
+        \ArrayObject $second,
+        \SplStack $third,
+        \SplQueue $fourth,
+        \SplFixedArray $fifth,
+        \ArrayIterator $sixth,
+        \SplObjectStorage $seventh,
+        \DateTime $eighth,
+        \DateInterval $ninth,
+        \DateTimeZone $tenth,
+        private readonly \SplDoublyLinkedList $firstOwn,
+        private readonly \SplMinHeap $secondOwn,
+        private readonly \SplMaxHeap $thirdOwn,
+        private readonly \SplPriorityQueue $fourthOwn,
+        private readonly \SplTempFileObject $fifthOwn,
+        private readonly \DatePeriod $sixthOwn,
+    ) {
+        parent::__construct($first, $second, $third, $fourth, $fifth, $sixth, $seventh, $eighth, $ninth, $tenth);
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/ParentConstructor/OwnConstructorChildService.php
+++ b/utils/phpstan/tests/Rule/Fixture/ParentConstructor/OwnConstructorChildService.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture\ParentConstructor;
+
+final class OwnConstructorChildService extends ParentService
+{
+    public function __construct(
+        private readonly \SplStack $own,
+    ) {
+        parent::__construct(new \stdClass(), new \ArrayObject());
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/ParentConstructor/ParentService.php
+++ b/utils/phpstan/tests/Rule/Fixture/ParentConstructor/ParentService.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture\ParentConstructor;
+
+class ParentService
+{
+    public function __construct(
+        protected \stdClass $first,
+        protected \ArrayObject $second,
+        protected \SplStack $third,
+        protected \SplQueue $fourth,
+        protected \SplFixedArray $fifth,
+        protected \ArrayIterator $sixth,
+        protected \SplObjectStorage $seventh,
+        protected \DateTime $eighth,
+        protected \DateInterval $ninth,
+        protected \DateTimeZone $tenth,
+    ) {
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/ParentConstructor/PromotedChildService.php
+++ b/utils/phpstan/tests/Rule/Fixture/ParentConstructor/PromotedChildService.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture\ParentConstructor;
+
+final class PromotedChildService extends ParentService
+{
+    public function __construct(
+        protected \stdClass $first,
+        protected \ArrayObject $second,
+    ) {
+        parent::__construct($first, $second);
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/ParentConstructor/ShortForwardingChildService.php
+++ b/utils/phpstan/tests/Rule/Fixture/ParentConstructor/ShortForwardingChildService.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture\ParentConstructor;
+
+final class ShortForwardingChildService extends ParentService
+{
+    public function __construct(
+        \stdClass $first,
+        \ArrayObject $second,
+        \SplStack $third,
+        private readonly \SplDoublyLinkedList $own,
+    ) {
+        parent::__construct($first, $second, $third, new \SplQueue(), new \SplFixedArray(), new \ArrayIterator(), new \SplObjectStorage(), new \DateTime(), new \DateInterval('P1D'), new \DateTimeZone('UTC'));
+    }
+}

--- a/utils/phpstan/tests/Rule/NoParentConstructorForwardingRuleTest.php
+++ b/utils/phpstan/tests/Rule/NoParentConstructorForwardingRuleTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use Utils\PHPStan\Rule\NoParentConstructorForwardingRule;
+
+/**
+ * @extends RuleTestCase<NoParentConstructorForwardingRule>
+ */
+final class NoParentConstructorForwardingRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new NoParentConstructorForwardingRule();
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse([
+            __DIR__.'/Fixture/ParentConstructor/ParentService.php',
+            __DIR__.'/Fixture/ParentConstructor/ForwardingChildService.php',
+            __DIR__.'/Fixture/ParentConstructor/ShortForwardingChildService.php',
+            __DIR__.'/Fixture/ParentConstructor/OwnConstructorChildService.php',
+            __DIR__.'/Fixture/ParentConstructor/PromotedChildService.php',
+            __DIR__.'/Fixture/ParentConstructor/HalfOwnChildService.php',
+            __DIR__.'/Fixture/ParentConstructor/ManyOwnChildService.php',
+        ], [
+            [
+                'Constructor hands 10 parameter(s) straight over to parent::__construct(), drop them and take the dependency of its own in an autowire*() method instead.',
+                9,
+            ],
+            [
+                'Constructor hands 10 parameter(s) straight over to parent::__construct(), drop them and take the dependency of its own in an autowire*() method instead.',
+                9,
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
* No BC break
* improved readability of local dependencies
* easier to extend children classes
* verified by PHPStan rule

What do you think?

---

A child controller that needs one dependency of its own currently has to repeat every parameter of its parent just to hand them back:

```php
public function __construct(
    ManagerRegistry $doctrine,
    ModelFactory $modelFactory,
    UserHelper $userHelper,
    CoreParametersHelper $coreParametersHelper,
    EventDispatcherInterface $dispatcher,
    Translator $translator,
    FlashBag $flashBag,
    RequestStack $requestStack,
    CorePermissions $security,
    private readonly AuthorizationCheckerInterface $authorizationChecker,
) {
    parent::__construct($doctrine, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security);
}
```

Every parameter the parent adds later has to be added again here, in the right order, in every child. An `autowire*()` method takes the new dependency alone and leaves the parent constructor alone:

```php
private ClientModel $clientModel;

#[Required]
public function autowireClientController(
    ClientModel $clientModel,
): void {
    $this->clientModel = $clientModel;
}
```

## How much leaner the classes get

The forwarded parameters and the `use` statements that only existed to type them both go away. `MarketplaceBundle/Controller/CacheController` keeps the same two dependencies of its own and drops 11 lines of constructor plus 9 imports:

```diff
 namespace Mautic\MarketplaceBundle\Controller;

-use Doctrine\Persistence\ManagerRegistry;
 use Mautic\CoreBundle\Controller\CommonController;
-use Mautic\CoreBundle\Factory\ModelFactory;
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
-use Mautic\CoreBundle\Helper\UserHelper;
-use Mautic\CoreBundle\Security\Permissions\CorePermissions;
-use Mautic\CoreBundle\Service\FlashBag;
-use Mautic\CoreBundle\Translation\Translator;
 use Mautic\MarketplaceBundle\Security\Permissions\MarketplacePermissions;
 use Mautic\MarketplaceBundle\Service\Allowlist;
 use Mautic\MarketplaceBundle\Service\Config;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\Service\Attribute\Required;

 final class CacheController extends CommonController
 {
-    public function __construct(
-        private readonly Config $config,
-        private readonly Allowlist $allowlist,
-        ManagerRegistry $doctrine,
-        ModelFactory $modelFactory,
-        UserHelper $userHelper,
-        CoreParametersHelper $coreParametersHelper,
-        EventDispatcherInterface $dispatcher,
-        Translator $translator,
-        FlashBag $flashBag,
-        RequestStack $requestStack,
-        CorePermissions $security,
-    ) {
-        parent::__construct($doctrine, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security);
+    private Config $config;
+
+    private Allowlist $allowlist;
+
+    #[Required]
+    public function autowireCacheController(
+        Config $config,
+        Allowlist $allowlist,
+    ): void {
+        $this->config    = $config;
+        $this->allowlist = $allowlist;
     }
```

Across the PR, the conversion removes far more than it adds:

| Scope | Files | Added | Removed | Net |
| --- | ---: | ---: | ---: | ---: |
| Controllers | 22 | 324 | 537 | **−213** |
| Models | 16 | 244 | 349 | **−105** |
| Integrations | 3 | 19 | 160 | **−141** |
| Tests and service config | 14 | 62 | 57 | +5 |
| **Conversion total** | **55** | **649** | **1103** | **−454** |

The rest of the diff is the rule itself — `NoParentConstructorForwardingRule`, its 7 fixtures and its test, plus two lines in `phpstan.neon` — 10 files and 400 added lines, none of it in `app/` or `plugins/`.

The rule only speaks up where the forwarding is the bulk of the constructor: at least 10 parameters handed over, and the dependencies of the class itself at most half of that count. A constructor that takes about as many dependencies of its own is a constructor in its own right, so `CampaignController` (9 own vs 10 forwarded) and `FormController` (7 own vs 11 forwarded) are left alone.
