### PR TITLE
[LeadBundle] Move action service injection to constructor injection

### DIFF
--- a/app/bundles/LeadBundle/Controller/AjaxController.php
+++ b/app/bundles/LeadBundle/Controller/AjaxController.php
@@ -54,6 +54,16 @@ final class AjaxController extends CommonAjaxController
     private LeadModel $leadModel;
 
     private DoNotContactRepository $doNotContactRepository;
+    private CorePermissions $corePermissions;
+    private FormFactoryInterface $formFactory;
+    private FormAdjustmentsProviderInterface $formAdjustmentsProvider;
+    private IntegrationHelper $integrationHelper;
+    private IntegrationHelper $helper;
+    private MembershipManager $membershipManager;
+    private ContactColumnsDictionary $contactColumnsDictionary;
+    private MailHelper $mailHelper;
+    private SegmentCampaignShare $segmentCampaignShareService;
+    private SegmentDependencyTreeFactory $segmentDependencyTreeFactory;
 
     #[Required]
     public function autowireLeadAjaxController(
@@ -62,12 +72,32 @@ final class AjaxController extends CommonAjaxController
         LeadFieldRepository $leadFieldRepository,
         LeadModel $leadModel,
         DoNotContactRepository $doNotContactRepository,
+        CorePermissions $corePermissions,
+        FormFactoryInterface $formFactory,
+        FormAdjustmentsProviderInterface $formAdjustmentsProvider,
+        IntegrationHelper $integrationHelper,
+        IntegrationHelper $helper,
+        MembershipManager $membershipManager,
+        ContactColumnsDictionary $contactColumnsDictionary,
+        MailHelper $mailHelper,
+        SegmentCampaignShare $segmentCampaignShareService,
+        SegmentDependencyTreeFactory $segmentDependencyTreeFactory,
     ): void {
         $this->leadModel = $leadModel;
         $this->doNotContactRepository = $doNotContactRepository;
         $this->leadRepository = $leadRepository;
         $this->emailRepository = $emailRepository;
         $this->leadFieldRepository = $leadFieldRepository;
+        $this->corePermissions = $corePermissions;
+        $this->formFactory = $formFactory;
+        $this->formAdjustmentsProvider = $formAdjustmentsProvider;
+        $this->integrationHelper = $integrationHelper;
+        $this->helper = $helper;
+        $this->membershipManager = $membershipManager;
+        $this->contactColumnsDictionary = $contactColumnsDictionary;
+        $this->mailHelper = $mailHelper;
+        $this->segmentCampaignShareService = $segmentCampaignShareService;
+        $this->segmentDependencyTreeFactory = $segmentDependencyTreeFactory;
     }
 
     public function userListAction(Request $request): JsonResponse
@@ -86,12 +116,12 @@ final class AjaxController extends CommonAjaxController
         return $this->sendJsonResponse($dataArray);
     }
 
-    public function contactListAction(Request $request, LeadModel $model, CorePermissions $corePermissions): JsonResponse
+    public function contactListAction(Request $request, LeadModel $model): JsonResponse
     {
         $filter['string'] = InputHelper::clean($request->query->get('filter'));
 
         // Do not show other's contacts if do not have permission.
-        if (!$corePermissions->isGranted(['lead:leads:viewother'], 'MATCH_ONE')) {
+        if (!$this->corePermissions->isGranted(['lead:leads:viewother'], 'MATCH_ONE')) {
             $filter['force'] = ' '.$this->translator->trans('mautic.core.searchcommand.ismine');
         }
 
@@ -151,8 +181,6 @@ final class AjaxController extends CommonAjaxController
 
     public function loadSegmentFilterFormAction(
         Request $request,
-        FormFactoryInterface $formFactory,
-        FormAdjustmentsProviderInterface $formAdjustmentsProvider,
         ListModel $listModel,
     ): JsonResponse {
         $fieldAlias  = InputHelper::clean($request->request->get('fieldAlias'));
@@ -161,10 +189,10 @@ final class AjaxController extends CommonAjaxController
         $search      = InputHelper::clean($request->request->get('search'));
         $filterNum   = (int) $request->request->get('filterNum');
 
-        $form = $formFactory->createNamed('RENAME', FilterPropertiesType::class);
+        $form = $this->formFactory->createNamed('RENAME', FilterPropertiesType::class);
 
         if ($fieldAlias && $operator) {
-            $formAdjustmentsProvider->adjustForm(
+            $this->formAdjustmentsProvider->adjustForm(
                 $form,
                 $fieldAlias,
                 $fieldObject,
@@ -196,7 +224,7 @@ final class AjaxController extends CommonAjaxController
     /**
      * Updates the cache and gets returns updated HTML.
      */
-    public function updateSocialProfileAction(Request $request, IntegrationHelper $integrationHelper): JsonResponse
+    public function updateSocialProfileAction(Request $request): JsonResponse
     {
         $dataArray = ['success' => 0];
         $network   = InputHelper::clean($request->request->get('network'));
@@ -207,8 +235,8 @@ final class AjaxController extends CommonAjaxController
 
             if (null !== $lead && $this->security->hasEntityAccess('lead:leads:editown', 'lead:leads:editown', $lead->getPermissionUser())) {
                 $leadFields        = $lead->getFields();
-                $socialProfiles    = $integrationHelper->getUserProfiles($lead, $leadFields, true, $network);
-                $socialProfileUrls = $integrationHelper->getSocialProfileUrlRegex(false);
+                $socialProfiles    = $this->integrationHelper->getUserProfiles($lead, $leadFields, true, $network);
+                $socialProfileUrls = $this->integrationHelper->getSocialProfileUrlRegex(false);
                 $integrations      = [];
                 $socialCount       = count($socialProfiles);
                 if (empty($network) || empty($socialCount)) {
@@ -223,7 +251,7 @@ final class AjaxController extends CommonAjaxController
                     $dataArray['socialCount'] = $socialCount;
                 } else {
                     foreach ($socialProfiles as $name => $details) {
-                        if ($integrationObject = $integrationHelper->getIntegrationObject($name)) {
+                        if ($integrationObject = $this->integrationHelper->getIntegrationObject($name)) {
                             if ($template = $integrationObject->getSocialProfileTemplate()) {
                                 $integrations[$name]['newContent'] = $this->renderView(
                                     $template,
@@ -250,7 +278,7 @@ final class AjaxController extends CommonAjaxController
     /**
      * Clears the cache for a network.
      */
-    public function clearSocialProfileAction(Request $request, IntegrationHelper $helper): JsonResponse
+    public function clearSocialProfileAction(Request $request): JsonResponse
     {
         $dataArray = ['success' => 0];
         $network   = InputHelper::clean($request->request->get('network'));
@@ -261,7 +289,7 @@ final class AjaxController extends CommonAjaxController
 
             if (null !== $lead && $this->security->hasEntityAccess('lead:leads:editown', 'lead:leads:editown', $lead->getPermissionUser())) {
                 $dataArray['success'] = 1;
-                $socialProfiles       = $helper->clearIntegrationCache($lead, $network);
+                $socialProfiles       = $this->helper->clearIntegrationCache($lead, $network);
                 $socialCount          = count($socialProfiles);
 
                 if (empty($socialCount)) {
@@ -270,7 +298,7 @@ final class AjaxController extends CommonAjaxController
                         [
                             'socialProfiles'    => $socialProfiles,
                             'lead'              => $lead,
-                            'socialProfileUrls' => $helper->getSocialProfileUrlRegex(false),
+                            'socialProfileUrls' => $this->helper->getSocialProfileUrlRegex(false),
                         ]
                     );
                 }
@@ -328,7 +356,7 @@ final class AjaxController extends CommonAjaxController
         return $this->sendJsonResponse($dataArray);
     }
 
-    public function toggleLeadCampaignAction(Request $request, MembershipManager $membershipManager, LeadModel $leadModel, CampaignModel $campaignModel): JsonResponse
+    public function toggleLeadCampaignAction(Request $request, LeadModel $leadModel, CampaignModel $campaignModel): JsonResponse
     {
         if (!$this->security->isGranted('campaign:campaigns:editown')
             && !$this->security->isGranted('campaign:campaigns:editother')) {
@@ -351,11 +379,11 @@ final class AjaxController extends CommonAjaxController
         }
 
         if ('add' === $action) {
-            $membershipManager->addContact($lead, $campaign);
+            $this->membershipManager->addContact($lead, $campaign);
         }
 
         if ('remove' === $action) {
-            $membershipManager->removeContact($lead, $campaign);
+            $this->membershipManager->removeContact($lead, $campaign);
         }
 
         $dataArray['success'] = 1;
@@ -430,7 +458,7 @@ final class AjaxController extends CommonAjaxController
     /**
      * Get the rows for new leads.
      */
-    public function getNewLeadsAction(Request $request, ContactColumnsDictionary $contactColumnsDictionary, LeadModel $model): array|JsonResponse
+    public function getNewLeadsAction(Request $request, LeadModel $model): array|JsonResponse
     {
         $dataArray = ['success' => 0];
         $maxId     = $request->get('maxId');
@@ -503,7 +531,7 @@ final class AjaxController extends CommonAjaxController
                         'security'      => $this->security,
                         'highlight'     => true,
                         'currentList'   => null,
-                        'columns'       => $contactColumnsDictionary->getColumns(),
+                        'columns'       => $this->contactColumnsDictionary->getColumns(),
                     ]
                 )->getContent();
                 $dataArray['indexMode'] = $indexMode;
@@ -515,7 +543,7 @@ final class AjaxController extends CommonAjaxController
         return $this->sendJsonResponse($dataArray);
     }
 
-    public function getEmailTemplateAction(Request $request, EmailModel $model, MailHelper $mailHelper): JsonResponse
+    public function getEmailTemplateAction(Request $request, EmailModel $model): JsonResponse
     {
         $data    = ['success' => 1, 'body' => '', 'subject' => ''];
         $emailId = $request->query->get('template');
@@ -530,10 +558,10 @@ final class AjaxController extends CommonAjaxController
                 $email->getCreatedBy()
             )
         ) {
-            $mailHelper->setEmail($email, true, [], true);
+            $this->mailHelper->setEmail($email, true, [], true);
 
-            $data['body']    = $mailHelper->getBody();
-            $data['subject'] = $mailHelper->getSubject();
+            $data['body']    = $this->mailHelper->getBody();
+            $data['subject'] = $this->mailHelper->getSubject();
         }
 
         return $this->sendJsonResponse($data);
@@ -770,12 +798,12 @@ final class AjaxController extends CommonAjaxController
         return $this->sendJsonResponse($dataArray);
     }
 
-    public function getCampaignShareStatsAction(Request $request, SegmentCampaignShare $segmentCampaignShareService): JsonResponse
+    public function getCampaignShareStatsAction(Request $request): JsonResponse
     {
         $ids      = $request->query->all()['ids'] ?? [];
         $entityid = $request->query->get('entityId');
 
-        $data = $segmentCampaignShareService->getCampaignsSegmentShare((int) $entityid, $ids);
+        $data = $this->segmentCampaignShareService->getCampaignsSegmentShare((int) $entityid, $ids);
 
         $data = [
             'success' => 1,
@@ -808,7 +836,7 @@ final class AjaxController extends CommonAjaxController
         );
     }
 
-    public function getSegmentDependencyTreeAction(Request $request, SegmentDependencyTreeFactory $segmentDependencyTreeFactory, ListModel $model): JsonResponse
+    public function getSegmentDependencyTreeAction(Request $request, ListModel $model): JsonResponse
     {
         $id      = (int) $request->get('id');
         $segment = $model->getEntity($id);
@@ -817,7 +845,7 @@ final class AjaxController extends CommonAjaxController
             return new JsonResponse(['message' => "Segment {$id} could not be found."], Response::HTTP_NOT_FOUND);
         }
 
-        $parentNode = $segmentDependencyTreeFactory->buildTree($segment);
+        $parentNode = $this->segmentDependencyTreeFactory->buildTree($segment);
         $formatter  = new JsPlumbFormatter();
 
         return new JsonResponse($formatter->format($parentNode));

--- a/app/bundles/LeadBundle/Controller/AuditlogController.php
+++ b/app/bundles/LeadBundle/Controller/AuditlogController.php
@@ -13,6 +13,8 @@ final class AuditlogController extends CommonController
 {
     use LeadAccessTrait;
     use LeadDetailsTrait;
+    private DateHelper $dateHelper;
+    private ExportHelper $exportHelper;
 
     public function indexAction(Request $request, $leadId, int $page = 1): Response
     {
@@ -64,7 +66,7 @@ final class AuditlogController extends CommonController
         );
     }
 
-    public function batchExportAction(Request $request, DateHelper $dateHelper, ExportHelper $exportHelper, $leadId): Response|\Symfony\Component\HttpFoundation\StreamedResponse
+    public function batchExportAction(Request $request, $leadId): Response|\Symfony\Component\HttpFoundation\StreamedResponse
     {
         if (empty($leadId)) {
             $this->throwAccessDenied();
@@ -100,7 +102,7 @@ final class AuditlogController extends CommonController
 
         $dataType = $request->get('filetype', 'csv');
 
-        $resultsCallback = function (array $event) use ($dateHelper): array {
+        $resultsCallback = function (array $event): array {
             $userName = $event['userName'] ?? $event['eventType'];
             if (is_array($userName)) {
                 $userName = $userName['label'];
@@ -109,7 +111,7 @@ final class AuditlogController extends CommonController
             return [
                 'userName'       => $userName,
                 'eventType'      => $event['eventType'] ?? '',
-                'eventTimestamp' => $dateHelper->toText($event['timestamp'], 'local', 'Y-m-d H:i:s', true),
+                'eventTimestamp' => $this->dateHelper->toText($event['timestamp'], 'local', 'Y-m-d H:i:s', true),
             ];
         };
 
@@ -144,6 +146,15 @@ final class AuditlogController extends CommonController
             ++$loop;
         }
 
-        return $this->exportResultsAs($toExport, $dataType, 'contact_auditlog', $exportHelper);
+        return $this->exportResultsAs($toExport, $dataType, 'contact_auditlog', $this->exportHelper);
+    }
+
+    #[\Symfony\Contracts\Service\Attribute\Required]
+    public function autowireAuditlogController(
+        DateHelper $dateHelper,
+        ExportHelper $exportHelper,
+    ): void {
+        $this->dateHelper = $dateHelper;
+        $this->exportHelper = $exportHelper;
     }
 }

--- a/app/bundles/LeadBundle/Controller/CompanyController.php
+++ b/app/bundles/LeadBundle/Controller/CompanyController.php
@@ -34,6 +34,10 @@ final class CompanyController extends FormController
     private CompanyModel $companyModel;
 
     private LeadModel $leadModel;
+    private PageHelperFactoryInterface $pageHelperFactory;
+    private CompanyColumnsDictionary $companyColumnsDictionary;
+    private CustomFieldFindReplace $findReplace;
+    private ExportHelper $exportHelper;
 
     #[Required]
     public function autowireCompanyController(
@@ -41,14 +45,22 @@ final class CompanyController extends FormController
         CompanyModel $companyModel,
         FieldModel $fieldModel,
         CompanyRepository $companyRepository,
+        PageHelperFactoryInterface $pageHelperFactory,
+        CompanyColumnsDictionary $companyColumnsDictionary,
+        CustomFieldFindReplace $findReplace,
+        ExportHelper $exportHelper,
     ): void {
         $this->leadModel = $leadModel;
         $this->companyModel = $companyModel;
         $this->fieldModel = $fieldModel;
         $this->companyRepository = $companyRepository;
+        $this->pageHelperFactory = $pageHelperFactory;
+        $this->companyColumnsDictionary = $companyColumnsDictionary;
+        $this->findReplace = $findReplace;
+        $this->exportHelper = $exportHelper;
     }
 
-    public function indexAction(Request $request, PageHelperFactoryInterface $pageHelperFactory, CompanyColumnsDictionary $companyColumnsDictionary, int $page = 1): Response
+    public function indexAction(Request $request, int $page = 1): Response
     {
         // set some permissions
         $permissions = $this->security->isGranted(
@@ -70,7 +82,7 @@ final class CompanyController extends FormController
 
         $this->setListFilters();
 
-        $pageHelper = $pageHelperFactory->make('mautic.company', $page);
+        $pageHelper = $this->pageHelperFactory->make('mautic.company', $page);
 
         $limit      = $pageHelper->getLimit();
         $start      = $pageHelper->getStart();
@@ -124,7 +136,7 @@ final class CompanyController extends FormController
                 'viewParameters' => [
                     'searchValue' => $search,
                     'leadCounts'  => $leadCounts,
-                    'columns'     => $companyColumnsDictionary->getColumns(),
+                    'columns'     => $this->companyColumnsDictionary->getColumns(),
                     'items'       => $companies,
                     'page'        => $page,
                     'limit'       => $limit,
@@ -819,7 +831,7 @@ final class CompanyController extends FormController
     /**
      * Bulk find and replace company field values.
      */
-    public function batchFindReplaceAction(Request $request, CompanyModel $model, CustomFieldFindReplace $findReplace): JsonResponse|Response
+    public function batchFindReplaceAction(Request $request, CompanyModel $model): JsonResponse|Response
     {
         $permissions = $this->security->isGranted(
             [
@@ -839,13 +851,13 @@ final class CompanyController extends FormController
         }
 
         if (Request::METHOD_POST === $request->getMethod()) {
-            return $this->processCompanyFindReplace($request, $model, $findReplace);
+            return $this->processCompanyFindReplace($request, $model);
         }
 
-        return $this->createCompanyFindReplaceFormResponse($request, $findReplace);
+        return $this->createCompanyFindReplaceFormResponse($request);
     }
 
-    private function processCompanyFindReplace(Request $request, CompanyModel $model, CustomFieldFindReplace $findReplace): JsonResponse
+    private function processCompanyFindReplace(Request $request, CompanyModel $model): JsonResponse
     {
         $requestData = $request->request->all();
         $data        = $requestData['lead_batch_find_replace'] ?? $requestData['find_replace'] ?? [];
@@ -855,7 +867,7 @@ final class CompanyController extends FormController
 
         if (is_string($fieldAlias) && is_array($ids)) {
             $entities = $this->getCompanyFindReplaceEntities($request, $model, $data, $ids);
-            $updated  = $this->replaceCompanyFieldValues($findReplace, $fieldAlias, $data, $entities, $model);
+            $updated  = $this->replaceCompanyFieldValues($fieldAlias, $data, $entities, $model);
 
             if ([] !== $updated) {
                 $model->saveEntities($updated);
@@ -913,10 +925,10 @@ final class CompanyController extends FormController
      *
      * @return array<int, Company>
      */
-    private function replaceCompanyFieldValues(CustomFieldFindReplace $findReplace, string $fieldAlias, array $data, iterable $entities, CompanyModel $model): array
+    private function replaceCompanyFieldValues(string $fieldAlias, array $data, iterable $entities, CompanyModel $model): array
     {
         /** @var array<int, Company> $updated */
-        $updated = $findReplace->replace(
+        $updated = $this->findReplace->replace(
             new CustomFieldFindReplaceCriteria('company', $fieldAlias, $data['find'] ?? null, $data['replace'] ?? null),
             $entities,
             function (CustomFieldEntityInterface $company, array $values) use ($model): void {
@@ -942,7 +954,7 @@ final class CompanyController extends FormController
         return $updated;
     }
 
-    private function createCompanyFindReplaceFormResponse(Request $request, CustomFieldFindReplace $findReplace): Response
+    private function createCompanyFindReplaceFormResponse(Request $request): Response
     {
         $route = $this->generateUrl(
             'mautic_company_action',
@@ -957,7 +969,7 @@ final class CompanyController extends FormController
                     'form' => $this->formFactory->createNamed('lead_batch_find_replace', FindReplaceType::class, [], [
                         'action'        => $route,
                         'all_items'     => $request->query->getBoolean('all'),
-                        'field_choices' => $findReplace->getFieldChoices('company'),
+                        'field_choices' => $this->findReplace->getFieldChoices('company'),
                         'field_label'   => 'mautic.company.batch.find_replace.field',
                     ])->createView(),
                 ],
@@ -1147,7 +1159,7 @@ final class CompanyController extends FormController
     /**
      * Export company's data.
      */
-    public function companyExportAction(Request $request, ExportHelper $exportHelper, $companyId): Response|\Symfony\Component\HttpFoundation\StreamedResponse
+    public function companyExportAction(Request $request, $companyId): Response|\Symfony\Component\HttpFoundation\StreamedResponse
     {
         // set some permissions
         $permissions = $this->security->isGranted(
@@ -1177,6 +1189,6 @@ final class CompanyController extends FormController
             ];
         }
 
-        return $this->exportResultsAs($export, $dataType, 'company_data_'.($companyFields['companyemail'] ?: $companyFields['id']), $exportHelper);
+        return $this->exportResultsAs($export, $dataType, 'company_data_'.($companyFields['companyemail'] ?: $companyFields['id']), $this->exportHelper);
     }
 }

--- a/app/bundles/LeadBundle/Controller/FieldController.php
+++ b/app/bundles/LeadBundle/Controller/FieldController.php
@@ -20,12 +20,15 @@ use Symfony\Contracts\Service\Attribute\Required;
 final class FieldController extends FormController
 {
     private FieldModel $fieldModel;
+    private FieldAliasHelper $fieldAliasHelper;
 
     #[Required]
     public function autowireFieldController(
         FieldModel $fieldModel,
+        FieldAliasHelper $fieldAliasHelper,
     ): void {
         $this->fieldModel = $fieldModel;
+        $this->fieldAliasHelper = $fieldAliasHelper;
     }
 
     /**
@@ -367,7 +370,7 @@ final class FieldController extends FormController
     /**
      * Clone an entity.
      */
-    public function cloneAction(Request $request, FieldAliasHelper $fieldAliasHelper, FieldModel $fieldModel, $objectId): RedirectResponse|Response
+    public function cloneAction(Request $request, FieldModel $fieldModel, $objectId): RedirectResponse|Response
     {
         $entity = $fieldModel->getEntity($objectId);
 
@@ -377,7 +380,7 @@ final class FieldController extends FormController
 
         $clone = clone $entity;
 
-        $fieldAliasHelper->makeAliasUnique($clone);
+        $this->fieldAliasHelper->makeAliasUnique($clone);
 
         $action    = $this->generateUrl('mautic_contactfield_action', ['objectAction' => 'new']);
         $form      = $fieldModel->createForm($clone, $this->formFactory, $action);

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -8,7 +8,6 @@ use Mautic\CampaignBundle\Model\CampaignModel;
 use Mautic\CoreBundle\Cache\ResultCacheOptions;
 use Mautic\CoreBundle\Controller\FormController;
 use Mautic\CoreBundle\Form\Type\FindReplaceType;
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\ExportHelper;
 use Mautic\CoreBundle\Helper\IpLookupHelper;
 use Mautic\CoreBundle\Helper\UserHelper;
@@ -102,6 +101,17 @@ final class LeadController extends FormController
     private DoNotContactRepository $doNotContactRepository;
 
     private EmailRepository $emailRepository;
+    private ContactColumnsDictionary $contactColumnsDictionary;
+    private TokenStorageInterface $tokenStorage;
+    private IntegrationHelper $integrationHelper;
+    private UserHelper $userHelper;
+    private AvatarHelper $avatarHelper;
+    private ContactMerger $contactMerger;
+    private MailHelper $mailHelper;
+    private MembershipManager $membershipManager;
+    private CustomFieldFindReplace $findReplace;
+    private ExportHelper $exportHelper;
+    private IpLookupHelper $ipLookupHelper;
 
     #[Required]
     public function autowireLeadController(
@@ -120,6 +130,17 @@ final class LeadController extends FormController
         UserRepository $userRepository,
         DoNotContactRepository $doNotContactRepository,
         EmailRepository $emailRepository,
+        ContactColumnsDictionary $contactColumnsDictionary,
+        TokenStorageInterface $tokenStorage,
+        IntegrationHelper $integrationHelper,
+        UserHelper $userHelper,
+        AvatarHelper $avatarHelper,
+        ContactMerger $contactMerger,
+        MailHelper $mailHelper,
+        MembershipManager $membershipManager,
+        CustomFieldFindReplace $findReplace,
+        ExportHelper $exportHelper,
+        IpLookupHelper $ipLookupHelper,
     ): void {
         $this->leadModel = $leadModel;
         $this->stageModel = $stageModel;
@@ -136,6 +157,17 @@ final class LeadController extends FormController
         $this->userRepository = $userRepository;
         $this->doNotContactRepository = $doNotContactRepository;
         $this->emailRepository = $emailRepository;
+        $this->contactColumnsDictionary = $contactColumnsDictionary;
+        $this->tokenStorage = $tokenStorage;
+        $this->integrationHelper = $integrationHelper;
+        $this->userHelper = $userHelper;
+        $this->avatarHelper = $avatarHelper;
+        $this->contactMerger = $contactMerger;
+        $this->mailHelper = $mailHelper;
+        $this->membershipManager = $membershipManager;
+        $this->findReplace = $findReplace;
+        $this->exportHelper = $exportHelper;
+        $this->ipLookupHelper = $ipLookupHelper;
     }
 
     /**
@@ -144,7 +176,6 @@ final class LeadController extends FormController
     public function indexAction(
         Request $request,
         DoNotContactModel $leadDNCModel,
-        ContactColumnsDictionary $contactColumnsDictionary,
         $page = 1,
     ): Response {
         // set some permissions
@@ -281,7 +312,7 @@ final class LeadController extends FormController
             [
                 'viewParameters' => [
                     'searchValue'      => $search,
-                    'columns'          => $contactColumnsDictionary->getColumns(),
+                    'columns'          => $this->contactColumnsDictionary->getColumns(),
                     'items'            => $leads,
                     'page'             => $page,
                     'totalItems'       => $count,
@@ -307,7 +338,7 @@ final class LeadController extends FormController
         );
     }
 
-    public function quickAddAction(Request $request, TokenStorageInterface $tokenStorage): Response
+    public function quickAddAction(Request $request): Response
     {
         // set some permissions
         $permissions = $this->security->isGranted(
@@ -373,7 +404,7 @@ final class LeadController extends FormController
         $quickForm = $this->leadModel->createForm($this->leadModel->getEntity(), $this->formFactory, $action, ['fields' => $fields, 'isShortForm' => true]);
 
         // set the default owner to the currently logged in user
-        $currentUser = $tokenStorage->getToken()->getUser();
+        $currentUser = $this->tokenStorage->getToken()->getUser();
         $quickForm->get('owner')->setData($currentUser);
 
         if ($request->isMethod(Request::METHOD_POST)) {
@@ -398,7 +429,7 @@ final class LeadController extends FormController
     /**
      * Loads a specific lead into the detailed panel.
      */
-    public function viewAction(Request $request, IntegrationHelper $integrationHelper, PointGroupModel $pointGroupModel, CoreParametersHelper $coreParametersHelper, $objectId): Response
+    public function viewAction(Request $request, PointGroupModel $pointGroupModel, $objectId): Response
     {
         $lead = $this->leadModel->getEntity($objectId);
 
@@ -455,13 +486,13 @@ final class LeadController extends FormController
         }
 
         $fields            = $lead->getFields();
-        $socialProfiles    = (array) $integrationHelper->getUserProfiles($lead, $fields);
-        $socialProfileUrls = $integrationHelper->getSocialProfileUrlRegex(false);
+        $socialProfiles    = (array) $this->integrationHelper->getUserProfiles($lead, $fields);
+        $socialProfileUrls = $this->integrationHelper->getSocialProfileUrlRegex(false);
 
         $companies     = $this->companyRepository->getCompaniesByLeadId($objectId);
         // Set the social profile templates
         foreach ($socialProfiles as $integration => &$details) {
-            if ($integrationObject = $integrationHelper->getIntegrationObject($integration)) {
+            if ($integrationObject = $this->integrationHelper->getIntegrationObject($integration)) {
                 if ($template = $integrationObject->getSocialProfileTemplate()) {
                     $details['social_profile_template'] = $template;
                 }
@@ -515,7 +546,7 @@ final class LeadController extends FormController
                     //    ]
                     // )->getContent(),
                 ],
-                'allowMultipleCompanies' => $coreParametersHelper->get('contact_allow_multiple_companies'),
+                'allowMultipleCompanies' => $this->coreParametersHelper->get('contact_allow_multiple_companies'),
                 'contentTemplate'        => '@MauticLead/Lead/lead.html.twig',
                 'passthroughVars'        => [
                     'activeLink'    => '#mautic_contact_index',
@@ -535,7 +566,7 @@ final class LeadController extends FormController
     /**
      * Generates new form and processes post data.
      */
-    public function newAction(Request $request, UserHelper $userHelper, AvatarHelper $avatarHelper, TokenStorageInterface $tokenStorage): Response
+    public function newAction(Request $request): Response
     {
         $lead  = $this->leadModel->getEntity();
 
@@ -581,7 +612,7 @@ final class LeadController extends FormController
                         'lead',
                         'lead',
                         null,
-                        $userHelper->getUser()->getName()
+                        $this->userHelper->getUser()->getName()
                     ));
 
                     // Save here as we need the entity with an ID for the company code bellow.
@@ -599,7 +630,7 @@ final class LeadController extends FormController
                     if ('custom' === $image) {
                         // Check for a file
                         if ($form['custom_avatar']->getData()) {
-                            $this->uploadAvatar($request, $avatarHelper, $lead);
+                            $this->uploadAvatar($request, $lead);
                         }
                     }
 
@@ -634,11 +665,11 @@ final class LeadController extends FormController
                         $returnUrl = $this->generateUrl('mautic_contact_action', $viewParameters);
                         $template  = 'Mautic\LeadBundle\Controller\LeadController::viewAction';
                     } else {
-                        return $this->editAction($request, $userHelper, $avatarHelper, $lead->getId(), true);
+                        return $this->editAction($request, $lead->getId(), true);
                     }
                 } else {
                     if ($request->get('qf', false)) {
-                        return $this->quickAddAction($request, $tokenStorage);
+                        return $this->quickAddAction($request);
                     }
 
                     $formErrors = $this->getFormErrorMessages($form);
@@ -670,7 +701,7 @@ final class LeadController extends FormController
             }
         } else {
             // set the default owner to the currently logged in user
-            $currentUser = $tokenStorage->getToken()->getUser();
+            $currentUser = $this->tokenStorage->getToken()->getUser();
             $form->get('owner')->setData($currentUser);
         }
 
@@ -701,7 +732,7 @@ final class LeadController extends FormController
      *
      * @param bool|false $ignorePost
      */
-    public function editAction(Request $request, UserHelper $userHelper, AvatarHelper $avatarHelper, $objectId, $ignorePost = false): Response
+    public function editAction(Request $request, $objectId, $ignorePost = false): Response
     {
         $lead  = $this->leadModel->getEntity($objectId);
 
@@ -783,7 +814,7 @@ final class LeadController extends FormController
                         'lead',
                         'lead',
                         $objectId,
-                        $userHelper->getUser()->getName()
+                        $this->userHelper->getUser()->getName()
                     ));
                     $this->leadModel->modifyCompanies($lead, $companies);
                     $this->leadModel->saveEntity($lead, $this->getFormButton($form, ['buttons', 'save'])->isClicked());
@@ -794,7 +825,7 @@ final class LeadController extends FormController
                         // Check for a file
                         $file = $form['custom_avatar']->getData();
                         if ($file instanceof UploadedFile) {
-                            $this->uploadAvatar($request, $avatarHelper, $lead);
+                            $this->uploadAvatar($request, $lead);
 
                             // Note the avatar update so that it can be forced to update
                             $request->getSession()->set('mautic.lead.avatar.updated', true);
@@ -883,11 +914,11 @@ final class LeadController extends FormController
     /**
      * Upload an asset.
      */
-    private function uploadAvatar(Request $request, AvatarHelper $avatarHelper, Lead $lead): void
+    private function uploadAvatar(Request $request, Lead $lead): void
     {
         $leadInformation = $request->files->get('lead', []);
         $file            = $leadInformation['custom_avatar'] ?? null;
-        $avatarDir       = $avatarHelper->getAvatarPath(true);
+        $avatarDir       = $this->avatarHelper->getAvatarPath(true);
 
         if (!file_exists($avatarDir)) {
             mkdir($avatarDir);
@@ -902,7 +933,7 @@ final class LeadController extends FormController
     /**
      * Generates merge form and action.
      */
-    public function mergeAction(Request $request, ContactMerger $contactMerger, $objectId): Response
+    public function mergeAction(Request $request, $objectId): Response
     {
         $mainLead = $this->leadModel->getEntity($objectId);
         $page     = $request->getSession()->get('mautic.lead.page', 1);
@@ -1026,7 +1057,7 @@ final class LeadController extends FormController
 
                     // Both leads are good so now we merge them
                     try {
-                        $mainLead = $contactMerger->merge($mainLead, $secLead);
+                        $mainLead = $this->contactMerger->merge($mainLead, $secLead);
                     } catch (SameContactException) {
                     }
                 }
@@ -1402,7 +1433,7 @@ final class LeadController extends FormController
     /**
      * @param int $objectId
      */
-    public function emailAction(Request $request, UserHelper $userHelper, MailHelper $mailHelper, LeadModel $leadModel, EmailModel $emailModel, $objectId = 0): JsonResponse|Response
+    public function emailAction(Request $request, LeadModel $leadModel, EmailModel $emailModel, $objectId = 0): JsonResponse|Response
     {
         $valid = $cancelled = false;
 
@@ -1426,7 +1457,7 @@ final class LeadController extends FormController
         $mailerIsOwner    = $this->coreParametersHelper->get('mailer_is_owner');
 
         // Set onwer ID to be the current user ID so it will use his signature
-        $leadFields['owner_id'] = $userHelper->getUser()->getId();
+        $leadFields['owner_id'] = $this->userHelper->getUser()->getId();
 
         $inList = ('GET' === $request->getMethod())
             ? $request->get('list', 0)
@@ -1464,7 +1495,7 @@ final class LeadController extends FormController
                 if ($valid = $this->isFormValid($form)) {
                     $email = $form->getData();
 
-                    $mailer      = $mailHelper->getMailer();
+                    $mailer      = $this->mailHelper->getMailer();
                     $emailEntity = null;
                     $subject     = $email['subject'];
 
@@ -1593,7 +1624,7 @@ final class LeadController extends FormController
      *
      * @param int $objectId
      */
-    public function batchCampaignsAction(Request $request, MembershipManager $membershipManager, $objectId = 0): JsonResponse|Response
+    public function batchCampaignsAction(Request $request, $objectId = 0): JsonResponse|Response
     {
         if ('POST' === $request->getMethod()) {
             $data  = $request->request->all()['lead_batch'] ?? [];
@@ -1644,13 +1675,13 @@ final class LeadController extends FormController
 
                 if (!empty($add)) {
                     foreach ($add as $cid) {
-                        $membershipManager->addContacts(new ArrayCollection($entities), $campaigns[$cid]);
+                        $this->membershipManager->addContacts(new ArrayCollection($entities), $campaigns[$cid]);
                     }
                 }
 
                 if (!empty($remove)) {
                     foreach ($remove as $cid) {
-                        $membershipManager->removeContacts(new ArrayCollection($entities), $campaigns[$cid]);
+                        $this->membershipManager->removeContacts(new ArrayCollection($entities), $campaigns[$cid]);
                     }
                 }
             }
@@ -1973,7 +2004,7 @@ final class LeadController extends FormController
     /**
      * Bulk find and replace contact field values.
      */
-    public function batchFindReplaceAction(Request $request, LeadModel $model, CustomFieldFindReplace $findReplace): JsonResponse|Response
+    public function batchFindReplaceAction(Request $request, LeadModel $model): JsonResponse|Response
     {
         $permissions = $this->security->isGranted(
             [
@@ -1993,16 +2024,16 @@ final class LeadController extends FormController
         }
 
         if (Request::METHOD_POST === $request->getMethod()) {
-            return $this->processContactFindReplace($request, $model, $findReplace, $permissions);
+            return $this->processContactFindReplace($request, $model, $permissions);
         }
 
-        return $this->createContactFindReplaceFormResponse($request, $findReplace);
+        return $this->createContactFindReplaceFormResponse($request);
     }
 
     /**
      * @param array<string, bool> $permissions
      */
-    private function processContactFindReplace(Request $request, LeadModel $model, CustomFieldFindReplace $findReplace, array $permissions): JsonResponse
+    private function processContactFindReplace(Request $request, LeadModel $model, array $permissions): JsonResponse
     {
         $requestData = $request->request->all();
         $data        = $requestData['lead_batch_find_replace'] ?? $requestData['find_replace'] ?? [];
@@ -2012,7 +2043,7 @@ final class LeadController extends FormController
 
         if (is_string($fieldAlias) && is_array($ids)) {
             $entities = $this->getContactFindReplaceEntities($request, $model, $data, $ids, $permissions);
-            $updated  = $this->replaceContactFieldValues($findReplace, $fieldAlias, $data, $entities, $model);
+            $updated  = $this->replaceContactFieldValues($fieldAlias, $data, $entities, $model);
 
             if ([] !== $updated) {
                 $model->saveEntities($updated);
@@ -2071,10 +2102,10 @@ final class LeadController extends FormController
      *
      * @return array<int, Lead>
      */
-    private function replaceContactFieldValues(CustomFieldFindReplace $findReplace, string $fieldAlias, array $data, iterable $entities, LeadModel $model): array
+    private function replaceContactFieldValues(string $fieldAlias, array $data, iterable $entities, LeadModel $model): array
     {
         /** @var array<int, Lead> $updated */
-        $updated = $findReplace->replace(
+        $updated = $this->findReplace->replace(
             new CustomFieldFindReplaceCriteria('lead', $fieldAlias, $data['find'] ?? null, $data['replace'] ?? null),
             $entities,
             function (CustomFieldEntityInterface $lead, array $values) use ($model): void {
@@ -2100,7 +2131,7 @@ final class LeadController extends FormController
         return $updated;
     }
 
-    private function createContactFindReplaceFormResponse(Request $request, CustomFieldFindReplace $findReplace): Response
+    private function createContactFindReplaceFormResponse(Request $request): Response
     {
         $route = $this->generateUrl(
             'mautic_contact_action',
@@ -2115,7 +2146,7 @@ final class LeadController extends FormController
                     'form' => $this->formFactory->createNamed('lead_batch_find_replace', FindReplaceType::class, [], [
                         'action'        => $route,
                         'all_items'     => $request->query->getBoolean('all'),
-                        'field_choices' => $findReplace->getFieldChoices('lead'),
+                        'field_choices' => $this->findReplace->getFieldChoices('lead'),
                         'field_label'   => 'mautic.lead.batch.find_replace.field',
                     ])->createView(),
                 ],
@@ -2159,7 +2190,7 @@ final class LeadController extends FormController
      *
      * @throws \Exception
      */
-    public function batchExportAction(Request $request, ExportHelper $exportHelper, EventDispatcherInterface $dispatcher): Response
+    public function batchExportAction(Request $request): Response
     {
         // set some permissions
         $permissions = $this->security->isGranted(
@@ -2241,20 +2272,20 @@ final class LeadController extends FormController
         }
 
         if ('csv' === $fileType && $this->coreParametersHelper->get('contact_export_in_background', false)) {
-            return $this->contactExportCSVScheduler($dispatcher, $permissions);
+            return $this->contactExportCSVScheduler($this->dispatcher, $permissions);
         }
 
         $iterator = new IteratorExportDataModel(
             $this->leadModel,
             $args,
-            fn (Lead $contact): array => $exportHelper->parseLeadToExport($contact)
+            fn (Lead $contact): array => $this->exportHelper->parseLeadToExport($contact)
         );
-        $response = $this->exportResultsAs($iterator, $fileType, 'contacts', $exportHelper);
+        $response = $this->exportResultsAs($iterator, $fileType, 'contacts', $this->exportHelper);
 
         $details['total'] = $iterator->getTotal();
         $details['args']  = $iterator->getArgs();
 
-        $dispatcher->dispatch(
+        $this->dispatcher->dispatch(
             new ContactExportEvent($details, 'ContactExports'),
             LeadEvents::POST_CONTACT_EXPORT
         );
@@ -2262,7 +2293,7 @@ final class LeadController extends FormController
         return $response;
     }
 
-    public function contactExportAction(Request $request, ExportHelper $exportHelper, EventDispatcherInterface $dispatcher, $contactId): Response|\Symfony\Component\HttpFoundation\StreamedResponse
+    public function contactExportAction(Request $request, $contactId): Response|\Symfony\Component\HttpFoundation\StreamedResponse
     {
         // set some permissions
         $permissions = $this->security->isGranted(
@@ -2299,12 +2330,12 @@ final class LeadController extends FormController
             ];
         }
 
-        $dispatcher->dispatch(
+        $this->dispatcher->dispatch(
             new ContactExportEvent($args, 'ContactExport'),
             LeadEvents::POST_CONTACT_EXPORT
         );
 
-        return $this->exportResultsAs($export, $dataType, 'contact_data_'.($contactFields['email'] ?: $contactFields['id']), $exportHelper);
+        return $this->exportResultsAs($export, $dataType, 'contact_data_'.($contactFields['email'] ?: $contactFields['id']), $this->exportHelper);
     }
 
     public function downloadExportAction(string $fileName = ''): Response
@@ -2374,7 +2405,6 @@ final class LeadController extends FormController
         Request $request,
         LeadModel $model,
         PointGroupModel $pointGroupModel,
-        IpLookupHelper $ipLookupHelper,
         int $objectId): Response
     {
         $lead  = $model->getEntity($objectId);
@@ -2432,7 +2462,7 @@ final class LeadController extends FormController
                             $log->setType('manual');
                             $log->setEventName($this->translator->trans('mautic.point.event.manual_change'));
                             $log->setActionName('');
-                            $log->setIpAddress($ipLookupHelper->getIpAddress());
+                            $log->setIpAddress($this->ipLookupHelper->getIpAddress());
                             $log->setDateAdded(new \DateTime());
                             $log->setGroup($group);
                             $lead->addPointsChangeLog($log);

--- a/app/bundles/LeadBundle/Controller/ListController.php
+++ b/app/bundles/LeadBundle/Controller/ListController.php
@@ -37,16 +37,25 @@ final class ListController extends FormController
     private ListModel $listModel;
 
     private LeadModel $leadModel;
+    private SegmentDependencies $segmentDependencies;
+    private SegmentCampaignShare $segmentCampaignShare;
+    private PageHelperFactoryInterface $pageHelperFactory;
 
     #[Required]
     public function autowireListController(
         LeadModel $leadModel,
         ListModel $listModel,
         LeadListRepository $leadListRepository,
+        SegmentDependencies $segmentDependencies,
+        SegmentCampaignShare $segmentCampaignShare,
+        PageHelperFactoryInterface $pageHelperFactory,
     ): void {
         $this->leadModel = $leadModel;
         $this->listModel = $listModel;
         $this->leadListRepository = $leadListRepository;
+        $this->segmentDependencies = $segmentDependencies;
+        $this->segmentCampaignShare = $segmentCampaignShare;
+        $this->pageHelperFactory = $pageHelperFactory;
     }
 
     public const ROUTE_SEGMENT_CONTACTS = 'mautic_segment_contacts';
@@ -183,7 +192,7 @@ final class ListController extends FormController
     /**
      * Generate's new form and processes post data.
      */
-    public function newAction(Request $request, SegmentDependencies $segmentDependencies, SegmentCampaignShare $segmentCampaignShare, ListModel $listModel, AuditLogModel $auditLogModel): Response
+    public function newAction(Request $request, ListModel $listModel, AuditLogModel $auditLogModel): Response
     {
         if (!$this->security->isGranted(LeadPermissions::LISTS_CREATE)) {
             $this->throwAccessDenied();
@@ -195,8 +204,6 @@ final class ListController extends FormController
         return $this->createSegmentNewResponse(
             $request,
             $list,
-            $segmentDependencies,
-            $segmentCampaignShare,
             $listModel,
             $auditLogModel,
             [],
@@ -211,7 +218,7 @@ final class ListController extends FormController
      * @param int  $objectId
      * @param bool $ignorePost
      */
-    public function cloneAction(Request $request, SegmentDependencies $segmentDependencies, SegmentCampaignShare $segmentCampaignShare, ListModel $listModel, AuditLogModel $auditLogModel, $objectId, $ignorePost = false): Response
+    public function cloneAction(Request $request, ListModel $listModel, AuditLogModel $auditLogModel, $objectId, $ignorePost = false): Response
     {
         if (!$this->security->isGranted(LeadPermissions::LISTS_CREATE)) {
             $this->throwAccessDenied();
@@ -224,8 +231,6 @@ final class ListController extends FormController
             return $this->createSegmentNewResponse(
                 $request,
                 clone $segment,
-                $segmentDependencies,
-                $segmentCampaignShare,
                 $listModel,
                 $auditLogModel,
                 $postActionVars,
@@ -253,7 +258,7 @@ final class ListController extends FormController
      * @param int  $objectId
      * @param bool $ignorePost
      */
-    public function editAction(Request $request, SegmentDependencies $segmentDependencies, SegmentCampaignShare $segmentCampaignShare, ListModel $listModel, AuditLogModel $auditLogModel, $objectId, $ignorePost = false, bool $isNew = false): Response
+    public function editAction(Request $request, ListModel $listModel, AuditLogModel $auditLogModel, $objectId, $ignorePost = false, bool $isNew = false): Response
     {
         $postActionVars = $this->getPostActionVars($request, $objectId);
 
@@ -267,8 +272,6 @@ final class ListController extends FormController
             return $this->createSegmentModifyResponse(
                 $request,
                 $segment,
-                $segmentDependencies,
-                $segmentCampaignShare,
                 $listModel,
                 $auditLogModel,
                 $postActionVars,
@@ -319,7 +322,7 @@ final class ListController extends FormController
      *
      * @param array<string, string> $postActionVars
      */
-    private function createSegmentNewResponse(Request $request, LeadList $segment, SegmentDependencies $segmentDependencies, SegmentCampaignShare $segmentCampaignShare, ListModel $segmentModel, AuditLogModel $auditLogModel, array $postActionVars, string $action, bool $ignorePost): Response
+    private function createSegmentNewResponse(Request $request, LeadList $segment, ListModel $segmentModel, AuditLogModel $auditLogModel, array $postActionVars, string $action, bool $ignorePost): Response
     {
         // set the page we came from
         $page = $request->getSession()->get('mautic.segment.page', 1);
@@ -360,7 +363,7 @@ final class ListController extends FormController
                 ]));
             }
             if ($valid) {
-                return $this->editAction($request, $segmentDependencies, $segmentCampaignShare, $segmentModel, $auditLogModel, $segment->getId(), true);
+                return $this->editAction($request, $segmentModel, $auditLogModel, $segment->getId(), true);
             }
         }
 
@@ -384,7 +387,7 @@ final class ListController extends FormController
      *
      * @return Response
      */
-    private function createSegmentModifyResponse(Request $request, LeadList $segment, SegmentDependencies $segmentDependencies, SegmentCampaignShare $segmentCampaignShare, ListModel $segmentModel, AuditLogModel $auditLogModel, array $postActionVars, string $action, $ignorePost)
+    private function createSegmentModifyResponse(Request $request, LeadList $segment, ListModel $segmentModel, AuditLogModel $auditLogModel, array $postActionVars, string $action, $ignorePost)
     {
         if ($segmentModel->isLocked($segment)) {
             return $this->isLocked($postActionVars, $segment, 'lead.list');
@@ -428,7 +431,7 @@ final class ListController extends FormController
                         return $this->postActionRedirect($postActionVars);
                     }
 
-                    return $this->viewAction($request, $segmentDependencies, $segmentCampaignShare, $segmentModel, $auditLogModel, $segment->getId());
+                    return $this->viewAction($request, $segmentModel, $auditLogModel, $segment->getId());
                 }
             } else {
                 // unlock the entity
@@ -724,7 +727,7 @@ final class ListController extends FormController
     /**
      * Loads a specific form into the detailed panel.
      */
-    public function viewAction(Request $request, SegmentDependencies $segmentDependencies, SegmentCampaignShare $segmentCampaignShare, ListModel $listModel, AuditLogModel $auditLogModel, $objectId): Response
+    public function viewAction(Request $request, ListModel $listModel, AuditLogModel $auditLogModel, $objectId): Response
     {
         /** @var LeadList $list */
         $list = $listModel->getEntity($objectId);
@@ -796,8 +799,8 @@ final class ListController extends FormController
             'returnUrl'      => $this->generateUrl('mautic_segment_action', ['objectAction' => 'view', 'objectId' => $list->getId()]),
             'viewParameters' => [
                 'logs'               => $logs,
-                'usageStats'         => $segmentDependencies->getChannelsIds($list->getId()),
-                'campaignStats'      => $segmentCampaignShare->getCampaignList($list->getId()),
+                'usageStats'         => $this->segmentDependencies->getChannelsIds($list->getId()),
+                'campaignStats'      => $this->segmentCampaignShare->getCampaignList($list->getId()),
                 'stats'              => $segmentContactsLineChartData,
                 'list'               => $list,
                 'segmentCount'       => $this->leadListRepository->getLeadCount($list->getId()),
@@ -937,7 +940,7 @@ final class ListController extends FormController
      *
      * @return JsonResponse|RedirectResponse|Response
      */
-    public function contactsAction(Request $request, PageHelperFactoryInterface $pageHelperFactory, $objectId, $page = 1)
+    public function contactsAction(Request $request, $objectId, $page = 1)
     {
         $session = $request->getSession();
         $session->set('mautic.segment.contact.page', $page);
@@ -967,7 +970,7 @@ final class ListController extends FormController
 
         return $this->generateContactsGrid(
             $request,
-            $pageHelperFactory,
+            $this->pageHelperFactory,
             $objectId,
             $page,
             LeadPermissions::LISTS_VIEW,

--- a/app/bundles/LeadBundle/Controller/TimelineController.php
+++ b/app/bundles/LeadBundle/Controller/TimelineController.php
@@ -13,6 +13,8 @@ final class TimelineController extends CommonController
 {
     use LeadAccessTrait;
     use LeadDetailsTrait;
+    private DateHelper $dateHelper;
+    private ExportHelper $exportHelper;
 
     public function indexAction(Request $request, $leadId, int $page = 1): Response
     {
@@ -187,7 +189,7 @@ final class TimelineController extends CommonController
         );
     }
 
-    public function batchExportAction(Request $request, DateHelper $dateHelper, ExportHelper $exportHelper, $leadId): Response
+    public function batchExportAction(Request $request, $leadId): Response
     {
         if (empty($leadId)) {
             $this->throwAccessDenied();
@@ -223,7 +225,7 @@ final class TimelineController extends CommonController
 
         $dataType = $request->get('filetype', 'csv');
 
-        $resultsCallback = function (array $event) use ($dateHelper): array {
+        $resultsCallback = function (array $event): array {
             $eventLabel = $event['eventLabel'] ?? $event['eventType'];
             if (is_array($eventLabel)) {
                 $eventLabel = $eventLabel['label'];
@@ -232,7 +234,7 @@ final class TimelineController extends CommonController
             return [
                 'eventName'      => $eventLabel,
                 'eventType'      => $event['eventType'] ?? '',
-                'eventTimestamp' => $dateHelper->toText($event['timestamp'], 'local', 'Y-m-d H:i:s', true),
+                'eventTimestamp' => $this->dateHelper->toText($event['timestamp'], 'local', 'Y-m-d H:i:s', true),
             ];
         };
 
@@ -267,6 +269,15 @@ final class TimelineController extends CommonController
             ++$loop;
         }
 
-        return $this->exportResultsAs($toExport, $dataType, 'contact_timeline', $exportHelper);
+        return $this->exportResultsAs($toExport, $dataType, 'contact_timeline', $this->exportHelper);
+    }
+
+    #[\Symfony\Contracts\Service\Attribute\Required]
+    public function autowireTimelineController(
+        DateHelper $dateHelper,
+        ExportHelper $exportHelper,
+    ): void {
+        $this->dateHelper = $dateHelper;
+        $this->exportHelper = $exportHelper;
     }
 }


### PR DESCRIPTION
Part of #16948 — that PR splits into one PR per bundle, this is LeadBundle.

Services that Symfony autowires per action move to constructor / `#[Required]` injection, so action signatures carry only request data. Applied by `ControllerMethodInjectionToConstructorRector`; the rule itself is enabled in #16948 and should land after all bundles are converted.

`TimelineController`:

```diff
+    private DateHelper $dateHelper;
+    private ExportHelper $exportHelper;

-    public function batchExportAction(Request $request, DateHelper $dateHelper, ExportHelper $exportHelper, $leadId): Response
+    public function batchExportAction(Request $request, $leadId): Response
     {
         // ...
-        $resultsCallback = function (array $event) use ($dateHelper): array {
+        $resultsCallback = function (array $event): array {
             return [
-                'eventTimestamp' => $dateHelper->toText($event['timestamp'], 'local', 'Y-m-d H:i:s', true),
+                'eventTimestamp' => $this->dateHelper->toText($event['timestamp'], 'local', 'Y-m-d H:i:s', true),
             ];
         };

-        return $this->exportResultsAs($toExport, $dataType, 'contact_timeline', $exportHelper);
+        return $this->exportResultsAs($toExport, $dataType, 'contact_timeline', $this->exportHelper);
+    }
+
+    #[Required]
+    public function autowireTimelineController(
+        DateHelper $dateHelper,
+        ExportHelper $exportHelper,
+    ): void {
+        $this->dateHelper   = $dateHelper;
+        $this->exportHelper = $exportHelper;
     }
```

`batchExportAction()` now takes only `$request` and the route's `$leadId`, and the closure no longer needs a `use` clause to reach the helper.
