### PR TITLE
fix(plugin): align Facebook user data return type

### DIFF
--- a/app/bundles/PluginBundle/Integration/AbstractIntegration.php
+++ b/app/bundles/PluginBundle/Integration/AbstractIntegration.php
@@ -1336,7 +1336,7 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
     /**
      * Get an array of public data.
      *
-     * @return mixed[]|void
+     * @return mixed[]|object|void|null
      */
     public function getUserData($identifier, &$socialCache)
     {

--- a/plugins/MauticSocialBundle/Integration/FacebookIntegration.php
+++ b/plugins/MauticSocialBundle/Integration/FacebookIntegration.php
@@ -3,7 +3,6 @@
 namespace MauticPlugin\MauticSocialBundle\Integration;
 
 use MauticPlugin\MauticSocialBundle\Form\Type\FacebookType;
-use Psr\Http\Message\ResponseInterface;
 
 final class FacebookIntegration extends SocialIntegration
 {
@@ -73,10 +72,8 @@ final class FacebookIntegration extends SocialIntegration
 
     /**
      * Get public data.
-     *
-     * @return array|ResponseInterface|null
      */
-    public function getUserData($identifier, &$socialCache)
+    public function getUserData($identifier, &$socialCache): ?object
     {
         $this->persistNewLead = false;
         $accessToken          = $this->getContactAccessToken($socialCache);


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌
| Related user documentation PR URL      | ❌
| Related developer documentation PR URL | ❌
| Issue(s) addressed                     | ❌ No related issue; this fixes CI failures on `7.x`.

## Description

### What changed

Updated `FacebookIntegration::getUserData()` to declare the `?object` native return type that matches its actual return values, and widened the inherited `AbstractIntegration::getUserData()` PHPDoc contract to allow implementations that return an object or null.

### Why this is needed

The `7.x` branch currently fails PHPStan and Rector after #16918 (`[types] apply code quality set`) exposed an existing mismatch in `FacebookIntegration::getUserData()`.

Observed CI failures:

- PHPStan reports that `FacebookIntegration::getUserData()` never returns `array`, so `array` can be removed from the return type.
- Rector reports that `FacebookIntegration::getUserData()` should declare `: ?object` via `ReturnNullableTypeRector`.

This also affects unrelated PRs that are based on the current `7.x` branch, for example #15960, because the static analysis jobs run repo-wide.

### How it works

The Facebook integration already returns the API response object when user data is found and `null` when it is not. The change makes the method signature and inherited PHPDoc reflect that existing behavior.

### Impact

This is a static-analysis and type-contract cleanup only. It does not change runtime behavior, database schema, configuration, plugin APIs, or user-facing functionality.

---

### 📋 Steps to test this PR:

1. Check out this PR locally or open it in GitHub Codespaces.
2. Run Rector:

```bash
ddev composer rector
```
3. Confirm Rector no longer reports a required return type change for `plugins/MauticSocialBundle/Integration/FacebookIntegration.php`.
4. Run PHPStan:
```bash
ddev composer phpstan
```
5. Confirm PHPStan no longer reports that `FacebookIntegration::getUserData()` has an unused array return type.
6. Optional regression check: confirm the Facebook integration method still returns `null` when no access token is available and returns the API response object when Facebook user data is found.