### PR TITLE
Remove unnecessary re-casting in tests

### DIFF
--- a/app/bundles/AssetBundle/Tests/EventListener/LeadSubscriberFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/EventListener/LeadSubscriberFunctionalTest.php
@@ -90,7 +90,7 @@ final class LeadSubscriberFunctionalTest extends MauticMysqlTestCase
         $this->em->persist($download);
         $this->em->flush();
 
-        return [(int) $lead->getId(), (int) $download->getId()];
+        return [$lead->getId(), $download->getId()];
     }
 
     /**

--- a/app/bundles/IntegrationsBundle/Tests/Unit/EventListener/LeadSubscriberTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/EventListener/LeadSubscriberTest.php
@@ -253,11 +253,11 @@ final class LeadSubscriberTest extends TestCase
 
         $this->fieldChangeRepository->expects($this->once())
             ->method('deleteEntitiesForObject')
-            ->with((int) $deletedId, Lead::class);
+            ->with($deletedId, Lead::class);
 
         $this->objectMappingRepository->expects($this->once())
             ->method('deleteEntitiesForObject')
-            ->with((int) $deletedId, MauticSyncDataExchange::OBJECT_CONTACT);
+            ->with($deletedId, MauticSyncDataExchange::OBJECT_CONTACT);
 
         $this->subscriber->onLeadPostDelete(new LeadEvent($lead));
     }
@@ -398,11 +398,11 @@ final class LeadSubscriberTest extends TestCase
 
         $this->fieldChangeRepository->expects($this->once())
             ->method('deleteEntitiesForObject')
-            ->with((int) $deletedId, Company::class);
+            ->with($deletedId, Company::class);
 
         $this->objectMappingRepository->expects($this->once())
             ->method('deleteEntitiesForObject')
-            ->with((int) $deletedId, MauticSyncDataExchange::OBJECT_COMPANY);
+            ->with($deletedId, MauticSyncDataExchange::OBJECT_COMPANY);
 
         $this->subscriber->onCompanyPostDelete($this->companyEvent);
     }

--- a/plugins/MauticFocusBundle/Tests/EventListener/LeadSubscriberFunctionalTest.php
+++ b/plugins/MauticFocusBundle/Tests/EventListener/LeadSubscriberFunctionalTest.php
@@ -45,8 +45,8 @@ final class LeadSubscriberFunctionalTest extends MauticMysqlTestCase
      */
     private function searchPhrase(string $phrase, Lead $lead, FocusModel $focusModel): array
     {
-        $searchViewStats  = $focusModel->getStatRepository()->getStatsViewByLead((int) $lead->getId(), ['search'=>$phrase]);
-        $searchClickStats = $focusModel->getStatRepository()->getStatsClickByLead((int) $lead->getId(), ['search'=>$phrase]);
+        $searchViewStats  = $focusModel->getStatRepository()->getStatsViewByLead($lead->getId(), ['search'=>$phrase]);
+        $searchClickStats = $focusModel->getStatRepository()->getStatsClickByLead($lead->getId(), ['search'=>$phrase]);
 
         return array_merge($searchViewStats, $searchClickStats);
     }


### PR DESCRIPTION
Values are already of the target type, so the cast is a no-op.

```diff
-return [(int) $lead->getId(), (int) $download->getId()];
+return [$lead->getId(), $download->getId()];
```

```diff
 $this->fieldChangeRepository->expects($this->once())
     ->method("deleteEntitiesForObject")
-    ->with((int) $deletedId, Lead::class);
+    ->with($deletedId, Lead::class);
```

Follow-up of #16903.