### PR TITLE
[UserBundle] Move action service injection to constructor injection

### DIFF
--- a/app/bundles/UserBundle/Controller/Api/UserApiController.php
+++ b/app/bundles/UserBundle/Controller/Api/UserApiController.php
@@ -47,6 +47,7 @@ final class UserApiController extends CommonApiController
         EventDispatcherInterface $dispatcher,
         CoreParametersHelper $coreParametersHelper,
         UserModel $userModel,
+        private TokenStorageInterface $tokenStorage,
     ) {
         $this->model            = $userModel;
         $this->entityClass      = User::class;
@@ -63,9 +64,9 @@ final class UserApiController extends CommonApiController
      *
      * @throws NotFoundHttpException
      */
-    public function getSelfAction(TokenStorageInterface $tokenStorage): Response
+    public function getSelfAction(): Response
     {
-        $currentUser = $tokenStorage->getToken()->getUser();
+        $currentUser = $this->tokenStorage->getToken()->getUser();
         $view        = $this->view($currentUser, Response::HTTP_OK);
 
         return $this->handleView($view);

--- a/app/bundles/UserBundle/Controller/ProfileController.php
+++ b/app/bundles/UserBundle/Controller/ProfileController.php
@@ -20,22 +20,33 @@ use Symfony\Contracts\Service\Attribute\Required;
 final class ProfileController extends FormController
 {
     private UserModel $userModel;
+    private LanguageHelper $languageHelper;
+    private UserPasswordHasherInterface $hasher;
+    private TokenStorageInterface $tokenStorage;
+    private SAMLHelper $samlHelper;
 
     #[Required]
     public function autowireProfileController(
         UserModel $userModel,
+        LanguageHelper $languageHelper,
+        UserPasswordHasherInterface $hasher,
+        TokenStorageInterface $tokenStorage,
+        SAMLHelper $samlHelper,
     ): void {
         $this->userModel = $userModel;
+        $this->languageHelper = $languageHelper;
+        $this->hasher = $hasher;
+        $this->tokenStorage = $tokenStorage;
+        $this->samlHelper = $samlHelper;
     }
 
     /**
      * Generate's account profile.
      */
-    public function indexAction(Request $request, LanguageHelper $languageHelper, UserPasswordHasherInterface $hasher,
-        TokenStorageInterface $tokenStorage, SAMLHelper $samlHelper): Response|RedirectResponse
+    public function indexAction(Request $request): Response|RedirectResponse
     {
         // get current user
-        $me = $tokenStorage->getToken()->getUser();
+        $me = $this->tokenStorage->getToken()->getUser();
         \assert($me instanceof User);
 
         // set some permissions
@@ -160,7 +171,7 @@ final class ProfileController extends FormController
             // check to see if the password needs to be rehashed
             $formUser              = $request->request->all()['user'] ?? [];
             $submittedPassword     = $formUser['plainPassword']['password'] ?? null;
-            $overrides['password'] = $this->userModel->checkNewPassword($me, $hasher, $submittedPassword);
+            $overrides['password'] = $this->userModel->checkNewPassword($me, $this->hasher, $submittedPassword);
             if (!$cancelled = $this->isFormCancelled($form)) {
                 if ($this->isFormValid($form)) {
                     foreach ($overrides as $k => $v) {
@@ -172,10 +183,10 @@ final class ProfileController extends FormController
                     $this->userModel->saveEntity($me);
 
                     // check if the user's locale has been downloaded already, fetch it if not
-                    $installedLanguages = $languageHelper->getSupportedLanguages();
+                    $installedLanguages = $this->languageHelper->getSupportedLanguages();
 
                     if ($me->getLocale() && !array_key_exists($me->getLocale(), $installedLanguages)) {
-                        $fetchLanguage = $languageHelper->extractLanguagePackage($me->getLocale());
+                        $fetchLanguage = $this->languageHelper->extractLanguagePackage($me->getLocale());
 
                         // If there is an error, we need to reset the user's locale to the default
                         if ($fetchLanguage['error']) {
@@ -233,7 +244,7 @@ final class ProfileController extends FormController
         }
         $request->getSession()->set('formProcessed', 0);
 
-        $isSamlUser    = $samlHelper->isSamlSession();
+        $isSamlUser    = $this->samlHelper->isSamlSession();
         if ($isSamlUser) {
             $form->remove('plainPassword');
         }

--- a/app/bundles/UserBundle/Controller/PublicController.php
+++ b/app/bundles/UserBundle/Controller/PublicController.php
@@ -22,20 +22,26 @@ final class PublicController extends FormController
     private UserRepository $userRepository;
 
     private UserModel $userModel;
+    private LoggerInterface $logger;
+    private UserPasswordHasherInterface $hasher;
 
     #[Required]
     public function autowirePublicController(
         UserModel $userModel,
         UserRepository $userRepository,
+        LoggerInterface $logger,
+        UserPasswordHasherInterface $hasher,
     ): void {
         $this->userModel = $userModel;
         $this->userRepository = $userRepository;
+        $this->logger = $logger;
+        $this->hasher = $hasher;
     }
 
     /**
      * Generates a new password for the user and emails it to them.
      */
-    public function passwordResetAction(Request $request, LoggerInterface $logger): RedirectResponse|Response
+    public function passwordResetAction(Request $request): RedirectResponse|Response
     {
         $data   = ['identifier' => ''];
         $action = $this->generateUrl('mautic_user_passwordreset');
@@ -61,7 +67,7 @@ final class PublicController extends FormController
                     }
                     $this->addFlashMessage('mautic.user.user.notice.passwordreset');
                 } catch (\RuntimeException $e) {
-                    $logger->error($this->translator->trans('mautic.user.password.reset.email.failed', [], 'messages').': '.$e->getMessage());
+                    $this->logger->error($this->translator->trans('mautic.user.password.reset.email.failed', [], 'messages').': '.$e->getMessage());
                     $this->addFlashMessage('mautic.user.user.notice.passwordreset.error', [], 'error');
                 }
 
@@ -87,7 +93,7 @@ final class PublicController extends FormController
         ]);
     }
 
-    public function passwordResetConfirmAction(Request $request, UserPasswordHasherInterface $hasher): RedirectResponse|Response
+    public function passwordResetConfirmAction(Request $request): RedirectResponse|Response
     {
         $action   = $this->generateUrl('mautic_user_passwordresetconfirm');
         $form     = $this->formFactory->create(PasswordResetConfirmType::class, [], ['action' => $action]);
@@ -102,7 +108,7 @@ final class PublicController extends FormController
         if ('POST' === $request->getMethod()) {
             if ($isValid = $this->isFormValid($form)) {
                 $data     = $form->getData();
-                $response = $this->handlePasswordResetConfirm($request, $hasher, $data);
+                $response = $this->handlePasswordResetConfirm($request, $data);
             }
         }
 
@@ -112,7 +118,7 @@ final class PublicController extends FormController
     /**
      * @param array<string, mixed> $data
      */
-    private function handlePasswordResetConfirm(Request $request, UserPasswordHasherInterface $hasher, array $data): ?Response
+    private function handlePasswordResetConfirm(Request $request, array $data): ?Response
     {
         $response = null;
         $user     = $this->userRepository->findByIdentifier($data['identifier']);
@@ -126,7 +132,7 @@ final class PublicController extends FormController
 
             $response = $this->redirectToRoute('mautic_user_passwordresetconfirm');
         } elseif ($this->userModel->confirmResetToken($user, $request->getSession()->get('resetToken'))) {
-            $encodedPassword = $this->userModel->checkNewPassword($user, $hasher, $data['plainPassword']);
+            $encodedPassword = $this->userModel->checkNewPassword($user, $this->hasher, $data['plainPassword']);
             $user->setPassword($encodedPassword);
             $this->userModel->saveEntity($user);
 
@@ -152,7 +158,7 @@ final class PublicController extends FormController
         ]);
     }
 
-    public function inviteAction(Request $request, UserPasswordHasherInterface $hasher, UserModel $model, LoggerInterface $logger): RedirectResponse|Response
+    public function inviteAction(Request $request, UserModel $model): RedirectResponse|Response
     {
         $token    = $request->attributes->getString('token');
         $invite   = $model->getInvite($token);
@@ -189,14 +195,14 @@ final class PublicController extends FormController
                         $formUser          = $request->request->all()['user_invite_registration'] ?? [];
                         $submittedPassword = $formUser['plainPassword']['password'] ?? null;
 
-                        $user->setPassword($model->checkNewPassword($user, $hasher, $submittedPassword));
+                        $user->setPassword($model->checkNewPassword($user, $this->hasher, $submittedPassword));
                         $model->markInviteUsed($invite);
                         $model->saveEntity($user);
                         $this->addFlashMessage('mautic.user.invite.account_created', [], 'notice', 'flashes');
 
                         $response = $this->redirectToRoute('login');
                     } catch (\Doctrine\DBAL\Exception $e) {
-                        $logger->error($this->translator->trans('mautic.user.invite.registration.database.error', [], 'messages').': '.$e->getMessage());
+                        $this->logger->error($this->translator->trans('mautic.user.invite.registration.database.error', [], 'messages').': '.$e->getMessage());
                         $this->addFlashMessage('mautic.user.invite.error.database', [], 'error', 'flashes');
                     }
                 }

--- a/app/bundles/UserBundle/Controller/RoleController.php
+++ b/app/bundles/UserBundle/Controller/RoleController.php
@@ -31,12 +31,15 @@ final class RoleController extends FormController
     private const TEMPLATE_FORM = '@MauticUser/Role/form.html.twig';
 
     private RoleModel $roleModel;
+    private PageHelperFactoryInterface $pageHelperFactory;
 
     #[Required]
     public function autowireRoleController(
         RoleModel $roleModel,
+        PageHelperFactoryInterface $pageHelperFactory,
     ): void {
         $this->roleModel = $roleModel;
+        $this->pageHelperFactory = $pageHelperFactory;
     }
 
     /**
@@ -56,7 +59,7 @@ final class RoleController extends FormController
     /**
      * Generate's default role list view.
      */
-    public function indexAction(Request $request, PageHelperFactoryInterface $pageHelperFactory, int $page = 1): Response
+    public function indexAction(Request $request, int $page = 1): Response
     {
         if (!$this->security->isGranted(self::PERMISSION_VIEW)) {
             $this->throwAccessDenied();
@@ -64,7 +67,7 @@ final class RoleController extends FormController
 
         $this->setListFilters();
 
-        $pageHelper = $pageHelperFactory->make('mautic.role', $page);
+        $pageHelper = $this->pageHelperFactory->make('mautic.role', $page);
 
         $limit      = $pageHelper->getLimit();
         $start      = $pageHelper->getStart();

--- a/app/bundles/UserBundle/Controller/SecurityController.php
+++ b/app/bundles/UserBundle/Controller/SecurityController.php
@@ -20,17 +20,25 @@ use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 use Symfony\Contracts\Service\Attribute\Required;
-use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class SecurityController extends CommonController implements EventSubscriberInterface
 {
     private AuthorizationCheckerInterface $authorizationChecker;
+    private AuthenticationUtils $authenticationUtils;
+    private IntegrationHelper $integrationHelper;
+    private SAMLHelper $samlHelper;
 
     #[Required]
     public function autowireSecurityController(
         AuthorizationCheckerInterface $authorizationChecker,
+        AuthenticationUtils $authenticationUtils,
+        IntegrationHelper $integrationHelper,
+        SAMLHelper $samlHelper,
     ): void {
         $this->authorizationChecker = $authorizationChecker;
+        $this->authenticationUtils = $authenticationUtils;
+        $this->integrationHelper = $integrationHelper;
+        $this->samlHelper = $samlHelper;
     }
 
     public function onRequest(RequestEvent $event): void
@@ -54,13 +62,13 @@ final class SecurityController extends CommonController implements EventSubscrib
     /**
      * Generates login form and processes login.
      */
-    public function loginAction(Request $request, AuthenticationUtils $authenticationUtils, IntegrationHelper $integrationHelper, TranslatorInterface $translator): Response
+    public function loginAction(Request $request): Response
     {
-        $error = $authenticationUtils->getLastAuthenticationError();
+        $error = $this->authenticationUtils->getLastAuthenticationError();
 
         if (null !== $error) {
             if ($error instanceof WeakPasswordException) {
-                $this->addFlash(FlashBag::LEVEL_ERROR, $translator->trans('mautic.user.auth.error.weakpassword', [], 'flashes'));
+                $this->addFlash(FlashBag::LEVEL_ERROR, $this->translator->trans('mautic.user.auth.error.weakpassword', [], 'flashes'));
 
                 return $this->forward('Mautic\UserBundle\Controller\PublicController::passwordResetAction');
             }
@@ -80,11 +88,11 @@ final class SecurityController extends CommonController implements EventSubscrib
         $request->query->set('tmpl', 'login');
 
         // Get a list of SSO integrations
-        $integrations = $integrationHelper->getIntegrationObjects(null, ['sso_service'], true, null, true);
+        $integrations = $this->integrationHelper->getIntegrationObjects(null, ['sso_service'], true, null, true);
 
         return $this->delegateView([
             'viewParameters' => [
-                'last_username' => $authenticationUtils->getLastUsername(),
+                'last_username' => $this->authenticationUtils->getLastUsername(),
                 'integrations'  => $integrations,
             ],
             'contentTemplate' => '@MauticUser/Security/login.html.twig',
@@ -114,9 +122,9 @@ final class SecurityController extends CommonController implements EventSubscrib
         return new RedirectResponse($this->generateUrl('login'));
     }
 
-    public function samlLoginRetryAction(Request $request, SAMLHelper $samlHelper, SessionInterface $session): Response
+    public function samlLoginRetryAction(Request $request, SessionInterface $session): Response
     {
-        if (!$samlHelper->isSamlEnabled()) {
+        if (!$this->samlHelper->isSamlEnabled()) {
             return new RedirectResponse($this->generateUrl('login'));
         }
 

--- a/app/bundles/UserBundle/Controller/UserController.php
+++ b/app/bundles/UserBundle/Controller/UserController.php
@@ -38,6 +38,13 @@ final class UserController extends FormController
     private UserModel $userModel;
 
     private AuditLogModel $auditLogModel;
+    private PageHelperFactoryInterface $pageHelperFactory;
+    private LanguageHelper $languageHelper;
+    private UserPasswordHasherInterface $hasher;
+    private SAMLHelper $samlHelper;
+    private SerializerInterface $serializer;
+    private MailHelper $mailer;
+    private IpLookupHelper $ipLookupHelper;
 
     #[Required]
     public function autowireUserController(
@@ -46,22 +53,36 @@ final class UserController extends FormController
         RoleModel $roleModel,
         AuditLogRepository $auditLogRepository,
         RoleRepository $roleRepository,
+        PageHelperFactoryInterface $pageHelperFactory,
+        LanguageHelper $languageHelper,
+        UserPasswordHasherInterface $hasher,
+        SAMLHelper $samlHelper,
+        SerializerInterface $serializer,
+        MailHelper $mailer,
+        IpLookupHelper $ipLookupHelper,
     ): void {
         $this->userModel = $userModel;
         $this->auditLogModel = $auditLogModel;
         $this->auditLogRepository = $auditLogRepository;
         $this->roleRepository = $roleRepository;
+        $this->pageHelperFactory = $pageHelperFactory;
+        $this->languageHelper = $languageHelper;
+        $this->hasher = $hasher;
+        $this->samlHelper = $samlHelper;
+        $this->serializer = $serializer;
+        $this->mailer = $mailer;
+        $this->ipLookupHelper = $ipLookupHelper;
     }
 
     /**
      * Generate's default user list.
      */
-    public function indexAction(Request $request, PageHelperFactoryInterface $pageHelperFactory, int $page = 1): JsonResponse|Response
+    public function indexAction(Request $request, int $page = 1): JsonResponse|Response
     {
         if (!$this->security->isGranted('user:users:view')) {
             $this->throwAccessDenied();
         }
-        $pageHelper = $pageHelperFactory->make('mautic.user', $page);
+        $pageHelper = $this->pageHelperFactory->make('mautic.user', $page);
 
         $this->setListFilters();
 
@@ -202,7 +223,7 @@ final class UserController extends FormController
         ]);
     }
 
-    public function newAction(Request $request, LanguageHelper $languageHelper, UserPasswordHasherInterface $hasher, SAMLHelper $samlHelper): JsonResponse|Response
+    public function newAction(Request $request): JsonResponse|Response
     {
         if (!$this->security->isGranted('user:users:create')) {
             $this->throwAccessDenied();
@@ -218,20 +239,20 @@ final class UserController extends FormController
 
         // Check for a submitted form and process it
         if ('POST' === $request->getMethod()) {
-            $response = $this->handleNewUserPost($request, $languageHelper, $hasher, $samlHelper, $user, $form);
+            $response = $this->handleNewUserPost($request, $user, $form);
         }
 
         return $response ?? $this->renderNewUserForm($form, $action);
     }
 
-    private function handleNewUserPost(Request $request, LanguageHelper $languageHelper, UserPasswordHasherInterface $hasher, SAMLHelper $samlHelper, User $user, FormInterface $form): JsonResponse|Response|null
+    private function handleNewUserPost(Request $request, User $user, FormInterface $form): JsonResponse|Response|null
     {
         $response  = null;
         $cancelled = $this->isFormCancelled($form);
         $valid     = false;
 
         if (!$cancelled) {
-            $valid = $this->saveNewUserIfValid($request, $languageHelper, $hasher, $user, $form);
+            $valid = $this->saveNewUserIfValid($request, $user, $form);
         }
 
         if ($cancelled || ($valid && $this->getFormButton($form, ['buttons', 'save'])->isClicked())) {
@@ -245,23 +266,23 @@ final class UserController extends FormController
                 ],
             ]);
         } elseif ($valid) {
-            $response = $this->editAction($request, $languageHelper, $hasher, $samlHelper, $user->getId(), true);
+            $response = $this->editAction($request, $user->getId(), true);
         }
 
         return $response;
     }
 
-    private function saveNewUserIfValid(Request $request, LanguageHelper $languageHelper, UserPasswordHasherInterface $hasher, User $user, FormInterface $form): bool
+    private function saveNewUserIfValid(Request $request, User $user, FormInterface $form): bool
     {
         $formUser          = $request->request->all()['user'] ?? [];
         $submittedPassword = $formUser['plainPassword']['password'] ?? null;
-        $password          = $this->userModel->checkNewPassword($user, $hasher, $submittedPassword);
+        $password          = $this->userModel->checkNewPassword($user, $this->hasher, $submittedPassword);
         $valid             = $this->isFormValid($form);
 
         if ($valid) {
             $user->setPassword($password);
             $this->userModel->saveEntity($user);
-            $this->loadNewUserLocale($languageHelper, $user);
+            $this->loadNewUserLocale($user);
 
             $this->addFlashMessage('mautic.core.notice.created', [
                 '%name%'      => $user->getName(),
@@ -276,12 +297,12 @@ final class UserController extends FormController
         return $valid;
     }
 
-    private function loadNewUserLocale(LanguageHelper $languageHelper, User $user): void
+    private function loadNewUserLocale(User $user): void
     {
-        $installedLanguages = $languageHelper->getSupportedLanguages();
+        $installedLanguages = $this->languageHelper->getSupportedLanguages();
 
         if ($user->getLocale() && !array_key_exists($user->getLocale(), $installedLanguages)) {
-            $fetchLanguage = $languageHelper->extractLanguagePackage($user->getLocale());
+            $fetchLanguage = $this->languageHelper->extractLanguagePackage($user->getLocale());
 
             if ($fetchLanguage['error']) {
                 $user->setLocale(null);
@@ -315,7 +336,7 @@ final class UserController extends FormController
      *
      * @return JsonResponse|Response
      */
-    public function editAction(Request $request, LanguageHelper $languageHelper, UserPasswordHasherInterface $hasher, SAMLHelper $samlHelper, $objectId, $ignorePost = false)
+    public function editAction(Request $request, $objectId, $ignorePost = false)
     {
         if (!$this->security->isGranted('user:users:edit')) {
             $this->throwAccessDenied();
@@ -364,7 +385,7 @@ final class UserController extends FormController
         $action = $this->generateUrl('mautic_user_action', ['objectAction' => 'edit', 'objectId' => $objectId]);
         $form   = $this->userModel->createForm($user, $this->formFactory, $action);
 
-        $isSamlUser    = $samlHelper->isSamlSession();
+        $isSamlUser    = $this->samlHelper->isSamlSession();
         if ($isSamlUser) {
             $form->remove('plainPassword');
         }
@@ -377,7 +398,7 @@ final class UserController extends FormController
                 // check to see if the password needs to be rehashed
                 $formUser          = $request->request->all()['user'] ?? [];
                 $submittedPassword = $formUser['plainPassword']['password'] ?? null;
-                $password          = $this->userModel->checkNewPassword($user, $hasher, $submittedPassword);
+                $password          = $this->userModel->checkNewPassword($user, $this->hasher, $submittedPassword);
                 $newEmail          = $formUser['email'] ?? null;
 
                 if ($valid = $this->isFormValid($form)) {
@@ -393,10 +414,10 @@ final class UserController extends FormController
                     }
 
                     // check if the user's locale has been downloaded already, fetch it if not
-                    $installedLanguages = $languageHelper->getSupportedLanguages();
+                    $installedLanguages = $this->languageHelper->getSupportedLanguages();
 
                     if ($user->getLocale() && !array_key_exists($user->getLocale(), $installedLanguages)) {
-                        $fetchLanguage = $languageHelper->extractLanguagePackage($user->getLocale());
+                        $fetchLanguage = $this->languageHelper->extractLanguagePackage($user->getLocale());
 
                         // If there is an error, we need to reset the user's locale to the default
                         if ($fetchLanguage['error']) {
@@ -531,7 +552,7 @@ final class UserController extends FormController
      *
      * @param int $objectId
      */
-    public function contactAction(Request $request, SerializerInterface $serializer, MailHelper $mailer, IpLookupHelper $ipLookupHelper, $objectId): Response|\Symfony\Component\HttpFoundation\RedirectResponse
+    public function contactAction(Request $request, $objectId): Response|\Symfony\Component\HttpFoundation\RedirectResponse
     {
         $user  = $this->userModel->getEntity($objectId);
 
@@ -566,11 +587,11 @@ final class UserController extends FormController
                     $subject = InputHelper::clean($form->get('msg_subject')->getData());
                     $body    = InputHelper::clean($form->get('msg_body')->getData());
 
-                    $mailer->setFrom($currentUser->getEmail(), $currentUser->getName());
-                    $mailer->setSubject($subject);
-                    $mailer->setTo($user->getEmail(), $user->getName());
-                    $mailer->setBody($body);
-                    $mailer->send();
+                    $this->mailer->setFrom($currentUser->getEmail(), $currentUser->getName());
+                    $this->mailer->setSubject($subject);
+                    $this->mailer->setTo($user->getEmail(), $user->getName());
+                    $this->mailer->setBody($body);
+                    $this->mailer->send();
 
                     $reEntity = $form->get('entity')->getData();
                     if (empty($reEntity)) {
@@ -584,7 +605,7 @@ final class UserController extends FormController
                         $entityId = $form->get('id')->getData();
                     }
 
-                    $details = $serializer->serialize([
+                    $details = $this->serializer->serialize([
                         'from'    => $currentUser->getName(),
                         'to'      => $user->getName(),
                         'subject' => $subject,
@@ -597,7 +618,7 @@ final class UserController extends FormController
                         'objectId'  => $entityId,
                         'action'    => 'communication',
                         'details'   => $details,
-                        'ipAddress' => $ipLookupHelper->getIpAddressFromRequest(),
+                        'ipAddress' => $this->ipLookupHelper->getIpAddressFromRequest(),
                     ];
                     $this->auditLogModel->writeToLog($log);
 


### PR DESCRIPTION
Part of #16948 — that PR splits into one PR per bundle, this is UserBundle.

Services that Symfony autowires per action move to constructor / `#[Required]` injection, so action signatures carry only request data. Applied by `ControllerMethodInjectionToConstructorRector`; the rule itself is enabled in #16948 and should land after all bundles are converted.

`UserBundle\Controller\PublicController`:

```diff
     #[Required]
     public function autowirePublicController(
         UserModel $userModel,
         UserRepository $userRepository,
+        LoggerInterface $logger,
+        UserPasswordHasherInterface $hasher,
     ): void {
         $this->userModel = $userModel;
         $this->userRepository = $userRepository;
+        $this->logger = $logger;
+        $this->hasher = $hasher;
     }

-    public function passwordResetAction(Request $request, LoggerInterface $logger): RedirectResponse|Response
+    public function passwordResetAction(Request $request): RedirectResponse|Response
     {
         // ...
                 } catch (\RuntimeException $e) {
-                    $logger->error(...);
+                    $this->logger->error(...);
```

`UserController` also stops passing `$this->hasher` / `$this->languageHelper` down its own private helpers (`handleNewUserPost()` → `saveNewUserIfValid()` → `loadNewUserLocale()`); those read the properties directly now.
