### PR TITLE
[CampaignBundle] Move action service injection to constructor injection

### DIFF
--- a/app/bundles/CampaignBundle/Controller/Api/CampaignApiController.php
+++ b/app/bundles/CampaignBundle/Controller/Api/CampaignApiController.php
@@ -59,11 +59,13 @@ final class CampaignApiController extends CommonApiController
         ModelFactory $modelFactory,
         EventDispatcherInterface $dispatcher,
         CoreParametersHelper $coreParametersHelper,
+        private UserHelper $userHelper,
         private ValidatorInterface $validator,
         private EventModel $eventModel,
         private CampaignContactCountHelper $contactCountHelper,
         CampaignModel $campaignModel,
         private LeadModel $leadModel,
+        private ImportHelper $importHelper,
     ) {
         $this->model             = $campaignModel;
         $this->entityClass       = Campaign::class;
@@ -426,7 +428,7 @@ final class CampaignApiController extends CommonApiController
         return $this->handleView($view);
     }
 
-    public function importCampaignAction(Request $request, UserHelper $userHelper, ImportHelper $importHelper): Response
+    public function importCampaignAction(Request $request): Response
     {
         // Check if user has permission to import campaigns
         if (!$this->security->isGranted('campaign:imports:create')) {
@@ -468,7 +470,7 @@ final class CampaignApiController extends CommonApiController
             }
 
             try {
-                $data = $importHelper->readZipFile($zipPath);
+                $data = $this->importHelper->readZipFile($zipPath);
             } catch (\RuntimeException $e) {
                 unlink($zipPath);
 
@@ -477,8 +479,8 @@ final class CampaignApiController extends CommonApiController
                 );
             }
         }
-        $importHelper->recursiveRemoveEmailaddress($data);
-        $userId = $userHelper->getUser()->getId();
+        $this->importHelper->recursiveRemoveEmailaddress($data);
+        $userId = $this->userHelper->getUser()->getId();
 
         foreach ($data as $entity) {
             $event  = new EntityImportEvent(Campaign::ENTITY_NAME, $entity, $userId);

--- a/app/bundles/CampaignBundle/Controller/CampaignController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignController.php
@@ -116,6 +116,8 @@ class CampaignController extends AbstractStandardFormController
         private readonly CampaignRepository $campaignRepository,
         private readonly SummaryRepository $summaryRepository,
         private readonly LeadEventLogRepository $leadEventLogRepository,
+        private ExportHelper $exportHelper,
+        private PageHelperFactoryInterface $pageHelperFactory,
     ) {
         parent::__construct($formFactory, $fieldHelper, $managerRegistry, $modelFactory, $userHelper, $coreParametersHelper, $dispatcher, $translator, $flashBag, $requestStack, $security);
     }
@@ -156,12 +158,11 @@ class CampaignController extends AbstractStandardFormController
      * @param array<int, mixed> $assetList
      */
     private function handleExportDownload(
-        ExportHelper $exportHelper,
         string $jsonOutput,
         array $assetList,
         string $exportFileName,
     ): JsonResponse|BinaryFileResponse {
-        $filePath = $exportHelper->writeToZipFile($jsonOutput, $assetList, '');
+        $filePath = $this->exportHelper->writeToZipFile($jsonOutput, $assetList, '');
         if (!file_exists($filePath)) {
             $this->logger->error('Export file could not be created', ['filePath' => $filePath]);
             $this->addFlashMessage('mautic.campaign.error.export.file_not_found', ['%path%' => $filePath], FlashBag::LEVEL_ERROR);
@@ -172,10 +173,10 @@ class CampaignController extends AbstractStandardFormController
             ], 400);
         }
 
-        return $exportHelper->downloadAsZip($filePath, $exportFileName);
+        return $this->exportHelper->downloadAsZip($filePath, $exportFileName);
     }
 
-    public function exportAction(ExportHelper $exportHelper, CampaignModel $campaignModel, int $objectId): JsonResponse|BinaryFileResponse|Response
+    public function exportAction(CampaignModel $campaignModel, int $objectId): JsonResponse|BinaryFileResponse|Response
     {
         if (!$this->security->isGranted('campaign:export:enable', 'MATCH_ONE')) {
             $this->logger->error('Access denied for campaign export', ['user' => $this->user->getId()]);
@@ -204,10 +205,10 @@ class CampaignController extends AbstractStandardFormController
         $assetListEvent = $this->dispatcher->dispatch($assetListEvent);
         $assetList      = $assetListEvent->getList();
 
-        return $this->handleExportDownload($exportHelper, $jsonOutput, $assetList, $exportFileName);
+        return $this->handleExportDownload($jsonOutput, $assetList, $exportFileName);
     }
 
-    public function batchExportAction(Request $request, ExportHelper $exportHelper): JsonResponse|BinaryFileResponse|Response
+    public function batchExportAction(Request $request): JsonResponse|BinaryFileResponse|Response
     {
         // set some permissions
         $permissions = $this->security->isGranted(
@@ -281,7 +282,7 @@ class CampaignController extends AbstractStandardFormController
 
         $jsonOutput = json_encode($allData, JSON_PRETTY_PRINT);
 
-        return $this->handleExportDownload($exportHelper, $jsonOutput, $assetList, $exportFileName);
+        return $this->handleExportDownload($jsonOutput, $assetList, $exportFileName);
     }
 
     /**
@@ -293,7 +294,6 @@ class CampaignController extends AbstractStandardFormController
      */
     public function contactsAction(
         Request $request,
-        PageHelperFactoryInterface $pageHelperFactory,
         $objectId,
         $page = 1,
         $count = null,
@@ -311,7 +311,7 @@ class CampaignController extends AbstractStandardFormController
 
         return $this->generateContactsGrid(
             $request,
-            $pageHelperFactory,
+            $this->pageHelperFactory,
             $objectId,
             $page,
             $permissions,

--- a/app/bundles/CampaignBundle/Controller/CampaignMapStatsController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignMapStatsController.php
@@ -34,6 +34,7 @@ final class CampaignMapStatsController extends AbstractController
 
     public function __construct(
         private readonly CampaignModel $model,
+        private readonly CorePermissions $security,
     ) {
     }
 
@@ -47,9 +48,9 @@ final class CampaignMapStatsController extends AbstractController
         return $this->model->getCountryStats($entity, $dateFromObject, $dateToObject);
     }
 
-    public function hasAccess(CorePermissions $security, Campaign $entity): bool
+    public function hasAccess(Campaign $entity): bool
     {
-        return $security->hasEntityAccess(
+        return $this->security->hasEntityAccess(
             'email:emails:viewown',
             'email:emails:viewother',
             $entity->getCreatedBy()
@@ -79,14 +80,13 @@ final class CampaignMapStatsController extends AbstractController
      * @throws \Exception
      */
     public function viewAction(
-        CorePermissions $security,
         int $objectId,
         string $dateFrom = '',
         string $dateTo = '',
     ): Response {
         $entity = $this->model->getEntity($objectId);
 
-        if (!$entity instanceof Campaign || !$this->hasAccess($security, $entity)) {
+        if (!$entity instanceof Campaign || !$this->hasAccess($entity)) {
             throw new AccessDeniedHttpException();
         }
 

--- a/app/bundles/CampaignBundle/Controller/CampaignMetricsController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignMetricsController.php
@@ -22,11 +22,12 @@ final class CampaignMetricsController extends AbstractController
     public function __construct(
         private readonly Translator $translator,
         private readonly CoreParametersHelper $coreParametersHelper,
+        private readonly EmailPeriodMetrics $emailPeriodMetrics,
+        private readonly EventDispatcherInterface $eventDispatcher,
     ) {
     }
 
     public function emailWeekdaysAction(
-        EmailPeriodMetrics $emailPeriodMetrics,
         CampaignModel $model,
         int $objectId,
         string $dateFrom = '',
@@ -39,7 +40,7 @@ final class CampaignMetricsController extends AbstractController
 
         $dateTimeHelper        = new DateTimeHelper();
         $defaultTimezoneOffset = $dateTimeHelper->getLocalDateTime()->format('Z');
-        $stats                 = $emailPeriodMetrics->emailMetricsPerWeekdayByCampaignEvents($eventsIds, $dateFromObject, $dateToObject, $defaultTimezoneOffset);
+        $stats                 = $this->emailPeriodMetrics->emailMetricsPerWeekdayByCampaignEvents($eventsIds, $dateFromObject, $dateToObject, $defaultTimezoneOffset);
 
         $chart  = new BarChart([
             $this->translator->trans('mautic.core.date.monday'),
@@ -66,7 +67,6 @@ final class CampaignMetricsController extends AbstractController
     }
 
     public function emailHoursAction(
-        EmailPeriodMetrics $emailPeriodMetrics,
         CampaignModel $model,
         int $objectId,
         string $dateFrom = '',
@@ -80,7 +80,7 @@ final class CampaignMetricsController extends AbstractController
         $dateTimeHelper        = new DateTimeHelper();
         $defaultTimezoneOffset = $dateTimeHelper->getLocalDateTime()->format('Z');
 
-        $stats = $emailPeriodMetrics->emailMetricsPerHourByCampaignEvents($eventsIds, $dateFromObject, $dateToObject, $defaultTimezoneOffset);
+        $stats = $this->emailPeriodMetrics->emailMetricsPerHourByCampaignEvents($eventsIds, $dateFromObject, $dateToObject, $defaultTimezoneOffset);
 
         $hoursRange = range(0, 23);
         $labels     = [];
@@ -110,7 +110,6 @@ final class CampaignMetricsController extends AbstractController
     }
 
     public function eventDetailsAction(
-        EventDispatcherInterface $eventDispatcher,
         EventModel $eventModel,
         int $objectId,
     ): JsonResponse {
@@ -123,7 +122,7 @@ final class CampaignMetricsController extends AbstractController
         }
 
         $eventDetailsAction = new EventPreview($event);
-        $eventDispatcher->dispatch($eventDetailsAction);
+        $this->eventDispatcher->dispatch($eventDetailsAction);
 
         return $this->json($eventDetailsAction->eventStats);
     }

--- a/app/bundles/CampaignBundle/Controller/ImportController.php
+++ b/app/bundles/CampaignBundle/Controller/ImportController.php
@@ -50,6 +50,7 @@ final class ImportController extends AbstractFormController
     private PathsHelper $pathsHelper;
 
     private FormFactoryInterface $formFactory;
+    private ImportHelper $importHelper;
 
     #[Required]
     public function autowireImportController(
@@ -58,12 +59,14 @@ final class ImportController extends AbstractFormController
         LoggerInterface $logger,
         PathsHelper $pathsHelper,
         FormFactoryInterface $formFactory,
+        ImportHelper $importHelper,
     ): void {
         $this->userHelper   = $userHelper;
         $this->requestStack = $requestStack;
         $this->logger       = $logger;
         $this->pathsHelper  = $pathsHelper;
         $this->formFactory  = $formFactory;
+        $this->importHelper = $importHelper;
     }
 
     public function newAction(): Response
@@ -237,13 +240,12 @@ final class ImportController extends AbstractFormController
         return $fileName;
     }
 
-    public function progressAction(ImportHelper $importHelper): Response
+    public function progressAction(): Response
     {
         $session       = $this->requestStack->getSession();
         $session->get('mautic.campaign.import.progress', 0);
         $step          = $session->get('mautic.campaign.import.step', self::STEP_PROGRESS_BAR);
         $fullPath      = $session->get('mautic.campaign.import.file');
-
         // If there's no valid file, show an error
         if (!$fullPath || !file_exists($fullPath)) {
             if (self::STEP_UPLOAD_ZIP !== $step) {
@@ -253,9 +255,8 @@ final class ImportController extends AbstractFormController
 
             return $this->redirectToRoute('mautic_campaign_import_action', ['objectAction' => 'new']);
         }
-
         if (self::STEP_PROGRESS_BAR === $step) {
-            $analyzeSummary = $this->analyzeData($importHelper, $fullPath);
+            $analyzeSummary = $this->analyzeData($fullPath);
 
             if (empty($analyzeSummary)) {
                 $this->addFlashMessage('mautic.campaign.import.nofile', [], FlashBag::LEVEL_ERROR, 'validators');
@@ -277,13 +278,13 @@ final class ImportController extends AbstractFormController
             ]);
         }
         try {
-            $fileData      = $importHelper->readZipFile($fullPath);
+            $fileData      = $this->importHelper->readZipFile($fullPath);
             $userId        = $this->userHelper->getUser()->getId();
             $importSummary = [];
 
             $importActions = $this->requestStack->getCurrentRequest()->get('importAction', []);
 
-            $importHelper->recursiveRemoveEmailaddress($fileData);
+            $this->importHelper->recursiveRemoveEmailaddress($fileData);
 
             // Loop through importActions and clean UUIDs for 'create' actions
             foreach ($fileData as &$group) {
@@ -382,10 +383,10 @@ final class ImportController extends AbstractFormController
     /**
      * @return array<int|string, array<string, mixed>>
      */
-    private function analyzeData(ImportHelper $importHelper, string $fullPath): array
+    private function analyzeData(string $fullPath): array
     {
         try {
-            $fileData = $importHelper->readZipFile($fullPath);
+            $fileData = $this->importHelper->readZipFile($fullPath);
         } catch (\RuntimeException $e) {
             $this->logger->error($e->getMessage());
             $this->removeImportFile($fullPath);

--- a/app/bundles/CampaignBundle/Tests/Controller/CampaignMapStatsControllerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/CampaignMapStatsControllerTest.php
@@ -12,6 +12,7 @@ use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CampaignBundle\Model\CampaignModel;
 use Mautic\CoreBundle\Entity\IpAddress;
 use Mautic\CoreBundle\Helper\MapHelper;
+use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Entity\Stat;
@@ -29,7 +30,7 @@ final class CampaignMapStatsControllerTest extends MauticMysqlTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->mapController           = new CampaignMapStatsController($this->createStub(CampaignModel::class));
+        $this->mapController           = new CampaignMapStatsController($this->createStub(CampaignModel::class), $this->createStub(CorePermissions::class));
     }
 
     /**


### PR DESCRIPTION
Part of #16948 — that PR splits into one PR per bundle, this is CampaignBundle.

Services that Symfony autowires per action move to constructor / `#[Required]` injection, so action signatures carry only request data. Applied by `ControllerMethodInjectionToConstructorRector`; the rule itself is enabled in #16948 and should land after all bundles are converted.

`CampaignMapStatsController`:

```diff
     public function __construct(
         private readonly CampaignModel $model,
+        private readonly CorePermissions $security,
     ) {
     }

-    public function hasAccess(CorePermissions $security, Campaign $entity): bool
+    public function hasAccess(Campaign $entity): bool
     {
-        return $security->hasEntityAccess(
+        return $this->security->hasEntityAccess(

     public function viewAction(
-        CorePermissions $security,
         int $objectId,
         string $dateFrom = '',
         string $dateTo = '',
     ): Response {
-        if (!$entity instanceof Campaign || !$this->hasAccess($security, $entity)) {
+        if (!$entity instanceof Campaign || !$this->hasAccess($entity)) {
```

`CampaignMapStatsControllerTest` is updated for the new constructor.

`CampaignController` also stops handing `$this->exportHelper` to its own private `handleExportDownload()`, which reads the property instead.
