### PR TITLE
[PageBundle] Inject PageRepository into PreferenceCenterListType

### DIFF
--- a/app/bundles/PageBundle/Form/Type/PreferenceCenterListType.php
+++ b/app/bundles/PageBundle/Form/Type/PreferenceCenterListType.php
@@ -3,7 +3,7 @@
 namespace Mautic\PageBundle\Form\Type;
 
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
-use Mautic\PageBundle\Model\PageModel;
+use Mautic\PageBundle\Entity\PageRepository;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\Options;
@@ -14,22 +14,21 @@ final class PreferenceCenterListType extends AbstractType
     private readonly bool $canViewOther;
 
     public function __construct(
-        private readonly PageModel $model,
         CorePermissions $corePermissions,
+        private readonly PageRepository $pageRepository,
     ) {
         $this->canViewOther = $corePermissions->isGranted('page:pages:viewother');
     }
 
     public function configureOptions(OptionsResolver $resolver): void
     {
-        $model        = $this->model;
         $canViewOther = $this->canViewOther;
 
         $resolver->setDefaults(
             [
-                'choices' => function (Options $options) use ($model, $canViewOther): array {
+                'choices' => function (Options $options) use ($canViewOther): array {
                     $choices = [];
-                    $pages   = $model->getRepository()->getPageList('', 0, 0, $canViewOther, $options['top_level'], $options['ignore_ids'], ['isPreferenceCenter']);
+                    $pages   = $this->pageRepository->getPageList('', 0, 0, $canViewOther, $options['top_level'], $options['ignore_ids'], ['isPreferenceCenter']);
                     foreach ($pages as $page) {
                         if ($page['isPreferenceCenter']) {
                             $choices[$page['language']]["{$page['title']} ({$page['id']})"] = $page['id'];


### PR DESCRIPTION
The form type only needs the page repository, not the whole `PageModel`. Injecting the repository directly removes a layer of indirection and makes the dependency explicit.

```diff
 public function __construct(
-    private readonly PageModel $model,
     CorePermissions $corePermissions,
+    private readonly PageRepository $pageRepository,
 ) {
```

```diff
-$pages = $model->getRepository()->getPageList(...);
+$pages = $this->pageRepository->getPageList(...);
```