### PR TITLE
fix: preserve existing mailer_dsn during migration [backport M5]

### DIFF
--- a/app/migrations/Version20230615101328.php
+++ b/app/migrations/Version20230615101328.php
@@ -16,13 +16,8 @@ final class Version20230615101328 extends PreUpAssertionMigration
         $configurator = $this->getConfigurator();
 
         $this->skipAssertion(
-            fn () => !$configurator->isFileWritable(),
-            'The local.php file is not writable. Skipping the email configuration migration.'
-        );
-
-        $this->skipAssertion(
-            fn () => array_key_exists('mailer_dsn', $configurator->getParameters()),
-            'The mailer_dsn parameter is already set. Skipping the email configuration migration.'
+            fn () => !$configurator->isFileWritable() || array_key_exists('mailer_dsn', $configurator->getParameters()),
+            'The local.php file is not writable or the mailer_dsn parameter is already set. Skipping the email configuration migration.'
         );
     }
 


### PR DESCRIPTION
⚠️ This PR is provided for use as a patch and is not intended for merging into this Mautic release, as that release is no longer maintained.

## Summary

`Version20230615101328` could overwrite an existing `mailer_dsn` in `config/local.php`.

`PreUpAssertionMigration::skipAssertion()` skips only when all assertions return `true`. The migration registered file-writable and existing-DSN checks separately. A writable file made the first assertion return `false`, so the existing-DSN check was never reached and `up()` overwrote the setting.

This change combines both skip conditions with OR logic. Existing `mailer_dsn` values remain unchanged.