### PR TITLE
MTC-11122 Fix issues with inheritance themes

### DIFF
--- a/plugins/GrapesJsBuilderBundle/Assets/library/js/plugins/grapesjs-mjmlThemeTokens/blocks.js
+++ b/plugins/GrapesJsBuilderBundle/Assets/library/js/plugins/grapesjs-mjmlThemeTokens/blocks.js
@@ -75,7 +75,7 @@ export const createBlockPatcher = ({ editor, options, classNames }) => {
       requiresTokens: false,
       getPatch: (mjClass) => ({
         content: mjClass
-          ? `<mj-button mj-class="${mjClass}" href="https://">Button</mj-button>`
+          ? `<mj-button mj-class="${mjClass}" href="#">Button</mj-button>`
           : '<mj-button>Button</mj-button>',
       }),
     },
@@ -188,7 +188,7 @@ export const createBlockPatcher = ({ editor, options, classNames }) => {
       getBlock: (mjClass) => ({
         label: Mautic.translate('grapesjsbuilder.secondaryButtonBlockLabel'),
         category: Mautic.translate('grapesjsbuilder.categoryBlockLabel'),
-        content: `<mj-button mj-class="${mjClass}" href="https://">Button</mj-button>`,
+        content: `<mj-button mj-class="${mjClass}" href="#">Button</mj-button>`,
         media: `<svg viewBox="0 0 24 24">
             <path fill="currentColor" d="M20 20.5C20 21.3 19.3 22 18.5 22H13C12.6 22 12.3 21.9 12 21.6L8 17.4L8.7 16.6C8.9 16.4 9.2 16.3 9.5 16.3H9.7L12 18V9C12 8.4 12.4 8 13 8S14 8.4 14 9V13.5L15.2 13.6L19.1 15.8C19.6 16 20 16.6 20 17.1V20.5M20 2H4C2.9 2 2 2.9 2 4V12C2 13.1 2.9 14 4 14H8V12H4V4H20V12H18V14H20C21.1 14 22 13.1 22 12V4C22 2.9 21.1 2 20 2Z" />
           </svg>`,

--- a/themes/paprika/html/email.mjml.twig
+++ b/themes/paprika/html/email.mjml.twig
@@ -2,7 +2,7 @@
   <mj-head>
     <mj-attributes>
       <!-- Global defaults -->
-      <mj-all font-family="Ubuntu, Helvetica, Arial, sans-serif, Helvetica, Arial, sans-serif" color="#000000"></mj-all>
+      <mj-all font-family="Ubuntu, Helvetica, Arial, sans-serif, Helvetica, Arial, sans-serif" color="green"></mj-all>
       <mj-text mj-class="t-body"></mj-text>
       <mj-button border-radius="3px" padding="15px 30px"></mj-button>
       <mj-section></mj-section>
@@ -18,10 +18,10 @@
   <mj-body background-color="#d6dde5">
     <mj-section mj-class="t-section" padding-bottom="20px" padding-top="20">
       <mj-column width="66.66666666666666%" vertical-align="middle">
-        <mj-text align="left" font-size="11px" padding-bottom="0px" padding-top="0"><span style="font-size: 11px">{subject}</span></mj-text>
+        <mj-text align="left" font-size="11px" padding-bottom="0px" padding-top="0" color="#000000"><span style="font-size: 11px">{subject}</span></mj-text>
       </mj-column>
       <mj-column width="33.33333333333333%" vertical-align="middle">
-        <mj-text align="right" font-size="11px" padding-bottom="0px" padding-top="0"><span style="font-size: 11px"><a href="https://mjml.io" style="text-decoration: none; color: inherit;">{webview_text}</a></span></mj-text>
+        <mj-text align="right" font-size="11px" padding-bottom="0px" padding-top="0" color="#000000"><span style="font-size: 11px"><a href="https://mjml.io" style="text-decoration: none; color: inherit;">{webview_text}</a></span></mj-text>
       </mj-column>
     </mj-section>
     <mj-section mj-class="t-surface-1" padding-bottom="20px" padding-top="20">
@@ -29,15 +29,15 @@
         <mj-image href="https://mjml.io" src="{{ getAssetUrl('themes/'~template~'/assets/logo.jpg', null, null, true) }}" alt="Paprika logo" align="center" border="none" width="400px" padding-left="0px" padding-right="0px" padding-bottom="0px" padding-top="0"></mj-image>
       </mj-column>
       <mj-column width="33.33333333333333%" vertical-align="top">
-        <mj-text align="center" color="green" padding-bottom="10px" padding-top="10" font-weight="bold">YELLOW PEPPER
+        <mj-text align="center" padding-bottom="10px" padding-top="10" font-weight="bold">YELLOW PEPPER
            </mj-text>
       </mj-column>
       <mj-column width="33.33333333333333%" vertical-align="top">
-        <mj-text align="center" color="green" padding-bottom="10px" padding-top="10" font-weight="bold">RED PEPPER
+        <mj-text align="center" padding-bottom="10px" padding-top="10" font-weight="bold">RED PEPPER
            </mj-text>
       </mj-column>
       <mj-column width="33.33333333333333%" vertical-align="top">
-        <mj-text align="center" color="green" padding-bottom="10px" padding-top="10" font-weight="bold">GREEN PEPPER
+        <mj-text align="center" padding-bottom="10px" padding-top="10" font-weight="bold">GREEN PEPPER
            </mj-text>
       </mj-column>
     </mj-section>
@@ -45,8 +45,8 @@
       <mj-column width="100%" vertical-align="top">
       <mj-image src="{{ getAssetUrl('themes/'~template~'/assets/amazing_paprika.jpg', null, null, true) }}" alt="Amazing Paprikas" align="center" border="none" width="600px" padding-left="0px" padding-right="0px" padding-bottom="0px" padding-top="0"></mj-image>
         <mj-text align="left" padding-bottom="0px" padding-top="20">
-          <p><span style="color: green;font-weight: bold;font-size: 24px;">LOREM IPSUM DOLOR</span></p>
-          <p><span style="color: green;font-size: 16px;line-height: 1.5;">Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem.<br/><br/>Phasellus viverra nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies</span></p>
+          <p><span style="font-weight: bold;font-size: 24px;">LOREM IPSUM DOLOR</span></p>
+          <p><span style="font-size: 16px;line-height: 1.5;">Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem.<br/><br/>Phasellus viverra nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies</span></p>
         </mj-text>
       </mj-column>
             <mj-section>
@@ -57,17 +57,17 @@
       <mj-section>
         <mj-column width="33.33333333333333%" vertical-align="top">
           <mj-image src="{{ getAssetUrl('themes/'~template~'/assets/p_red.png', null, null, true) }}" alt="Red Pepper" align="center" border="none" width="180px" padding-left="0px" padding-right="0px" padding-bottom="0px" padding-top="0"></mj-image>
-        <mj-text align="center" color="green" padding-bottom="10px" padding-top="10" font-weight="bold">Lorem impsum dolor
+        <mj-text align="center" padding-bottom="10px" padding-top="10" font-weight="bold">Lorem impsum dolor
            </mj-text>
       </mj-column>
       <mj-column width="33.33333333333333%" vertical-align="top">
         <mj-image src="{{ getAssetUrl('themes/'~template~'/assets/p_yellow.png', null, null, true) }}" alt="Yellow Pepper" align="center" border="none" width="180px" padding-left="0px" padding-right="0px" padding-bottom="0px" padding-top="0"></mj-image>
-        <mj-text align="center" color="green" font-size="14px" padding-bottom="10px" padding-top="10" font-weight="bold">Lorem impsum dolor
+        <mj-text align="center" font-size="14px" padding-bottom="10px" padding-top="10" font-weight="bold">Lorem impsum dolor
            </mj-text>
       </mj-column>
       <mj-column width="33.33333333333333%" vertical-align="top">
         <mj-image src="{{ getAssetUrl('themes/'~template~'/assets/p_green.png', null, null, true) }}" alt="Green Pepper" align="center" border="none" width="180px" padding-left="0px" padding-right="0px" padding-bottom="0px" padding-top="0"></mj-image>
-        <mj-text align="center" color="green" padding-bottom="10px" padding-top="10" font-weight="bold">Lorem impsum dolor
+        <mj-text align="center" padding-bottom="10px" padding-top="10" font-weight="bold">Lorem impsum dolor
            </mj-text>
       </mj-column>
       </mj-section>
@@ -76,21 +76,21 @@
         <mj-image src="{{ getAssetUrl('themes/'~template~'/assets/paprikas.jpg', null, null, true) }}" alt="Paprikas" align="center" border="none" width="290px" padding-left="0px" padding-right="0px" padding-bottom="0px" padding-top="0"></mj-image>
           </mj-column>
         <mj-column width="50%" vertical-align="top">
-        <mj-text align="center" color="green" font-size="22px" padding-bottom="10px" padding-top="10" font-weight="bold">Lorem impsum dolor
+        <mj-text align="center" font-size="22px" padding-bottom="10px" padding-top="10" font-weight="bold">Lorem impsum dolor
            </mj-text>
-           <mj-text align="center" color="green" font-size="14px" padding-bottom="10px" padding-top="10">Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+           <mj-text align="center" font-size="14px" padding-bottom="10px" padding-top="10">Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
            </mj-text>
-          <mj-text align="center" color="green" font-size="14px" padding-bottom="10px" padding-top="10"><a href="#">Lorem impsum dolor</a>
+          <mj-text align="center" font-size="14px" padding-bottom="10px" padding-top="10"><a href="#">Lorem impsum dolor</a>
            </mj-text>
         </mj-column>
       </mj-section>
           <mj-section>
         <mj-column width="50%" vertical-align="top">
-        <mj-text align="center" color="green" font-size="22px" padding-bottom="10px" padding-top="10" font-weight="bold">Lorem impsum dolor
+        <mj-text align="center" font-size="22px" padding-bottom="10px" padding-top="10" font-weight="bold">Lorem impsum dolor
            </mj-text>
-                  <mj-text align="center" color="green" font-size="14px" padding-bottom="10px" padding-top="10">Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
+                  <mj-text align="center" font-size="14px" padding-bottom="10px" padding-top="10">Lorem ipsum dolor sit amet, consectetuer adipiscing elit.
            </mj-text>
-          <mj-text align="center" color="green" font-size="14px" padding-bottom="10px" padding-top="10"><a href="#">Lorem impsum dolor</a>
+          <mj-text align="center" font-size="14px" padding-bottom="10px" padding-top="10"><a href="#">Lorem impsum dolor</a>
            </mj-text>
             </mj-column>mj-column>
           <mj-column width="50%" vertical-align="top">
@@ -107,8 +107,8 @@
       <mj-column width="100%" vertical-align="top">
 
         <mj-text align="left" padding-bottom="0px" padding-top="20">
-          <p><span style="color: green;font-weight: bold;font-size: 24px;">LOREM IPSUM DOLOR</span></p>
-          <p><span style="color: green;font-size: 16px;line-height: 1.5;">Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem.</span></p>
+          <p><span style="font-weight: bold;font-size: 24px;">LOREM IPSUM DOLOR</span></p>
+          <p><span style="font-size: 16px;line-height: 1.5;">Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem.</span></p>
         </mj-text>
                 <mj-button mj-class="t-btn t-btn-primary" align="center" vertical-align="middle" border="none" href="https://mjml.io"
           padding-left="25px" padding-right="25px" padding-bottom="10px" padding-top="10">LEARN MORE</mj-button>
@@ -128,10 +128,10 @@
     </mj-section>
     <mj-section mj-class="t-section" padding-bottom="20px" padding-top="20">
       <mj-column width="100%" vertical-align="middle">
-        <mj-text align="center" font-size="11px" padding-bottom="0px" padding-top="0">
+        <mj-text align="center" color="#000000" font-size="11px" padding-bottom="0px" padding-top="0">
           <p style="font-size:11px">Spicy Company 11111 EU Planet Earth</p>
         </mj-text>
-        <mj-text align="center" font-size="11px" padding-bottom="0px" padding-top="0">
+        <mj-text align="center" color="#000000" font-size="11px" padding-bottom="0px" padding-top="0">
           <p style="font-size:11px">{unsubscribe_text}</p>
         </mj-text>
       </mj-column>


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
This PR solves two issues with email themes:
1. While adding inheritance support for all Mautic themes (https://github.com/mautic/mautic/pull/16778), the Paprika theme got the wrong color for text areas added (black instead of green)
2. When adding buttons to themes the href used to be 'https://' which was not accepted when saving the theme. Now it href when adding buttons has changed to '#'



<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is crucial. Take the time to write very clear, annotated and step by step test instructions, because testers may not be developers.
-->
1. Open this PR on GitHub Codespaces or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create an email using the paprika theme and drag and drop a text area --> see that the text inside is green by default instead of black
3. Run 'npm run build' on the grapesjsbundle. When now adding a new button to an email and saving it, you shouldn't receive an error message anymore.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->