### PR TITLE
Inject repository services directly instead of Model::getRepository()

### DIFF
--- a/app/bundles/AssetBundle/Form/Type/AssetListType.php
+++ b/app/bundles/AssetBundle/Form/Type/AssetListType.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\AssetBundle\Form\Type;
 
-use Mautic\AssetBundle\Model\AssetModel;
+use Mautic\AssetBundle\Entity\AssetRepository;
 use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Symfony\Component\Form\AbstractType;
@@ -16,8 +16,8 @@ final class AssetListType extends AbstractType
 {
     public function __construct(
         private readonly CorePermissions $corePermissions,
-        private readonly AssetModel $assetModel,
         private readonly UserHelper $userHelper,
+        private readonly AssetRepository $assetRepository,
     ) {
     }
 
@@ -41,9 +41,9 @@ final class AssetListType extends AbstractType
     {
         $choices   = [];
         $viewOther = $this->corePermissions->isGranted('asset:assets:viewother');
-        $repo      = $this->assetModel->getRepository();
-        $repo->setCurrentUser($this->userHelper->getUser());
-        $assets = $repo->getAssetList('', 0, 0, $viewOther);
+
+        $this->assetRepository->setCurrentUser($this->userHelper->getUser());
+        $assets = $this->assetRepository->getAssetList('', 0, 0, $viewOther);
 
         foreach ($assets as $asset) {
             $choices[$asset['language']][$asset['title']] = $asset['id'];

--- a/app/bundles/AssetBundle/Model/AssetModel.php
+++ b/app/bundles/AssetBundle/Model/AssetModel.php
@@ -12,6 +12,7 @@ use Mautic\AssetBundle\Entity\DownloadRepository;
 use Mautic\AssetBundle\Event\AssetEvent;
 use Mautic\AssetBundle\Event\AssetLoadEvent;
 use Mautic\AssetBundle\Form\Type\AssetType;
+use Mautic\CategoryBundle\Entity\CategoryRepository;
 use Mautic\CategoryBundle\Model\CategoryModel;
 use Mautic\CoreBundle\Helper\Chart\ChartQuery;
 use Mautic\CoreBundle\Helper\Chart\LineChart;
@@ -72,6 +73,7 @@ class AssetModel extends FormModel implements GlobalSearchInterface
         private readonly EmailRepository $emailRepository,
         private readonly AssetRepository $assetRepository,
         private readonly DownloadRepository $downloadRepository,
+        private readonly CategoryRepository $categoryRepository,
     ) {
         $this->maxAssetSize           = $coreParametersHelper->get('max_size');
 
@@ -395,7 +397,7 @@ class AssetModel extends FormModel implements GlobalSearchInterface
                 $results = $this->assetRepository->getAssetList($filter, $limit, 0, $viewOther);
                 break;
             case 'category':
-                $results = $this->categoryModel->getRepository()->getCategoryList($filter, $limit, 0);
+                $results = $this->categoryRepository->getCategoryList($filter, $limit, 0);
                 break;
         }
 

--- a/app/bundles/AssetBundle/Tests/Model/AssetModelTest.php
+++ b/app/bundles/AssetBundle/Tests/Model/AssetModelTest.php
@@ -12,6 +12,7 @@ use Mautic\AssetBundle\Entity\Download;
 use Mautic\AssetBundle\Entity\DownloadRepository;
 use Mautic\AssetBundle\Model\AssetModel;
 use Mautic\CacheBundle\Cache\CacheProvider;
+use Mautic\CategoryBundle\Entity\CategoryRepository;
 use Mautic\CategoryBundle\Model\CategoryModel;
 use Mautic\CoreBundle\Entity\IpAddress;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
@@ -118,9 +119,10 @@ final class AssetModelTest extends \PHPUnit\Framework\TestCase
             $this->userHelper,
             $this->logger,
             $this->coreParametersHelper,
-            $this->createStub(EmailRepository::class), // $emailRepository
+            $this->createStub(EmailRepository::class),
             $this->assetRepository,
-            $this->createStub(DownloadRepository::class), // $downloadRepository
+            $this->createStub(DownloadRepository::class),
+            $this->createStub(CategoryRepository::class),
         );
     }
 
@@ -320,6 +322,7 @@ final class AssetModelTest extends \PHPUnit\Framework\TestCase
                 $this->createStub(EmailRepository::class),
                 $this->createStub(AssetRepository::class),
                 $this->createStub(DownloadRepository::class),
+                $this->createStub(CategoryRepository::class),
             ])
             ->onlyMethods(['getEntity'])
             ->getMock();

--- a/app/bundles/CampaignBundle/Form/Type/CampaignListType.php
+++ b/app/bundles/CampaignBundle/Form/Type/CampaignListType.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\CampaignBundle\Form\Type;
 
-use Mautic\CampaignBundle\Model\CampaignModel;
+use Mautic\CampaignBundle\Entity\CampaignRepository;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -17,8 +17,8 @@ final class CampaignListType extends AbstractType
     private readonly bool $canViewOther;
 
     public function __construct(
-        private readonly CampaignModel $model,
         CorePermissions $security,
+        private readonly CampaignRepository $campaignRepository,
     ) {
         $this->canViewOther = $security->isGranted('campaign:campaigns:viewother');
     }
@@ -29,7 +29,7 @@ final class CampaignListType extends AbstractType
             [
                 'choices'      => function (Options $options): array {
                     $choices   = [];
-                    $campaigns = $this->model->getRepository()->getPublishedCampaigns(null, null, true, $this->canViewOther);
+                    $campaigns = $this->campaignRepository->getPublishedCampaigns(null, null, true, $this->canViewOther);
                     foreach ($campaigns as $campaign) {
                         $choices[$campaign['name']] = $campaign['id'];
                     }

--- a/app/bundles/CampaignBundle/Model/CampaignModel.php
+++ b/app/bundles/CampaignBundle/Model/CampaignModel.php
@@ -32,6 +32,7 @@ use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\CoreBundle\Translation\Translator;
 use Mautic\EmailBundle\Entity\StatRepository;
 use Mautic\FormBundle\Entity\Form;
+use Mautic\FormBundle\Entity\FormRepository;
 use Mautic\FormBundle\Model\FormModel;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList;
@@ -70,6 +71,7 @@ class CampaignModel extends CommonFormModel implements GlobalSearchInterface
         private readonly LeadRepository $leadRepository,
         private readonly LeadEventLogRepository $leadEventLogRepository,
         private readonly StatRepository $statRepository,
+        private readonly FormRepository $formRepository,
     ) {
         parent::__construct($em, $security, $dispatcher, $router, $translator, $userHelper, $mauticLogger, $coreParametersHelper);
     }
@@ -543,10 +545,9 @@ class CampaignModel extends CommonFormModel implements GlobalSearchInterface
             case null:
                 $choices['forms'] = [];
                 $viewOther        = $this->security->isGranted('form:forms:viewother');
-                $repo             = $this->formModel->getRepository();
-                $repo->setCurrentUser($this->userHelper->getUser());
+                $this->formRepository->setCurrentUser($this->userHelper->getUser());
 
-                $forms = $repo->getFormList('', 0, 0, $viewOther);
+                $forms = $this->formRepository->getFormList('', 0, 0, $viewOther);
 
                 foreach ($forms as $form) {
                     $choices['forms'][$form['id']] = $form['name'];

--- a/app/bundles/CampaignBundle/Tests/CampaignTestAbstract.php
+++ b/app/bundles/CampaignBundle/Tests/CampaignTestAbstract.php
@@ -72,10 +72,6 @@ abstract class CampaignTestAbstract extends TestCase
             ->setConstructorArgs([12 => $entityManager])
             ->getMock();
 
-        $formModel
-            ->method('getRepository')
-            ->willReturn($formRepository);
-
         return new CampaignModel(
             $leadListModel,
             $formModel,
@@ -96,6 +92,7 @@ abstract class CampaignTestAbstract extends TestCase
             $this->createStub(LeadRepository::class), // $leadRepository
             $this->createStub(LeadEventLogRepository::class), // $leadEventLogRepository
             $this->createStub(StatRepository::class), // $statRepository
+            $formRepository, // $formRepository
         );
     }
 }

--- a/app/bundles/CampaignBundle/Tests/Model/CampaignModelTransactionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Model/CampaignModelTransactionalTest.php
@@ -20,6 +20,7 @@ use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\CoreBundle\Translation\Translator;
 use Mautic\EmailBundle\Entity\StatRepository;
+use Mautic\FormBundle\Entity\FormRepository;
 use Mautic\FormBundle\Model\FormModel;
 use Mautic\LeadBundle\Model\ListModel;
 use Mautic\LeadBundle\Tracker\ContactTracker;
@@ -68,6 +69,7 @@ final class CampaignModelTransactionalTest extends TestCase
                 $this->createStub(LeadRepository::class),
                 $this->createStub(LeadEventLogRepository::class),
                 $this->createStub(StatRepository::class),
+                $this->createStub(FormRepository::class),
             ])
             ->onlyMethods(['saveEntity'])
             ->getMock();

--- a/app/bundles/CategoryBundle/Entity/CategoryRepository.php
+++ b/app/bundles/CategoryBundle/Entity/CategoryRepository.php
@@ -8,7 +8,7 @@ use Mautic\CoreBundle\Entity\CommonRepository;
 /**
  * @extends CommonRepository<Category>
  */
-final class CategoryRepository extends CommonRepository
+class CategoryRepository extends CommonRepository
 {
     /**
      * Get a list of entities.

--- a/app/bundles/ChannelBundle/Model/MessageQueueModel.php
+++ b/app/bundles/ChannelBundle/Model/MessageQueueModel.php
@@ -11,6 +11,7 @@ use Mautic\ChannelBundle\Event\MessageQueueProcessEvent;
 use Mautic\CoreBundle\Model\FormModel;
 use Mautic\LeadBundle\Entity\FrequencyRuleRepository;
 use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Model\CompanyModel;
 use Mautic\LeadBundle\Model\LeadModel;
 use Symfony\Contracts\EventDispatcher\Event;
@@ -34,17 +35,21 @@ class MessageQueueModel extends FormModel
 
     private FrequencyRuleRepository $frequencyRuleRepository;
 
+    private LeadRepository $leadRepository;
+
     #[Required]
     public function autowireMessageQueueModel(
         LeadModel $leadModel,
         CompanyModel $companyModel,
         MessageQueueRepository $messageQueueRepository,
         FrequencyRuleRepository $frequencyRuleRepository,
+        LeadRepository $leadRepository,
     ): void {
         $this->leadModel               = $leadModel;
         $this->companyModel            = $companyModel;
         $this->messageQueueRepository  = $messageQueueRepository;
         $this->frequencyRuleRepository = $frequencyRuleRepository;
+        $this->leadRepository = $leadRepository;
     }
 
     public function getRepository(): MessageQueueRepository
@@ -212,7 +217,7 @@ class MessageQueueModel extends FormModel
             }
         }
         if (!empty($contacts)) {
-            $contactData = $this->leadModel->getRepository()->getContacts($contacts);
+            $contactData = $this->leadRepository->getContacts($contacts);
             foreach ($contacts as $messageId => $contactId) {
                 $queue[$messageId]->getLead()->setFields($contactData[$contactId]);
             }

--- a/app/bundles/ChannelBundle/Tests/Model/MessageQueueModelTest.php
+++ b/app/bundles/ChannelBundle/Tests/Model/MessageQueueModelTest.php
@@ -34,11 +34,6 @@ final class MessageQueueModelTest extends \PHPUnit\Framework\TestCase
     private MessageQueue $message;
 
     /**
-     * @var MockObject&LeadModel
-     */
-    private MockObject $leadModel;
-
-    /**
      * @var MockObject&EntityManagerInterface
      */
     private MockObject $entityManager;
@@ -48,11 +43,16 @@ final class MessageQueueModelTest extends \PHPUnit\Framework\TestCase
      */
     private MockObject $messageQueueRepository;
 
+    /**
+     * @var MockObject&LeadRepository
+     */
+    private MockObject $leadRepository;
+
     protected function setUp(): void
     {
-        $this->leadModel              = $this->createMock(LeadModel::class);
         $this->entityManager          = $this->createMock(EntityManagerInterface::class);
         $this->messageQueueRepository = $this->createMock(MessageQueueRepository::class);
+        $this->leadRepository         = $this->createMock(LeadRepository::class);
 
         $this->messageQueue = new MessageQueueModel(
             $this->entityManager,
@@ -65,10 +65,11 @@ final class MessageQueueModelTest extends \PHPUnit\Framework\TestCase
             $this->createStub(CoreParametersHelper::class),
         );
         $this->messageQueue->autowireMessageQueueModel(
-            $this->leadModel,
+            $this->createStub(LeadModel::class),
             $this->createStub(CompanyModel::class),
             $this->messageQueueRepository,
-            $this->createStub(FrequencyRuleRepository::class)
+            $this->createStub(FrequencyRuleRepository::class),
+            $this->leadRepository
         );
 
         $message      = new MessageQueue();
@@ -127,9 +128,7 @@ final class MessageQueueModelTest extends \PHPUnit\Framework\TestCase
             ],
         ];
 
-        $leadRepository = $this->createMock(LeadRepository::class);
-        $this->leadModel->method('getRepository')->willReturn($leadRepository);
-        $leadRepository->method('getContacts')->willReturn($contactData);
+        $this->leadRepository->method('getContacts')->willReturn($contactData);
 
         $this->entityManager->expects($this->exactly(1))
             ->method('detach');
@@ -153,9 +152,7 @@ final class MessageQueueModelTest extends \PHPUnit\Framework\TestCase
             ],
         ];
 
-        $leadRepository = $this->createMock(LeadRepository::class);
-        $this->leadModel->method('getRepository')->willReturn($leadRepository);
-        $leadRepository->method('getContacts')->willReturn($contactData);
+        $this->leadRepository->method('getContacts')->willReturn($contactData);
 
         $this->messageQueue->processMessageQueue($this->message);
         $this->assertArrayNotHasKey('companies', $this->message->getLead()->getFields());

--- a/app/bundles/CoreBundle/Form/Type/DynamicContentFilterEntryType.php
+++ b/app/bundles/CoreBundle/Form/Type/DynamicContentFilterEntryType.php
@@ -6,7 +6,7 @@ use Mautic\IntegrationsBundle\Exception\IntegrationNotFoundException;
 use Mautic\IntegrationsBundle\Helper\BuilderIntegrationsHelper;
 use Mautic\LeadBundle\Helper\FormFieldHelper;
 use Mautic\LeadBundle\Model\ListModel;
-use Mautic\StageBundle\Model\StageModel;
+use Mautic\StageBundle\Entity\StageRepository;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
@@ -47,8 +47,8 @@ final class DynamicContentFilterEntryType extends AbstractType
 
     public function __construct(
         ListModel $listModel,
-        private readonly StageModel $stageModel,
         private readonly BuilderIntegrationsHelper $builderIntegrationsHelper,
+        private readonly StageRepository $stageRepository,
     ) {
         $this->fieldChoices = $listModel->getChoiceFields();
 
@@ -153,7 +153,7 @@ final class DynamicContentFilterEntryType extends AbstractType
 
     private function getStageList(): array
     {
-        $stages = $this->stageModel->getRepository()->getSimpleList();
+        $stages = $this->stageRepository->getSimpleList();
 
         foreach ($stages as $stage) {
             $stages[$stage['value']] = $stage['label'];

--- a/app/bundles/CoreBundle/Tests/Unit/Form/Type/ConfigTypeTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Form/Type/ConfigTypeTest.php
@@ -12,7 +12,6 @@ use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\CoreBundle\Shortener\Shortener;
 use Mautic\PageBundle\Entity\PageRepository;
 use Mautic\PageBundle\Form\Type\PageListType;
-use Mautic\PageBundle\Model\PageModel;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
 use Symfony\Component\Form\PreloadedExtension;
@@ -145,11 +144,7 @@ final class ConfigTypeTest extends TypeTestCase
                  ->method('getPageList')
                  ->willReturn([]);
 
-        $pageModelMock = $this->createMock(PageModel::class);
-        $pageModelMock
-                      ->method('getRepository')
-                      ->willReturn($repoMock);
-        $pageListType = new PageListType($pageModelMock, $this->createStub(CorePermissions::class));
+        $pageListType = new PageListType($this->createStub(CorePermissions::class), $repoMock);
 
         return [
             // register the type instances with the PreloadedExtension

--- a/app/bundles/DynamicContentBundle/Form/Type/DynamicContentType.php
+++ b/app/bundles/DynamicContentBundle/Form/Type/DynamicContentType.php
@@ -16,6 +16,7 @@ use Mautic\CoreBundle\Form\Type\YesNoButtonGroupType;
 use Mautic\DynamicContentBundle\DynamicContent\TypeList;
 use Mautic\DynamicContentBundle\Entity\DynamicContent;
 use Mautic\EmailBundle\Form\Type\EmailUtmTagsType;
+use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Form\DataTransformer\FieldFilterTransformer;
 use Mautic\LeadBundle\Helper\FormFieldHelper;
 use Mautic\LeadBundle\Model\LeadModel;
@@ -88,9 +89,10 @@ final class DynamicContentType extends AbstractType
         private readonly EntityManagerInterface $em,
         ListModel $listModel,
         private readonly TranslatorInterface $translator,
-        private readonly LeadModel $leadModel,
+        LeadModel $leadModel,
         private TypeList $typeList,
         private readonly RelativeDate $relativeDate,
+        private readonly LeadRepository $leadRepository,
     ) {
         $this->fieldChoices    = $listModel->getChoiceFields();
         $this->timezoneChoices = FormFieldHelper::getTimezonesChoices();
@@ -343,7 +345,7 @@ final class DynamicContentType extends AbstractType
     {
         unset($this->fieldChoices['company']);
 
-        $customFields = $this->leadModel->getRepository()->getCustomFieldList('lead');
+        $customFields = $this->leadRepository->getCustomFieldList('lead');
 
         $this->fieldChoices['lead'] = array_filter(
             $this->fieldChoices['lead'],

--- a/app/bundles/DynamicContentBundle/Tests/Form/Type/DynamicContentTypeTest.php
+++ b/app/bundles/DynamicContentBundle/Tests/Form/Type/DynamicContentTypeTest.php
@@ -40,10 +40,6 @@ final class DynamicContentTypeTest extends TestCase
 
         $leadRepositoryMock = $this->createMock(LeadRepository::class);
 
-        $leadModelMock->expects($this->once())
-            ->method('getRepository')
-            ->willReturn($leadRepositoryMock);
-
         $leadRepositoryMock->expects($this->once())
             ->method('getCustomFieldList')
             ->with('lead')
@@ -61,6 +57,7 @@ final class DynamicContentTypeTest extends TestCase
             $leadModelMock,
             new TypeList(),
             $relativeDateMock,
+            $leadRepositoryMock,
         );
 
         $formBuilderInterfaceMock = $this->createMock(FormBuilderInterface::class);

--- a/app/bundles/EmailBundle/DataFixtures/ORM/LoadEmailData.php
+++ b/app/bundles/EmailBundle/DataFixtures/ORM/LoadEmailData.php
@@ -8,12 +8,12 @@ use Doctrine\Persistence\ObjectManager;
 use Mautic\CoreBundle\Helper\CsvHelper;
 use Mautic\CoreBundle\Helper\Serializer;
 use Mautic\EmailBundle\Entity\Email;
-use Mautic\EmailBundle\Model\EmailModel;
+use Mautic\EmailBundle\Entity\EmailRepository;
 
 final class LoadEmailData extends AbstractFixture implements OrderedFixtureInterface
 {
     public function __construct(
-        private readonly EmailModel $emailModel,
+        private readonly EmailRepository $emailRepository,
     ) {
     }
 
@@ -36,7 +36,7 @@ final class LoadEmailData extends AbstractFixture implements OrderedFixtureInter
             }
             $email->addList($this->getReference('lead-list'));
 
-            $this->emailModel->getRepository()->saveEntity($email);
+            $this->emailRepository->saveEntity($email);
             $this->setReference('email-'.$key, $email);
         }
     }

--- a/app/bundles/EmailBundle/Form/Type/EmailType.php
+++ b/app/bundles/EmailBundle/Form/Type/EmailType.php
@@ -30,7 +30,7 @@ use Mautic\LeadBundle\Helper\FormFieldHelper;
 use Mautic\PageBundle\Entity\Page;
 use Mautic\PageBundle\Form\Type\PreferenceCenterListType;
 use Mautic\ProjectBundle\Form\Type\ProjectType;
-use Mautic\StageBundle\Model\StageModel;
+use Mautic\StageBundle\Entity\StageRepository;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
@@ -56,12 +56,12 @@ final class EmailType extends AbstractType
     public function __construct(
         private readonly TranslatorInterface $translator,
         private readonly EntityManagerInterface $em,
-        private readonly StageModel $stageModel,
         private readonly CoreParametersHelper $coreParametersHelper,
         private readonly ThemeHelperInterface $themeHelper,
         private readonly CorePermissions $corePermissions,
         EmailConfigInterface $emailConfig,
         private readonly EmailDefaultsHelper $defaultsHelper,
+        private readonly StageRepository $stageRepository,
     ) {
         $this->isDraftEnabled = $emailConfig->isDraftEnabled();
     }
@@ -683,7 +683,7 @@ final class EmailType extends AbstractType
 
     public function buildView(FormView $view, FormInterface $form, array $options): void
     {
-        $stages       = $this->stageModel->getRepository()->getSimpleList();
+        $stages       = $this->stageRepository->getSimpleList();
         $stageChoices = [];
 
         foreach ($stages as $stage) {

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -54,6 +54,7 @@ use Mautic\EmailBundle\Model\AbTest\EmailVariantConverterService;
 use Mautic\EmailBundle\MonitoredEmail\Mailbox;
 use Mautic\EmailBundle\Stats\FetchOptions\EmailStatOptions;
 use Mautic\EmailBundle\Stats\Helper\FilterTrait;
+use Mautic\LeadBundle\Entity\CompanyRepository;
 use Mautic\LeadBundle\Entity\DoNotContact;
 use Mautic\LeadBundle\Entity\DoNotContactRepository;
 use Mautic\LeadBundle\Entity\Lead;
@@ -140,6 +141,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
         private readonly TrackableRepository $trackableRepository,
         private readonly LeadRepository $leadRepository,
         private readonly LeadEventLogRepository $leadEventLogRepository,
+        private readonly CompanyRepository $companyRepository,
     ) {
         $this->connection = $em->getConnection(); // Necessary for FilterTrait
         parent::__construct($em, $security, $dispatcher, $router, $translator, $userHelper, $mauticLogger, $coreParametersHelper);
@@ -542,7 +544,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
             }
 
             if (null !== $hitDateTime && $lead->getLastActive() < $hitDateTime) { // We need to perform the update after all is saved
-                $this->leadModel->getRepository()->updateLastActive($lead->getId(), $hitDateTime);
+                $this->leadRepository->updateLastActive($lead->getId(), $hitDateTime);
             }
         }
     }
@@ -1613,7 +1615,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
 
         $mailer            = $this->mailHelper->getMailer();
         if (!isset($lead['companies'])) {
-            $lead['companies'] = $this->companyModel->getRepository()->getCompaniesByLeadId($lead['id']);
+            $lead['companies'] = $this->companyRepository->getCompaniesByLeadId($lead['id']);
         }
         $mailer->setLead($lead, true);
         $mailer->setTokens($tokens);
@@ -2194,8 +2196,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
             return $contact;
         }
 
-        $companies = $this->companyModel
-            ->getRepository()
+        $companies = $this->companyRepository
             ->getCompaniesForContacts([$contact['id']]);
 
         $contact['companies'] = $companies[$contact['id']] ?? [];

--- a/app/bundles/EmailBundle/MonitoredEmail/Processor/Reply.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Processor/Reply.php
@@ -13,7 +13,7 @@ use Mautic\EmailBundle\MonitoredEmail\Exception\ReplyNotFound;
 use Mautic\EmailBundle\MonitoredEmail\Message;
 use Mautic\EmailBundle\MonitoredEmail\Processor\Reply\Parser;
 use Mautic\EmailBundle\MonitoredEmail\Search\ContactFinder;
-use Mautic\LeadBundle\Model\LeadModel;
+use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Tracker\ContactTracker;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -23,11 +23,11 @@ final readonly class Reply implements ProcessorInterface
     public function __construct(
         private EmailStatModel $emailStatModel,
         private ContactFinder $contactFinder,
-        private LeadModel $leadModel,
         private EventDispatcherInterface $dispatcher,
         private LoggerInterface $logger,
         private ContactTracker $contactTracker,
         private EmailAddressHelper $addressHelper,
+        private readonly LeadRepository $leadRepository,
     ) {
     }
 
@@ -69,7 +69,7 @@ final readonly class Reply implements ProcessorInterface
         $this->dispatchEvent($stat);
 
         if (null !== $stat->getLead()) {
-            $this->leadModel->getRepository()->detachEntity($stat->getLead());
+            $this->leadRepository->detachEntity($stat->getLead());
         }
         $this->emailStatModel->getRepository()->detachEntity($stat);
     }

--- a/app/bundles/EmailBundle/Tests/Form/Type/EmailTypeTest.php
+++ b/app/bundles/EmailBundle/Tests/Form/Type/EmailTypeTest.php
@@ -12,7 +12,7 @@ use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Form\Type\EmailType;
 use Mautic\EmailBundle\Helper\EmailConfigInterface;
 use Mautic\EmailBundle\Helper\EmailDefaultsHelper;
-use Mautic\StageBundle\Model\StageModel;
+use Mautic\StageBundle\Entity\StageRepository;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -43,12 +43,12 @@ final class EmailTypeTest extends \PHPUnit\Framework\TestCase
         $this->form                 = new EmailType(
             $translator,
             $this->createStub(EntityManager::class),
-            $this->createStub(StageModel::class),
             $this->createStub(CoreParametersHelper::class),
             $this->themeHelper,
             $corePermissions,
             $emailConfig,
             $this->createStub(EmailDefaultsHelper::class),
+            $this->createStub(StageRepository::class),
         );
 
         $this->formBuilder->method('create')->willReturnSelf();

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
@@ -742,7 +742,8 @@ final class EmailModelTest extends \PHPUnit\Framework\TestCase
             $this->leadModel,
             $this->companyModel,
             $this->createStub(MessageQueueRepository::class),
-            $this->frequencyRepository
+            $this->frequencyRepository,
+            $this->createStub(LeadRepository::class)
         );
 
         $emailModel = new EmailModel(

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
@@ -294,6 +294,7 @@ final class EmailModelTest extends \PHPUnit\Framework\TestCase
             $this->createStub(TrackableRepository::class), // $trackableRepository
             $this->createStub(LeadRepository::class), // $leadRepository
             $this->createStub(LeadEventLogRepository::class), // $leadEventLogRepository
+            $this->companyRepository, // $companyRepository
         );
 
         $this->emailStatModel->method('getRepository')->willReturn($this->statRepository);
@@ -587,8 +588,8 @@ final class EmailModelTest extends \PHPUnit\Framework\TestCase
             ->willReturn([1 => 'someone@domain.com']);
 
         // If it makes it to the point of calling getContactCompanies then DNC failed
-        $this->companyModel->expects($this->exactly(0))
-            ->method('getRepository');
+        $this->companyRepository->expects($this->exactly(0))
+            ->method('getCompaniesForContacts');
 
         $this->emailEntity->method('getId')
             ->willReturn(1);
@@ -638,6 +639,7 @@ final class EmailModelTest extends \PHPUnit\Framework\TestCase
             $this->createStub(TrackableRepository::class), // $trackableRepository
             $this->createStub(LeadRepository::class), // $leadRepository
             $this->createStub(LeadEventLogRepository::class), // $leadEventLogRepository
+            $this->companyRepository, // $companyRepository
         );
 
         $contacts = [
@@ -781,6 +783,7 @@ final class EmailModelTest extends \PHPUnit\Framework\TestCase
             $this->createStub(TrackableRepository::class), // $trackableRepository
             $this->createStub(LeadRepository::class), // $leadRepository
             $this->createStub(LeadEventLogRepository::class), // $leadEventLogRepository
+            $this->companyRepository, // $companyRepository
         );
 
         $this->emailEntity->method('getId')

--- a/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/ReplyTest.php
+++ b/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/ReplyTest.php
@@ -20,7 +20,6 @@ use Mautic\EmailBundle\MonitoredEmail\Search\ContactFinder;
 use Mautic\EmailBundle\MonitoredEmail\Search\Result;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadRepository;
-use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\LeadBundle\Tracker\ContactTracker;
 use Monolog\Logger;
 use PHPUnit\Framework\Attributes\TestDox;
@@ -68,20 +67,18 @@ final class ReplyTest extends \PHPUnit\Framework\TestCase
         $this->statRepo           = $this->createMock(StatRepository::class);
         $this->emailStatModel     = $this->createMock(EmailStatModel::class);
         $this->contactFinder      = $this->createMock(ContactFinder::class);
-        $leadModel                = $this->createMock(LeadModel::class);
         $this->dispatcher         = $this->createMock(EventDispatcherInterface::class);
         $this->contactTracker     = $this->createMock(ContactTracker::class);
         $emailAddressHelper       = new EmailAddressHelper();
         $this->leadRepository     = $this->createMock(LeadRepository::class);
-        $leadModel->method('getRepository')->willReturn($this->leadRepository);
         $this->processor          = new Reply(
             $this->emailStatModel,
             $this->contactFinder,
-            $leadModel,
             $this->dispatcher,
             $this->createStub(Logger::class),
             $this->contactTracker,
-            $emailAddressHelper
+            $emailAddressHelper,
+            $this->leadRepository
         );
 
         $this->emailStatModel->method('getRepository')->willReturn($this->statRepo);

--- a/app/bundles/FormBundle/DataFixtures/ORM/LoadFormData.php
+++ b/app/bundles/FormBundle/DataFixtures/ORM/LoadFormData.php
@@ -9,10 +9,11 @@ use Mautic\CoreBundle\Doctrine\Common\DataFixtures\Event\PreExecuteEvent;
 use Mautic\CoreBundle\Helper\CsvHelper;
 use Mautic\CoreBundle\Helper\Serializer;
 use Mautic\FormBundle\Entity\Action;
+use Mautic\FormBundle\Entity\ActionRepository;
 use Mautic\FormBundle\Entity\Field;
+use Mautic\FormBundle\Entity\FieldRepository;
 use Mautic\FormBundle\Entity\Form;
-use Mautic\FormBundle\Model\ActionModel;
-use Mautic\FormBundle\Model\FieldModel;
+use Mautic\FormBundle\Entity\FormRepository;
 use Mautic\FormBundle\Model\FormModel;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -37,9 +38,10 @@ final class LoadFormData extends AbstractFixture implements OrderedFixtureInterf
 
     public function __construct(
         private readonly FormModel $formModel,
-        private readonly FieldModel $formFieldModel,
-        private readonly ActionModel $actionModel,
         EventDispatcherInterface $eventDispatcher,
+        private readonly FormRepository $formRepository,
+        private readonly FieldRepository $fieldRepository,
+        private readonly ActionRepository $actionRepository,
     ) {
         // this will load the data before fixtures are loaded
         $eventDispatcher->addListener(PreExecuteEvent::class, function (PreExecuteEvent $event): void {
@@ -76,7 +78,7 @@ final class LoadFormData extends AbstractFixture implements OrderedFixtureInterf
 
             // because form table data will be deleted we must have same autoincrement as before the insertion
             // to have the form_results table to match the form id in table name e.g. form_results_69_kaleidosco
-            $formTableName = $this->formModel->getRepository()->getTableName();
+            $formTableName = $this->formRepository->getTableName();
             $event->getEntityManager()->getConnection()->executeStatement(
                 'ALTER TABLE '.$formTableName.' AUTO_INCREMENT='.$firstId
             );
@@ -90,16 +92,16 @@ final class LoadFormData extends AbstractFixture implements OrderedFixtureInterf
         $this->getActionEntities();
 
         foreach ($this->formEntities as $key => $formEntity) {
-            $this->formModel->getRepository()->saveEntity($formEntity);
+            $this->formRepository->saveEntity($formEntity);
             $this->setReference(self::FORM_PREFIX.$key, $formEntity);
         }
 
         foreach ($this->fieldEntities as $field) {
-            $this->formFieldModel->getRepository()->saveEntity($field);
+            $this->fieldRepository->saveEntity($field);
         }
 
         foreach ($this->actionEntities as $action) {
-            $this->actionModel->getRepository()->saveEntity($action);
+            $this->actionRepository->saveEntity($action);
         }
     }
 

--- a/app/bundles/FormBundle/DataFixtures/ORM/LoadFormResultData.php
+++ b/app/bundles/FormBundle/DataFixtures/ORM/LoadFormResultData.php
@@ -7,14 +7,14 @@ use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Mautic\CoreBundle\Helper\CsvHelper;
 use Mautic\FormBundle\Entity\Submission;
-use Mautic\FormBundle\Model\SubmissionModel;
+use Mautic\FormBundle\Entity\SubmissionRepository;
 use Mautic\PageBundle\Model\PageModel;
 
 final class LoadFormResultData extends AbstractFixture implements OrderedFixtureInterface
 {
     public function __construct(
         private readonly PageModel $pageModel,
-        private readonly SubmissionModel $submissionModel,
+        private readonly SubmissionRepository $submissionRepository,
     ) {
     }
 
@@ -48,7 +48,7 @@ final class LoadFormResultData extends AbstractFixture implements OrderedFixture
                 }
 
                 $submission->setResults($rows);
-                $this->submissionModel->getRepository()->saveEntity($submission);
+                $this->submissionRepository->saveEntity($submission);
             }
         };
 

--- a/app/bundles/FormBundle/Form/Type/FormListType.php
+++ b/app/bundles/FormBundle/Form/Type/FormListType.php
@@ -4,7 +4,7 @@ namespace Mautic\FormBundle\Form\Type;
 
 use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
-use Mautic\FormBundle\Model\FormModel;
+use Mautic\FormBundle\Entity\FormRepository;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\Options;
@@ -17,23 +17,22 @@ final class FormListType extends AbstractType
 {
     private readonly bool $viewOther;
 
-    private readonly \Mautic\FormBundle\Entity\FormRepository $repo;
-
-    public function __construct(CorePermissions $security, FormModel $model, UserHelper $userHelper)
-    {
+    public function __construct(
+        CorePermissions $security,
+        UserHelper $userHelper,
+        private readonly FormRepository $formRepository,
+    ) {
         $this->viewOther = $security->isGranted('form:forms:viewother');
-        $this->repo      = $model->getRepository();
 
-        $this->repo->setCurrentUser($userHelper->getUser());
+        $this->formRepository->setCurrentUser($userHelper->getUser());
     }
 
     public function configureOptions(OptionsResolver $resolver): void
     {
         $viewOther = $this->viewOther;
-        $repo      = $this->repo;
 
         $resolver->setDefaults([
-            'choices' => function (Options $options) use ($repo, $viewOther): array {
+            'choices' => function (Options $options) use ($viewOther): array {
                 static $choices;
 
                 if (is_array($choices)) {
@@ -42,7 +41,7 @@ final class FormListType extends AbstractType
 
                 $choices = [];
 
-                $forms = $repo->getFormList('', 0, 0, $viewOther, $options['form_type']);
+                $forms = $this->formRepository->getFormList('', 0, 0, $viewOther, $options['form_type']);
                 foreach ($forms as $form) {
                     $choices[$form['name'].' ('.$form['id'].')'] = $form['id'];
                 }

--- a/app/bundles/LeadBundle/DataFixtures/ORM/LoadCompanyData.php
+++ b/app/bundles/LeadBundle/DataFixtures/ORM/LoadCompanyData.php
@@ -7,12 +7,12 @@ use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Mautic\CoreBundle\Helper\CsvHelper;
 use Mautic\LeadBundle\Entity\Company;
-use Mautic\LeadBundle\Model\CompanyModel;
+use Mautic\LeadBundle\Entity\CompanyRepository;
 
 final class LoadCompanyData extends AbstractFixture implements OrderedFixtureInterface
 {
     public function __construct(
-        private readonly CompanyModel $companyModel,
+        private readonly CompanyRepository $companyRepository,
     ) {
     }
 
@@ -26,7 +26,7 @@ final class LoadCompanyData extends AbstractFixture implements OrderedFixtureInt
             foreach ($l as $col => $val) {
                 $company->addUpdatedField($col, $val);
             }
-            $this->companyModel->getRepository()->saveEntity($company);
+            $this->companyRepository->saveEntity($company);
 
             $this->setReference('company-'.$count, $company);
         }

--- a/app/bundles/LeadBundle/Deduplicate/ContactMerger.php
+++ b/app/bundles/LeadBundle/Deduplicate/ContactMerger.php
@@ -9,6 +9,7 @@ use Mautic\LeadBundle\Deduplicate\Helper\MergeValueHelper;
 use Mautic\LeadBundle\Entity\CompanyLead;
 use Mautic\LeadBundle\Entity\CompanyLeadRepository;
 use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Entity\MergeRecord;
 use Mautic\LeadBundle\Entity\MergeRecordRepository;
 use Mautic\LeadBundle\Event\LeadMergeEvent;
@@ -35,6 +36,7 @@ class ContactMerger
         protected EventDispatcherInterface $dispatcher,
         protected LoggerInterface $logger,
         protected CompanyLeadRepository $companyLeadRepository,
+        private readonly LeadRepository $leadRepository,
     ) {
     }
 
@@ -126,11 +128,11 @@ class ContactMerger
 
         // It may happen that the Lead entities doesn't have fields fill in. Fill them in if not.
         if (!$newest->hasFields()) {
-            $newest->setFields($this->leadModel->getRepository()->getFieldValues($newest->getId()));
+            $newest->setFields($this->leadRepository->getFieldValues($newest->getId()));
         }
 
         if (!$oldest->hasFields()) {
-            $oldest->setFields($this->leadModel->getRepository()->getFieldValues($oldest->getId()));
+            $oldest->setFields($this->leadRepository->getFieldValues($oldest->getId()));
         }
 
         $newestFields = $newest->getProfileFields();

--- a/app/bundles/LeadBundle/Form/Type/CampaignEventLeadFieldValueType.php
+++ b/app/bundles/LeadBundle/Form/Type/CampaignEventLeadFieldValueType.php
@@ -4,8 +4,8 @@ namespace Mautic\LeadBundle\Form\Type;
 
 use Mautic\CoreBundle\Helper\ArrayHelper;
 use Mautic\CoreBundle\Translation\Translator;
+use Mautic\LeadBundle\Entity\LeadFieldRepository;
 use Mautic\LeadBundle\Helper\FormFieldHelper;
-use Mautic\LeadBundle\Model\FieldModel;
 use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\LeadBundle\Segment\OperatorOptions;
 use Symfony\Component\Form\AbstractType;
@@ -25,7 +25,7 @@ final class CampaignEventLeadFieldValueType extends AbstractType
     public function __construct(
         private readonly Translator $translator,
         private readonly LeadModel $leadModel,
-        private readonly FieldModel $fieldModel,
+        private readonly LeadFieldRepository $leadFieldRepository,
     ) {
     }
 
@@ -67,7 +67,7 @@ final class CampaignEventLeadFieldValueType extends AbstractType
             $operator    = '=';
 
             if (isset($data['field'])) {
-                $field    = $this->fieldModel->getRepository()->findOneBy(['alias' => $data['field']]);
+                $field    = $this->leadFieldRepository->findOneBy(['alias' => $data['field']]);
                 $operator = $data['operator'];
 
                 if ($field) {

--- a/app/bundles/LeadBundle/Form/Validator/Constraints/UniqueCustomFieldValidator.php
+++ b/app/bundles/LeadBundle/Form/Validator/Constraints/UniqueCustomFieldValidator.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Mautic\LeadBundle\Form\Validator\Constraints;
 
 use Mautic\LeadBundle\Entity\Company;
+use Mautic\LeadBundle\Entity\CompanyRepository;
 use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Field\FieldsWithUniqueIdentifier;
-use Mautic\LeadBundle\Model\CompanyModel;
-use Mautic\LeadBundle\Model\LeadModel;
 use Symfony\Component\Form\Form;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Validator\Constraint;
@@ -17,9 +17,9 @@ use Symfony\Component\Validator\ConstraintValidator;
 final class UniqueCustomFieldValidator extends ConstraintValidator
 {
     public function __construct(
-        private readonly LeadModel $leadModel,
-        private readonly CompanyModel $companyModel,
         private readonly FieldsWithUniqueIdentifier $fieldsWithUniqueIdentifier,
+        private readonly LeadRepository $leadRepository,
+        private readonly CompanyRepository $companyRepository,
     ) {
     }
 
@@ -88,11 +88,10 @@ final class UniqueCustomFieldValidator extends ConstraintValidator
      */
     private function getLeadFieldsValid(Lead $lead, array $fieldsData): array
     {
-        $leadRepository = $this->leadModel->getRepository();
-        if ('orWhere' === $leadRepository->getUniqueIdentifiersWherePart()) {
+        if ('orWhere' === $this->leadRepository->getUniqueIdentifiersWherePart()) {
             $fieldsValidation = [];
             foreach ($fieldsData as $field => $data) {
-                $leads = $leadRepository->getLeadIdsByUniqueFields([$field => $data]);
+                $leads = $this->leadRepository->getLeadIdsByUniqueFields([$field => $data]);
 
                 $fieldsValidation[] = $this->isValid($leads, [$field], $lead->getId());
             }
@@ -101,7 +100,7 @@ final class UniqueCustomFieldValidator extends ConstraintValidator
         }
 
         // Can't use getEntities, because it refreshes some field data, that can be used in the form
-        $leads = $leadRepository->getLeadIdsByUniqueFields($fieldsData);
+        $leads = $this->leadRepository->getLeadIdsByUniqueFields($fieldsData);
 
         return $this->isValid($leads, array_keys($fieldsData), $lead->getId());
     }
@@ -113,11 +112,10 @@ final class UniqueCustomFieldValidator extends ConstraintValidator
      */
     private function getCompanyFieldsValid(Company $company, array $fieldsData): array
     {
-        $companyRepository = $this->companyModel->getRepository();
-        if ('orWhere' === $companyRepository->getUniqueIdentifiersWherePart()) {
+        if ('orWhere' === $this->companyRepository->getUniqueIdentifiersWherePart()) {
             $fieldsValidation = [];
             foreach ($fieldsData as $field => $data) {
-                $companies = $companyRepository->getCompanyIdsByUniqueFields([$field => $data]);
+                $companies = $this->companyRepository->getCompanyIdsByUniqueFields([$field => $data]);
 
                 $fieldsValidation[] = $this->isValid($companies, [$field], (int) $company->getId());
             }
@@ -126,7 +124,7 @@ final class UniqueCustomFieldValidator extends ConstraintValidator
         }
 
         // Can't use getEntities, because it refreshes some field data, that can be used in the form
-        $companies = $companyRepository->getCompanyIdsByUniqueFields($fieldsData);
+        $companies = $this->companyRepository->getCompanyIdsByUniqueFields($fieldsData);
 
         return $this->isValid($companies, array_keys($fieldsData), (int) $company->getId());
     }

--- a/app/bundles/LeadBundle/Helper/FieldAliasHelper.php
+++ b/app/bundles/LeadBundle/Helper/FieldAliasHelper.php
@@ -3,12 +3,14 @@
 namespace Mautic\LeadBundle\Helper;
 
 use Mautic\LeadBundle\Entity\LeadField;
+use Mautic\LeadBundle\Entity\LeadFieldRepository;
 use Mautic\LeadBundle\Model\FieldModel;
 
 class FieldAliasHelper
 {
     public function __construct(
         private readonly FieldModel $fieldModel,
+        private readonly LeadFieldRepository $leadFieldRepository,
     ) {
     }
 
@@ -29,9 +31,8 @@ class FieldAliasHelper
         $alias = $this->fieldModel->cleanAlias($alias, 'f_', 25);
 
         // make sure alias is not already taken
-        $repo      = $this->fieldModel->getRepository();
         $testAlias = $alias;
-        $aliases   = $repo->getAliases($field->getId(), false, true, null);
+        $aliases   = $this->leadFieldRepository->getAliases($field->getId(), false, true, null);
         $count     = (int) in_array($testAlias, $aliases);
         $aliasTag  = $count;
 

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -33,6 +33,7 @@ use Mautic\LeadBundle\DataObject\LeadManipulator;
 use Mautic\LeadBundle\Entity\Company;
 use Mautic\LeadBundle\Entity\CompanyLead;
 use Mautic\LeadBundle\Entity\CompanyLeadRepository;
+use Mautic\LeadBundle\Entity\CompanyRepository;
 use Mautic\LeadBundle\Entity\DoNotContact as DNC;
 use Mautic\LeadBundle\Entity\DoNotContactRepository;
 use Mautic\LeadBundle\Entity\FrequencyRule;
@@ -164,6 +165,7 @@ class LeadModel extends FormModel
         private readonly CompanyLeadRepository $companyLeadRepository,
         private readonly DoNotContactRepository $doNotContactRepository,
         private readonly StatRepository $statRepository,
+        private readonly CompanyRepository $companyRepository,
     ) {
         parent::__construct($em, $security, $dispatcher, $router, $translator, $userHelper, $mauticLogger, $coreParametersHelper);
     }
@@ -2294,7 +2296,7 @@ class LeadModel extends FormModel
         }
 
         if (!empty($entities)) {
-            $this->companyModel->getRepository()->saveEntities($entities);
+            $this->companyRepository->saveEntities($entities);
         }
 
         return $success;

--- a/app/bundles/LeadBundle/Segment/Stat/SegmentCampaignShare.php
+++ b/app/bundles/LeadBundle/Segment/Stat/SegmentCampaignShare.php
@@ -3,15 +3,15 @@
 namespace Mautic\LeadBundle\Segment\Stat;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Mautic\CampaignBundle\Model\CampaignModel;
+use Mautic\CampaignBundle\Entity\CampaignRepository;
 use Mautic\CoreBundle\Helper\CacheStorageHelper;
 
 final readonly class SegmentCampaignShare
 {
     public function __construct(
-        private CampaignModel $campaignModel,
         private CacheStorageHelper $cacheStorageHelper,
         private EntityManagerInterface $entityManager,
+        private CampaignRepository $campaignRepository,
     ) {
     }
 
@@ -22,7 +22,7 @@ final readonly class SegmentCampaignShare
      */
     public function getCampaignsSegmentShare(int $segmentId, array $campaignIds = []): array
     {
-        $campaigns = $this->campaignModel->getRepository()->getCampaignsSegmentShare($segmentId, $campaignIds);
+        $campaigns = $this->campaignRepository->getCampaignsSegmentShare($segmentId, $campaignIds);
         foreach ($campaigns as $campaign) {
             $this->cacheStorageHelper->set($this->getCachedKey($segmentId, $campaign['id']), $campaign['segmentCampaignShare']);
         }
@@ -40,7 +40,7 @@ final readonly class SegmentCampaignShare
         $q = $this->entityManager->getConnection()->createQueryBuilder();
         $q->select('c.id, c.name, null as share')
             ->from(MAUTIC_TABLE_PREFIX.'campaigns', 'c')
-            ->where($this->campaignModel->getRepository()->getPublishedByDateExpression($q))
+            ->where($this->campaignRepository->getPublishedByDateExpression($q))
             ->orderBy('c.id', 'DESC');
 
         $campaigns = $q->executeQuery()->fetchAllAssociative();

--- a/app/bundles/LeadBundle/Segment/Stat/SegmentChartQueryFactory.php
+++ b/app/bundles/LeadBundle/Segment/Stat/SegmentChartQueryFactory.php
@@ -2,14 +2,20 @@
 
 namespace Mautic\LeadBundle\Segment\Stat;
 
+use Mautic\LeadBundle\Entity\LeadListRepository;
 use Mautic\LeadBundle\Model\ListModel;
 use Mautic\LeadBundle\Segment\Stat\ChartQuery\SegmentContactsLineChartQuery;
 
 class SegmentChartQueryFactory
 {
+    public function __construct(
+        private readonly LeadListRepository $leadListRepository,
+    ) {
+    }
+
     public function getContactsTotal(SegmentContactsLineChartQuery $query, ListModel $listModel): array
     {
-        $total = $listModel->getRepository()->getLeadCount($query->getSegmentId());
+        $total = $this->leadListRepository->getLeadCount($query->getSegmentId());
 
         return $query->getTotalStats($total);
     }

--- a/app/bundles/LeadBundle/Services/SegmentDependencyTreeFactory.php
+++ b/app/bundles/LeadBundle/Services/SegmentDependencyTreeFactory.php
@@ -7,7 +7,7 @@ namespace Mautic\LeadBundle\Services;
 use Mautic\CoreBundle\Helper\Tree\IntNode;
 use Mautic\CoreBundle\Helper\Tree\NodeInterface;
 use Mautic\LeadBundle\Entity\LeadList;
-use Mautic\LeadBundle\Model\ListModel;
+use Mautic\LeadBundle\Entity\LeadListRepository;
 use Symfony\Component\Routing\RouterInterface;
 
 final class SegmentDependencyTreeFactory
@@ -18,8 +18,8 @@ final class SegmentDependencyTreeFactory
     private array $usedSegmentIds = [];
 
     public function __construct(
-        private readonly ListModel $segmentModel,
         private readonly RouterInterface $router,
+        private readonly LeadListRepository $leadListRepository,
     ) {
     }
 
@@ -75,7 +75,7 @@ final class SegmentDependencyTreeFactory
             }
         }
 
-        return $this->segmentModel->getRepository()->findBy(['id' => $childSegmentIds]);
+        return $this->leadListRepository->findBy(['id' => $childSegmentIds]);
     }
 
     private function generateSegmentDetailRoute(LeadList $segment): string

--- a/app/bundles/LeadBundle/Tests/Deduplicate/ContactMergerTest.php
+++ b/app/bundles/LeadBundle/Tests/Deduplicate/ContactMergerTest.php
@@ -40,17 +40,17 @@ final class ContactMergerTest extends \PHPUnit\Framework\TestCase
 
     private \PHPUnit\Framework\MockObject\MockObject&CompanyLeadRepository $companyLeadRepo;
 
+    private \PHPUnit\Framework\MockObject\MockObject&LeadRepository $leadRepository;
+
     protected function setUp(): void
     {
         $this->leadModel       = $this->createMock(LeadModel::class);
-        $leadRepo              = $this->createMock(LeadRepository::class);
+        $this->leadRepository  = $this->createMock(LeadRepository::class);
         $this->mergeRecordRepo = $this->createMock(MergeRecordRepository::class);
         $this->logger          = $this->createMock(Logger::class);
         $this->companyLeadRepo = $this->createMock(CompanyLeadRepository::class);
 
-        $this->leadModel->method('getRepository')->willReturn($leadRepo);
-
-        $leadRepo->method('getFieldValues')->willReturn([]);
+        $this->leadRepository->method('getFieldValues')->willReturn([]);
     }
 
     public function testMergeTimestamps(): void
@@ -866,7 +866,8 @@ final class ContactMergerTest extends \PHPUnit\Framework\TestCase
             $this->mergeRecordRepo,
             $this->createStub(EventDispatcher::class),
             $this->logger,
-            $this->companyLeadRepo
+            $this->companyLeadRepo,
+            $this->leadRepository
         );
     }
 }

--- a/app/bundles/LeadBundle/Tests/Helper/FieldAliasHelperTest.php
+++ b/app/bundles/LeadBundle/Tests/Helper/FieldAliasHelperTest.php
@@ -19,7 +19,7 @@ final class FieldAliasHelperTest extends \PHPUnit\Framework\TestCase
 
         $fieldRepository = $this->createMock(LeadFieldRepository::class);
         $fieldModel      = $this->getMockBuilder(FieldModel::class)
-            ->onlyMethods(['cleanAlias', 'getRepository'])
+            ->onlyMethods(['cleanAlias'])
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -31,9 +31,7 @@ final class FieldAliasHelperTest extends \PHPUnit\Framework\TestCase
 
         $fieldModel->method('cleanAlias')->willReturnCallback(fn (): mixed => func_get_args()[0]);
 
-        $fieldModel->method('getRepository')->willReturn($fieldRepository);
-
-        $this->helper = new FieldAliasHelper($fieldModel);
+        $this->helper = new FieldAliasHelper($fieldModel, $fieldRepository);
     }
 
     public function testDuplicatedAliasWithAliasSet(): void

--- a/app/bundles/LeadBundle/Tests/Model/LeadModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/LeadModelTest.php
@@ -20,6 +20,7 @@ use Mautic\EmailBundle\Entity\StatRepository;
 use Mautic\EmailBundle\Helper\EmailValidator;
 use Mautic\LeadBundle\DataObject\LeadManipulator;
 use Mautic\LeadBundle\Entity\CompanyLeadRepository;
+use Mautic\LeadBundle\Entity\CompanyRepository;
 use Mautic\LeadBundle\Entity\DoNotContactRepository;
 use Mautic\LeadBundle\Entity\FrequencyRuleRepository;
 use Mautic\LeadBundle\Entity\Lead;
@@ -199,6 +200,7 @@ final class LeadModelTest extends \PHPUnit\Framework\TestCase
             $this->companyLeadRepositoryMock,
             $this->createStub(DoNotContactRepository::class), // $doNotContactRepository
             $this->createStub(StatRepository::class), // $statRepository
+            $this->createStub(CompanyRepository::class), // $companyRepository
         );
 
         $this->setSecurity($this->leadModel);
@@ -654,7 +656,7 @@ final class LeadModelTest extends \PHPUnit\Framework\TestCase
         $action = 'post_batch_save';
 
         // Lead Model that provides access to dispatchBatchEvent
-        $leadModel = new class($this->requestStack, $this->createStub(IpLookupHelper::class), $this->createStub(PathsHelper::class), $this->createStub(IntegrationHelper::class), $this->fieldModelMock, $this->fieldsWithUniqueIdentifier, $this->createStub(ListModel::class), $this->createStub(FormFactory::class), $this->companyModelMock, $this->createStub(CategoryModel::class), $this->channelListHelperMock, $this->coreParametersHelperMock, $this->emailValidatorMock, $this->createStub(UserProvider::class), $this->createStub(ContactTracker::class), $this->createStub(DeviceTracker::class), $this->createStub(IpAddressModel::class), $this->entityManagerMock, $this->createStub(CorePermissions::class), $this->dispatcherMock, $this->createStub(UrlGeneratorInterface::class), $this->translator, $this->userHelperMock, $this->createStub(LoggerInterface::class), $this->leadRepositoryMock, $this->createStub(TagRepository::class), $this->createStub(PointsChangeLogRepository::class), $this->createStub(UtmTagRepository::class), $this->createStub(LeadDeviceRepository::class), $this->createStub(LeadEventLogRepository::class), $this->createStub(FrequencyRuleRepository::class), $this->stagesChangeLogRepositoryMock, $this->createStub(LeadCategoryRepository::class), $this->createStub(MergeRecordRepository::class), $this->createStub(LeadListRepository::class), $this->createStub(GroupContactScoreRepository::class), $this->stageRepositoryMock, $this->createStub(UserRepository::class), $this->companyLeadRepositoryMock, $this->createStub(DoNotContactRepository::class), $this->createStub(StatRepository::class)) extends LeadModel {
+        $leadModel = new class($this->requestStack, $this->createStub(IpLookupHelper::class), $this->createStub(PathsHelper::class), $this->createStub(IntegrationHelper::class), $this->fieldModelMock, $this->fieldsWithUniqueIdentifier, $this->createStub(ListModel::class), $this->createStub(FormFactory::class), $this->companyModelMock, $this->createStub(CategoryModel::class), $this->channelListHelperMock, $this->coreParametersHelperMock, $this->emailValidatorMock, $this->createStub(UserProvider::class), $this->createStub(ContactTracker::class), $this->createStub(DeviceTracker::class), $this->createStub(IpAddressModel::class), $this->entityManagerMock, $this->createStub(CorePermissions::class), $this->dispatcherMock, $this->createStub(UrlGeneratorInterface::class), $this->translator, $this->userHelperMock, $this->createStub(LoggerInterface::class), $this->leadRepositoryMock, $this->createStub(TagRepository::class), $this->createStub(PointsChangeLogRepository::class), $this->createStub(UtmTagRepository::class), $this->createStub(LeadDeviceRepository::class), $this->createStub(LeadEventLogRepository::class), $this->createStub(FrequencyRuleRepository::class), $this->stagesChangeLogRepositoryMock, $this->createStub(LeadCategoryRepository::class), $this->createStub(MergeRecordRepository::class), $this->createStub(LeadListRepository::class), $this->createStub(GroupContactScoreRepository::class), $this->stageRepositoryMock, $this->createStub(UserRepository::class), $this->companyLeadRepositoryMock, $this->createStub(DoNotContactRepository::class), $this->createStub(StatRepository::class), $this->createStub(CompanyRepository::class)) extends LeadModel {
             /**
              * @param array<mixed> $leads
              */

--- a/app/bundles/NotificationBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/NotificationBundle/EventListener/CampaignSubscriber.php
@@ -12,6 +12,7 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Model\DoNotContact as DoNotContactModel;
 use Mautic\NotificationBundle\Api\AbstractNotificationApi;
 use Mautic\NotificationBundle\Entity\Notification;
+use Mautic\NotificationBundle\Entity\NotificationRepository;
 use Mautic\NotificationBundle\Event\NotificationSendEvent;
 use Mautic\NotificationBundle\Form\Type\MobileNotificationSendType;
 use Mautic\NotificationBundle\Form\Type\NotificationSendType;
@@ -49,6 +50,7 @@ class CampaignSubscriber implements EventSubscriberInterface
         private readonly EventDispatcherInterface $dispatcher,
         private readonly DoNotContactModel $doNotContact,
         private readonly TranslatorInterface $translator,
+        private readonly NotificationRepository $notificationRepository,
     ) {
     }
 
@@ -265,7 +267,7 @@ class CampaignSubscriber implements EventSubscriberInterface
         }
 
         $this->notificationModel->createStatEntry($notification, $log->getLead(), 'campaign.event', $event->getEvent()->getId());
-        $this->notificationModel->getRepository()->upCount($notification->getId());
+        $this->notificationRepository->upCount($notification->getId());
 
         $result = [
             'status'  => 'mautic.notification.timeline.status.delivered',

--- a/app/bundles/NotificationBundle/Tests/Functional/EventListener/CampaignSubscriberTest.php
+++ b/app/bundles/NotificationBundle/Tests/Functional/EventListener/CampaignSubscriberTest.php
@@ -16,6 +16,7 @@ use Mautic\LeadBundle\Model\DoNotContact as DoNotContactModel;
 use Mautic\NotificationBundle\Api\AbstractNotificationApi;
 use Mautic\NotificationBundle\Api\OneSignalApi;
 use Mautic\NotificationBundle\Entity\Notification;
+use Mautic\NotificationBundle\Entity\NotificationRepository;
 use Mautic\NotificationBundle\EventListener\CampaignSubscriber;
 use Mautic\NotificationBundle\Model\NotificationModel;
 use Mautic\NotificationBundle\Tests\NotificationTrait;
@@ -420,7 +421,7 @@ final class CampaignSubscriberTest extends MauticMysqlTestCase
 
     public function testNotificationsSentInBatches(): void
     {
-        $subscriber = new class(static::getContainer()->get(IntegrationHelper::class), static::getContainer()->get(NotificationModel::class), static::getContainer()->get(OneSignalApi::class), static::getContainer()->get(EventDispatcherInterface::class), static::getContainer()->get(DoNotContactModel::class), static::getContainer()->get(TranslatorInterface::class)) extends CampaignSubscriber {
+        $subscriber = new class(static::getContainer()->get(IntegrationHelper::class), static::getContainer()->get(NotificationModel::class), static::getContainer()->get(OneSignalApi::class), static::getContainer()->get(EventDispatcherInterface::class), static::getContainer()->get(DoNotContactModel::class), static::getContainer()->get(TranslatorInterface::class), static::getContainer()->get(NotificationRepository::class)) extends CampaignSubscriber {
             protected const MAX_PLAYER_IDS_PER_REQUEST = 2;
         };
         static::getContainer()->set('mautic.notification.campaignbundle.subscriber', $subscriber);

--- a/app/bundles/PageBundle/DataFixtures/ORM/LoadPageCategoryData.php
+++ b/app/bundles/PageBundle/DataFixtures/ORM/LoadPageCategoryData.php
@@ -6,12 +6,12 @@ use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Mautic\CategoryBundle\Entity\Category;
-use Mautic\CategoryBundle\Model\CategoryModel;
+use Mautic\CategoryBundle\Entity\CategoryRepository;
 
 final class LoadPageCategoryData extends AbstractFixture implements OrderedFixtureInterface
 {
     public function __construct(
-        private readonly CategoryModel $categoryModel,
+        private readonly CategoryRepository $categoryRepository,
     ) {
     }
 
@@ -26,7 +26,7 @@ final class LoadPageCategoryData extends AbstractFixture implements OrderedFixtu
         $cat->setTitle($events);
         $cat->setAlias(strtolower($events));
 
-        $this->categoryModel->getRepository()->saveEntity($cat);
+        $this->categoryRepository->saveEntity($cat);
         $this->setReference('page-cat-1', $cat);
     }
 

--- a/app/bundles/PageBundle/DataFixtures/ORM/LoadPageData.php
+++ b/app/bundles/PageBundle/DataFixtures/ORM/LoadPageData.php
@@ -8,12 +8,12 @@ use Doctrine\Persistence\ObjectManager;
 use Mautic\CoreBundle\Helper\CsvHelper;
 use Mautic\CoreBundle\Helper\Serializer;
 use Mautic\PageBundle\Entity\Page;
-use Mautic\PageBundle\Model\PageModel;
+use Mautic\PageBundle\Entity\PageRepository;
 
 final class LoadPageData extends AbstractFixture implements OrderedFixtureInterface
 {
     public function __construct(
-        private readonly PageModel $pageModel,
+        private readonly PageRepository $pageRepository,
     ) {
     }
 
@@ -39,7 +39,7 @@ final class LoadPageData extends AbstractFixture implements OrderedFixtureInterf
                 }
             }
             $page->setCategory($this->getReference('page-cat-1'));
-            $this->pageModel->getRepository()->saveEntity($page);
+            $this->pageRepository->saveEntity($page);
 
             $this->setReference('page-'.$key, $page);
         }

--- a/app/bundles/PageBundle/DataFixtures/ORM/LoadPageHitData.php
+++ b/app/bundles/PageBundle/DataFixtures/ORM/LoadPageHitData.php
@@ -8,12 +8,12 @@ use Doctrine\Persistence\ObjectManager;
 use Mautic\CoreBundle\Helper\CsvHelper;
 use Mautic\CoreBundle\Helper\Serializer;
 use Mautic\PageBundle\Entity\Hit;
-use Mautic\PageBundle\Model\PageModel;
+use Mautic\PageBundle\Entity\PageRepository;
 
 final class LoadPageHitData extends AbstractFixture implements OrderedFixtureInterface
 {
     public function __construct(
-        private readonly PageModel $pageModel,
+        private readonly PageRepository $pageRepository,
     ) {
     }
 
@@ -38,7 +38,7 @@ final class LoadPageHitData extends AbstractFixture implements OrderedFixtureInt
                     }
                 }
             }
-            $this->pageModel->getRepository()->saveEntity($hit);
+            $this->pageRepository->saveEntity($hit);
         }
     }
 

--- a/app/bundles/PageBundle/Form/Type/PageListType.php
+++ b/app/bundles/PageBundle/Form/Type/PageListType.php
@@ -3,7 +3,7 @@
 namespace Mautic\PageBundle\Form\Type;
 
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
-use Mautic\PageBundle\Model\PageModel;
+use Mautic\PageBundle\Entity\PageRepository;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\Options;
@@ -17,23 +17,22 @@ final class PageListType extends AbstractType
     private readonly bool $canViewOther;
 
     public function __construct(
-        private readonly PageModel $model,
         CorePermissions $corePermissions,
+        private readonly PageRepository $pageRepository,
     ) {
         $this->canViewOther = $corePermissions->isGranted('page:pages:viewother');
     }
 
     public function configureOptions(OptionsResolver $resolver): void
     {
-        $model        = $this->model;
         $canViewOther = $this->canViewOther;
 
         $resolver->setDefaults(
             [
-                'choices' => function (Options $options) use ($model, $canViewOther): array {
+                'choices' => function (Options $options) use ($canViewOther): array {
                     $choices       = [];
                     $publishedOnly = $options['published_only'] ?? false;
-                    $pages         = $model->getRepository()->getPageList('', 0, 0, $canViewOther, $options['top_level'], $options['ignore_ids'], [], $publishedOnly);
+                    $pages         = $this->pageRepository->getPageList('', 0, 0, $canViewOther, $options['top_level'], $options['ignore_ids'], [], $publishedOnly);
                     foreach ($pages as $page) {
                         $choices[$page['language']]["{$page['title']} ({$page['id']})"] = $page['id'];
                     }

--- a/app/bundles/PageBundle/Form/Type/PageType.php
+++ b/app/bundles/PageBundle/Form/Type/PageType.php
@@ -16,8 +16,8 @@ use Mautic\CoreBundle\Helper\ThemeHelperInterface;
 use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\PageBundle\Entity\Page;
+use Mautic\PageBundle\Entity\PageRepository;
 use Mautic\PageBundle\Helper\PageConfigInterface;
-use Mautic\PageBundle\Model\PageModel;
 use Mautic\ProjectBundle\Form\Type\ProjectType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
@@ -43,11 +43,11 @@ final class PageType extends AbstractType
 
     public function __construct(
         private readonly EntityManagerInterface $em,
-        private readonly PageModel $model,
         CorePermissions $corePermissions,
         UserHelper $userHelper,
         private readonly ThemeHelperInterface $themeHelper,
         private readonly PageConfigInterface $pageConfig,
+        private readonly PageRepository $pageRepository,
     ) {
         $this->canViewOther = $corePermissions->isGranted('page:pages:viewother');
         $this->user         = $userHelper->getUser();
@@ -139,10 +139,10 @@ final class PageType extends AbstractType
         $builder->add('sessionId', HiddenType::class);
 
         // Custom field for redirect URL
-        $this->model->getRepository()->setCurrentUser($this->user);
+        $this->pageRepository->setCurrentUser($this->user);
 
         $redirectUrlDataOptions = '';
-        $pages                  = $this->model->getRepository()->getPageList('', 0, 0, $this->canViewOther, 'variant', [$options['data']->getId()]);
+        $pages                  = $this->pageRepository->getPageList('', 0, 0, $this->canViewOther, 'variant', [$options['data']->getId()]);
         foreach ($pages as $page) {
             $redirectUrlDataOptions .= "|{$page['alias']}";
         }

--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -30,6 +30,7 @@ use Mautic\EmailBundle\Helper\BotRatioHelper;
 use Mautic\LeadBundle\DataObject\LeadManipulator;
 use Mautic\LeadBundle\Entity\Company;
 use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Entity\UtmTag;
 use Mautic\LeadBundle\Entity\UtmTagRepository;
 use Mautic\LeadBundle\Helper\ContactRequestHelper;
@@ -45,6 +46,8 @@ use Mautic\PageBundle\Entity\HitRepository;
 use Mautic\PageBundle\Entity\Page;
 use Mautic\PageBundle\Entity\PageRepository;
 use Mautic\PageBundle\Entity\Redirect;
+use Mautic\PageBundle\Entity\RedirectRepository;
+use Mautic\PageBundle\Entity\TrackableRepository;
 use Mautic\PageBundle\Event\PageBuilderEvent;
 use Mautic\PageBundle\Event\PageEvent;
 use Mautic\PageBundle\Event\PageHitEvent;
@@ -119,6 +122,9 @@ class PageModel extends FormModel implements GlobalSearchInterface
         private readonly HitRepository $hitRepository,
         private readonly EmailRepository $emailRepository,
         private readonly UtmTagRepository $utmTagRepository,
+        private readonly RedirectRepository $redirectRepository,
+        private readonly TrackableRepository $trackableRepository,
+        private readonly LeadRepository $leadRepository,
     ) {
         $this->dateTimeHelper = new DateTimeHelper();
 
@@ -629,11 +635,11 @@ class PageModel extends FormModel implements GlobalSearchInterface
             }
         } elseif ($page instanceof Redirect) {
             try {
-                $this->pageRedirectModel->getRepository()->upHitCount($page->getId(), 1, $isUnique);
+                $this->redirectRepository->upHitCount($page->getId(), 1, $isUnique);
 
                 // If this is a trackable, up the trackable counts as well
                 if ($hit->getSource() && $hit->getSourceId()) {
-                    $this->pageTrackableModel->getRepository()->upHitCount(
+                    $this->trackableRepository->upHitCount(
                         $page->getId(),
                         $hit->getSource(),
                         $hit->getSourceId(),
@@ -706,7 +712,7 @@ class PageModel extends FormModel implements GlobalSearchInterface
         if (null !== $hitDate) {
             if (null === $lead->getLastActive() || $lead->getLastActive() < $hitDate) {
                 try {
-                    $this->leadModel->getRepository()->updateLastActive($lead->getId(), $hitDate);
+                    $this->leadRepository->updateLastActive($lead->getId(), $hitDate);
                 } catch (\Exception $e) {
                     $data = [
                         'unique'             => ($isUnique ? 'true' : 'false'),

--- a/app/bundles/PageBundle/Tests/Form/Type/PageListTypeTest.php
+++ b/app/bundles/PageBundle/Tests/Form/Type/PageListTypeTest.php
@@ -7,7 +7,6 @@ namespace Mautic\PageBundle\Tests\Form\Type;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\PageBundle\Entity\PageRepository;
 use Mautic\PageBundle\Form\Type\PageListType;
-use Mautic\PageBundle\Model\PageModel;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -17,26 +16,21 @@ final class PageListTypeTest extends TestCase
     private PageListType $page;
 
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject&PageModel
+     * @var \PHPUnit\Framework\MockObject\MockObject&PageRepository
      */
-    private \PHPUnit\Framework\MockObject\MockObject $pageModelMock;
+    private \PHPUnit\Framework\MockObject\MockObject $pageRepositoryMock;
 
     protected function setUp(): void
     {
-        $this->pageModelMock   = $this->createMock(PageModel::class);
-        $this->page            = new PageListType($this->pageModelMock, $this->createStub(CorePermissions::class));
+        $this->pageRepositoryMock = $this->createMock(PageRepository::class);
+        $this->page               = new PageListType($this->createStub(CorePermissions::class), $this->pageRepositoryMock);
     }
 
     public function testPageListTypeOptionsChoices(): void
     {
-        $pageRepository = $this->createMock(PageRepository::class);
-        $resolver       = new OptionsResolver();
+        $resolver = new OptionsResolver();
 
-        $this->pageModelMock
-            ->method('getRepository')
-            ->willReturn($pageRepository);
-
-        $pageRepository->method('getPageList')
+        $this->pageRepositoryMock->method('getPageList')
             ->willReturn([]);
 
         $this->page->configureOptions($resolver);

--- a/app/bundles/PageBundle/Tests/PageTestAbstract.php
+++ b/app/bundles/PageBundle/Tests/PageTestAbstract.php
@@ -18,6 +18,7 @@ use Mautic\EmailBundle\Entity\EmailRepository;
 use Mautic\EmailBundle\Entity\StatRepository;
 use Mautic\EmailBundle\Helper\BotRatioHelper;
 use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Entity\UtmTagRepository;
 use Mautic\LeadBundle\Helper\ContactRequestHelper;
 use Mautic\LeadBundle\Model\CompanyModel;
@@ -31,6 +32,7 @@ use Mautic\PageBundle\Entity\Page;
 use Mautic\PageBundle\Entity\PageRepository;
 use Mautic\PageBundle\Entity\Redirect;
 use Mautic\PageBundle\Entity\RedirectRepository;
+use Mautic\PageBundle\Entity\TrackableRepository;
 use Mautic\PageBundle\Model\PageModel;
 use Mautic\PageBundle\Model\RedirectModel;
 use Mautic\PageBundle\Model\TrackableModel;
@@ -156,6 +158,9 @@ abstract class PageTestAbstract extends TestCase
             $this->createStub(HitRepository::class), // $hitRepository
             $this->createStub(EmailRepository::class), // $emailRepository
             $this->createStub(UtmTagRepository::class), // $utmTagRepository
+            $this->createStub(RedirectRepository::class),
+            $this->createStub(TrackableRepository::class),
+            $this->createStub(LeadRepository::class)
         );
     }
 

--- a/app/bundles/SmsBundle/Broadcast/BroadcastExecutioner.php
+++ b/app/bundles/SmsBundle/Broadcast/BroadcastExecutioner.php
@@ -6,6 +6,7 @@ use Mautic\CampaignBundle\Executioner\ContactFinder\Limiter\ContactLimiter;
 use Mautic\ChannelBundle\Event\ChannelBroadcastEvent;
 use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\SmsBundle\Entity\Sms;
+use Mautic\SmsBundle\Entity\SmsRepository;
 use Mautic\SmsBundle\Model\SmsModel;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -20,13 +21,14 @@ final class BroadcastExecutioner
         private readonly BroadcastQuery $broadcastQuery,
         private readonly TranslatorInterface $translator,
         private readonly LeadRepository $leadRepository,
+        private readonly SmsRepository $smsRepository,
     ) {
     }
 
     public function execute(ChannelBroadcastEvent $event): void
     {
         // Get list of published broadcasts or broadcast if there is only a single ID
-        $smses = $this->smsModel->getRepository()->getPublishedBroadcastsIterable($event->getId());
+        $smses = $this->smsRepository->getPublishedBroadcastsIterable($event->getId());
         foreach ($smses as $sms) {
             $this->contactLimiter = new ContactLimiter($event->getBatch(), null, $event->getMinContactIdFilter(), $event->getMaxContactIdFilter(), [], $event->getThreadId(), $event->getMaxThreads(), $event->getLimit());
             $this->result         = new BroadcastResult();

--- a/app/bundles/SmsBundle/Broadcast/BroadcastQuery.php
+++ b/app/bundles/SmsBundle/Broadcast/BroadcastQuery.php
@@ -8,7 +8,7 @@ use Mautic\CampaignBundle\Entity\ContactLimiterTrait;
 use Mautic\CampaignBundle\Executioner\ContactFinder\Limiter\ContactLimiter;
 use Mautic\ChannelBundle\Entity\MessageQueue;
 use Mautic\SmsBundle\Entity\Sms;
-use Mautic\SmsBundle\Model\SmsModel;
+use Mautic\SmsBundle\Entity\SmsRepository;
 
 final class BroadcastQuery
 {
@@ -18,7 +18,7 @@ final class BroadcastQuery
 
     public function __construct(
         private EntityManagerInterface $entityManager,
-        private SmsModel $smsModel,
+        private readonly SmsRepository $smsRepository,
     ) {
     }
 
@@ -44,7 +44,7 @@ final class BroadcastQuery
 
     public function getBasicQuery(Sms $sms): QueryBuilder
     {
-        $this->query = $this->smsModel->getRepository()->getSegmentsContactsQuery($sms->getId());
+        $this->query = $this->smsRepository->getSegmentsContactsQuery($sms->getId());
         $this->query->andWhere(
             $this->query->expr()->or(
                 $this->query->expr()->or(

--- a/app/bundles/StageBundle/Form/Type/StageListType.php
+++ b/app/bundles/StageBundle/Form/Type/StageListType.php
@@ -3,7 +3,7 @@
 namespace Mautic\StageBundle\Form\Type;
 
 use Mautic\StageBundle\Entity\Stage;
-use Mautic\StageBundle\Model\StageModel;
+use Mautic\StageBundle\Entity\StageRepository;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -19,7 +19,7 @@ final class StageListType extends AbstractType
     private array $choices = [];
 
     public function __construct(
-        private readonly StageModel $stageModel,
+        private readonly StageRepository $stageRepository,
     ) {
     }
 
@@ -48,7 +48,7 @@ final class StageListType extends AbstractType
             return $this->choices;
         }
 
-        $stages = $this->stageModel->getRepository()->getEntities([
+        $stages = $this->stageRepository->getEntities([
             'filter' => [
                 'force' => [
                     [

--- a/app/bundles/UserBundle/Form/Type/RoleListType.php
+++ b/app/bundles/UserBundle/Form/Type/RoleListType.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\UserBundle\Form\Type;
 
-use Mautic\UserBundle\Model\RoleModel;
+use Mautic\UserBundle\Entity\RoleRepository;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -13,7 +13,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 final class RoleListType extends AbstractType
 {
     public function __construct(
-        private readonly RoleModel $roleModel,
+        private readonly RoleRepository $roleRepository,
     ) {
     }
 
@@ -38,7 +38,7 @@ final class RoleListType extends AbstractType
     private function getRoleChoices(): array
     {
         $choices = [];
-        $roles   = $this->roleModel->getRepository()->getEntities(
+        $roles   = $this->roleRepository->getEntities(
             [
                 'filter' => [
                     'force' => [

--- a/app/bundles/UserBundle/Form/Type/UserListType.php
+++ b/app/bundles/UserBundle/Form/Type/UserListType.php
@@ -2,7 +2,7 @@
 
 namespace Mautic\UserBundle\Form\Type;
 
-use Mautic\UserBundle\Model\UserModel;
+use Mautic\UserBundle\Entity\UserRepository;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -18,7 +18,7 @@ final class UserListType extends AbstractType
     private array $choices = [];
 
     public function __construct(
-        private readonly UserModel $userModel,
+        private readonly UserRepository $userRepository,
     ) {
     }
 
@@ -49,7 +49,7 @@ final class UserListType extends AbstractType
             return $this->choices;
         }
 
-        $users = $this->userModel->getRepository()->getEntities(
+        $users = $this->userRepository->getEntities(
             [
                 'filter' => [
                     'force' => [

--- a/app/bundles/WebhookBundle/Helper/CampaignHelper.php
+++ b/app/bundles/WebhookBundle/Helper/CampaignHelper.php
@@ -6,9 +6,9 @@ use Doctrine\Common\Collections\Collection;
 use GuzzleHttp\Client;
 use GuzzleHttp\RequestOptions;
 use Mautic\CoreBundle\Helper\AbstractFormFieldHelper;
+use Mautic\LeadBundle\Entity\CompanyRepository;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Helper\TokenHelper;
-use Mautic\LeadBundle\Model\CompanyModel;
 use Mautic\WebhookBundle\Event\WebhookRequestEvent;
 use Mautic\WebhookBundle\WebhookEvents;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -22,8 +22,8 @@ final class CampaignHelper
 
     public function __construct(
         private readonly Client $client,
-        private readonly CompanyModel $companyModel,
         private readonly EventDispatcherInterface $dispatcher,
+        private readonly CompanyRepository $companyRepository,
     ) {
     }
 
@@ -141,7 +141,7 @@ final class CampaignHelper
         if (empty($this->contactsValues[$contact->getId()])) {
             $this->contactsValues[$contact->getId()]              = $contact->getProfileFields();
             $this->contactsValues[$contact->getId()]['ipAddress'] = $this->ipAddressesToCsv($contact->getIpAddresses());
-            $this->contactsValues[$contact->getId()]['companies'] = $this->companyModel->getRepository()->getCompaniesByLeadId($contact->getId());
+            $this->contactsValues[$contact->getId()]['companies'] = $this->companyRepository->getCompaniesByLeadId($contact->getId());
         }
 
         return $this->contactsValues[$contact->getId()];

--- a/app/bundles/WebhookBundle/Tests/Unit/Helper/CampaignHelperTest.php
+++ b/app/bundles/WebhookBundle/Tests/Unit/Helper/CampaignHelperTest.php
@@ -12,7 +12,6 @@ use Mautic\CoreBundle\Entity\IpAddress;
 use Mautic\LeadBundle\Entity\Company;
 use Mautic\LeadBundle\Entity\CompanyRepository;
 use Mautic\LeadBundle\Entity\Lead;
-use Mautic\LeadBundle\Model\CompanyModel;
 use Mautic\WebhookBundle\Helper\CampaignHelper;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -37,7 +36,6 @@ final class CampaignHelperTest extends \PHPUnit\Framework\TestCase
 
         $this->contact           = $this->createMock(Lead::class);
         $this->client            = $this->createMock(Client::class);
-        $companyModel            = $this->createMock(CompanyModel::class);
         $ipCollection            = new ArrayCollection();
         $companyRepository       = $this->getMockBuilder(CompanyRepository::class)
             ->disableOriginalConstructor()
@@ -46,9 +44,7 @@ final class CampaignHelperTest extends \PHPUnit\Framework\TestCase
 
         $companyRepository->method('getCompaniesByLeadId')->willReturn([new Company()]);
 
-        $companyModel->method('getRepository')->willReturn($companyRepository);
-
-        $this->campaignHelper = new CampaignHelper($this->client, $companyModel, $this->createStub(EventDispatcherInterface::class));
+        $this->campaignHelper = new CampaignHelper($this->client, $this->createStub(EventDispatcherInterface::class), $companyRepository);
 
         $ipCollection->add((new IpAddress())->setIpAddress('127.0.0.1'));
         $ipCollection->add((new IpAddress())->setIpAddress('127.0.0.2'));

--- a/plugins/MauticClearbitBundle/Helper/LookupHelper.php
+++ b/plugins/MauticClearbitBundle/Helper/LookupHelper.php
@@ -9,7 +9,9 @@ use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\IntegrationsBundle\Exception\IntegrationNotFoundException;
 use Mautic\IntegrationsBundle\Helper\IntegrationsHelper;
 use Mautic\LeadBundle\Entity\Company;
+use Mautic\LeadBundle\Entity\CompanyRepository;
 use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Model\CompanyModel;
 use Mautic\LeadBundle\Model\LeadModel;
 use MauticPlugin\MauticClearbitBundle\Integration\ClearbitIntegration;
@@ -27,6 +29,8 @@ final class LookupHelper
         private readonly LoggerInterface $logger,
         private readonly LeadModel $leadModel,
         private readonly CompanyModel $companyModel,
+        private readonly LeadRepository $leadRepository,
+        private readonly CompanyRepository $companyRepository,
     ) {
         try {
             /** @var ClearbitIntegration $integration */
@@ -63,7 +67,7 @@ final class LookupHelper
                         $lead->setSocialCache($cache);
 
                         if ($checkAuto) {
-                            $this->leadModel->getRepository()->saveEntity($lead);
+                            $this->leadRepository->saveEntity($lead);
                         } else {
                             $this->leadModel->saveEntity($lead);
                         }
@@ -101,7 +105,7 @@ final class LookupHelper
                         ];
                         $company->setSocialCache($cache);
                         if ($checkAuto) {
-                            $this->companyModel->getRepository()->saveEntity($company);
+                            $this->companyRepository->saveEntity($company);
                         } else {
                             $this->companyModel->saveEntity($company);
                         }

--- a/plugins/MauticClearbitBundle/Tests/Unit/Helper/LookupHelperTest.php
+++ b/plugins/MauticClearbitBundle/Tests/Unit/Helper/LookupHelperTest.php
@@ -8,7 +8,9 @@ use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\IntegrationsBundle\Exception\IntegrationNotFoundException;
 use Mautic\IntegrationsBundle\Helper\IntegrationsHelper;
 use Mautic\LeadBundle\Entity\Company;
+use Mautic\LeadBundle\Entity\CompanyRepository;
 use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Model\CompanyModel;
 use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\PluginBundle\Entity\Integration;
@@ -32,6 +34,10 @@ final class LookupHelperTest extends TestCase
 
     private MockObject&CompanyModel $companyModel;
 
+    private MockObject&LeadRepository $leadRepository;
+
+    private MockObject&CompanyRepository $companyRepository;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -41,6 +47,8 @@ final class LookupHelperTest extends TestCase
         $this->logger             = $this->createStub(LoggerInterface::class);
         $this->leadModel          = $this->createMock(LeadModel::class);
         $this->companyModel       = $this->createMock(CompanyModel::class);
+        $this->leadRepository     = $this->createMock(LeadRepository::class);
+        $this->companyRepository  = $this->createMock(CompanyRepository::class);
     }
 
     public function testConstructorLeavesIntegrationNullWhenNotFound(): void
@@ -92,7 +100,7 @@ final class LookupHelperTest extends TestCase
         $lead->method('getEmail')->willReturn(null);
 
         $this->leadModel->expects($this->never())->method('saveEntity');
-        $this->leadModel->expects($this->never())->method('getRepository');
+        $this->leadRepository->expects($this->never())->method('saveEntity');
 
         $this->makeHelper()->lookupContact($lead);
     }
@@ -106,7 +114,7 @@ final class LookupHelperTest extends TestCase
         $lead->method('getEmail')->willReturn('john@example.com');
 
         $this->leadModel->expects($this->never())->method('saveEntity');
-        $this->leadModel->expects($this->never())->method('getRepository');
+        $this->leadRepository->expects($this->never())->method('saveEntity');
 
         $this->makeHelper()->lookupContact($lead, false, true);
     }
@@ -120,7 +128,7 @@ final class LookupHelperTest extends TestCase
         $company->method('getFieldValue')->with('companywebsite')->willReturn(null);
 
         $this->companyModel->expects($this->never())->method('saveEntity');
-        $this->companyModel->expects($this->never())->method('getRepository');
+        $this->companyRepository->expects($this->never())->method('saveEntity');
 
         $this->makeHelper()->lookupCompany($company);
     }
@@ -179,6 +187,8 @@ final class LookupHelperTest extends TestCase
             $this->logger,
             $this->leadModel,
             $this->companyModel,
+            $this->leadRepository,
+            $this->companyRepository,
         );
     }
 

--- a/plugins/MauticFullContactBundle/Helper/LookupHelper.php
+++ b/plugins/MauticFullContactBundle/Helper/LookupHelper.php
@@ -5,7 +5,9 @@ namespace MauticPlugin\MauticFullContactBundle\Helper;
 use Mautic\CoreBundle\Helper\EncryptionHelper;
 use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\LeadBundle\Entity\Company;
+use Mautic\LeadBundle\Entity\CompanyRepository;
 use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Model\CompanyModel;
 use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\PluginBundle\Helper\IntegrationHelper;
@@ -30,6 +32,8 @@ final class LookupHelper
         private readonly Router $router,
         private readonly LeadModel $leadModel,
         private readonly CompanyModel $companyModel,
+        private readonly LeadRepository $leadRepository,
+        private readonly CompanyRepository $companyRepository,
     ) {
         $this->integration  = $integrationHelper->getIntegrationObject('FullContact');
     }
@@ -68,7 +72,7 @@ final class LookupHelper
                         $lead->setSocialCache($cache);
 
                         if ($checkAuto) {
-                            $this->leadModel->getRepository()->saveEntity($lead);
+                            $this->leadRepository->saveEntity($lead);
                         } else {
                             $this->leadModel->saveEntity($lead);
                         }
@@ -114,7 +118,7 @@ final class LookupHelper
                         ];
                         $company->setSocialCache($cache);
                         if ($checkAuto) {
-                            $this->companyModel->getRepository()->saveEntity($company);
+                            $this->companyRepository->saveEntity($company);
                         } else {
                             $this->companyModel->saveEntity($company);
                         }


### PR DESCRIPTION
Inject repository services directly instead of going through `Model::getRepository()`.

Services that only need a repository no longer have to depend on the whole model. The dependency becomes explicit and typed, tests get simpler (mock a repository instead of a model + its repository), and the model class is free to drop `getRepository()` later.

Covers AssetBundle, CampaignBundle, ChannelBundle, DynamicContentBundle, EmailBundle, FormBundle, LeadBundle, NotificationBundle, PageBundle, SmsBundle, StageBundle, UserBundle, WebhookBundle and plugins.

```diff
 final class LoadCompanyData extends AbstractFixture implements OrderedFixtureInterface
 {
     public function __construct(
-        private readonly CompanyModel $companyModel,
+        private readonly CompanyRepository $companyRepository,
     ) {
     }

     public function load(ObjectManager $manager): void
     {
         ...
-        $this->companyModel->getRepository()->saveEntity($company);
+        $this->companyRepository->saveEntity($company);
     }
 }
```

Same in services:

```diff
 class ContactMerger
 {
     public function __construct(
         protected LeadModel $leadModel,
         ...
+        private readonly LeadRepository $leadRepository,
     ) {
     }

     public function mergeFields(Lead $winner, Lead $loser): Lead
     {
         if (!$newest->hasFields()) {
-            $newest->setFields($this->leadModel->getRepository()->getFieldValues($newest->getId()));
+            $newest->setFields($this->leadRepository->getFieldValues($newest->getId()));
         }
     }
 }
```

Replaces #16909, #16910, #16912, #16913, #16914, #16915, #16917 and #16920, which are closed in favor of this single PR.

