### PR TITLE
[PageBundle] Inject repositories directly into PageModel and page fixtures

### DIFF
--- a/app/bundles/PageBundle/DataFixtures/ORM/LoadPageData.php
+++ b/app/bundles/PageBundle/DataFixtures/ORM/LoadPageData.php
@@ -8,12 +8,12 @@ use Doctrine\Persistence\ObjectManager;
 use Mautic\CoreBundle\Helper\CsvHelper;
 use Mautic\CoreBundle\Helper\Serializer;
 use Mautic\PageBundle\Entity\Page;
-use Mautic\PageBundle\Model\PageModel;
+use Mautic\PageBundle\Entity\PageRepository;
 
 final class LoadPageData extends AbstractFixture implements OrderedFixtureInterface
 {
     public function __construct(
-        private readonly PageModel $pageModel,
+        private readonly PageRepository $pageRepository,
     ) {
     }
 
@@ -39,7 +39,7 @@ final class LoadPageData extends AbstractFixture implements OrderedFixtureInterf
                 }
             }
             $page->setCategory($this->getReference('page-cat-1'));
-            $this->pageModel->getRepository()->saveEntity($page);
+            $this->pageRepository->saveEntity($page);
 
             $this->setReference('page-'.$key, $page);
         }

--- a/app/bundles/PageBundle/DataFixtures/ORM/LoadPageHitData.php
+++ b/app/bundles/PageBundle/DataFixtures/ORM/LoadPageHitData.php
@@ -8,12 +8,12 @@ use Doctrine\Persistence\ObjectManager;
 use Mautic\CoreBundle\Helper\CsvHelper;
 use Mautic\CoreBundle\Helper\Serializer;
 use Mautic\PageBundle\Entity\Hit;
-use Mautic\PageBundle\Model\PageModel;
+use Mautic\PageBundle\Entity\PageRepository;
 
 final class LoadPageHitData extends AbstractFixture implements OrderedFixtureInterface
 {
     public function __construct(
-        private readonly PageModel $pageModel,
+        private readonly PageRepository $pageRepository,
     ) {
     }
 
@@ -38,7 +38,7 @@ final class LoadPageHitData extends AbstractFixture implements OrderedFixtureInt
                     }
                 }
             }
-            $this->pageModel->getRepository()->saveEntity($hit);
+            $this->pageRepository->saveEntity($hit);
         }
     }
 

--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -30,6 +30,7 @@ use Mautic\EmailBundle\Helper\BotRatioHelper;
 use Mautic\LeadBundle\DataObject\LeadManipulator;
 use Mautic\LeadBundle\Entity\Company;
 use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Entity\UtmTag;
 use Mautic\LeadBundle\Entity\UtmTagRepository;
 use Mautic\LeadBundle\Helper\ContactRequestHelper;
@@ -45,6 +46,8 @@ use Mautic\PageBundle\Entity\HitRepository;
 use Mautic\PageBundle\Entity\Page;
 use Mautic\PageBundle\Entity\PageRepository;
 use Mautic\PageBundle\Entity\Redirect;
+use Mautic\PageBundle\Entity\RedirectRepository;
+use Mautic\PageBundle\Entity\TrackableRepository;
 use Mautic\PageBundle\Event\PageBuilderEvent;
 use Mautic\PageBundle\Event\PageEvent;
 use Mautic\PageBundle\Event\PageHitEvent;
@@ -119,6 +122,9 @@ class PageModel extends FormModel implements GlobalSearchInterface
         private readonly HitRepository $hitRepository,
         private readonly EmailRepository $emailRepository,
         private readonly UtmTagRepository $utmTagRepository,
+        private readonly RedirectRepository $redirectRepository,
+        private readonly TrackableRepository $trackableRepository,
+        private readonly LeadRepository $leadRepository,
     ) {
         $this->dateTimeHelper = new DateTimeHelper();
 
@@ -629,11 +635,11 @@ class PageModel extends FormModel implements GlobalSearchInterface
             }
         } elseif ($page instanceof Redirect) {
             try {
-                $this->pageRedirectModel->getRepository()->upHitCount($page->getId(), 1, $isUnique);
+                $this->redirectRepository->upHitCount($page->getId(), 1, $isUnique);
 
                 // If this is a trackable, up the trackable counts as well
                 if ($hit->getSource() && $hit->getSourceId()) {
-                    $this->pageTrackableModel->getRepository()->upHitCount(
+                    $this->trackableRepository->upHitCount(
                         $page->getId(),
                         $hit->getSource(),
                         $hit->getSourceId(),
@@ -706,7 +712,7 @@ class PageModel extends FormModel implements GlobalSearchInterface
         if (null !== $hitDate) {
             if (null === $lead->getLastActive() || $lead->getLastActive() < $hitDate) {
                 try {
-                    $this->leadModel->getRepository()->updateLastActive($lead->getId(), $hitDate);
+                    $this->leadRepository->updateLastActive($lead->getId(), $hitDate);
                 } catch (\Exception $e) {
                     $data = [
                         'unique'             => ($isUnique ? 'true' : 'false'),

--- a/app/bundles/PageBundle/Tests/PageTestAbstract.php
+++ b/app/bundles/PageBundle/Tests/PageTestAbstract.php
@@ -18,6 +18,7 @@ use Mautic\EmailBundle\Entity\EmailRepository;
 use Mautic\EmailBundle\Entity\StatRepository;
 use Mautic\EmailBundle\Helper\BotRatioHelper;
 use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Entity\UtmTagRepository;
 use Mautic\LeadBundle\Helper\ContactRequestHelper;
 use Mautic\LeadBundle\Model\CompanyModel;
@@ -31,6 +32,7 @@ use Mautic\PageBundle\Entity\Page;
 use Mautic\PageBundle\Entity\PageRepository;
 use Mautic\PageBundle\Entity\Redirect;
 use Mautic\PageBundle\Entity\RedirectRepository;
+use Mautic\PageBundle\Entity\TrackableRepository;
 use Mautic\PageBundle\Model\PageModel;
 use Mautic\PageBundle\Model\RedirectModel;
 use Mautic\PageBundle\Model\TrackableModel;
@@ -156,6 +158,9 @@ abstract class PageTestAbstract extends TestCase
             $this->createStub(HitRepository::class), // $hitRepository
             $this->createStub(EmailRepository::class), // $emailRepository
             $this->createStub(UtmTagRepository::class), // $utmTagRepository
+            $this->createStub(RedirectRepository::class),
+            $this->createStub(TrackableRepository::class),
+            $this->createStub(LeadRepository::class)
         );
     }
 


### PR DESCRIPTION
Final part. `PageModel` reached into three other models just to get their repositories; inject the repositories instead.

```diff
 private readonly UtmTagRepository $utmTagRepository,
+private readonly RedirectRepository $redirectRepository,
+private readonly TrackableRepository $trackableRepository,
+private readonly LeadRepository $leadRepository,
```

```diff
-$this->pageRedirectModel->getRepository()->upHitCount($page->getId(), 1, $isUnique);
+$this->redirectRepository->upHitCount($page->getId(), 1, $isUnique);

-$this->pageTrackableModel->getRepository()->upHitCount(...);
+$this->trackableRepository->upHitCount(...);

-$this->leadModel->getRepository()->updateLastActive($lead->getId(), $hitDate);
+$this->leadRepository->updateLastActive($lead->getId(), $hitDate);
```

Page fixtures get the same treatment (`PageModel` → `PageRepository`).

Part 3/3.