### PR TITLE
[CoreBundle] Move action service injection to constructor injection

### DIFF
--- a/app/bundles/CoreBundle/Controller/AjaxController.php
+++ b/app/bundles/CoreBundle/Controller/AjaxController.php
@@ -27,12 +27,27 @@ use Symfony\Contracts\Service\Attribute\Required;
 class AjaxController extends CommonController
 {
     private NotificationModel $notificationModel;
+    private AuthorizationCheckerInterface $authorizationChecker;
+    private SearchCommandListInterface $searchCommandList;
+    private TokenSorter $tokenSorter;
+    private IpLookupFactory $ipServiceFactory;
+    private FormFactoryInterface $formFactory;
 
     #[Required]
     public function autowireCoreAjaxController(
         NotificationModel $notificationModel,
+        AuthorizationCheckerInterface $authorizationChecker,
+        SearchCommandListInterface $searchCommandList,
+        TokenSorter $tokenSorter,
+        IpLookupFactory $ipServiceFactory,
+        FormFactoryInterface $formFactory,
     ): void {
         $this->notificationModel = $notificationModel;
+        $this->authorizationChecker = $authorizationChecker;
+        $this->searchCommandList = $searchCommandList;
+        $this->tokenSorter = $tokenSorter;
+        $this->ipServiceFactory = $ipServiceFactory;
+        $this->formFactory = $formFactory;
     }
 
     /**
@@ -63,7 +78,6 @@ class AjaxController extends CommonController
      */
     public function delegateAjaxAction(
         Request $request,
-        AuthorizationCheckerInterface $authorizationChecker,
     ): Response|JsonResponse {
         // process ajax actions
         $action     = $request->get('action');
@@ -73,7 +87,7 @@ class AjaxController extends CommonController
             $action = $request->request->get('action');
         }
 
-        if ($authorizationChecker->isGranted('IS_AUTHENTICATED_REMEMBERED')) {
+        if ($this->authorizationChecker->isGranted('IS_AUTHENTICATED_REMEMBERED')) {
             if (str_contains($action, ':')) {
                 // call the specified bundle's ajax action
                 $parts     = explode(':', $action);
@@ -177,9 +191,9 @@ class AjaxController extends CommonController
         return $this->sendJsonResponse($dataArray);
     }
 
-    public function globalCommandListAction(SearchCommandListInterface $searchCommandList): JsonResponse
+    public function globalCommandListAction(): JsonResponse
     {
-        $allCommands = $searchCommandList->getList();
+        $allCommands = $this->searchCommandList->getList();
         $dataArray   = [];
         $dupChecker  = [];
         foreach ($allCommands as $commands) {
@@ -332,7 +346,7 @@ class AjaxController extends CommonController
         return $this->sendJsonResponse(['success' => 1]);
     }
 
-    public function getBuilderTokensAction(Request $request, TokenSorter $tokenSorter): JsonResponse
+    public function getBuilderTokensAction(Request $request): JsonResponse
     {
         $builderComponents = [];
 
@@ -342,7 +356,7 @@ class AjaxController extends CommonController
         }
 
         if (array_key_exists('tokens', $builderComponents)) {
-            $builderComponents['tokens'] = $tokenSorter->sortTokens($builderComponents['tokens']);
+            $builderComponents['tokens'] = $this->tokenSorter->sortTokens($builderComponents['tokens']);
         }
 
         return $this->sendJsonResponse($builderComponents);
@@ -351,7 +365,7 @@ class AjaxController extends CommonController
     /**
      * Fetch remote data store.
      */
-    public function downloadIpLookupDataStoreAction(Request $request, IpLookupFactory $ipServiceFactory): JsonResponse
+    public function downloadIpLookupDataStoreAction(Request $request): JsonResponse
     {
         $dataArray = ['success' => 0];
 
@@ -359,7 +373,7 @@ class AjaxController extends CommonController
             $serviceName = $request->request->get('service');
             $serviceAuth = $request->request->get('auth');
 
-            $ipService = $ipServiceFactory->getService($serviceName, $serviceAuth);
+            $ipService = $this->ipServiceFactory->getService($serviceName, $serviceAuth);
 
             if ($ipService instanceof AbstractLocalDataLookup) {
                 if ($ipService->downloadRemoteDataStore()) {
@@ -392,14 +406,14 @@ class AjaxController extends CommonController
     /**
      * Fetch IP Lookup form.
      */
-    public function getIpLookupFormAction(Request $request, FormFactoryInterface $formFactory, IpLookupFactory $ipServiceFactory): JsonResponse
+    public function getIpLookupFormAction(Request $request): JsonResponse
     {
         $dataArray = ['html' => '', 'attribution' => ''];
 
         if ($request->query->has('service')) {
             $serviceName = $request->query->get('service');
 
-            $ipService = $ipServiceFactory->getService($serviceName);
+            $ipService = $this->ipServiceFactory->getService($serviceName);
 
             if ($ipService instanceof AbstractLookup) {
                 $dataArray['attribution'] = $ipService->getAttribution();
@@ -408,7 +422,7 @@ class AjaxController extends CommonController
                         $themes   = $ipService->getConfigFormThemes();
                         $themes[] = '@MauticCore/FormTheme/Config/config_layout.html.twig';
 
-                        $form = $formFactory->createBuilder()
+                        $form = $this->formFactory->createBuilder()
                             ->add(
                                 'ip_lookup_config',
                                 $formType,

--- a/app/bundles/CoreBundle/Controller/Api/FileApiController.php
+++ b/app/bundles/CoreBundle/Controller/Api/FileApiController.php
@@ -44,6 +44,8 @@ final class FileApiController extends CommonApiController
         ModelFactory $modelFactory,
         EventDispatcherInterface $dispatcher,
         CoreParametersHelper $coreParametersHelper,
+        private PathsHelper $pathsHelper,
+        private LoggerInterface $mauticLogger,
     ) {
         $this->entityNameOne     = 'file';
         $this->entityNameMulti   = 'files';
@@ -57,10 +59,10 @@ final class FileApiController extends CommonApiController
      *
      * @return Response
      */
-    public function createAction(Request $request, PathsHelper $pathsHelper, LoggerInterface $mauticLogger, $dir)
+    public function createAction(Request $request, $dir)
     {
         try {
-            $path = $this->getAbsolutePath($request, $pathsHelper, $mauticLogger, $dir, true);
+            $path = $this->getAbsolutePath($request, $dir, true);
         } catch (\Exception $e) {
             return $this->returnError($e->getMessage(), Response::HTTP_NOT_ACCEPTABLE);
         }
@@ -96,10 +98,10 @@ final class FileApiController extends CommonApiController
      *
      * @return Response
      */
-    public function listAction(Request $request, PathsHelper $pathsHelper, LoggerInterface $mauticLogger, $dir)
+    public function listAction(Request $request, $dir)
     {
         try {
-            $filePath = $this->getAbsolutePath($request, $pathsHelper, $mauticLogger, $dir);
+            $filePath = $this->getAbsolutePath($request, $dir);
         } catch (\Exception $e) {
             return $this->returnError($e->getMessage(), Response::HTTP_NOT_ACCEPTABLE);
         }
@@ -127,12 +129,12 @@ final class FileApiController extends CommonApiController
      *
      * @return Response
      */
-    public function deleteAction(Request $request, PathsHelper $pathsHelper, LoggerInterface $mauticLogger, $dir, $file)
+    public function deleteAction(Request $request, $dir, $file)
     {
         $response = ['success' => false];
 
         try {
-            $filePath = $this->getAbsolutePath($request, $pathsHelper, $mauticLogger, $dir).'/'.basename($file);
+            $filePath = $this->getAbsolutePath($request, $dir).'/'.basename($file);
         } catch (\Exception $e) {
             return $this->returnError($e->getMessage(), Response::HTTP_NOT_ACCEPTABLE);
         }
@@ -157,7 +159,7 @@ final class FileApiController extends CommonApiController
      * @param string $dir
      * @param bool   $createDir
      */
-    protected function getAbsolutePath(Request $request, PathsHelper $pathsHelper, LoggerInterface $mauticLogger, $dir, $createDir = false): string
+    protected function getAbsolutePath(Request $request, $dir, $createDir = false): string
     {
         try {
             $possibleDirs = ['media', 'images'];
@@ -177,7 +179,7 @@ final class FileApiController extends CommonApiController
             }
 
             if ('images' === $dir) {
-                $absoluteDir = realpath($pathsHelper->getSystemPath($dir, true));
+                $absoluteDir = realpath($this->pathsHelper->getSystemPath($dir, true));
             } elseif ('media' === $dir) {
                 $absoluteDir = realpath($this->coreParametersHelper->get('upload_dir'));
             }
@@ -204,7 +206,7 @@ final class FileApiController extends CommonApiController
 
             return $path;
         } catch (\Exception $e) {
-            $mauticLogger->error($e->getMessage(), ['exception' => $e]);
+            $this->mauticLogger->error($e->getMessage(), ['exception' => $e]);
 
             throw $e;
         }

--- a/app/bundles/CoreBundle/Controller/Api/StatsApiController.php
+++ b/app/bundles/CoreBundle/Controller/Api/StatsApiController.php
@@ -15,6 +15,8 @@ use Symfony\Component\HttpFoundation\Response;
  */
 final class StatsApiController extends CommonApiController
 {
+    private UserHelper $userHelper;
+
     /**
      * Lists stats for a database table.
      *
@@ -22,7 +24,7 @@ final class StatsApiController extends CommonApiController
      * @param array  $order
      * @param array  $where
      */
-    public function listAction(Request $request, UserHelper $userHelper, $table = null, string $itemsName = 'stats', $order = [], $where = [], int $start = 0, int $limit = 100): Response
+    public function listAction(Request $request, $table = null, string $itemsName = 'stats', $order = [], $where = [], int $start = 0, int $limit = 100): Response
     {
         $response = [];
         $where    = InputHelper::cleanArray(empty($where) ? $request->query->all()['where'] ?? [] : $where);
@@ -35,7 +37,7 @@ final class StatsApiController extends CommonApiController
         $this->sanitizeWhereClauseArrayFromRequest($where);
 
         try {
-            $event = new StatsEvent($table, $start, $limit, $order, $where, $userHelper->getUser());
+            $event = new StatsEvent($table, $start, $limit, $order, $where, $this->userHelper->getUser());
             $this->dispatcher->dispatch($event, CoreEvents::LIST_STATS);
 
             // Return available tables if no result was set
@@ -59,5 +61,12 @@ final class StatsApiController extends CommonApiController
         $view = $this->view($response);
 
         return $this->handleView($view);
+    }
+
+    #[\Symfony\Contracts\Service\Attribute\Required]
+    public function autowireStatsApiController(
+        UserHelper $userHelper,
+    ): void {
+        $this->userHelper = $userHelper;
     }
 }

--- a/app/bundles/CoreBundle/Controller/Api/ThemeApiController.php
+++ b/app/bundles/CoreBundle/Controller/Api/ThemeApiController.php
@@ -18,12 +18,15 @@ use Symfony\Contracts\Service\Attribute\Required;
 final class ThemeApiController extends CommonApiController
 {
     private readonly ThemeHelper $themeHelper;
+    private PathsHelper $pathsHelper;
 
     #[Required]
     public function autowireThemeApiController(
         ThemeHelper $themeHelper,
+        PathsHelper $pathsHelper,
     ): void {
         $this->themeHelper = $themeHelper;
+        $this->pathsHelper = $pathsHelper;
     }
 
     /**
@@ -31,7 +34,7 @@ final class ThemeApiController extends CommonApiController
      *
      * @return Response
      */
-    public function newAction(Request $request, PathsHelper $pathsHelper)
+    public function newAction(Request $request)
     {
         if (!$this->security->isGranted('core:themes:create')) {
             return $this->accessDenied();
@@ -54,7 +57,7 @@ final class ThemeApiController extends CommonApiController
             );
         }
         $fileName  = InputHelper::filename($themeZip->getClientOriginalName());
-        $dir       = $pathsHelper->getSystemPath('themes', true);
+        $dir       = $this->pathsHelper->getSystemPath('themes', true);
 
         try {
             $themeZip->move($dir, $fileName);

--- a/app/bundles/CoreBundle/Controller/ExceptionController.php
+++ b/app/bundles/CoreBundle/Controller/ExceptionController.php
@@ -12,7 +12,9 @@ use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;
 
 final class ExceptionController extends CommonController
 {
-    public function showAction(Request $request, \Throwable $exception, ThemeHelper $themeHelper, ?DebugLoggerInterface $logger = null): JsonResponse|Response
+    private ThemeHelper $themeHelper;
+
+    public function showAction(Request $request, \Throwable $exception, ?DebugLoggerInterface $logger = null): JsonResponse|Response
     {
         $exception      = FlattenException::createFromThrowable($exception, $exception->getCode(), $request->headers->all());
         $class          = $exception->getClass();
@@ -71,7 +73,7 @@ final class ExceptionController extends CommonController
         $anonymous    = $this->security->isAnonymous();
         $baseTemplate = '@MauticCore/Default/slim.html.twig';
         if ($anonymous) {
-            if ($templatePage = $themeHelper->getTheme()->getErrorPageTemplate((string) $code)) {
+            if ($templatePage = $this->themeHelper->getTheme()->getErrorPageTemplate((string) $code)) {
                 $baseTemplate = $templatePage;
             }
         }
@@ -121,5 +123,12 @@ final class ExceptionController extends CommonController
         Response::closeOutputBuffers($startObLevel + 1, true);
 
         return ob_get_clean();
+    }
+
+    #[\Symfony\Contracts\Service\Attribute\Required]
+    public function autowireExceptionController(
+        ThemeHelper $themeHelper,
+    ): void {
+        $this->themeHelper = $themeHelper;
     }
 }

--- a/app/bundles/CoreBundle/Controller/FileController.php
+++ b/app/bundles/CoreBundle/Controller/FileController.php
@@ -19,22 +19,24 @@ final class FileController extends AjaxController
     private array $response = [];
 
     private int $statusCode = Response::HTTP_OK;
+    private PathsHelper $pathsHelper;
+    private FileUploader $fileUploader;
 
     /**
      * Uploads a file.
      *
      * @throws FileUploadException
      */
-    public function uploadAction(Request $request, PathsHelper $pathsHelper, FileUploader $fileUploader): JsonResponse
+    public function uploadAction(Request $request): JsonResponse
     {
         $editor   = $request->get('editor');
-        $mediaDir = $this->getMediaAbsolutePath($pathsHelper);
+        $mediaDir = $this->getMediaAbsolutePath();
         if (!isset($this->response['error'])) {
             foreach ($request->files as $file) {
                 /** @var UploadedFile $file */
                 try {
-                    $fileUploader->validateImage($file);
-                    $fileName = $fileUploader->upload($mediaDir, $file);
+                    $this->fileUploader->validateImage($file);
+                    $fileName = $this->fileUploader->upload($mediaDir, $file);
                     $this->successfulResponse($request, $fileName, $editor);
                 } catch (FileUploadException) {
                     $this->failureResponse($editor);
@@ -48,18 +50,18 @@ final class FileController extends AjaxController
     /**
      * List the files in /media directory.
      */
-    public function listAction(Request $request, PathsHelper $pathsHelper, FileUploader $fileUploader): JsonResponse
+    public function listAction(Request $request): JsonResponse
     {
-        $fnames = scandir($this->getMediaAbsolutePath($pathsHelper));
+        $fnames = scandir($this->getMediaAbsolutePath());
 
         if ($fnames) {
             foreach ($fnames as $name) {
-                $imagePath = $this->getMediaAbsolutePath($pathsHelper).'/'.$name;
+                $imagePath = $this->getMediaAbsolutePath().'/'.$name;
                 $imageUrl  = $this->getMediaUrl($request).'/'.$name;
                 $imageFile = new File($imagePath, checkPath: false);
                 if (!is_dir($name)) {
                     try {
-                        $fileUploader->validateImage($imageFile);
+                        $this->fileUploader->validateImage($imageFile);
                         $this->response[] = [
                             'url'   => $imageUrl,
                             'thumb' => $imageUrl,
@@ -79,10 +81,10 @@ final class FileController extends AjaxController
     /**
      * Delete a file from /media directory.
      */
-    public function deleteAction(Request $request, PathsHelper $pathsHelper): JsonResponse
+    public function deleteAction(Request $request): JsonResponse
     {
         $src       = InputHelper::clean($request->request->get('src'));
-        $imagePath = $this->getMediaAbsolutePath($pathsHelper).'/'.basename($src);
+        $imagePath = $this->getMediaAbsolutePath().'/'.basename($src);
 
         if (!file_exists($imagePath)) {
             $this->response['error'] = 'File does not exist';
@@ -103,15 +105,13 @@ final class FileController extends AjaxController
      *
      * @return string
      */
-    public function getMediaAbsolutePath(PathsHelper $pathsHelper): string|false
+    public function getMediaAbsolutePath(): string|false
     {
-        $mediaDir = realpath($pathsHelper->getSystemPath('images', true));
-
+        $mediaDir = realpath($this->pathsHelper->getSystemPath('images', true));
         if (false === $mediaDir) {
             $this->response['error'] = 'Media dir does not exist';
             $this->statusCode        = Response::HTTP_INTERNAL_SERVER_ERROR;
         }
-
         if (false === is_writable($mediaDir)) {
             $this->response['error'] = 'Media dir is not writable';
             $this->statusCode        = Response::HTTP_INTERNAL_SERVER_ERROR;
@@ -151,5 +151,14 @@ final class FileController extends AjaxController
         } else {
             $this->response['error'] = $errorMsg;
         }
+    }
+
+    #[\Symfony\Contracts\Service\Attribute\Required]
+    public function autowireFileController(
+        PathsHelper $pathsHelper,
+        FileUploader $fileUploader,
+    ): void {
+        $this->pathsHelper = $pathsHelper;
+        $this->fileUploader = $fileUploader;
     }
 }

--- a/app/bundles/CoreBundle/Controller/ThemeController.php
+++ b/app/bundles/CoreBundle/Controller/ThemeController.php
@@ -17,7 +17,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 final class ThemeController extends FormController
 {
-    public function indexAction(Request $request, ThemeHelperInterface $themeHelper, BuilderIntegrationsHelper $builderIntegrationsHelper, PathsHelper $pathsHelper): Response
+    private ThemeHelperInterface $themeHelper;
+    private BuilderIntegrationsHelper $builderIntegrationsHelper;
+    private PathsHelper $pathsHelper;
+    private CorePermissions $corePermissions;
+
+    public function indexAction(Request $request): Response
     {
         // set some permissions
         $permissions = $this->security->isGranted([
@@ -31,7 +36,7 @@ final class ThemeController extends FormController
             $this->throwAccessDenied();
         }
 
-        $dir    = $pathsHelper->getSystemPath('themes', true);
+        $dir    = $this->pathsHelper->getSystemPath('themes', true);
         $action = $this->generateUrl('mautic_themes_index');
         $form   = $this->formFactory->create(ThemeUploadType::class, [], ['action' => $action]);
 
@@ -55,7 +60,7 @@ final class ThemeController extends FormController
                         if ('zip' === $extension) {
                             try {
                                 $fileData->move($dir, $fileName);
-                                $themeHelper->install($dir.'/'.$fileName);
+                                $this->themeHelper->install($dir.'/'.$fileName);
                                 $this->addFlashMessage('mautic.core.theme.installed', ['%name%' => $themeName]);
                             } catch (\Exception $e) {
                                 $form->addError(
@@ -80,9 +85,9 @@ final class ThemeController extends FormController
 
         return $this->delegateView([
             'viewParameters' => [
-                'items'         => $themeHelper->getInstalledThemes('all', true, true),
-                'builders'      => $builderIntegrationsHelper->getBuilderNames(),
-                'defaultThemes' => $themeHelper->getDefaultThemes(),
+                'items'         => $this->themeHelper->getInstalledThemes('all', true, true),
+                'builders'      => $this->builderIntegrationsHelper->getBuilderNames(),
+                'defaultThemes' => $this->themeHelper->getDefaultThemes(),
                 'form'          => $form->createView(),
                 'permissions'   => $permissions,
                 'security'      => $this->security,
@@ -99,7 +104,7 @@ final class ThemeController extends FormController
     /**
      * Download a theme.
      */
-    public function downloadAction(Request $request, ThemeHelperInterface $themeHelper, string $objectId): Response
+    public function downloadAction(Request $request, string $objectId): Response
     {
         $flashes = [];
         $error   = false;
@@ -109,7 +114,7 @@ final class ThemeController extends FormController
         }
 
         $themeName = $objectId;
-        if (!$themeHelper->exists($themeName)) {
+        if (!$this->themeHelper->exists($themeName)) {
             $flashes[] = [
                 'type'    => 'error',
                 'msg'     => 'mautic.core.theme.error.notfound',
@@ -119,7 +124,7 @@ final class ThemeController extends FormController
         }
 
         try {
-            $zipPath = $themeHelper->zip($themeName);
+            $zipPath = $this->themeHelper->zip($themeName);
         } catch (\Exception $e) {
             $flashes[] = [
                 'type' => 'error',
@@ -162,13 +167,13 @@ final class ThemeController extends FormController
     /**
      * Deletes the theme.
      */
-    public function deleteAction(Request $request, ThemeHelperInterface $themeHelper, string $objectId): Response
+    public function deleteAction(Request $request, string $objectId): Response
     {
         $flashes = [];
 
         $themeName = $objectId;
         if ('POST' === $request->getMethod()) {
-            $flashes = $this->deleteTheme($themeHelper, $themeName);
+            $flashes = $this->deleteTheme($themeName);
         }
 
         return $this->postActionRedirect(
@@ -181,7 +186,7 @@ final class ThemeController extends FormController
     /**
      * Deletes a group of themes.
      */
-    public function batchDeleteAction(Request $request, ThemeHelperInterface $themeHelper): Response
+    public function batchDeleteAction(Request $request): Response
     {
         $flashes = [];
         $error   = [];
@@ -190,7 +195,7 @@ final class ThemeController extends FormController
             $themeNames = json_decode($request->query->get('ids', '{}'));
 
             foreach ($themeNames as $themeName) {
-                $flash = $this->deleteTheme($themeHelper, $themeName)[0];
+                $flash = $this->deleteTheme($themeName)[0];
 
                 if ('error' === $flash['type']) {
                     $error[] = $flash;
@@ -224,11 +229,11 @@ final class ThemeController extends FormController
         );
     }
 
-    public function deleteTheme(ThemeHelperInterface $themeHelper, $themeName): array
+    public function deleteTheme($themeName): array
     {
         $flashes = [];
 
-        if (!$themeHelper->exists($themeName)) {
+        if (!$this->themeHelper->exists($themeName)) {
             $flashes[] = [
                 'type'    => 'error',
                 'msg'     => 'mautic.core.theme.error.notfound',
@@ -236,7 +241,7 @@ final class ThemeController extends FormController
             ];
         } elseif (!$this->security->isGranted('core:themes:delete')) {
             $this->throwAccessDenied();
-        } elseif (in_array($themeName, $themeHelper->getDefaultThemes())) {
+        } elseif (in_array($themeName, $this->themeHelper->getDefaultThemes())) {
             $flashes[] = [
                 'type'    => 'error',
                 'msg'     => 'mautic.core.theme.cannot.be.removed',
@@ -244,8 +249,8 @@ final class ThemeController extends FormController
             ];
         } else {
             try {
-                $theme = $themeHelper->getTheme($themeName);
-                $themeHelper->delete($themeName);
+                $theme = $this->themeHelper->getTheme($themeName);
+                $this->themeHelper->delete($themeName);
             } catch (\Exception $e) {
                 $flashes[] = [
                     'type'    => 'error',
@@ -285,16 +290,16 @@ final class ThemeController extends FormController
     /**
      * Change default theme's visibility.
      */
-    public function visibilityAction(string $objectId, Request $request, CorePermissions $corePermissions, ThemeHelperInterface $themeHelper): Response
+    public function visibilityAction(string $objectId, Request $request): Response
     {
-        if (!$corePermissions->isGranted('core:themes:view')) {
+        if (!$this->corePermissions->isGranted('core:themes:view')) {
             $this->throwAccessDenied();
         }
 
         $flashes = [];
 
         if (Request::METHOD_POST === $request->getMethod()) {
-            $flashes = $this->visibility($objectId, $themeHelper);
+            $flashes = $this->visibility($objectId);
         }
 
         return $this->postActionRedirect(
@@ -307,9 +312,9 @@ final class ThemeController extends FormController
     /**
      * @return array<mixed>
      */
-    private function visibility(string $themeName, ThemeHelperInterface $themeHelper): array
+    private function visibility(string $themeName): array
     {
-        if (!$themeHelper->exists($themeName)) {
+        if (!$this->themeHelper->exists($themeName)) {
             return [
                 [
                     'type'    => 'error',
@@ -319,7 +324,7 @@ final class ThemeController extends FormController
             ];
         }
 
-        if (!in_array($themeName, $themeHelper->getDefaultThemes())) {
+        if (!in_array($themeName, $this->themeHelper->getDefaultThemes())) {
             return [
                 [
                     'type'    => 'error',
@@ -332,8 +337,8 @@ final class ThemeController extends FormController
         $flashes = [];
 
         try {
-            $theme = $themeHelper->getTheme($themeName);
-            $themeHelper->toggleVisibility($themeName);
+            $theme = $this->themeHelper->getTheme($themeName);
+            $this->themeHelper->toggleVisibility($themeName);
             $flashes[] = [
                 'type'    => 'notice',
                 'msg'     => 'mautic.core.theme.visibility.changed',
@@ -360,5 +365,18 @@ final class ThemeController extends FormController
         }
 
         return $flashes;
+    }
+
+    #[\Symfony\Contracts\Service\Attribute\Required]
+    public function autowireThemeController(
+        ThemeHelperInterface $themeHelper,
+        BuilderIntegrationsHelper $builderIntegrationsHelper,
+        PathsHelper $pathsHelper,
+        CorePermissions $corePermissions,
+    ): void {
+        $this->themeHelper = $themeHelper;
+        $this->builderIntegrationsHelper = $builderIntegrationsHelper;
+        $this->pathsHelper = $pathsHelper;
+        $this->corePermissions = $corePermissions;
     }
 }

--- a/app/bundles/SmsBundle/Controller/AjaxController.php
+++ b/app/bundles/SmsBundle/Controller/AjaxController.php
@@ -11,7 +11,6 @@ use Mautic\SmsBundle\Broadcast\BroadcastQuery;
 use Mautic\SmsBundle\Event\TokensBuildEvent;
 use Mautic\SmsBundle\Model\SmsModel;
 use Mautic\SmsBundle\SmsEvents;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Contracts\Service\Attribute\Required;
@@ -23,17 +22,26 @@ final class AjaxController extends CommonAjaxController
     private EmailModel $emailModel;
 
     private SmsModel $smsModel;
+    private BroadcastQuery $broadcastQuery;
+    private CacheStorageHelper $cacheStorageHelper;
+    private TokenSorter $smsTokenSorter;
 
     #[Required]
     public function autowireSmsAjaxController(
         EmailModel $emailModel,
         SmsModel $smsModel,
+        BroadcastQuery $broadcastQuery,
+        CacheStorageHelper $cacheStorageHelper,
+        TokenSorter $smsTokenSorter,
     ): void {
         $this->emailModel = $emailModel;
         $this->smsModel = $smsModel;
+        $this->broadcastQuery = $broadcastQuery;
+        $this->cacheStorageHelper = $cacheStorageHelper;
+        $this->smsTokenSorter = $smsTokenSorter;
     }
 
-    public function getSmsCountStatsAction(Request $request, BroadcastQuery $broadcastQuery, CacheStorageHelper $cacheStorageHelper): JsonResponse
+    public function getSmsCountStatsAction(Request $request): JsonResponse
     {
         $id  = $request->get('id');
         $ids = $request->query->all()['ids'] ?? [];
@@ -50,8 +58,8 @@ final class AjaxController extends CommonAjaxController
                     continue;
                 }
 
-                $pending = $broadcastQuery->getPendingCount($sms);
-                $cacheStorageHelper->set(sprintf('%s|%s|%s', 'sms', $sms->getId(), 'pending'), $pending);
+                $pending = $this->broadcastQuery->getPendingCount($sms);
+                $this->cacheStorageHelper->set(sprintf('%s|%s|%s', 'sms', $sms->getId(), 'pending'), $pending);
                 if (!$pending) {
                     continue;
                 }
@@ -78,14 +86,14 @@ final class AjaxController extends CommonAjaxController
         return new JsonResponse($data);
     }
 
-    public function getBuilderTokensAction(Request $request, TokenSorter $tokenSorter, ?EventDispatcherInterface $eventDispatcher = null): JsonResponse
+    public function getBuilderTokensAction(Request $request): JsonResponse
     {
         $query = $request->query->get('query', '');
 
         $tokens = $this->getBuilderTokens($query);
         $event  = new TokensBuildEvent($tokens);
-        $eventDispatcher->dispatch($event, SmsEvents::ON_SMS_TOKENS_BUILD);
-        $sortedTokens = $tokenSorter->sortTokens($event->getTokens());
+        $this->dispatcher->dispatch($event, SmsEvents::ON_SMS_TOKENS_BUILD);
+        $sortedTokens = $this->smsTokenSorter->sortTokens($event->getTokens());
 
         return $this->sendJsonResponse(['tokens' => $sortedTokens]);
     }


### PR DESCRIPTION
Part of #16948 — that PR splits into one PR per bundle, this is CoreBundle.

Services that Symfony autowires per action move to constructor / `#[Required]` injection, so action signatures carry only request data. Applied by `ControllerMethodInjectionToConstructorRector`; the rule itself is enabled in #16948 and should land after all bundles are converted.

`CoreBundle\Controller\AjaxController`:

```diff
-    public function globalCommandListAction(SearchCommandListInterface $searchCommandList): JsonResponse
+    public function globalCommandListAction(): JsonResponse
     {
-        $allCommands = $searchCommandList->getList();
+        $allCommands = $this->searchCommandList->getList();
```

Same for `getBuilderTokensAction()`, `downloadIpLookupDataStoreAction()` and `getIpLookupFormAction()`.

### One file outside CoreBundle

`app/bundles/SmsBundle/Controller/AjaxController.php` is included here, not in the SmsBundle PR. It overrides `getBuilderTokensAction()`, so its signature has to change in the same commit as the parent — otherwise PHP fatals with `Declaration ... must be compatible with`. The rest of SmsBundle follows in its own PR.

Also renames `autowireAjaxController()` to `autowireCoreAjaxController()`: a `#[Required]` method named after the base class is shadowed by any subclass declaring the same name, which silently drops the parent's injection.
