### PR TITLE
Remove unnecessary re-casting in entities and repositories

### DIFF
--- a/app/bundles/CampaignBundle/Entity/LeadRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadRepository.php
@@ -534,7 +534,7 @@ class LeadRepository extends CommonRepository
     {
         $membershipConditions = $qb->expr()->and(
             $qb->expr()->eq('cl.lead_id', 'll.lead_id'),
-            $qb->expr()->eq('cl.campaign_id', (int) $campaignId)
+            $qb->expr()->eq('cl.campaign_id', $campaignId)
         );
 
         if ($campaignCanBeRestarted) {

--- a/app/bundles/LeadBundle/Entity/LeadDeviceRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadDeviceRepository.php
@@ -153,7 +153,7 @@ class LeadDeviceRepository extends CommonRepository
         return $qb->select('*')
             ->from(MAUTIC_TABLE_PREFIX.'lead_devices', 'es')
             ->where('lead_id = :leadId')
-            ->setParameter('leadId', (int) $lead->getId())
+            ->setParameter('leadId', $lead->getId())
             ->orderBy('date_added', 'desc')
             ->executeQuery()
             ->fetchAllAssociative();

--- a/app/bundles/LeadBundle/Entity/LeadField.php
+++ b/app/bundles/LeadBundle/Entity/LeadField.php
@@ -834,7 +834,7 @@ class LeadField extends FormEntity implements CacheInvalidateInterface, UuidInte
 
     public function getOriginalIsPublishedValue(): bool
     {
-        return (bool) $this->originalIsPublishedValue;
+        return $this->originalIsPublishedValue;
     }
 
     public function getCacheNamespacesToDelete(): array

--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -866,7 +866,7 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
 
                 // logic. In query, Sum(manually_removed) should be less than the current)
                 $pluck    = count($imploder);
-                $imploder = (string) implode(',', $imploder);
+                $imploder = implode(',', $imploder);
 
                 $sq = $this->getEntityManager()->getConnection()->createQueryBuilder();
                 $sq->select('duplicate.lead_id')


### PR DESCRIPTION
Values are already of the target type, so the cast is a no-op.

```diff
 $membershipConditions = $qb->expr()->and(
     $qb->expr()->eq("cl.lead_id", "ll.lead_id"),
-    $qb->expr()->eq("cl.campaign_id", (int) $campaignId)
+    $qb->expr()->eq("cl.campaign_id", $campaignId)
 );
```

```diff
 public function getOriginalIsPublishedValue(): bool
 {
-    return (bool) $this->originalIsPublishedValue;
+    return $this->originalIsPublishedValue;
 }
```

Property is already `private bool $originalIsPublishedValue`. Same for the other 2 spots in `LeadDeviceRepository` and `LeadRepository`.