### PR TITLE
[EmailBundle] Use PageRepository mock in ConfigTypeTest

### DIFF
--- a/app/bundles/EmailBundle/Tests/Form/Type/ConfigTypeTest.php
+++ b/app/bundles/EmailBundle/Tests/Form/Type/ConfigTypeTest.php
@@ -19,7 +19,6 @@ use Mautic\EmailBundle\Validator\EmailOrEmailTokenListValidator;
 use Mautic\LeadBundle\Validator\CustomFieldValidator;
 use Mautic\PageBundle\Entity\PageRepository;
 use Mautic\PageBundle\Form\Type\PreferenceCenterListType;
-use Mautic\PageBundle\Model\PageModel;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
@@ -45,9 +44,6 @@ final class ConfigTypeTest extends TypeTestCase
         $repoMock = $this->createMock(PageRepository::class);
         $repoMock->method('getPageList')->willReturn([]);
 
-        $pageModelMock = $this->createMock(PageModel::class);
-        $pageModelMock->method('getRepository')->willReturn($repoMock);
-
         $permsMock = $this->createMock(CorePermissions::class);
         $permsMock->method('isGranted')->willReturn(false);
 
@@ -56,7 +52,7 @@ final class ConfigTypeTest extends TypeTestCase
             $this->createStub(CoreParametersHelper::class),
         );
         $configType                     = new ConfigType($translator);
-        $preferenceCenterList           = new PreferenceCenterListType($pageModelMock, $permsMock);
+        $preferenceCenterList           = new PreferenceCenterListType($permsMock, $repoMock);
         $configMonitoredEmail           = new ConfigMonitoredEmailType(new EventDispatcher());
         $configMonitoredMailboxes       = new ConfigMonitoredMailboxesType($this->createStub(Mailbox::class));
         $dsnValidator                   = new DsnValidator($this->createStub(TransportFactory::class));


### PR DESCRIPTION
Follow-up to #16919 — drops the now-unneeded `PageModel` mock and passes the page repository mock straight to `PreferenceCenterListType`.

```diff
-$pageModelMock = $this->createMock(PageModel::class);
-$pageModelMock->method('getRepository')->willReturn($repoMock);
-
-$preferenceCenterList = new PreferenceCenterListType($pageModelMock, $permsMock);
+$preferenceCenterList = new PreferenceCenterListType($permsMock, $repoMock);
```

Depends on #16919; tests pass once that one is merged.