### PR TITLE
[PageBundle] Inject repositories into PreferenceCenterListType and page category fixture

### DIFF
--- a/app/bundles/ConfigBundle/Tests/Form/Helper/RestrictionHelperTest.php
+++ b/app/bundles/ConfigBundle/Tests/Form/Helper/RestrictionHelperTest.php
@@ -27,7 +27,6 @@ use Mautic\EmailBundle\MonitoredEmail\Processor\FeedbackLoop;
 use Mautic\EmailBundle\MonitoredEmail\Processor\Unsubscribe;
 use Mautic\PageBundle\Entity\PageRepository;
 use Mautic\PageBundle\Form\Type\PreferenceCenterListType;
-use Mautic\PageBundle\Model\PageModel;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\TestDox;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -235,8 +234,6 @@ final class RestrictionHelperTest extends TypeTestCase
 
         $pageRepoMock = $this->createMock(PageRepository::class);
         $pageRepoMock->method('getPageList')->willReturn([]);
-        $pageModelMock = $this->createMock(PageModel::class);
-        $pageModelMock->method('getRepository')->willReturn($pageRepoMock);
 
         return [
             // register the type instances with the PreloadedExtension
@@ -252,7 +249,7 @@ final class RestrictionHelperTest extends TypeTestCase
                     new ButtonGroupType(),
                     new EmailConfigType($translator),
                     new DsnType($this->createStub(DsnTransformerFactory::class), $this->createStub(CoreParametersHelper::class)),
-                    new PreferenceCenterListType($pageModelMock, $this->createStub(CorePermissions::class)),
+                    new PreferenceCenterListType($this->createStub(CorePermissions::class), $pageRepoMock),
                     new ConfigMonitoredEmailType($dispatcher),
                     new ConfigMonitoredMailboxesType($this->createStub(Mailbox::class)),
                     new ConfigType($restrictionHelper, $escapeTransformer),

--- a/app/bundles/EmailBundle/Tests/Form/Type/ConfigTypeTest.php
+++ b/app/bundles/EmailBundle/Tests/Form/Type/ConfigTypeTest.php
@@ -19,7 +19,6 @@ use Mautic\EmailBundle\Validator\EmailOrEmailTokenListValidator;
 use Mautic\LeadBundle\Validator\CustomFieldValidator;
 use Mautic\PageBundle\Entity\PageRepository;
 use Mautic\PageBundle\Form\Type\PreferenceCenterListType;
-use Mautic\PageBundle\Model\PageModel;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
@@ -45,9 +44,6 @@ final class ConfigTypeTest extends TypeTestCase
         $repoMock = $this->createMock(PageRepository::class);
         $repoMock->method('getPageList')->willReturn([]);
 
-        $pageModelMock = $this->createMock(PageModel::class);
-        $pageModelMock->method('getRepository')->willReturn($repoMock);
-
         $permsMock = $this->createMock(CorePermissions::class);
         $permsMock->method('isGranted')->willReturn(false);
 
@@ -56,7 +52,7 @@ final class ConfigTypeTest extends TypeTestCase
             $this->createStub(CoreParametersHelper::class),
         );
         $configType                     = new ConfigType($translator);
-        $preferenceCenterList           = new PreferenceCenterListType($pageModelMock, $permsMock);
+        $preferenceCenterList           = new PreferenceCenterListType($permsMock, $repoMock);
         $configMonitoredEmail           = new ConfigMonitoredEmailType(new EventDispatcher());
         $configMonitoredMailboxes       = new ConfigMonitoredMailboxesType($this->createStub(Mailbox::class));
         $dsnValidator                   = new DsnValidator($this->createStub(TransportFactory::class));

--- a/app/bundles/PageBundle/DataFixtures/ORM/LoadPageCategoryData.php
+++ b/app/bundles/PageBundle/DataFixtures/ORM/LoadPageCategoryData.php
@@ -6,12 +6,12 @@ use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Mautic\CategoryBundle\Entity\Category;
-use Mautic\CategoryBundle\Model\CategoryModel;
+use Mautic\CategoryBundle\Entity\CategoryRepository;
 
 final class LoadPageCategoryData extends AbstractFixture implements OrderedFixtureInterface
 {
     public function __construct(
-        private readonly CategoryModel $categoryModel,
+        private readonly CategoryRepository $categoryRepository,
     ) {
     }
 
@@ -26,7 +26,7 @@ final class LoadPageCategoryData extends AbstractFixture implements OrderedFixtu
         $cat->setTitle($events);
         $cat->setAlias(strtolower($events));
 
-        $this->categoryModel->getRepository()->saveEntity($cat);
+        $this->categoryRepository->saveEntity($cat);
         $this->setReference('page-cat-1', $cat);
     }
 

--- a/app/bundles/PageBundle/Form/Type/PreferenceCenterListType.php
+++ b/app/bundles/PageBundle/Form/Type/PreferenceCenterListType.php
@@ -3,7 +3,7 @@
 namespace Mautic\PageBundle\Form\Type;
 
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
-use Mautic\PageBundle\Model\PageModel;
+use Mautic\PageBundle\Entity\PageRepository;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\Options;
@@ -14,22 +14,21 @@ final class PreferenceCenterListType extends AbstractType
     private readonly bool $canViewOther;
 
     public function __construct(
-        private readonly PageModel $model,
         CorePermissions $corePermissions,
+        private readonly PageRepository $pageRepository,
     ) {
         $this->canViewOther = $corePermissions->isGranted('page:pages:viewother');
     }
 
     public function configureOptions(OptionsResolver $resolver): void
     {
-        $model        = $this->model;
         $canViewOther = $this->canViewOther;
 
         $resolver->setDefaults(
             [
-                'choices' => function (Options $options) use ($model, $canViewOther): array {
+                'choices' => function (Options $options) use ($canViewOther): array {
                     $choices = [];
-                    $pages   = $model->getRepository()->getPageList('', 0, 0, $canViewOther, $options['top_level'], $options['ignore_ids'], ['isPreferenceCenter']);
+                    $pages   = $this->pageRepository->getPageList('', 0, 0, $canViewOther, $options['top_level'], $options['ignore_ids'], ['isPreferenceCenter']);
                     foreach ($pages as $page) {
                         if ($page['isPreferenceCenter']) {
                             $choices[$page['language']]["{$page['title']} ({$page['id']})"] = $page['id'];


### PR DESCRIPTION
Same idea as #16915, applied to `PreferenceCenterListType` and `LoadPageCategoryData`.

```diff
 public function __construct(
-    private readonly PageModel $model,
     CorePermissions $corePermissions,
+    private readonly PageRepository $pageRepository,
 ) {
```

```diff
-private readonly CategoryModel $categoryModel,
+private readonly CategoryRepository $categoryRepository,
 ...
-$this->categoryModel->getRepository()->saveEntity($cat);
+$this->categoryRepository->saveEntity($cat);
```

Tests in ConfigBundle and EmailBundle updated to pass the repository mock straight in.

Part 2/3.