### PR TITLE
[PageBundle] Inject CategoryRepository into LoadPageCategoryData fixture

### DIFF
--- a/app/bundles/PageBundle/DataFixtures/ORM/LoadPageCategoryData.php
+++ b/app/bundles/PageBundle/DataFixtures/ORM/LoadPageCategoryData.php
@@ -6,12 +6,12 @@ use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Mautic\CategoryBundle\Entity\Category;
-use Mautic\CategoryBundle\Model\CategoryModel;
+use Mautic\CategoryBundle\Entity\CategoryRepository;
 
 final class LoadPageCategoryData extends AbstractFixture implements OrderedFixtureInterface
 {
     public function __construct(
-        private readonly CategoryModel $categoryModel,
+        private readonly CategoryRepository $categoryRepository,
     ) {
     }
 
@@ -26,7 +26,7 @@ final class LoadPageCategoryData extends AbstractFixture implements OrderedFixtu
         $cat->setTitle($events);
         $cat->setAlias(strtolower($events));
 
-        $this->categoryModel->getRepository()->saveEntity($cat);
+        $this->categoryRepository->saveEntity($cat);
         $this->setReference('page-cat-1', $cat);
     }
 


### PR DESCRIPTION
The fixture only uses the category repository to save one entity, so inject the repository instead of `CategoryModel`.

```diff
-private readonly CategoryModel $categoryModel,
+private readonly CategoryRepository $categoryRepository,
```

```diff
-$this->categoryModel->getRepository()->saveEntity($cat);
+$this->categoryRepository->saveEntity($cat);
```