### PR TITLE
[EmailBundle] Move action service injection to constructor injection

### DIFF
--- a/app/bundles/EmailBundle/Controller/AjaxController.php
+++ b/app/bundles/EmailBundle/Controller/AjaxController.php
@@ -24,7 +24,6 @@ use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
 use Symfony\Component\Mailer\Transport\TransportInterface;
 use Symfony\Component\Mime\Address;
 use Symfony\Contracts\Service\Attribute\Required;
-use Twig\Environment;
 
 final class AjaxController extends CommonAjaxController
 {
@@ -32,21 +31,42 @@ final class AjaxController extends CommonAjaxController
     use AjaxLookupControllerTrait;
 
     private EmailModel $emailModel;
+    private FormFactoryInterface $formFactory;
+    private Mailbox $mailbox;
+    private TransportInterface $transport;
+    private UserHelper $userHelper;
+    private CoreParametersHelper $parametersHelper;
+    private CacheProvider $cacheProvider;
+    private EmailDependencies $emailDependencies;
 
     #[Required]
     public function autowireEmailAjaxController(
         EmailModel $emailModel,
+        FormFactoryInterface $formFactory,
+        Mailbox $mailbox,
+        TransportInterface $transport,
+        UserHelper $userHelper,
+        CoreParametersHelper $parametersHelper,
+        CacheProvider $cacheProvider,
+        EmailDependencies $emailDependencies,
     ): void {
         $this->emailModel = $emailModel;
+        $this->formFactory = $formFactory;
+        $this->mailbox = $mailbox;
+        $this->transport = $transport;
+        $this->userHelper = $userHelper;
+        $this->parametersHelper = $parametersHelper;
+        $this->cacheProvider = $cacheProvider;
+        $this->emailDependencies = $emailDependencies;
     }
 
-    public function getAbTestFormAction(Request $request, FormFactoryInterface $formFactory, EmailModel $emailModel, Environment $twig): JsonResponse
+    public function getAbTestFormAction(Request $request, EmailModel $emailModel): JsonResponse
     {
         return $this->sendJsonResponse($this->getAbTestForm(
             $request,
             $emailModel,
-            fn ($formType, $formOptions): FormInterface => $formFactory->create(AbTestPropertiesType::class, [], ['formType' => $formType, 'formTypeOptions' => $formOptions]),
-            fn (FormInterface $form): string => $this->renderView('@MauticEmail/AbTest/form.html.twig', ['form' => $this->setFormTheme($form, $twig, ['@MauticEmail/AbTest/form.html.twig', '@MauticEmail/FormTheme/Email/layout.html.twig'])]),
+            fn ($formType, $formOptions): FormInterface => $this->formFactory->create(AbTestPropertiesType::class, [], ['formType' => $formType, 'formTypeOptions' => $formOptions]),
+            fn (FormInterface $form): string => $this->renderView('@MauticEmail/AbTest/form.html.twig', ['form' => $this->setFormTheme($form, $this->twig, ['@MauticEmail/AbTest/form.html.twig', '@MauticEmail/FormTheme/Email/layout.html.twig'])]),
             'email_abtest_settings',
             'emailform'
         ));
@@ -132,7 +152,7 @@ final class AjaxController extends CommonAjaxController
     /**
      * Tests monitored email connection settings.
      */
-    public function testMonitoredEmailServerConnectionAction(Request $request, Mailbox $mailbox): JsonResponse
+    public function testMonitoredEmailServerConnectionAction(Request $request): JsonResponse
     {
         $dataArray = ['success' => 0, 'message' => ''];
 
@@ -147,8 +167,8 @@ final class AjaxController extends CommonAjaxController
             }
 
             try {
-                $mailbox->setMailboxSettings($settings);
-                $folders = $mailbox->getListingFolders();
+                $this->mailbox->setMailboxSettings($settings);
+                $folders = $this->mailbox->getListingFolders();
                 if (!empty($folders)) {
                     $dataArray['folders'] = '';
                     foreach ($folders as $folder) {
@@ -165,20 +185,18 @@ final class AjaxController extends CommonAjaxController
         return $this->sendJsonResponse($dataArray);
     }
 
-    public function sendTestEmailAction(TransportInterface $transport, UserHelper $userHelper, CoreParametersHelper $parametersHelper): JsonResponse
+    public function sendTestEmailAction(): JsonResponse
     {
-        $user  = $userHelper->getUser();
+        $user  = $this->userHelper->getUser();
         $email = (new MauticMessage())
             ->subject($this->translator->trans('mautic.email.config.mailer.transport.test_send.subject'))
             ->text($this->translator->trans('mautic.email.config.mailer.transport.test_send.body'))
-            ->from(new Address($parametersHelper->get('mailer_from_email'), $parametersHelper->get('mailer_from_name') ?: ''))
+            ->from(new Address($this->parametersHelper->get('mailer_from_email'), $this->parametersHelper->get('mailer_from_name') ?: ''))
             ->to(new Address($user->getEmail(), trim($user->getFirstName().' '.$user->getLastName()) ?: ''));
-
         $success = 1;
         $message = $this->translator->trans('mautic.core.success');
-
         try {
-            $transport->send($email);
+            $this->transport->send($email);
         } catch (TransportExceptionInterface $e) {
             $success = 0;
             $message = $e->getMessage();
@@ -230,7 +248,7 @@ final class AjaxController extends CommonAjaxController
         return new JsonResponse($data);
     }
 
-    public function getEmailDeliveredCountAction(Request $request, CacheProvider $cacheProvider): JsonResponse
+    public function getEmailDeliveredCountAction(Request $request): JsonResponse
     {
         $emailId = (int) InputHelper::clean($request->query->get('id'));
 
@@ -242,7 +260,7 @@ final class AjaxController extends CommonAjaxController
         }
 
         $cacheTimeout = (int) $this->coreParametersHelper->get('cached_data_timeout');
-        $cacheItem    = $cacheProvider->getItem('email.stats.delivered.'.$emailId);
+        $cacheItem    = $this->cacheProvider->getItem('email.stats.delivered.'.$emailId);
 
         if ($cacheItem->isHit()) {
             $deliveredCount = $cacheItem->get();
@@ -257,7 +275,7 @@ final class AjaxController extends CommonAjaxController
             $deliveredCount = $this->emailModel->getDeliveredCount($email);
             $cacheItem->set($deliveredCount);
             $cacheItem->expiresAfter($cacheTimeout * 60);
-            $cacheProvider->save($cacheItem);
+            $this->cacheProvider->save($cacheItem);
         }
 
         return $this->sendJsonResponse([
@@ -310,7 +328,7 @@ final class AjaxController extends CommonAjaxController
         ]);
     }
 
-    public function getEmailUsagesAction(Request $request, EmailDependencies $emailDependencies): JsonResponse
+    public function getEmailUsagesAction(Request $request): JsonResponse
     {
         $emailId = (int) $request->query->get('id');
 
@@ -322,7 +340,7 @@ final class AjaxController extends CommonAjaxController
 
         $usagesHtml = $this->renderView('@MauticCore/Helper/usage.html.twig', [
             'title'    => $this->translator->trans('mautic.email.usages'),
-            'stats'    => $emailDependencies->getChannelsIds($emailId),
+            'stats'    => $this->emailDependencies->getChannelsIds($emailId),
             'noUsages' => $this->translator->trans('mautic.email.no_usages'),
         ]);
 

--- a/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
+++ b/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
@@ -57,6 +57,8 @@ final class EmailApiController extends CommonApiController
         EventDispatcherInterface $dispatcher,
         CoreParametersHelper $coreParametersHelper,
         EmailModel $emailModel,
+        private Reply $replyService,
+        private RandomHelperInterface $randomHelper,
     ) {
         $this->model            = $emailModel;
         $this->entityClass      = Email::class;
@@ -210,10 +212,10 @@ final class EmailApiController extends CommonApiController
     /**
      * @param string $trackingHash
      */
-    public function replyAction(Reply $replyService, RandomHelperInterface $randomHelper, $trackingHash): Response
+    public function replyAction($trackingHash): Response
     {
         try {
-            $replyService->createReplyByHash($trackingHash, "api-{$randomHelper->generate()}");
+            $this->replyService->createReplyByHash($trackingHash, "api-{$this->randomHelper->generate()}");
         } catch (EntityNotFoundException $e) {
             return $this->notFound($e->getMessage());
         }

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -49,6 +49,11 @@ final class EmailController extends FormController
     private ListModel $listModel;
 
     private AuditLogModel $auditLogModel;
+    private EmailConfig $emailConfig;
+    private ThemeHelper $themeHelper;
+    private CorePermissions $corePermissions;
+    private FakeContactHelper $fakeLeadHelper;
+    private PageHelperFactoryInterface $pageHelperFactory;
 
     #[Required]
     public function autowireEmailController(
@@ -56,11 +61,21 @@ final class EmailController extends FormController
         AuditLogModel $auditLogModel,
         EmailModel $emailModel,
         LeadRepository $leadRepository,
+        EmailConfig $emailConfig,
+        ThemeHelper $themeHelper,
+        CorePermissions $corePermissions,
+        FakeContactHelper $fakeLeadHelper,
+        PageHelperFactoryInterface $pageHelperFactory,
     ): void {
         $this->listModel = $listModel;
         $this->auditLogModel = $auditLogModel;
         $this->emailModel = $emailModel;
         $this->leadRepository = $leadRepository;
+        $this->emailConfig = $emailConfig;
+        $this->themeHelper = $themeHelper;
+        $this->corePermissions = $corePermissions;
+        $this->fakeLeadHelper = $fakeLeadHelper;
+        $this->pageHelperFactory = $pageHelperFactory;
     }
 
     public const EXAMPLE_EMAIL_SUBJECT_PREFIX = '[TEST]';
@@ -70,9 +85,9 @@ final class EmailController extends FormController
     /**
      * @param int $page
      */
-    public function indexAction(Request $request, EmailModel $model, EmailConfig $emailConfig, ThemeHelper $themeHelper, $page = 1): Response
+    public function indexAction(Request $request, EmailModel $model, $page = 1): Response
     {
-        $isDraftEnabled = $emailConfig->isDraftEnabled();
+        $isDraftEnabled = $this->emailConfig->isDraftEnabled();
         // set some permissions
         $permissions = $this->security->isGranted(
             [
@@ -136,7 +151,7 @@ final class EmailController extends FormController
 
         // retrieve a list of themes
         $listFilters['filters']['groups']['mautic.core.filter.themes'] = [
-            'options' => $themeHelper->getInstalledThemes('email'),
+            'options' => $this->themeHelper->getInstalledThemes('email'),
             'prefix'  => 'theme',
         ];
 
@@ -287,7 +302,7 @@ final class EmailController extends FormController
     /**
      * Loads a specific form into the detailed panel.
      */
-    public function viewAction(Request $request, EmailModel $model, EmailConfig $emailConfig, AbTestSettingsService $abTestSettingsService, AbTestResultService $abTestResultService, $objectId): Response
+    public function viewAction(Request $request, EmailModel $model, AbTestSettingsService $abTestSettingsService, AbTestResultService $abTestResultService, $objectId): Response
     {
         $security = $this->security;
 
@@ -397,7 +412,7 @@ final class EmailController extends FormController
             ];
         } else {
             $draftPreviewUrl = null;
-            if ($emailConfig->isDraftEnabled() && $email->hasDraft()) {
+            if ($this->emailConfig->isDraftEnabled() && $email->hasDraft()) {
                 $draftPreviewUrl = $this->generateUrl(
                     'mautic_email_preview',
                     [
@@ -505,10 +520,7 @@ final class EmailController extends FormController
     public function newAction(
         Request $request,
         AssetModel $assetModel,
-        CorePermissions $corePermissions,
-        EmailConfig $emailConfig,
         EmailModel $model,
-        ThemeHelper $themeHelper,
         $entity = null,
     ): Response {
         if (!$entity instanceof Email) {
@@ -548,7 +560,7 @@ final class EmailController extends FormController
 
                     $entity->setCustomHtml($content);
 
-                    $this->unpublishIfLackingPermission($entity, $corePermissions);
+                    $this->unpublishIfLackingPermission($entity);
 
                     try {
                         // form is valid so process the data
@@ -578,7 +590,7 @@ final class EmailController extends FormController
                             $template  = 'Mautic\EmailBundle\Controller\EmailController::viewAction';
                         } else {
                             // return edit view so that all the session stuff is loaded
-                            return $this->editAction($request, $assetModel, $corePermissions, $emailConfig, $model, $themeHelper, $entity->getId(), true);
+                            return $this->editAction($request, $assetModel, $model, $entity->getId(), true);
                         }
                     } catch (InvalidRenderedHtmlException $e) {
                         $valid                  = false;
@@ -648,7 +660,7 @@ final class EmailController extends FormController
                     'form'              => $form->createView(),
                     'isVariant'         => $entity->isVariant(true),
                     'email'             => $entity,
-                    'themes'            => $themeHelper->getInstalledThemes('email', true),
+                    'themes'            => $this->themeHelper->getInstalledThemes('email', true),
                     'updateSelect'      => $updateSelect,
                     'permissions'       => $permissions,
                     'invalidHtmlError'  => $this->invalidHtmlError,
@@ -672,10 +684,7 @@ final class EmailController extends FormController
     public function editAction(
         Request $request,
         AssetModel $assetModel,
-        CorePermissions $corePermissions,
-        EmailConfig $emailConfig,
         EmailModel $model,
-        ThemeHelper $themeHelper,
         $objectId,
         $ignorePost = false,
         $forceTypeSelection = false,
@@ -751,13 +760,13 @@ final class EmailController extends FormController
                     $content = $entity->getCustomHtml();
                     $entity->setCustomHtml($content);
 
-                    $this->unpublishIfLackingPermission($entity, $corePermissions);
+                    $this->unpublishIfLackingPermission($entity);
 
                     // form is valid so process the data
                     try {
                         $model->saveEntity($entity, $this->getFormButton($form, ['buttons', 'save'])->isClicked());
 
-                        if ($emailConfig->isDraftEnabled() && !empty($entity->getId())) {
+                        if ($this->emailConfig->isDraftEnabled() && !empty($entity->getId())) {
                             $this->dispatcher->dispatch(new EmailEditSubmitEvent(
                                 $existingEmail,
                                 $entity,
@@ -880,7 +889,7 @@ final class EmailController extends FormController
             'RETURN_ARRAY'
         );
         $draftPreviewUrl = '';
-        if ($emailConfig->isDraftEnabled() && $entity->hasDraft()) {
+        if ($this->emailConfig->isDraftEnabled() && $entity->hasDraft()) {
             $draftPreviewUrl = $this->generateUrl(
                 'mautic_email_preview',
                 ['objectId'       => $entity->getId(),
@@ -902,7 +911,7 @@ final class EmailController extends FormController
                 'viewParameters' => [
                     'form'               => $form->createView(),
                     'isVariant'          => $entity->isVariant(true),
-                    'themes'             => $themeHelper->getInstalledThemes('email', true),
+                    'themes'             => $this->themeHelper->getInstalledThemes('email', true),
                     'email'              => $entity,
                     'forceTypeSelection' => $forceTypeSelection,
                     'attachmentSize'     => $attachmentSize,
@@ -932,7 +941,7 @@ final class EmailController extends FormController
      *
      * @return JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse|Response
      */
-    public function cloneAction(Request $request, EmailModel $model, ThemeHelper $themeHelper, $objectId)
+    public function cloneAction(Request $request, EmailModel $model, $objectId)
     {
         $emailEntity  = $model->getEntity($objectId);
         $entity       = null;
@@ -1075,7 +1084,7 @@ final class EmailController extends FormController
                     'form'              => $form->createView(),
                     'isVariant'         => $entity->isVariant(true),
                     'email'             => $entity,
-                    'themes'            => $themeHelper->getInstalledThemes('email', true),
+                    'themes'            => $this->themeHelper->getInstalledThemes('email', true),
                     'permissions'       => $permissions,
                     'invalidHtmlError'  => $this->invalidHtmlError,
                 ],
@@ -1253,7 +1262,7 @@ final class EmailController extends FormController
      * @throws \Exception
      * @throws \Mautic\CoreBundle\Exception\FileNotFoundException
      */
-    public function builderAction(Request $request, ThemeHelper $themeHelper, $objectId): Response
+    public function builderAction(Request $request, $objectId): Response
     {
         // permission check
         if (str_contains($objectId, 'new')) {
@@ -1289,9 +1298,9 @@ final class EmailController extends FormController
             $entity->setContent($content);
         }
 
-        $logicalName = $themeHelper->checkForTwigTemplate('@themes/'.$template.'/html/email.html.twig');
+        $logicalName = $this->themeHelper->checkForTwigTemplate('@themes/'.$template.'/html/email.html.twig');
 
-        return new Response($themeHelper->renderThemeTemplate(
+        return new Response($this->themeHelper->renderThemeTemplate(
             $logicalName,
             [
                 'isNew'    => $isNew,
@@ -1303,7 +1312,7 @@ final class EmailController extends FormController
         ));
     }
 
-    public function abTestAction(Request $request, AssetModel $assetModel, CorePermissions $corePermissions, EmailConfig $emailConfig, EmailModel $model, ThemeHelper $themeHelper, int $objectId): Response
+    public function abTestAction(Request $request, AssetModel $assetModel, EmailModel $model, int $objectId): Response
     {
         $entity = $model->getEntity($objectId);
 
@@ -1330,7 +1339,7 @@ final class EmailController extends FormController
             $clone->setVariantParent($entity);
         }
 
-        return $this->newAction($request, $assetModel, $corePermissions, $emailConfig, $model, $themeHelper, $clone);
+        return $this->newAction($request, $assetModel, $model, $clone);
     }
 
     /**
@@ -1620,13 +1629,13 @@ final class EmailController extends FormController
         );
     }
 
-    public function scheduleSendAction(CorePermissions $security, EmailModel $model, Request $request, int $objectId): JsonResponse|Response
+    public function scheduleSendAction(EmailModel $model, Request $request, int $objectId): JsonResponse|Response
     {
         $entity = $model->getEntity($objectId);
 
         // not found or not allowed
         if (null === $entity
-            || (!$security->hasEntityAccess(
+            || (!$this->security->hasEntityAccess(
                 'email:emails:viewown',
                 'email:emails:viewother',
                 $entity->getCreatedBy()
@@ -1710,7 +1719,7 @@ final class EmailController extends FormController
      * Generating the modal box content for
      * the send multiple example email option.
      */
-    public function sendExampleAction(Request $request, $objectId, CorePermissions $security, EmailModel $model, LeadModel $leadModel, FakeContactHelper $fakeLeadHelper): Response
+    public function sendExampleAction(Request $request, $objectId, EmailModel $model, LeadModel $leadModel): Response
     {
         $entity = $model->getEntity($objectId);
 
@@ -1755,8 +1764,8 @@ final class EmailController extends FormController
                 }
 
                 if ($previewForContactId
-                    && (!$security->isAdmin()
-                        || !$security->hasEntityAccess('lead:leads:viewown', 'lead:leads:viewother', $user->getId())
+                    && (!$this->security->isAdmin()
+                        || !$this->security->hasEntityAccess('lead:leads:viewown', 'lead:leads:viewother', $user->getId())
                     )
                 ) {
                     // disallow displaying contact information
@@ -1771,7 +1780,7 @@ final class EmailController extends FormController
 
                 if (!isset($fields)) {
                     // Prepare a fake contact
-                    $fields = $fakeLeadHelper->prepareFakeContactWithPrimaryCompany();
+                    $fields = $this->fakeLeadHelper->prepareFakeContactWithPrimaryCompany();
                 }
 
                 $errors = [];
@@ -1831,7 +1840,6 @@ final class EmailController extends FormController
      */
     public function contactsAction(
         Request $request,
-        PageHelperFactoryInterface $pageHelperFactory,
         $objectId,
         $page = 1,
     ) {
@@ -1844,7 +1852,7 @@ final class EmailController extends FormController
 
         return $this->generateContactsGrid(
             $request,
-            $pageHelperFactory,
+            $this->pageHelperFactory,
             $objectId,
             $page,
             $permissions,
@@ -1885,9 +1893,9 @@ final class EmailController extends FormController
         $clonedEmail->setDraft($cloningEmail->getDraft());
     }
 
-    private function unpublishIfLackingPermission(Email $entity, CorePermissions $corePermissions): Email
+    private function unpublishIfLackingPermission(Email $entity): Email
     {
-        $canPublish = $corePermissions->hasPublishAccessForEntity(
+        $canPublish = $this->corePermissions->hasPublishAccessForEntity(
             $entity,
             'email:emails:publishown',
             'email:emails:publishother'

--- a/app/bundles/EmailBundle/Controller/EmailGraphStatsController.php
+++ b/app/bundles/EmailBundle/Controller/EmailGraphStatsController.php
@@ -13,6 +13,12 @@ use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 final class EmailGraphStatsController extends AbstractController
 {
+    public function __construct(
+        private readonly FormFactoryInterface $formFactory,
+        private readonly CorePermissions $security,
+    ) {
+    }
+
     /**
      * Loads a specific form into the detailed panel.
      *
@@ -26,8 +32,6 @@ final class EmailGraphStatsController extends AbstractController
     public function viewAction(
         Request $request,
         EmailModel $model,
-        FormFactoryInterface $formFactory,
-        CorePermissions $security,
         $objectId,
         $isVariant,
         $dateFrom = null,
@@ -39,9 +43,9 @@ final class EmailGraphStatsController extends AbstractController
         // Init the date range filter form
         $dateRangeValues = ['date_from' => $dateFrom, 'date_to' => $dateTo];
         $action          = $this->generateUrl('mautic_email_action', ['objectAction' => 'view', 'objectId' => $objectId]);
-        $dateRangeForm   = $formFactory->create(DateRangeType::class, $dateRangeValues, ['action' => $action]);
+        $dateRangeForm   = $this->formFactory->create(DateRangeType::class, $dateRangeValues, ['action' => $action]);
 
-        if (null === $email || !$security->hasEntityAccess(
+        if (null === $email || !$this->security->hasEntityAccess(
             'email:emails:viewown',
             'email:emails:viewother',
             $email->getCreatedBy()

--- a/app/bundles/EmailBundle/Controller/EmailMapStatsController.php
+++ b/app/bundles/EmailBundle/Controller/EmailMapStatsController.php
@@ -30,6 +30,7 @@ final class EmailMapStatsController extends AbstractController
 
     public function __construct(
         private readonly EmailModel $model,
+        private readonly CorePermissions $security,
     ) {
     }
 
@@ -56,9 +57,9 @@ final class EmailMapStatsController extends AbstractController
         );
     }
 
-    public function hasAccess(CorePermissions $security, Email $entity): bool
+    public function hasAccess(Email $entity): bool
     {
-        return $security->hasEntityAccess(
+        return $this->security->hasEntityAccess(
             'email:emails:viewown',
             'email:emails:viewother',
             $entity->getCreatedBy()
@@ -82,14 +83,13 @@ final class EmailMapStatsController extends AbstractController
      * @throws \Exception
      */
     public function viewAction(
-        CorePermissions $security,
         int $objectId,
         string $dateFrom = '',
         string $dateTo = '',
     ): Response {
         $entity = $this->model->getEntity($objectId);
 
-        if (!$entity instanceof Email || !$this->hasAccess($security, $entity)) {
+        if (!$entity instanceof Email || !$this->hasAccess($entity)) {
             throw new AccessDeniedHttpException();
         }
 

--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -50,19 +50,58 @@ final class PublicController extends CommonFormController
     private EmailModel $emailModel;
 
     private LeadModel $leadModel;
+    private AnalyticsHelper $analyticsHelper;
+    private MessageBusInterface $messageBus;
+    private LoggerInterface $logger;
+    private ContactTracker $contactTracker;
+    private MailHashHelper $mailHash;
+    private ThemeHelper $themeHelper;
+    private EmailDefaultsHelper $emailDefaultsHelper;
+    private AssetsHelper $assetsHelper;
+    private EmailConfig $emailConfig;
+    private FakeContactHelper $fakeLeadHelper;
+    private IntegrationHelper $integrationHelper;
+    private MailHelper $mailer;
+    private LoggerInterface $mauticLogger;
 
     #[Required]
     public function autowirePublicController(
         LeadModel $leadModel,
         EmailModel $emailModel,
         LeadRepository $leadRepository,
+        AnalyticsHelper $analyticsHelper,
+        MessageBusInterface $messageBus,
+        LoggerInterface $logger,
+        ContactTracker $contactTracker,
+        MailHashHelper $mailHash,
+        ThemeHelper $themeHelper,
+        EmailDefaultsHelper $emailDefaultsHelper,
+        AssetsHelper $assetsHelper,
+        EmailConfig $emailConfig,
+        FakeContactHelper $fakeLeadHelper,
+        IntegrationHelper $integrationHelper,
+        MailHelper $mailer,
+        LoggerInterface $mauticLogger,
     ): void {
         $this->leadModel = $leadModel;
         $this->emailModel = $emailModel;
         $this->leadRepository = $leadRepository;
+        $this->analyticsHelper = $analyticsHelper;
+        $this->messageBus = $messageBus;
+        $this->logger = $logger;
+        $this->contactTracker = $contactTracker;
+        $this->mailHash = $mailHash;
+        $this->themeHelper = $themeHelper;
+        $this->emailDefaultsHelper = $emailDefaultsHelper;
+        $this->assetsHelper = $assetsHelper;
+        $this->emailConfig = $emailConfig;
+        $this->fakeLeadHelper = $fakeLeadHelper;
+        $this->integrationHelper = $integrationHelper;
+        $this->mailer = $mailer;
+        $this->mauticLogger = $mauticLogger;
     }
 
-    public function indexAction(Request $request, AnalyticsHelper $analyticsHelper, $idHash): Response
+    public function indexAction(Request $request, $idHash): Response
     {
         $stat  = $this->emailModel->getEmailStatus($idHash);
 
@@ -91,7 +130,7 @@ final class PublicController extends CommonFormController
                 $content = '';
             }
 
-            $content = $analyticsHelper->addCode($content);
+            $content = $this->analyticsHelper->addCode($content);
 
             // Add subject as title
             if (!empty($subject)) {
@@ -110,14 +149,12 @@ final class PublicController extends CommonFormController
 
     public function trackingImageAction(
         Request $request,
-        MessageBusInterface $messageBus,
-        LoggerInterface $logger,
         string $idHash,
     ): Response {
         try {
-            $messageBus->dispatch(new EmailHitNotification($idHash, $request));
+            $this->messageBus->dispatch(new EmailHitNotification($idHash, $request));
         } catch (\Exception $exception) {
-            $logger->error($exception->getMessage(), ['idHash' => $idHash]);
+            $this->logger->error($exception->getMessage(), ['idHash' => $idHash]);
 
             $this->emailModel->hitEmail($idHash, $request);
         }
@@ -129,7 +166,7 @@ final class PublicController extends CommonFormController
      * @throws \Exception
      * @throws \Mautic\CoreBundle\Exception\FileNotFoundException
      */
-    public function unsubscribeAction(Request $request, ContactTracker $contactTracker, EmailModel $model, LeadModel $leadModel, FormModel $formModel, PageModel $pageModel, MailHashHelper $mailHash, ThemeHelper $themeHelper, EmailDefaultsHelper $emailDefaultsHelper, $idHash, ?string $urlEmail = null, ?string $secretHash = null): Response
+    public function unsubscribeAction(Request $request, EmailModel $model, LeadModel $leadModel, FormModel $formModel, PageModel $pageModel, $idHash, ?string $urlEmail = null, ?string $secretHash = null): Response
     {
         $stat                   = $model->getEmailStatus($idHash);
         $message                = '';
@@ -170,17 +207,17 @@ final class PublicController extends CommonFormController
             $template = $formTemplate;
         }
 
-        $theme = $themeHelper->getTheme($template);
+        $theme = $this->themeHelper->getTheme($template);
         if ($theme->getTheme() != $template) {
             $template = $theme->getTheme();
         }
-        $contentTemplate = $themeHelper->checkForTwigTemplate('@themes/'.$template.'/html/message.html.twig');
-        $isCorrectHash   = $secretHash && $urlEmail && $mailHash->getEmailHash($urlEmail) === $secretHash;
+        $contentTemplate = $this->themeHelper->checkForTwigTemplate('@themes/'.$template.'/html/message.html.twig');
+        $isCorrectHash   = $secretHash && $urlEmail && $this->mailHash->getEmailHash($urlEmail) === $secretHash;
         if (!empty($stat) || $isCorrectHash) {
             $successSessionName = 'mautic.email.prefscenter.success';
             if (!empty($stat) && $lead = $stat->getLead()) {
                 // Set the lead as current lead
-                $contactTracker->setTrackedContact($lead);
+                $this->contactTracker->setTrackedContact($lead);
 
                 // Set lead lang
                 if ($language = $lead->getPreferredLocale()) {
@@ -202,15 +239,15 @@ final class PublicController extends CommonFormController
 
             if (!$isHeadRequest && (!$showContactPreferences || $isUnsubscribeAll)) {
                 if (!empty($stat)) {
-                    $message = $this->getUnsubscribeMessage($idHash, $model, $stat, $this->translator);
+                    $message = $this->getUnsubscribeMessage($idHash, $model, $stat);
                 } elseif ($lead && $lead instanceof Lead) {
-                    $message = $this->getUnsubscribeMessageLead($idHash, $model, $lead, $this->translator, $urlEmail);
+                    $message = $this->getUnsubscribeMessageLead($idHash, $model, $lead, $urlEmail);
                 }
             } elseif ($lead) {
                 $params = ['idHash' => $idHash, 'urlEmail' => $urlEmail];
 
                 if ($urlEmail) {
-                    $params['secretHash'] = $mailHash->getEmailHash($urlEmail);
+                    $params['secretHash'] = $this->mailHash->getEmailHash($urlEmail);
                 }
 
                 $action          = $this->generateUrl('mautic_email_unsubscribe', $params);
@@ -245,7 +282,6 @@ final class PublicController extends CommonFormController
                     $viewParameters,
                     $language ?? null,
                     $successSessionName,
-                    $emailDefaultsHelper,
                     $pageModel
                 );
 
@@ -270,22 +306,22 @@ final class PublicController extends CommonFormController
         if (!empty($formContent)) {
             $viewParams['content'] = $formContent;
             if (in_array('form', $config['features'])) {
-                $contentTemplate = $themeHelper->checkForTwigTemplate('@themes/'.$template.'/html/form.html.twig');
+                $contentTemplate = $this->themeHelper->checkForTwigTemplate('@themes/'.$template.'/html/form.html.twig');
             } else {
                 $viewParams['content'] = '';
                 $viewParams['message'] = $message.$formContent;
             }
         }
 
-        return new Response($themeHelper->renderThemeTemplate($contentTemplate, $viewParams));
+        return new Response($this->themeHelper->renderThemeTemplate($contentTemplate, $viewParams));
     }
 
     /**
      * @param array<mixed> $viewParameters
      */
-    private function getPreferenceCenterHtml(Request $request, Lead $lead, ?Email $email, FormView $formView, array $viewParameters, ?string $language, string $successSessionName, EmailDefaultsHelper $emailDefaultsHelper, PageModel $pageModel): ?string
+    private function getPreferenceCenterHtml(Request $request, Lead $lead, ?Email $email, FormView $formView, array $viewParameters, ?string $language, string $successSessionName, PageModel $pageModel): ?string
     {
-        $prefCenter = $email instanceof Email ? $emailDefaultsHelper->resolvePreferenceCenter($email) : null;
+        $prefCenter = $email instanceof Email ? $this->emailDefaultsHelper->resolvePreferenceCenter($email) : null;
         if (!$prefCenter instanceof Page) {
             return null;
         }
@@ -340,7 +376,7 @@ final class PublicController extends CommonFormController
      * @throws \Exception
      * @throws \Mautic\CoreBundle\Exception\FileNotFoundException
      */
-    public function resubscribeAction(ContactTracker $contactTracker, EmailModel $model, MailHashHelper $mailHash, ThemeHelper $themeHelper, AssetsHelper $assetsHelper, AnalyticsHelper $analyticsHelper, $idHash): Response
+    public function resubscribeAction(EmailModel $model, $idHash): Response
     {
         $stat = $model->getEmailStatus($idHash);
 
@@ -350,7 +386,7 @@ final class PublicController extends CommonFormController
 
             if ($lead) {
                 // Set the lead as current lead
-                $contactTracker->setTrackedContact($lead);
+                $this->contactTracker->setTrackedContact($lead);
 
                 if (!$this->translator instanceof LocaleAwareInterface) {
                     throw new \LogicException(sprintf('$this->translator must be an instance of "%s"', LocaleAwareInterface::class));
@@ -366,7 +402,7 @@ final class PublicController extends CommonFormController
 
             $message         = $this->coreParametersHelper->get('resubscribe_message');
             $toEmail         = $stat->getEmailAddress();
-            $unsubscribeHash = $mailHash->getEmailHash($toEmail);
+            $unsubscribeHash = $this->mailHash->getEmailHash($toEmail);
 
             if (!$message) {
                 $message = $this->translator->trans(
@@ -395,27 +431,27 @@ final class PublicController extends CommonFormController
 
         $template = (!empty($email) && 'mautic_code_mode' !== $email->getTemplate()) ? $email->getTemplate() : $this->coreParametersHelper->get('theme');
 
-        $theme = $themeHelper->getTheme($template);
+        $theme = $this->themeHelper->getTheme($template);
 
         if ($theme->getTheme() != $template) {
             $template = $theme->getTheme();
         }
 
         // Ensure template still exists
-        $theme = $themeHelper->getTheme($template);
+        $theme = $this->themeHelper->getTheme($template);
         if (empty($theme) || $theme->getTheme() !== $template) {
             $template = $this->coreParametersHelper->get('theme');
         }
 
-        $analytics = $analyticsHelper->getCode();
+        $analytics = $this->analyticsHelper->getCode();
 
         if (!empty($analytics)) {
-            $assetsHelper->addCustomDeclaration($analytics);
+            $this->assetsHelper->addCustomDeclaration($analytics);
         }
 
-        $logicalName = $themeHelper->checkForTwigTemplate('@themes/'.$template.'/html/message.html.twig');
+        $logicalName = $this->themeHelper->checkForTwigTemplate('@themes/'.$template.'/html/message.html.twig');
 
-        return new Response($themeHelper->renderThemeTemplate(
+        return new Response($this->themeHelper->renderThemeTemplate(
             $logicalName,
             [
                 'message'  => $message,
@@ -442,14 +478,9 @@ final class PublicController extends CommonFormController
      * Preview email.
      */
     public function previewAction(
-        AnalyticsHelper $analyticsHelper,
-        ThemeHelper $themeHelper,
-        AssetsHelper $assetsHelper,
-        EmailConfig $emailConfig,
         EmailModel $model,
         Request $request,
         LeadModel $leadModel,
-        FakeContactHelper $fakeLeadHelper,
         string $objectId,
         ?string $objectType = null,
     ): Response {
@@ -461,7 +492,7 @@ final class PublicController extends CommonFormController
         }
 
         $publicPreview = $emailEntity->isPublicPreview();
-        $draftEnabled  = $emailConfig->isDraftEnabled();
+        $draftEnabled  = $this->emailConfig->isDraftEnabled();
         if ('draft' === $objectType && $draftEnabled && $emailEntity->hasDraft()) {
             $publicPreview = $emailEntity->getDraft()->isPublicPreview();
         }
@@ -500,11 +531,11 @@ final class PublicController extends CommonFormController
         if (empty($content) && $emailEntity->getTemplate()) {
             $template = $emailEntity->getTemplate();
 
-            $assetsHelper->addCustomDeclaration('<meta name="robots" content="noindex">');
+            $this->assetsHelper->addCustomDeclaration('<meta name="robots" content="noindex">');
 
-            $logicalName = $themeHelper->checkForTwigTemplate('@themes/'.$template.'/html/email.html.twig');
+            $logicalName = $this->themeHelper->checkForTwigTemplate('@themes/'.$template.'/html/email.html.twig');
 
-            $content = $themeHelper->renderThemeTemplate(
+            $content = $this->themeHelper->renderThemeTemplate(
                 $logicalName,
                 [
                     'inBrowser' => true,
@@ -522,13 +553,11 @@ final class PublicController extends CommonFormController
         // Prepare contact
         if ($contactId) {
             // We have one from request parameter
-            /** @var LeadModel $leadModel */
             $contact = $this->leadRepository->getLead($contactId);
             $contact = $model->enrichedContactWithCompanies($contact);
         } else {
             // Make fake contact.
-            /** @var FakeContactHelper $fakeLeadHelper */
-            $contact = $fakeLeadHelper->prepareFakeContactWithPrimaryCompany();
+            $contact = $this->fakeLeadHelper->prepareFakeContactWithPrimaryCompany();
         }
         // Generate and replace tokens
         $event = new EmailSendEvent(
@@ -547,7 +576,7 @@ final class PublicController extends CommonFormController
         $content = $event->getContent(true);
 
         if ($this->security->isAnonymous()) {
-            $content = $analyticsHelper->addCode($content);
+            $content = $this->analyticsHelper->addCode($content);
         }
 
         return new Response($content);
@@ -556,14 +585,12 @@ final class PublicController extends CommonFormController
     /**
      * @throws \Exception
      */
-    private function doTracking(Request $request, IntegrationHelper $integrationHelper, MailHelper $mailer, LoggerInterface $mauticLogger, $integration): void
+    private function doTracking(Request $request, $integration): void
     {
-        $logger = $mauticLogger;
-
         // if additional data were sent with the tracking pixel
         $query_string = $request->server->get('QUERY_STRING');
         if (!$query_string) {
-            $logger->log('error', $integration.': query string is not available');
+            $this->mauticLogger->log('error', $integration.': query string is not available');
 
             return;
         }
@@ -576,16 +603,16 @@ final class PublicController extends CommonFormController
 
         // URL attr 'd' is encoded so let's decode it first.
         if (!isset($query['d'], $query['sig'])) {
-            $logger->log('error', $integration.': query variables are not found');
+            $this->mauticLogger->log('error', $integration.': query variables are not found');
 
             return;
         }
 
         // get secret from plugin settings
-        $myIntegration = $integrationHelper->getIntegrationObject($integration);
+        $myIntegration = $this->integrationHelper->getIntegrationObject($integration);
 
         if (!$myIntegration) {
-            $logger->log('error', $integration.': integration not found');
+            $this->mauticLogger->log('error', $integration.': integration not found');
 
             return;
         }
@@ -607,19 +634,19 @@ final class PublicController extends CommonFormController
             parse_str($gz, $query);
         } else {
             // signatures don't match: stop
-            $logger->log('error', $integration.': signatures don\'t match');
+            $this->mauticLogger->log('error', $integration.': signatures don\'t match');
 
             unset($query);
         }
 
         if (empty($query) || !isset($query['email'], $query['subject'], $query['body'])) {
-            $logger->log('error', $integration.': query variables are empty');
+            $this->mauticLogger->log('error', $integration.': query variables are empty');
 
             return;
         }
 
         if (MAUTIC_ENV === 'dev') {
-            $logger->log('error', $integration.': '.json_encode($query, JSON_PRETTY_PRINT));
+            $this->mauticLogger->log('error', $integration.': '.json_encode($query, JSON_PRETTY_PRINT));
         }
 
         // email is a semicolon delimited list of emails
@@ -642,7 +669,7 @@ final class PublicController extends CommonFormController
             // stat doesn't exist, create one
             if (null === $stat) {
                 $lead['email'] = $email; // needed for stat
-                $stat          = $this->addStat($mailer, $lead, $email, $query, $idHash);
+                $stat          = $this->addStat($lead, $email, $query, $idHash);
             }
 
             $stat->setSource('email.client');
@@ -653,9 +680,9 @@ final class PublicController extends CommonFormController
         }
     }
 
-    public function pluginTrackingGifAction(Request $request, IntegrationHelper $integrationHelper, MailHelper $mailer, LoggerInterface $mauticLogger, $integration): Response
+    public function pluginTrackingGifAction(Request $request, $integration): Response
     {
-        $this->doTracking($request, $integrationHelper, $mailer, $mauticLogger, $integration);
+        $this->doTracking($request, $integration);
 
         return TrackingPixelHelper::getResponse($request); // send gif
     }
@@ -663,29 +690,29 @@ final class PublicController extends CommonFormController
     /**
      * @param array<string, mixed> $query
      */
-    private function addStat(MailHelper $mailer, $lead, string $email, array $query, string $idHash): ?Stat
+    private function addStat($lead, string $email, array $query, string $idHash): ?Stat
     {
         if (null !== $lead) {
             // To lead
-            $mailer->addTo($email);
+            $this->mailer->addTo($email);
 
             // sanitize variables to prevent malicious content
             $from = filter_var($query['from'], FILTER_SANITIZE_EMAIL);
-            $mailer->setFrom($from, '');
+            $this->mailer->setFrom($from, '');
 
             // Set Content
             $body = htmlspecialchars(filter_var($query['body'], FILTER_UNSAFE_RAW, FILTER_FLAG_STRIP_HIGH));
-            $mailer->setBody($body);
-            $mailer->parsePlainText($body);
+            $this->mailer->setBody($body);
+            $this->mailer->parsePlainText($body);
 
             // Set lead
-            $mailer->setLead($lead);
-            $mailer->setIdHash($idHash);
+            $this->mailer->setLead($lead);
+            $this->mailer->setIdHash($idHash);
 
             $subject = htmlspecialchars(filter_var($query['subject'], FILTER_UNSAFE_RAW, FILTER_FLAG_STRIP_HIGH));
-            $mailer->setSubject($subject);
+            $this->mailer->setSubject($subject);
 
-            return $mailer->createEmailStat();
+            return $this->mailer->createEmailStat();
         }
 
         return null;
@@ -704,18 +731,18 @@ final class PublicController extends CommonFormController
         return $this->leadRepository->getLeadByEmail($email);
     }
 
-    public function getUnsubscribeMessage(string $idHash, $model, $stat, TranslatorInterface $translator): string
+    public function getUnsubscribeMessage(string $idHash, $model, $stat): string
     {
-        $model->setDoNotContact($stat, $translator->trans('mautic.email.dnc.unsubscribed'), DoNotContact::UNSUBSCRIBED);
+        $model->setDoNotContact($stat, $this->translator->trans('mautic.email.dnc.unsubscribed'), DoNotContact::UNSUBSCRIBED);
 
-        return $this->getUnsubscribeText($translator, $stat->getEmailAddress(), $idHash);
+        return $this->getUnsubscribeText($this->translator, $stat->getEmailAddress(), $idHash);
     }
 
-    public function getUnsubscribeMessageLead(string $idHash, EmailModel $model, Lead $lead, TranslatorInterface $translator, string $urlEmail): string
+    public function getUnsubscribeMessageLead(string $idHash, EmailModel $model, Lead $lead, string $urlEmail): string
     {
-        $model->setDoNotContactLead($lead, $translator->trans('mautic.email.dnc.unsubscribed'), DoNotContact::UNSUBSCRIBED);
+        $model->setDoNotContactLead($lead, $this->translator->trans('mautic.email.dnc.unsubscribed'), DoNotContact::UNSUBSCRIBED);
 
-        return $this->getUnsubscribeText($translator, $urlEmail, $idHash);
+        return $this->getUnsubscribeText($this->translator, $urlEmail, $idHash);
     }
 
     private function getUnsubscribeText(TranslatorInterface $translator, string $email, string $idHash): string

--- a/app/bundles/EmailBundle/Tests/Controller/AjaxControllerTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/AjaxControllerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Mautic\EmailBundle\Tests\Controller;
 
 use Doctrine\Persistence\ManagerRegistry;
+use Mautic\CacheBundle\Cache\CacheProvider;
 use Mautic\CoreBundle\Factory\ModelFactory;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\UserHelper;
@@ -14,14 +15,18 @@ use Mautic\CoreBundle\Translation\Translator;
 use Mautic\EmailBundle\Controller\AjaxController;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Model\EmailModel;
+use Mautic\EmailBundle\MonitoredEmail\Mailbox;
+use Mautic\EmailBundle\Stats\EmailDependencies;
 use PHPUnit\Framework\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ParameterBag\ContainerBagInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\Mailer\Transport\TransportInterface;
 
 final class AjaxControllerTest extends \PHPUnit\Framework\TestCase
 {
@@ -65,7 +70,16 @@ final class AjaxControllerTest extends \PHPUnit\Framework\TestCase
         );
 
         $this->controller->setContainer($containerMock);
-        $this->controller->autowireEmailAjaxController($this->modelMock);
+        $this->controller->autowireEmailAjaxController(
+            $this->modelMock,
+            $this->createStub(FormFactoryInterface::class),
+            $this->createStub(Mailbox::class),
+            $this->createStub(TransportInterface::class),
+            $this->createStub(UserHelper::class),
+            $this->createStub(CoreParametersHelper::class),
+            (new \ReflectionClass(CacheProvider::class))->newInstanceWithoutConstructor(),
+            (new \ReflectionClass(EmailDependencies::class))->newInstanceWithoutConstructor()
+        );
 
         $parameterBag = $this->createMock(ContainerBagInterface::class);
         $parameterBag->expects($this->once())

--- a/app/bundles/EmailBundle/Tests/Controller/EmailControllerTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailControllerTest.php
@@ -6,7 +6,9 @@ namespace Mautic\EmailBundle\Tests\Controller;
 
 use Doctrine\Persistence\ManagerRegistry;
 use Mautic\CoreBundle\Factory\ModelFactory;
+use Mautic\CoreBundle\Factory\PageHelperFactoryInterface;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
+use Mautic\CoreBundle\Helper\ThemeHelper;
 use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\CoreBundle\Model\AuditLogModel;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
@@ -16,6 +18,7 @@ use Mautic\EmailBundle\Controller\EmailController;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Event\ManualWinnerEvent;
 use Mautic\EmailBundle\Form\Type\ExampleSendType;
+use Mautic\EmailBundle\Helper\EmailConfig;
 use Mautic\EmailBundle\Model\EmailModel;
 use Mautic\FormBundle\Helper\FormFieldHelper;
 use Mautic\LeadBundle\Entity\LeadRepository;
@@ -131,7 +134,12 @@ final class EmailControllerTest extends TestCase
             $this->createStub(ListModel::class),
             $this->createStub(AuditLogModel::class),
             $this->modelMock,
-            $this->createStub(LeadRepository::class)
+            $this->createStub(LeadRepository::class),
+            new EmailConfig($this->createStub(CoreParametersHelper::class)),
+            $this->createStub(ThemeHelper::class),
+            $this->corePermissionsMock,
+            $this->createStub(FakeContactHelper::class),
+            $this->createStub(PageHelperFactoryInterface::class)
         );
 
         $this->sessionMock->method('getFlashBag')->willReturn($this->createStub(FlashBagInterface::class));
@@ -254,7 +262,7 @@ final class EmailControllerTest extends TestCase
 
         $request = new Request();
         $this->requestStack->push($request);
-        $this->controller->sendExampleAction($request, 1, $this->corePermissionsMock, $this->modelMock, $this->createStub(LeadModel::class), $this->createStub(FakeContactHelper::class));
+        $this->controller->sendExampleAction($request, 1, $this->modelMock, $this->createStub(LeadModel::class));
     }
 
     public function testWinnerActionForDispatchManualWinnerEvent(): void


### PR DESCRIPTION
Part of #16948 — that PR splits into one PR per bundle, this is EmailBundle.

Services that Symfony autowires per action move to constructor / `#[Required]` injection, so action signatures carry only request data. Applied by `ControllerMethodInjectionToConstructorRector`; the rule itself is enabled in #16948 and should land after all bundles are converted.

`EmailMapStatsController`:

```diff
     public function __construct(
         private readonly EmailModel $model,
+        private readonly CorePermissions $security,
     ) {
     }

-    public function hasAccess(CorePermissions $security, Email $entity): bool
+    public function hasAccess(Email $entity): bool
     {
-        return $security->hasEntityAccess(
+        return $this->security->hasEntityAccess(
             'email:emails:viewown',
             'email:emails:viewother',
             $entity->getCreatedBy()
         );
     }

     public function viewAction(
-        CorePermissions $security,
         int $objectId,
         string $dateFrom = '',
         string $dateTo = '',
     ): Response {
         $entity = $this->model->getEntity($objectId);

-        if (!$entity instanceof Email || !$this->hasAccess($security, $entity)) {
+        if (!$entity instanceof Email || !$this->hasAccess($entity)) {
             throw new AccessDeniedHttpException();
         }
```

`viewAction()` now takes only what the route provides.
