### PR TITLE
[phpstan] Avoid service juggling, use them directly instead of passing to same-class method

### DIFF
--- a/app/bundles/CoreBundle/Factory/TransifexFactory.php
+++ b/app/bundles/CoreBundle/Factory/TransifexFactory.php
@@ -30,7 +30,7 @@ final class TransifexFactory
     public function getTransifex(): TransifexInterface
     {
         if (!$this->transifex) {
-            $this->transifex = $this->create($this->client, $this->coreParametersHelper->get('transifex_api_token') ?? '');
+            $this->transifex = $this->create($this->coreParametersHelper->get('transifex_api_token') ?? '');
         }
 
         return $this->transifex;
@@ -39,13 +39,13 @@ final class TransifexFactory
     /**
      * @throws InvalidConfigurationException
      */
-    private function create(ClientInterface $client, string $apiToken): TransifexInterface
+    private function create(string $apiToken): TransifexInterface
     {
         $config = new Config();
         $config->setApiToken($apiToken);
         $config->setOrganization('mautic');
         $config->setProject('mautic');
 
-        return new Transifex($client, new RequestFactory(), new StreamFactory(), new UriFactory(), $config);
+        return new Transifex($this->client, new RequestFactory(), new StreamFactory(), new UriFactory(), $config);
     }
 }

--- a/app/bundles/InstallBundle/Command/InstallCommand.php
+++ b/app/bundles/InstallBundle/Command/InstallCommand.php
@@ -232,7 +232,7 @@ final class InstallCommand extends Command
             default:
             case InstallService::CHECK_STEP:
                 $output->writeln($step.' - Checking installation requirements...');
-                $messages = $this->stepAction($this->installer, ['site_url' => $siteUrl], $step);
+                $messages = $this->stepAction(['site_url' => $siteUrl], $step);
                 if (!empty($messages)) {
                     if (isset($messages['requirements']) && !empty($messages['requirements'])) {
                         // Stop install if requirements not met
@@ -273,7 +273,7 @@ final class InstallCommand extends Command
                 $connectionWrapper = $this->doctrineRegistry->getConnection();
                 $connectionWrapper->initConnection($dbParams);
 
-                $messages = $this->stepAction($this->installer, $dbParams, $step);
+                $messages = $this->stepAction($dbParams, $step);
                 if (!empty($messages)) {
                     $output->writeln('Errors in database configuration/installation:');
                     $this->handleInstallerErrors($output, $messages);
@@ -285,7 +285,7 @@ final class InstallCommand extends Command
 
                 $step = InstallService::DOCTRINE_STEP + .1;
                 $output->writeln($step.' - Creating schema...');
-                $messages = $this->stepAction($this->installer, $dbParams, $step);
+                $messages = $this->stepAction($dbParams, $step);
                 if (!empty($messages)) {
                     $output->writeln('Errors in schema configuration/installation:');
                     $this->handleInstallerErrors($output, $messages);
@@ -297,7 +297,7 @@ final class InstallCommand extends Command
 
                 $step = InstallService::DOCTRINE_STEP + .2;
                 $output->writeln($step.' - Loading fixtures...');
-                $messages = $this->stepAction($this->installer, $dbParams, $step);
+                $messages = $this->stepAction($dbParams, $step);
                 if (!empty($messages)) {
                     $output->writeln('Errors in fixtures configuration/installation:');
                     $this->handleInstallerErrors($output, $messages);
@@ -313,7 +313,7 @@ final class InstallCommand extends Command
                 // no break
             case InstallService::USER_STEP:
                 $output->writeln($step.' - Creating admin user...');
-                $messages = $this->stepAction($this->installer, $adminParam, $step);
+                $messages = $this->stepAction($adminParam, $step);
                 if (!empty($messages)) {
                     $output->writeln('Errors in admin user configuration/installation:');
                     $this->handleInstallerErrors($output, $messages);
@@ -328,7 +328,7 @@ final class InstallCommand extends Command
                 // no break
             case InstallService::FINAL_STEP:
                 $output->writeln($step.' - Final steps...');
-                $messages = $this->stepAction($this->installer, $allParams, $step);
+                $messages = $this->stepAction($allParams, $step);
                 if (!empty($messages)) {
                     $output->writeln('Errors in final step:');
                     $this->handleInstallerErrors($output, $messages);
@@ -352,13 +352,12 @@ final class InstallCommand extends Command
     /**
      * Controller action for install steps.
      *
-     * @param InstallService $installer The install process
-     * @param array          $params    The install parameters
-     * @param float          $index     The step number to process
+     * @param array $params The install parameters
+     * @param float $index  The step number to process
      *
      * @throws \Exception
      */
-    private function stepAction(InstallService $installer, array $params, float $index = 0): array
+    private function stepAction(array $params, float $index = 0): array
     {
         if ($index - floor($index) > 0) {
             $subIndex = (int) (round($index - floor($index), 1) * 10);
@@ -371,18 +370,18 @@ final class InstallCommand extends Command
         switch ($index) {
             case InstallService::CHECK_STEP:
                 // Check installation requirements
-                $step = $installer->getStep($index);
+                $step = $this->installer->getStep($index);
                 if ($step instanceof CheckStep) {
                     // Set all step fields based on parameters
                     $step->site_url = $params['site_url'];
                 }
 
-                $messages['requirements'] = $installer->checkRequirements($step);
-                $messages['optional']     = $installer->checkOptionalSettings($step);
+                $messages['requirements'] = $this->installer->checkRequirements($step);
+                $messages['optional']     = $this->installer->checkOptionalSettings($step);
                 break;
 
             case InstallService::DOCTRINE_STEP:
-                $step = $installer->getStep($index);
+                $step = $this->installer->getStep($index);
                 if ($step instanceof DoctrineStep) {
                     // Set all step fields based on parameters
                     foreach ($step as $key => $value) {
@@ -394,7 +393,7 @@ final class InstallCommand extends Command
 
                 if (!isset($subIndex)) {
                     // Install database
-                    $messages = $installer->createDatabaseStep($step, $params);
+                    $messages = $this->installer->createDatabaseStep($step, $params);
 
                     break;
                 }
@@ -402,27 +401,27 @@ final class InstallCommand extends Command
                 switch ($subIndex) {
                     case 1:
                         // Install schema
-                        $messages = $installer->createSchemaStep($params);
+                        $messages = $this->installer->createSchemaStep($params);
                         break;
 
                     case 2:
                         // Install fixtures
-                        $messages = $installer->createFixturesStep();
+                        $messages = $this->installer->createFixturesStep();
                         break;
                 }
                 break;
 
             case InstallService::USER_STEP:
                 // Create admin user
-                $messages = $installer->createAdminUserStep($params);
+                $messages = $this->installer->createAdminUserStep($params);
                 break;
 
             case InstallService::FINAL_STEP:
                 // Save final configuration
                 $siteUrl  = $params['site_url'];
-                $messages = $installer->createFinalConfigStep($siteUrl);
+                $messages = $this->installer->createFinalConfigStep($siteUrl);
                 if (empty($messages)) {
-                    $installer->finalMigrationStep();
+                    $this->installer->finalMigrationStep();
                 }
                 break;
         }

--- a/app/bundles/LeadBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/SearchSubscriber.php
@@ -88,7 +88,6 @@ final class SearchSubscriber implements EventSubscriberInterface
                 ]);
 
             $this->addGlobalSearchResults(
-                $this->twig,
                 $event,
                 $results,
                 'mautic.lead.leads',
@@ -133,7 +132,6 @@ final class SearchSubscriber implements EventSubscriberInterface
                 ]);
 
             $this->addGlobalSearchResults(
-                $this->twig,
                 $event,
                 $results,
                 'mautic.company.company',
@@ -527,7 +525,6 @@ final class SearchSubscriber implements EventSubscriberInterface
      * @param array<string, mixed> $templateParameters
      */
     private function addGlobalSearchResults(
-        Environment $twig,
         GlobalSearchEvent $event,
         array $results,
         string $resultKey,
@@ -541,12 +538,12 @@ final class SearchSubscriber implements EventSubscriberInterface
         }
 
         $renderedResults = array_map(
-            fn ($item): string => $twig->render($template, array_merge(['item' => $item], $templateParameters)),
+            fn ($item): string => $this->twig->render($template, array_merge(['item' => $item], $templateParameters)),
             $results['results']
         );
 
         if ($count > GlobalSearchEvent::RESULTS_LIMIT) {
-            $renderedResults[] = $twig->render($template, [
+            $renderedResults[] = $this->twig->render($template, [
                 'showMore'     => true,
                 'searchString' => $event->getSearchString(),
                 'remaining'    => $count - GlobalSearchEvent::RESULTS_LIMIT,

--- a/app/bundles/UserBundle/Controller/PublicController.php
+++ b/app/bundles/UserBundle/Controller/PublicController.php
@@ -102,7 +102,7 @@ final class PublicController extends FormController
         if ('POST' === $request->getMethod()) {
             if ($isValid = $this->isFormValid($form)) {
                 $data     = $form->getData();
-                $response = $this->handlePasswordResetConfirm($request, $this->userModel, $hasher, $data);
+                $response = $this->handlePasswordResetConfirm($request, $hasher, $data);
             }
         }
 
@@ -112,7 +112,7 @@ final class PublicController extends FormController
     /**
      * @param array<string, mixed> $data
      */
-    private function handlePasswordResetConfirm(Request $request, UserModel $model, UserPasswordHasherInterface $hasher, array $data): ?Response
+    private function handlePasswordResetConfirm(Request $request, UserPasswordHasherInterface $hasher, array $data): ?Response
     {
         $response = null;
         $user     = $this->userRepository->findByIdentifier($data['identifier']);
@@ -125,10 +125,10 @@ final class PublicController extends FormController
             $this->addFlashMessage('mautic.user.user.notice.passwordreset.missingtoken');
 
             $response = $this->redirectToRoute('mautic_user_passwordresetconfirm');
-        } elseif ($model->confirmResetToken($user, $request->getSession()->get('resetToken'))) {
-            $encodedPassword = $model->checkNewPassword($user, $hasher, $data['plainPassword']);
+        } elseif ($this->userModel->confirmResetToken($user, $request->getSession()->get('resetToken'))) {
+            $encodedPassword = $this->userModel->checkNewPassword($user, $hasher, $data['plainPassword']);
             $user->setPassword($encodedPassword);
-            $model->saveEntity($user);
+            $this->userModel->saveEntity($user);
 
             $this->addFlashMessage('mautic.user.user.notice.passwordreset.success');
             $request->getSession()->remove('resetToken');

--- a/app/bundles/UserBundle/Controller/UserController.php
+++ b/app/bundles/UserBundle/Controller/UserController.php
@@ -218,20 +218,20 @@ final class UserController extends FormController
 
         // Check for a submitted form and process it
         if ('POST' === $request->getMethod()) {
-            $response = $this->handleNewUserPost($request, $languageHelper, $hasher, $samlHelper, $this->userModel, $user, $form);
+            $response = $this->handleNewUserPost($request, $languageHelper, $hasher, $samlHelper, $user, $form);
         }
 
         return $response ?? $this->renderNewUserForm($form, $action);
     }
 
-    private function handleNewUserPost(Request $request, LanguageHelper $languageHelper, UserPasswordHasherInterface $hasher, SAMLHelper $samlHelper, UserModel $model, User $user, FormInterface $form): JsonResponse|Response|null
+    private function handleNewUserPost(Request $request, LanguageHelper $languageHelper, UserPasswordHasherInterface $hasher, SAMLHelper $samlHelper, User $user, FormInterface $form): JsonResponse|Response|null
     {
         $response  = null;
         $cancelled = $this->isFormCancelled($form);
         $valid     = false;
 
         if (!$cancelled) {
-            $valid = $this->saveNewUserIfValid($request, $languageHelper, $hasher, $model, $user, $form);
+            $valid = $this->saveNewUserIfValid($request, $languageHelper, $hasher, $user, $form);
         }
 
         if ($cancelled || ($valid && $this->getFormButton($form, ['buttons', 'save'])->isClicked())) {
@@ -251,17 +251,17 @@ final class UserController extends FormController
         return $response;
     }
 
-    private function saveNewUserIfValid(Request $request, LanguageHelper $languageHelper, UserPasswordHasherInterface $hasher, UserModel $model, User $user, FormInterface $form): bool
+    private function saveNewUserIfValid(Request $request, LanguageHelper $languageHelper, UserPasswordHasherInterface $hasher, User $user, FormInterface $form): bool
     {
         $formUser          = $request->request->all()['user'] ?? [];
         $submittedPassword = $formUser['plainPassword']['password'] ?? null;
-        $password          = $model->checkNewPassword($user, $hasher, $submittedPassword);
+        $password          = $this->userModel->checkNewPassword($user, $hasher, $submittedPassword);
         $valid             = $this->isFormValid($form);
 
         if ($valid) {
             $user->setPassword($password);
-            $model->saveEntity($user);
-            $this->loadNewUserLocale($languageHelper, $model, $user);
+            $this->userModel->saveEntity($user);
+            $this->loadNewUserLocale($languageHelper, $user);
 
             $this->addFlashMessage('mautic.core.notice.created', [
                 '%name%'      => $user->getName(),
@@ -276,7 +276,7 @@ final class UserController extends FormController
         return $valid;
     }
 
-    private function loadNewUserLocale(LanguageHelper $languageHelper, UserModel $model, User $user): void
+    private function loadNewUserLocale(LanguageHelper $languageHelper, User $user): void
     {
         $installedLanguages = $languageHelper->getSupportedLanguages();
 
@@ -285,7 +285,7 @@ final class UserController extends FormController
 
             if ($fetchLanguage['error']) {
                 $user->setLocale(null);
-                $model->saveEntity($user);
+                $this->userModel->saveEntity($user);
                 $this->addFlashMessage(
                     $fetchLanguage['message'] ?? 'mautic.core.could.not.set.language',
                     $fetchLanguage['vars'] ?? []

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -257,6 +257,7 @@ rules:
 	- Utils\PHPStan\Rule\NoServicesInBundleConfigRule
 	#- Utils\PHPStan\Rule\NoUnusedServiceAliasRule
 	- Utils\PHPStan\Rule\NoParentConstructorForwardingRule
+	- Utils\PHPStan\Rule\NoServiceJugglingRule
 
 #services:
 #	-

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -222,16 +222,10 @@ parameters:
 			path: app/bundles/ApiBundle/Serializer/Driver/ApiMetadataDriver.php
 		-
 			identifier: typePerfect.noArrayAccessOnObject
-		# the service is picked per call, so it is an argument of its own, not a dependency of the called method
+		# @todo the form factory has to move into FormModel::createForm() first, which every model shares
 		-
 			identifier: mautic.noServiceJuggling
-			paths:
-				# a different model per batch: events and contacts
-				- app/bundles/CampaignBundle/Controller/Api/EventLogApiController.php
-				# FormModel::createForm() takes the form factory of whoever builds the form
-				- app/bundles/LeadBundle/Model/LeadModel.php
-				# the same query runs on the unbuffered connection and on the active one
-				- app/bundles/StageBundle/Entity/LeadStageLogRepository.php
+			path: app/bundles/LeadBundle/Model/LeadModel.php
 
 	scanDirectories:
 		# the kernel boot reflects these classes, so PHPStan can no longer locate them by autoloading

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -222,6 +222,16 @@ parameters:
 			path: app/bundles/ApiBundle/Serializer/Driver/ApiMetadataDriver.php
 		-
 			identifier: typePerfect.noArrayAccessOnObject
+		# the service is picked per call, so it is an argument of its own, not a dependency of the called method
+		-
+			identifier: mautic.noServiceJuggling
+			paths:
+				# a different model per batch: events and contacts
+				- app/bundles/CampaignBundle/Controller/Api/EventLogApiController.php
+				# FormModel::createForm() takes the form factory of whoever builds the form
+				- app/bundles/LeadBundle/Model/LeadModel.php
+				# the same query runs on the unbuffered connection and on the active one
+				- app/bundles/StageBundle/Entity/LeadStageLogRepository.php
 
 	scanDirectories:
 		# the kernel boot reflects these classes, so PHPStan can no longer locate them by autoloading

--- a/plugins/MauticTagManagerBundle/Controller/TagController.php
+++ b/plugins/MauticTagManagerBundle/Controller/TagController.php
@@ -177,7 +177,7 @@ final class TagController extends FormController
         // get the user form factory
         $form = $this->tagManagerModel->createForm($tag, $this->formFactory, $action);
 
-        $response = $this->handleNewActionPost($request, $tagDependencies, $tag, $this->tagManagerModel, $form, $returnUrl, $page);
+        $response = $this->handleNewActionPost($request, $tagDependencies, $tag, $form, $returnUrl, $page);
         if (null === $response) {
             $response = $this->delegateView([
                 'viewParameters' => [
@@ -196,7 +196,7 @@ final class TagController extends FormController
         return $response;
     }
 
-    private function handleNewActionPost(Request $request, TagDependencies $tagDependencies, \MauticPlugin\MauticTagManagerBundle\Entity\Tag $tag, TagManagerModel $model, FormInterface $form, string $returnUrl, int $page): ?Response
+    private function handleNewActionPost(Request $request, TagDependencies $tagDependencies, \MauticPlugin\MauticTagManagerBundle\Entity\Tag $tag, FormInterface $form, string $returnUrl, int $page): ?Response
     {
         if (Request::METHOD_POST !== $request->getMethod()) {
             return null;
@@ -218,7 +218,7 @@ final class TagController extends FormController
                         ]),
                     ]);
                 } else {
-                    $model->saveEntity($tag);
+                    $this->tagManagerModel->saveEntity($tag);
 
                     $this->addFlashMessage('mautic.core.notice.created', [
                         '%name%'      => $tag->getTag(),

--- a/utils/phpstan/src/Rule/NoServiceJugglingRule.php
+++ b/utils/phpstan/src/Rule/NoServiceJugglingRule.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Utils\PHPStan\Rule;
 
 use PhpParser\Node;
+use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticCall;
@@ -88,40 +89,35 @@ final class NoServiceJugglingRule implements Rule
             return [];
         }
 
+        $ownMethodCalls = $this->resolveOwnMethodCalls($class, $classReflection);
+        if ([] === $ownMethodCalls) {
+            return [];
+        }
+
+        $constantArgumentKeys = $this->resolveConstantArgumentKeys($ownMethodCalls);
+
         $ruleErrors = [];
 
-        foreach ($class->getMethods() as $classMethod) {
-            foreach ($this->resolveLocalCalls($classMethod) as $call) {
-                // "$this->toText(...)" has no arguments to look at
-                if ($call->isFirstClassCallable()) {
+        foreach ($ownMethodCalls as [$call, $calledMethodName]) {
+            foreach ($call->getArgs() as $position => $arg) {
+                $propertyName = $this->matchThisPropertyName($arg->value);
+                if (null === $propertyName || !isset($injectedServiceTypes[$propertyName])) {
                     continue;
                 }
 
-                $calledMethodName = $call->name instanceof Identifier ? $call->name->toString() : null;
-                if (null === $calledMethodName) {
+                if (!isset($constantArgumentKeys[$this->createArgumentKey($call, $calledMethodName, $arg, $position)])) {
                     continue;
                 }
 
-                if ($this->isDeclaredInTrait($this->resolveCalledClassReflection($call, $classReflection), $calledMethodName)) {
-                    continue;
-                }
-
-                foreach ($call->getArgs() as $arg) {
-                    $propertyName = $this->matchThisPropertyName($arg->value);
-                    if (null === $propertyName || !isset($injectedServiceTypes[$propertyName])) {
-                        continue;
-                    }
-
-                    $ruleErrors[] = RuleErrorBuilder::message(sprintf(
-                        'Service "$this->%s" is passed to "%s()" as an argument. Inject "%s" in the constructor of the class that uses it instead.',
-                        $propertyName,
-                        $calledMethodName,
-                        $injectedServiceTypes[$propertyName]
-                    ))
-                        ->identifier('mautic.noServiceJuggling')
-                        ->line($arg->getStartLine())
-                        ->build();
-                }
+                $ruleErrors[] = RuleErrorBuilder::message(sprintf(
+                    'Service "$this->%s" is passed to "%s()" as an argument. Inject "%s" in the constructor of the class that uses it instead.',
+                    $propertyName,
+                    $calledMethodName,
+                    $injectedServiceTypes[$propertyName]
+                ))
+                    ->identifier('mautic.noServiceJuggling')
+                    ->line($arg->getStartLine())
+                    ->build();
             }
         }
 
@@ -251,17 +247,98 @@ final class NoServiceJugglingRule implements Rule
     }
 
     /**
-     * The class the called method is looked up in: the current one for "$this->", the parent one for "parent::".
+     * The calls to a method the class itself owns, so the dependency can be moved into a constructor.
+     *
+     * @return list<array{MethodCall|StaticCall, string}>
+     */
+    private function resolveOwnMethodCalls(Class_ $class, ClassReflection $classReflection): array
+    {
+        $ownMethodCalls = [];
+
+        foreach ($class->getMethods() as $classMethod) {
+            foreach ($this->resolveLocalCalls($classMethod) as $call) {
+                // "$this->toText(...)" has no arguments to look at
+                if ($call->isFirstClassCallable()) {
+                    continue;
+                }
+
+                $calledMethodName = $call->name instanceof Identifier ? $call->name->toString() : null;
+                if (null === $calledMethodName) {
+                    continue;
+                }
+
+                if (!$this->isOwnMethod($call, $class, $classReflection, $calledMethodName)) {
+                    continue;
+                }
+
+                $ownMethodCalls[] = [$call, $calledMethodName];
+            }
+        }
+
+        return $ownMethodCalls;
+    }
+
+    /**
+     * A method the class can change: one declared right here, or the one of the parent an explicit "parent::" targets.
+     *
+     * An inherited method reached through "$this->" is left out: it is shared by every child, so the service is an
+     * argument of the call, not a dependency of the method - e.g. FormModel::createForm() takes the form factory of
+     * whoever builds the form. The same goes for a method brought in by a trait, as a trait has no constructor.
      *
      * @param MethodCall|StaticCall $call
      */
-    private function resolveCalledClassReflection(Node $call, ClassReflection $classReflection): ?ClassReflection
+    private function isOwnMethod(Node $call, Class_ $class, ClassReflection $classReflection, string $methodName): bool
     {
         if ($call instanceof StaticCall) {
-            return $classReflection->getParentClass();
+            return !$this->isDeclaredInTrait($classReflection->getParentClass(), $methodName);
         }
 
-        return $classReflection;
+        return $class->getMethod($methodName) instanceof ClassMethod;
+    }
+
+    /**
+     * The argument positions that always get the very same value, as only those stand for a fixed dependency.
+     *
+     * A position filled differently by another call is a parameter of its own: LeadStageLogRepository runs the same
+     * query on the injected unbuffered connection and on the active one, EventLogApiController fetches one batch
+     * with the event model and the next one with the contact model.
+     *
+     * @param list<array{MethodCall|StaticCall, string}> $ownMethodCalls
+     *
+     * @return array<string, true>
+     */
+    private function resolveConstantArgumentKeys(array $ownMethodCalls): array
+    {
+        $argumentValues = [];
+
+        foreach ($ownMethodCalls as [$call, $calledMethodName]) {
+            foreach ($call->getArgs() as $position => $arg) {
+                $argumentKey = $this->createArgumentKey($call, $calledMethodName, $arg, $position);
+
+                $argumentValues[$argumentKey][$this->matchThisPropertyName($arg->value) ?? '#other'] = true;
+            }
+        }
+
+        $constantArgumentKeys = [];
+
+        foreach ($argumentValues as $argumentKey => $values) {
+            if (1 === count($values)) {
+                $constantArgumentKeys[$argumentKey] = true;
+            }
+        }
+
+        return $constantArgumentKeys;
+    }
+
+    /**
+     * @param MethodCall|StaticCall $call
+     */
+    private function createArgumentKey(Node $call, string $calledMethodName, Arg $arg, int $position): string
+    {
+        $callKind = $call instanceof StaticCall ? 'parent' : 'this';
+        $argName  = $arg->name instanceof Identifier ? $arg->name->toString() : (string) $position;
+
+        return $callKind.'::'.$calledMethodName.'#'.$argName;
     }
 
     /**

--- a/utils/phpstan/src/Rule/NoServiceJugglingRule.php
+++ b/utils/phpstan/src/Rule/NoServiceJugglingRule.php
@@ -1,0 +1,276 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Rule;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\NullableType;
+use PhpParser\Node\Param;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\NodeFinder;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * A service injected in __construct() or an autowire*() method must not be handed over to another method call.
+ *
+ * Passing an own dependency around is service juggling - the service travels through a parameter list instead of
+ * being injected where it is used:
+ *
+ *     public function getContactEventsAction(Request $request): Response
+ *     {
+ *         return $this->getEntitiesAction($request, $this->userHelper);
+ *     }
+ *
+ * The called method has a constructor of its own, so it can take the service directly:
+ *
+ *     public function __construct(
+ *         private readonly UserHelper $userHelper,
+ *     ) {
+ *     }
+ *
+ *     public function getContactEventsAction(Request $request): Response
+ *     {
+ *         return $this->getEntitiesAction($request);
+ *     }
+ *
+ * @implements Rule<Class_>
+ */
+final class NoServiceJugglingRule implements Rule
+{
+    /**
+     * @var string
+     */
+    private const CONSTRUCTOR_NAME = '__construct';
+
+    /**
+     * @var string
+     */
+    private const AUTOWIRE_PREFIX = 'autowire';
+
+    /**
+     * @var string
+     */
+    private const REQUIRED_ATTRIBUTE = 'Symfony\Contracts\Service\Attribute\Required';
+
+    public function getNodeType(): string
+    {
+        return Class_::class;
+    }
+
+    /**
+     * @param Class_ $node
+     *
+     * @return list<\PHPStan\Rules\IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $injectedServiceTypes = $this->resolveInjectedServiceTypes($node);
+        if ([] === $injectedServiceTypes) {
+            return [];
+        }
+
+        $ruleErrors = [];
+
+        foreach ($node->getMethods() as $classMethod) {
+            foreach ($this->resolveLocalCalls($classMethod) as $call) {
+                // "$this->toText(...)" has no arguments to look at
+                if ($call->isFirstClassCallable()) {
+                    continue;
+                }
+
+                $calledMethodName = $call->name instanceof Identifier ? $call->name->toString() : null;
+                if (null === $calledMethodName) {
+                    continue;
+                }
+
+                foreach ($call->getArgs() as $arg) {
+                    $propertyName = $this->matchThisPropertyName($arg->value);
+                    if (null === $propertyName || !isset($injectedServiceTypes[$propertyName])) {
+                        continue;
+                    }
+
+                    $ruleErrors[] = RuleErrorBuilder::message(sprintf(
+                        'Service "$this->%s" is passed to "%s()" as an argument. Inject "%s" in the constructor of the class that uses it instead.',
+                        $propertyName,
+                        $calledMethodName,
+                        $injectedServiceTypes[$propertyName]
+                    ))
+                        ->identifier('mautic.noServiceJuggling')
+                        ->line($arg->getStartLine())
+                        ->build();
+                }
+            }
+        }
+
+        return $ruleErrors;
+    }
+
+    /**
+     * Properties filled by __construct() or an autowire*() method, e.g. "userHelper" => "Mautic\...\UserHelper".
+     *
+     * @return array<string, string>
+     */
+    private function resolveInjectedServiceTypes(Class_ $class): array
+    {
+        $injectedServiceTypes = [];
+
+        foreach ($class->getMethods() as $classMethod) {
+            if (!$this->isInjectingMethod($classMethod)) {
+                continue;
+            }
+
+            $paramTypes = [];
+
+            foreach ($classMethod->params as $param) {
+                $className = $this->matchObjectTypeName($param);
+                if (null === $className) {
+                    continue;
+                }
+
+                if (!$param->var instanceof Variable || !is_string($param->var->name)) {
+                    continue;
+                }
+
+                $paramTypes[$param->var->name] = $className;
+
+                // promoted property keeps the param name
+                if (0 !== $param->flags) {
+                    $injectedServiceTypes[$param->var->name] = $className;
+                }
+            }
+
+            foreach ($this->resolveAssignedProperties($classMethod) as $propertyName => $variableName) {
+                if (isset($paramTypes[$variableName])) {
+                    $injectedServiceTypes[$propertyName] = $paramTypes[$variableName];
+                }
+            }
+        }
+
+        return $injectedServiceTypes;
+    }
+
+    private function isInjectingMethod(ClassMethod $classMethod): bool
+    {
+        $methodName = $classMethod->name->toString();
+
+        if (self::CONSTRUCTOR_NAME === $classMethod->name->toLowerString()) {
+            return true;
+        }
+
+        if (str_starts_with($methodName, self::AUTOWIRE_PREFIX)) {
+            return true;
+        }
+
+        foreach ($classMethod->attrGroups as $attrGroup) {
+            foreach ($attrGroup->attrs as $attr) {
+                if (self::REQUIRED_ATTRIBUTE === $attr->name->toString()) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * The "$this->userHelper = $userHelper;" assignments, as "userHelper" => "userHelper".
+     *
+     * @return array<string, string>
+     */
+    private function resolveAssignedProperties(ClassMethod $classMethod): array
+    {
+        $assignedProperties = [];
+
+        $nodeFinder = new NodeFinder();
+
+        /** @var Node\Expr\Assign[] $assigns */
+        $assigns = $nodeFinder->findInstanceOf((array) $classMethod->stmts, Node\Expr\Assign::class);
+
+        foreach ($assigns as $assign) {
+            $propertyName = $this->matchThisPropertyName($assign->var);
+            if (null === $propertyName) {
+                continue;
+            }
+
+            if (!$assign->expr instanceof Variable || !is_string($assign->expr->name)) {
+                continue;
+            }
+
+            $assignedProperties[$propertyName] = $assign->expr->name;
+        }
+
+        return $assignedProperties;
+    }
+
+    /**
+     * The calls that stay inside the class hierarchy: "$this->someMethod()" and "parent::someMethod()".
+     *
+     * @return list<MethodCall|StaticCall>
+     */
+    private function resolveLocalCalls(ClassMethod $classMethod): array
+    {
+        $nodeFinder = new NodeFinder();
+
+        /** @var array<MethodCall|StaticCall> $calls */
+        $calls = $nodeFinder->find((array) $classMethod->stmts, static function (Node $node): bool {
+            if ($node instanceof MethodCall) {
+                return $node->var instanceof Variable && 'this' === $node->var->name;
+            }
+
+            if ($node instanceof StaticCall) {
+                return $node->class instanceof Name && 'parent' === $node->class->toLowerString();
+            }
+
+            return false;
+        });
+
+        return array_values($calls);
+    }
+
+    /**
+     * The property name of "$this->userHelper", null for anything else.
+     */
+    private function matchThisPropertyName(Node $node): ?string
+    {
+        if (!$node instanceof PropertyFetch) {
+            return null;
+        }
+
+        if (!$node->var instanceof Variable || 'this' !== $node->var->name) {
+            return null;
+        }
+
+        if (!$node->name instanceof Identifier) {
+            return null;
+        }
+
+        return $node->name->toString();
+    }
+
+    /**
+     * Only class types count, a scalar or an array is a value, not a service.
+     */
+    private function matchObjectTypeName(Param $param): ?string
+    {
+        $type = $param->type;
+        if ($type instanceof NullableType) {
+            $type = $type->type;
+        }
+
+        if (!$type instanceof Name) {
+            return null;
+        }
+
+        return $type->toString();
+    }
+}

--- a/utils/phpstan/src/Rule/NoServiceJugglingRule.php
+++ b/utils/phpstan/src/Rule/NoServiceJugglingRule.php
@@ -17,6 +17,9 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\NodeFinder;
 use PHPStan\Analyser\Scope;
+use PHPStan\Node\InClassNode;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\Php\PhpMethodReflection;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 
@@ -43,7 +46,7 @@ use PHPStan\Rules\RuleErrorBuilder;
  *         return $this->getEntitiesAction($request);
  *     }
  *
- * @implements Rule<Class_>
+ * @implements Rule<InClassNode>
  */
 final class NoServiceJugglingRule implements Rule
 {
@@ -64,24 +67,31 @@ final class NoServiceJugglingRule implements Rule
 
     public function getNodeType(): string
     {
-        return Class_::class;
+        return InClassNode::class;
     }
 
     /**
-     * @param Class_ $node
+     * @param InClassNode $node
      *
      * @return list<\PHPStan\Rules\IdentifierRuleError>
      */
     public function processNode(Node $node, Scope $scope): array
     {
-        $injectedServiceTypes = $this->resolveInjectedServiceTypes($node);
+        $class = $node->getOriginalNode();
+        if (!$class instanceof Class_) {
+            return [];
+        }
+
+        $classReflection = $node->getClassReflection();
+
+        $injectedServiceTypes = $this->resolveInjectedServiceTypes($class);
         if ([] === $injectedServiceTypes) {
             return [];
         }
 
         $ruleErrors = [];
 
-        foreach ($node->getMethods() as $classMethod) {
+        foreach ($class->getMethods() as $classMethod) {
             foreach ($this->resolveLocalCalls($classMethod) as $call) {
                 // "$this->toText(...)" has no arguments to look at
                 if ($call->isFirstClassCallable()) {
@@ -90,6 +100,10 @@ final class NoServiceJugglingRule implements Rule
 
                 $calledMethodName = $call->name instanceof Identifier ? $call->name->toString() : null;
                 if (null === $calledMethodName) {
+                    continue;
+                }
+
+                if ($this->isDeclaredInTrait($this->resolveCalledClassReflection($call, $classReflection), $calledMethodName)) {
                     continue;
                 }
 
@@ -235,6 +249,41 @@ final class NoServiceJugglingRule implements Rule
         });
 
         return array_values($calls);
+    }
+
+    /**
+     * The class the called method is looked up in: the current one for "$this->", the parent one for "parent::".
+     *
+     * @param MethodCall|StaticCall $call
+     */
+    private function resolveCalledClassReflection(Node $call, ClassReflection $classReflection): ?ClassReflection
+    {
+        if ($call instanceof StaticCall) {
+            return $classReflection->getParentClass();
+        }
+
+        return $classReflection;
+    }
+
+    /**
+     * A trait has no constructor to inject into, so its methods can only take the service as a parameter.
+     */
+    private function isDeclaredInTrait(?ClassReflection $classReflection, string $methodName): bool
+    {
+        if (!$classReflection instanceof ClassReflection) {
+            return false;
+        }
+
+        if (!$classReflection->hasNativeMethod($methodName)) {
+            return false;
+        }
+
+        $methodReflection = $classReflection->getNativeMethod($methodName);
+        if (!$methodReflection instanceof PhpMethodReflection) {
+            return false;
+        }
+
+        return $methodReflection->getDeclaringTrait() instanceof ClassReflection;
     }
 
     /**

--- a/utils/phpstan/src/Rule/NoServiceJugglingRule.php
+++ b/utils/phpstan/src/Rule/NoServiceJugglingRule.php
@@ -19,7 +19,6 @@ use PhpParser\NodeFinder;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\InClassNode;
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Reflection\Php\PhpMethodReflection;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 
@@ -274,16 +273,13 @@ final class NoServiceJugglingRule implements Rule
             return false;
         }
 
-        if (!$classReflection->hasNativeMethod($methodName)) {
-            return false;
+        foreach ($classReflection->getTraits(true) as $traitReflection) {
+            if ($traitReflection->hasNativeMethod($methodName)) {
+                return true;
+            }
         }
 
-        $methodReflection = $classReflection->getNativeMethod($methodName);
-        if (!$methodReflection instanceof PhpMethodReflection) {
-            return false;
-        }
-
-        return $methodReflection->getDeclaringTrait() instanceof ClassReflection;
+        return false;
     }
 
     /**

--- a/utils/phpstan/tests/Rule/Fixture/ServiceJuggling/AutowiredJugglingService.php
+++ b/utils/phpstan/tests/Rule/Fixture/ServiceJuggling/AutowiredJugglingService.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture\ServiceJuggling;
+
+final class AutowiredJugglingService extends ParentJugglingService
+{
+    private SomeUserHelper $userHelper;
+
+    public function autowireAutowiredJugglingService(SomeUserHelper $userHelper): void
+    {
+        $this->userHelper = $userHelper;
+    }
+
+    public function run(): void
+    {
+        parent::handle($this->userHelper);
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/ServiceJuggling/InheritedMethodJugglingService.php
+++ b/utils/phpstan/tests/Rule/Fixture/ServiceJuggling/InheritedMethodJugglingService.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture\ServiceJuggling;
+
+final class InheritedMethodJugglingService extends ParentJugglingService
+{
+    public function __construct(
+        private readonly SomeUserHelper $userHelper,
+    ) {
+    }
+
+    public function run(): void
+    {
+        // the method is shared by every child, so the service is an argument of the call, not a dependency
+        $this->handle($this->userHelper);
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/ServiceJuggling/ParentJugglingService.php
+++ b/utils/phpstan/tests/Rule/Fixture/ServiceJuggling/ParentJugglingService.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture\ServiceJuggling;
+
+abstract class ParentJugglingService
+{
+    public function handle(SomeUserHelper $userHelper): void
+    {
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/ServiceJuggling/PromotedJugglingService.php
+++ b/utils/phpstan/tests/Rule/Fixture/ServiceJuggling/PromotedJugglingService.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture\ServiceJuggling;
+
+final class PromotedJugglingService
+{
+    public function __construct(
+        private readonly SomeUserHelper $userHelper,
+    ) {
+    }
+
+    public function run(): void
+    {
+        $this->handle($this->userHelper);
+    }
+
+    public function handle(SomeUserHelper $userHelper): void
+    {
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/ServiceJuggling/SkippedJugglingService.php
+++ b/utils/phpstan/tests/Rule/Fixture/ServiceJuggling/SkippedJugglingService.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture\ServiceJuggling;
+
+final class SkippedJugglingService
+{
+    public function __construct(
+        private readonly SomeUserHelper $userHelper,
+        private readonly string $secret,
+    ) {
+    }
+
+    public function run(SomeUserHelper $localUserHelper): void
+    {
+        // a value, not a service
+        $this->handle($this->secret);
+
+        // a param of its own, the service is not taken from the class
+        $this->handleService($localUserHelper);
+
+        // another service is the one being called, not a method of this class
+        $this->userHelper->getUser();
+    }
+
+    public function handle(string $secret): void
+    {
+    }
+
+    public function handleService(SomeUserHelper $userHelper): void
+    {
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/ServiceJuggling/SomeHandleTrait.php
+++ b/utils/phpstan/tests/Rule/Fixture/ServiceJuggling/SomeHandleTrait.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture\ServiceJuggling;
+
+trait SomeHandleTrait
+{
+    public function handleInTrait(SomeUserHelper $userHelper): void
+    {
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/ServiceJuggling/SomeUserHelper.php
+++ b/utils/phpstan/tests/Rule/Fixture/ServiceJuggling/SomeUserHelper.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture\ServiceJuggling;
+
+final class SomeUserHelper
+{
+    public function getUser(): ?string
+    {
+        return null;
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/ServiceJuggling/TraitJugglingService.php
+++ b/utils/phpstan/tests/Rule/Fixture/ServiceJuggling/TraitJugglingService.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture\ServiceJuggling;
+
+final class TraitJugglingService
+{
+    use SomeHandleTrait;
+
+    public function __construct(
+        private readonly SomeUserHelper $userHelper,
+    ) {
+    }
+
+    public function run(): void
+    {
+        // the trait has no constructor of its own, so the service can only travel as a parameter
+        $this->handleInTrait($this->userHelper);
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/ServiceJuggling/VaryingArgumentJugglingService.php
+++ b/utils/phpstan/tests/Rule/Fixture/ServiceJuggling/VaryingArgumentJugglingService.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture\ServiceJuggling;
+
+final class VaryingArgumentJugglingService
+{
+    public function __construct(
+        private readonly SomeUserHelper $userHelper,
+    ) {
+    }
+
+    // the same position is filled differently, so it is a parameter of its own
+    public function run(SomeUserHelper $otherUserHelper): void
+    {
+        $this->handle($this->userHelper);
+        $this->handle($otherUserHelper);
+    }
+
+    public function handle(SomeUserHelper $userHelper): void
+    {
+    }
+}

--- a/utils/phpstan/tests/Rule/NoServiceJugglingRuleTest.php
+++ b/utils/phpstan/tests/Rule/NoServiceJugglingRuleTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use Utils\PHPStan\Rule\NoServiceJugglingRule;
+
+/**
+ * @extends RuleTestCase<NoServiceJugglingRule>
+ */
+final class NoServiceJugglingRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new NoServiceJugglingRule();
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/ServiceJuggling/PromotedJugglingService.php'], [
+            [
+                'Service "$this->userHelper" is passed to "handle()" as an argument. Inject "Utils\PHPStan\Tests\Rule\Fixture\ServiceJuggling\SomeUserHelper" in the constructor of the class that uses it instead.',
+                16,
+            ],
+        ]);
+
+        $this->analyse([
+            __DIR__.'/Fixture/ServiceJuggling/ParentJugglingService.php',
+            __DIR__.'/Fixture/ServiceJuggling/AutowiredJugglingService.php',
+        ], [
+            [
+                'Service "$this->userHelper" is passed to "handle()" as an argument. Inject "Utils\PHPStan\Tests\Rule\Fixture\ServiceJuggling\SomeUserHelper" in the constructor of the class that uses it instead.',
+                18,
+            ],
+        ]);
+
+        $this->analyse([__DIR__.'/Fixture/ServiceJuggling/SkippedJugglingService.php'], []);
+    }
+}

--- a/utils/phpstan/tests/Rule/NoServiceJugglingRuleTest.php
+++ b/utils/phpstan/tests/Rule/NoServiceJugglingRuleTest.php
@@ -39,5 +39,11 @@ final class NoServiceJugglingRuleTest extends RuleTestCase
 
         $this->analyse([__DIR__.'/Fixture/ServiceJuggling/SkippedJugglingService.php'], []);
         $this->analyse([__DIR__.'/Fixture/ServiceJuggling/TraitJugglingService.php'], []);
+        $this->analyse([__DIR__.'/Fixture/ServiceJuggling/VaryingArgumentJugglingService.php'], []);
+
+        $this->analyse([
+            __DIR__.'/Fixture/ServiceJuggling/ParentJugglingService.php',
+            __DIR__.'/Fixture/ServiceJuggling/InheritedMethodJugglingService.php',
+        ], []);
     }
 }

--- a/utils/phpstan/tests/Rule/NoServiceJugglingRuleTest.php
+++ b/utils/phpstan/tests/Rule/NoServiceJugglingRuleTest.php
@@ -38,5 +38,6 @@ final class NoServiceJugglingRuleTest extends RuleTestCase
         ]);
 
         $this->analyse([__DIR__.'/Fixture/ServiceJuggling/SkippedJugglingService.php'], []);
+        $this->analyse([__DIR__.'/Fixture/ServiceJuggling/TraitJugglingService.php'], []);
     }
 }


### PR DESCRIPTION
Adds a PHPStan rule that forbids **service juggling**: a service injected in `__construct()` or an `autowire*()` method must not be handed over as an argument to another method of the same class hierarchy. The called method has a constructor of its own, so it can take the dependency directly.

## What the rule reports

```diff
 public function __construct(
     private readonly InstallService $installer,
 ) {
 }

 protected function execute(InputInterface $input, OutputInterface $output): int
 {
-    $messages = $this->stepAction($this->installer, $dbParams, $step);
+    $messages = $this->stepAction($dbParams, $step);
 }

-private function stepAction(InstallService $installer, array $params, float $index = 0): array
+private function stepAction(array $params, float $index = 0): array
 {
-    $step = $installer->getStep($index);
+    $step = $this->installer->getStep($index);
 }
```

Error message:

```
Service "$this->installer" is passed to "stepAction()" as an argument.
Inject "Mautic\InstallBundle\Install\InstallService" in the constructor of the class that uses it instead.
```

## What the rule skips

The rule only reports a method the class can actually change, and only an argument that always holds the same service:

* **methods brought in by a trait** - a trait has no constructor to inject into, so `ImportExportTrait::performDuplicationCheck()` keeps taking the entity manager as a parameter
* **inherited methods reached through `$this->`** - they are shared by every child, so the service belongs to the call, not to the method
* **positions filled differently elsewhere** - `LeadStageLogRepository` runs the same query on the injected unbuffered connection and on the active one, `EventLogApiController` fetches one batch with the event model and the next with the contact model. Those are parameters of their own.

An explicit `parent::someMethod($this->someService)` is still reported - the parent is ours to change.

## Sites fixed

`InstallCommand` (6), `SearchSubscriber` (2), `TransifexFactory`, `PublicController`, `UserController`, `TagController`.

One `@todo` ignore is left for `LeadModel`: the form factory has to move into `FormModel::createForm()` first, which every model shares.
