### PR TITLE
fix: preserve existing mailer_dsn during migration

### DIFF
--- a/app/migrations/Version20230615101328.php
+++ b/app/migrations/Version20230615101328.php
@@ -16,13 +16,8 @@ final class Version20230615101328 extends PreUpAssertionMigration
         $configurator = $this->getConfigurator();
 
         $this->skipAssertion(
-            fn () => !$configurator->isFileWritable(),
-            'The local.php file is not writable. Skipping the email configuration migration.'
-        );
-
-        $this->skipAssertion(
-            fn () => array_key_exists('mailer_dsn', $configurator->getParameters()),
-            'The mailer_dsn parameter is already set. Skipping the email configuration migration.'
+            fn () => !$configurator->isFileWritable() || array_key_exists('mailer_dsn', $configurator->getParameters()),
+            'The local.php file is not writable or the mailer_dsn parameter is already set. Skipping the email configuration migration.'
         );
     }
 


### PR DESCRIPTION
| Q                                      | A |
| -------------------------------------- | --- |
| Bug fix? (use the a.b branch)          | ✔️ |
| New feature/enhancement? (use the a.x branch) | ❌ |
| Deprecations?                          | ❌ |
| BC breaks? (use the c.x branch)        | ❌ |
| Automated tests included?              | ❌ |
| Related user documentation PR URL      | N/A |
| Related developer documentation PR URL | N/A |
| Issue(s) addressed                     | No linked issue |

## Description

`Version20230615101328` registered the file-writable and existing-DSN checks as separate skip assertions. `PreUpAssertionMigration` skips only when all assertions pass. Therefore, a writable `local.php` with an existing `mailer_dsn` allowed the migration to overwrite the configured DSN.

The assertions are combined so the migration skips when `local.php` is not writable or when `mailer_dsn` already exists.

No new tests are included, as requested. Existing focused tests and static checks pass.

---
### 📋 Steps to test this PR:

Use a disposable Mautic 7 database and back up `config/local.php` before testing.

1. Ensure `config/local.php` is writable and contains an existing `mailer_dsn`.
2. Remove the migration record from the database:

   ```bash
   ddev exec php bin/console doctrine:query:sql "DELETE FROM migrations WHERE version = CONCAT('Mautic', CHAR(92), 'Migrations', CHAR(92), 'Version20230615101328')"
   ```

3. Execute the migration:

   ```bash
   ddev exec --raw -- php bin/console doctrine:migrations:execute 'Mautic\Migrations\Version20230615101328' --up --no-interaction
   ```

4. Confirm that the output reports the migration was skipped and that the existing `mailer_dsn` in `config/local.php` is unchanged.
5. Restore the database and `config/local.php` after testing.
