### PR TITLE
[PageBundle] Inject PageRepository directly into PageListType and PageType

### DIFF
--- a/app/bundles/CoreBundle/Tests/Unit/Form/Type/ConfigTypeTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Form/Type/ConfigTypeTest.php
@@ -12,7 +12,6 @@ use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\CoreBundle\Shortener\Shortener;
 use Mautic\PageBundle\Entity\PageRepository;
 use Mautic\PageBundle\Form\Type\PageListType;
-use Mautic\PageBundle\Model\PageModel;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
 use Symfony\Component\Form\PreloadedExtension;
@@ -145,11 +144,7 @@ final class ConfigTypeTest extends TypeTestCase
                  ->method('getPageList')
                  ->willReturn([]);
 
-        $pageModelMock = $this->createMock(PageModel::class);
-        $pageModelMock
-                      ->method('getRepository')
-                      ->willReturn($repoMock);
-        $pageListType = new PageListType($pageModelMock, $this->createStub(CorePermissions::class));
+        $pageListType = new PageListType($this->createStub(CorePermissions::class), $repoMock);
 
         return [
             // register the type instances with the PreloadedExtension

--- a/app/bundles/PageBundle/Form/Type/PageListType.php
+++ b/app/bundles/PageBundle/Form/Type/PageListType.php
@@ -3,7 +3,7 @@
 namespace Mautic\PageBundle\Form\Type;
 
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
-use Mautic\PageBundle\Model\PageModel;
+use Mautic\PageBundle\Entity\PageRepository;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\Options;
@@ -17,23 +17,22 @@ final class PageListType extends AbstractType
     private readonly bool $canViewOther;
 
     public function __construct(
-        private readonly PageModel $model,
         CorePermissions $corePermissions,
+        private readonly PageRepository $pageRepository,
     ) {
         $this->canViewOther = $corePermissions->isGranted('page:pages:viewother');
     }
 
     public function configureOptions(OptionsResolver $resolver): void
     {
-        $model        = $this->model;
         $canViewOther = $this->canViewOther;
 
         $resolver->setDefaults(
             [
-                'choices' => function (Options $options) use ($model, $canViewOther): array {
+                'choices' => function (Options $options) use ($canViewOther): array {
                     $choices       = [];
                     $publishedOnly = $options['published_only'] ?? false;
-                    $pages         = $model->getRepository()->getPageList('', 0, 0, $canViewOther, $options['top_level'], $options['ignore_ids'], [], $publishedOnly);
+                    $pages         = $this->pageRepository->getPageList('', 0, 0, $canViewOther, $options['top_level'], $options['ignore_ids'], [], $publishedOnly);
                     foreach ($pages as $page) {
                         $choices[$page['language']]["{$page['title']} ({$page['id']})"] = $page['id'];
                     }

--- a/app/bundles/PageBundle/Form/Type/PageType.php
+++ b/app/bundles/PageBundle/Form/Type/PageType.php
@@ -16,8 +16,8 @@ use Mautic\CoreBundle\Helper\ThemeHelperInterface;
 use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\PageBundle\Entity\Page;
+use Mautic\PageBundle\Entity\PageRepository;
 use Mautic\PageBundle\Helper\PageConfigInterface;
-use Mautic\PageBundle\Model\PageModel;
 use Mautic\ProjectBundle\Form\Type\ProjectType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
@@ -43,11 +43,11 @@ final class PageType extends AbstractType
 
     public function __construct(
         private readonly EntityManagerInterface $em,
-        private readonly PageModel $model,
         CorePermissions $corePermissions,
         UserHelper $userHelper,
         private readonly ThemeHelperInterface $themeHelper,
         private readonly PageConfigInterface $pageConfig,
+        private readonly PageRepository $pageRepository,
     ) {
         $this->canViewOther = $corePermissions->isGranted('page:pages:viewother');
         $this->user         = $userHelper->getUser();
@@ -139,10 +139,10 @@ final class PageType extends AbstractType
         $builder->add('sessionId', HiddenType::class);
 
         // Custom field for redirect URL
-        $this->model->getRepository()->setCurrentUser($this->user);
+        $this->pageRepository->setCurrentUser($this->user);
 
         $redirectUrlDataOptions = '';
-        $pages                  = $this->model->getRepository()->getPageList('', 0, 0, $this->canViewOther, 'variant', [$options['data']->getId()]);
+        $pages                  = $this->pageRepository->getPageList('', 0, 0, $this->canViewOther, 'variant', [$options['data']->getId()]);
         foreach ($pages as $page) {
             $redirectUrlDataOptions .= "|{$page['alias']}";
         }

--- a/app/bundles/PageBundle/Tests/Form/Type/PageListTypeTest.php
+++ b/app/bundles/PageBundle/Tests/Form/Type/PageListTypeTest.php
@@ -7,7 +7,6 @@ namespace Mautic\PageBundle\Tests\Form\Type;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\PageBundle\Entity\PageRepository;
 use Mautic\PageBundle\Form\Type\PageListType;
-use Mautic\PageBundle\Model\PageModel;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -17,26 +16,21 @@ final class PageListTypeTest extends TestCase
     private PageListType $page;
 
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject&PageModel
+     * @var \PHPUnit\Framework\MockObject\MockObject&PageRepository
      */
-    private \PHPUnit\Framework\MockObject\MockObject $pageModelMock;
+    private \PHPUnit\Framework\MockObject\MockObject $pageRepositoryMock;
 
     protected function setUp(): void
     {
-        $this->pageModelMock   = $this->createMock(PageModel::class);
-        $this->page            = new PageListType($this->pageModelMock, $this->createStub(CorePermissions::class));
+        $this->pageRepositoryMock = $this->createMock(PageRepository::class);
+        $this->page               = new PageListType($this->createStub(CorePermissions::class), $this->pageRepositoryMock);
     }
 
     public function testPageListTypeOptionsChoices(): void
     {
-        $pageRepository = $this->createMock(PageRepository::class);
-        $resolver       = new OptionsResolver();
+        $resolver = new OptionsResolver();
 
-        $this->pageModelMock
-            ->method('getRepository')
-            ->willReturn($pageRepository);
-
-        $pageRepository->method('getPageList')
+        $this->pageRepositoryMock->method('getPageList')
             ->willReturn([]);
 
         $this->page->configureOptions($resolver);


### PR DESCRIPTION
Form types only need the repository, not the whole model. Inject `PageRepository` instead of reaching through `PageModel::getRepository()`.

```diff
 public function __construct(
-    private readonly PageModel $model,
     CorePermissions $corePermissions,
+    private readonly PageRepository $pageRepository,
 ) {
```

```diff
-$pages = $model->getRepository()->getPageList(...);
+$pages = $this->pageRepository->getPageList(...);
```

Tests updated to construct the types with a `PageRepository` mock directly, dropping the `PageModel` mock middleman.

Part 1/3 of splitting out `Model::getRepository()` usage in PageBundle.