### PR TITLE
[solid] inline array return assign, ctor defaults to property, remove dead readonly on readonly classes

### DIFF
--- a/app/bundles/ApiBundle/Entity/oAuth2/Client.php
+++ b/app/bundles/ApiBundle/Entity/oAuth2/Client.php
@@ -47,18 +47,16 @@ class Client extends BaseClient
     /**
      * @var array<string>
      */
-    protected array $allowedGrantTypes;
+    protected array $allowedGrantTypes = [
+        OAuth2::GRANT_TYPE_AUTH_CODE,
+        OAuth2::GRANT_TYPE_REFRESH_TOKEN,
+    ];
 
     protected ?Role $role = null;
 
     public function __construct()
     {
         parent::__construct();
-
-        $this->allowedGrantTypes = [
-            OAuth2::GRANT_TYPE_AUTH_CODE,
-            OAuth2::GRANT_TYPE_REFRESH_TOKEN,
-        ];
 
         $this->users     = new ArrayCollection();
         $this->authCodes = new ArrayCollection();

--- a/app/bundles/ApiBundle/Entity/oAuth2/Client.php
+++ b/app/bundles/ApiBundle/Entity/oAuth2/Client.php
@@ -47,16 +47,18 @@ class Client extends BaseClient
     /**
      * @var array<string>
      */
-    protected array $allowedGrantTypes = [
-        OAuth2::GRANT_TYPE_AUTH_CODE,
-        OAuth2::GRANT_TYPE_REFRESH_TOKEN,
-    ];
+    protected array $allowedGrantTypes;
 
     protected ?Role $role = null;
 
     public function __construct()
     {
         parent::__construct();
+
+        $this->allowedGrantTypes = [
+            OAuth2::GRANT_TYPE_AUTH_CODE,
+            OAuth2::GRANT_TYPE_REFRESH_TOKEN,
+        ];
 
         $this->users     = new ArrayCollection();
         $this->authCodes = new ArrayCollection();

--- a/app/bundles/ApiBundle/Tests/Entity/oAuth2/ClientTest.php
+++ b/app/bundles/ApiBundle/Tests/Entity/oAuth2/ClientTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\ApiBundle\Tests\Entity\oAuth2;
+
+use Mautic\ApiBundle\Entity\oAuth2\Client;
+use OAuth2\OAuth2;
+use PHPUnit\Framework\TestCase;
+
+final class ClientTest extends TestCase
+{
+    public function testAllowedGrantTypesOnConstruction(): void
+    {
+        $client = new Client();
+
+        $allowedGrantTypes = $client->getAllowedGrantTypes();
+
+        $this->assertCount(2, $allowedGrantTypes);
+        $this->assertSame([
+            OAuth2::GRANT_TYPE_AUTH_CODE,
+            OAuth2::GRANT_TYPE_REFRESH_TOKEN,
+        ], $allowedGrantTypes);
+    }
+}

--- a/app/bundles/AssetBundle/EventListener/FormSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/FormSubscriber.php
@@ -29,7 +29,7 @@ final readonly class FormSubscriber implements EventSubscriberInterface
         private AssetsHelper $assetsHelper,
         private ThemeHelperInterface $themeHelper,
         private CoreParametersHelper $coreParametersHelper,
-        private readonly AssetRepository $assetRepository,
+        private AssetRepository $assetRepository,
     ) {
     }
 

--- a/app/bundles/CampaignBundle/Entity/Event.php
+++ b/app/bundles/CampaignBundle/Entity/Event.php
@@ -226,7 +226,7 @@ class Event implements ChannelInterface, UuidInterface
     private int $failedCount = 0;
 
     #[Groups(['event:read', 'event:write', 'campaign:read'])]
-    private ?Event $redirectEvent;
+    private ?Event $redirectEvent = null;
 
     #[Groups(['event:read', 'event:write', 'campaign:read'])]
     private ?\DateTime $dateLinked = null;
@@ -242,7 +242,6 @@ class Event implements ChannelInterface, UuidInterface
     {
         $this->log               = new ArrayCollection();
         $this->children          = new ArrayCollection();
-        $this->redirectEvent     = null;
         $this->redirectingEvents = new ArrayCollection();
 
         if ($dateAdded) {

--- a/app/bundles/CoreBundle/EventListener/CoreSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/CoreSubscriber.php
@@ -33,7 +33,7 @@ final readonly class CoreSubscriber implements EventSubscriberInterface
         private AuthorizationCheckerInterface $securityContext,
         private EventDispatcherInterface $dispatcher,
         private RequestStack $requestStack,
-        private readonly UserRepository $userRepository,
+        private UserRepository $userRepository,
     ) {
     }
 

--- a/app/bundles/CoreBundle/Model/IteratorExportDataModel.php
+++ b/app/bundles/CoreBundle/Model/IteratorExportDataModel.php
@@ -6,18 +6,18 @@ use Mautic\CoreBundle\Helper\DataExporterHelper;
 
 class IteratorExportDataModel implements \Iterator
 {
-    private int $position;
+    private int $position = 0;
 
     private $callback;
 
-    private int $total;
+    private int $total = 0;
 
     /**
      * @var ?mixed[]
      */
-    private ?array $data;
+    private ?array $data = [];
 
-    private int $totalResult;
+    private int $totalResult = 0;
 
     /**
      * @param AbstractCommonModel<T> $model
@@ -32,10 +32,6 @@ class IteratorExportDataModel implements \Iterator
         private readonly bool $skipOrdering = false,
     ) {
         $this->callback     = $callback;
-        $this->position     = 0;
-        $this->total        = 0;
-        $this->totalResult  = 0;
-        $this->data         = [];
     }
 
     /**

--- a/app/bundles/DynamicContentBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/DynamicContentBundle/EventListener/CampaignSubscriber.php
@@ -23,7 +23,7 @@ final readonly class CampaignSubscriber implements EventSubscriberInterface
         private DynamicContentModel $dynamicContentModel,
         private CacheProvider $cache,
         private EventDispatcherInterface $dispatcher,
-        private readonly DynamicContentRepository $dynamicContentRepository,
+        private DynamicContentRepository $dynamicContentRepository,
     ) {
     }
 

--- a/app/bundles/EmailBundle/EventListener/BroadcastSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/BroadcastSubscriber.php
@@ -18,7 +18,7 @@ final readonly class BroadcastSubscriber implements EventSubscriberInterface
         private EmailModel $model,
         private EntityManagerInterface $em,
         private TranslatorInterface $translator,
-        private readonly EmailRepository $emailRepository,
+        private EmailRepository $emailRepository,
     ) {
     }
 

--- a/app/bundles/EmailBundle/EventListener/EmailSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/EmailSubscriber.php
@@ -37,7 +37,7 @@ final readonly class EmailSubscriber implements EventSubscriberInterface
         private TranslatorInterface $translator,
         private EntityManagerInterface $entityManager,
         private EmailDraftModel $emailDraftModel,
-        private readonly EmailRepository $emailRepository,
+        private EmailRepository $emailRepository,
     ) {
     }
 

--- a/app/bundles/EmailBundle/MonitoredEmail/Processor/Reply.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Processor/Reply.php
@@ -27,7 +27,7 @@ final readonly class Reply implements ProcessorInterface
         private LoggerInterface $logger,
         private ContactTracker $contactTracker,
         private EmailAddressHelper $addressHelper,
-        private readonly LeadRepository $leadRepository,
+        private LeadRepository $leadRepository,
     ) {
     }
 

--- a/app/bundles/EmailBundle/Tests/Controller/Api/EmailApiControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/Api/EmailApiControllerFunctionalTest.php
@@ -827,12 +827,8 @@ final class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
     private function getUser(string $userName): ?User
     {
         $repository = $this->em->getRepository(User::class);
-        $user       = $repository->findOneBy(['username' => $userName]);
-        if (!$user instanceof User) {
-            return null;
-        }
 
-        return $user;
+        return $repository->findOneBy(['username' => $userName]);
     }
 
     /**

--- a/app/bundles/FormBundle/Entity/Form.php
+++ b/app/bundles/FormBundle/Entity/Form.php
@@ -175,7 +175,7 @@ class Form extends FormEntity implements UuidInterface
      * @var bool|null
      */
     #[Groups(['form:read', 'form:write', 'download:read', 'campaign:read', 'email:read'])]
-    private $noIndex;
+    private $noIndex = true;
 
     /**
      * @var int|null
@@ -211,7 +211,6 @@ class Form extends FormEntity implements UuidInterface
         $this->fields      = new ArrayCollection();
         $this->actions     = new ArrayCollection();
         $this->submissions = new ArrayCollection();
-        $this->noIndex     = true;
         $this->initializeProjects();
     }
 

--- a/app/bundles/FormBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/CampaignSubscriber.php
@@ -24,8 +24,8 @@ final readonly class CampaignSubscriber implements EventSubscriberInterface
         private FormModel $formModel,
         private RealTimeExecutioner $realTimeExecutioner,
         private FormFieldHelper $formFieldHelper,
-        private readonly FormRepository $formRepository,
-        private readonly SubmissionRepository $submissionRepository,
+        private FormRepository $formRepository,
+        private SubmissionRepository $submissionRepository,
     ) {
     }
 

--- a/app/bundles/FormBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/ReportSubscriber.php
@@ -35,7 +35,7 @@ final readonly class ReportSubscriber implements EventSubscriberInterface
         private CoreParametersHelper $coreParametersHelper,
         private TranslatorInterface $translator,
         private DncReportService $dncReportService,
-        private readonly FormRepository $formRepository,
+        private FormRepository $formRepository,
     ) {
     }
 

--- a/app/bundles/LeadBundle/Entity/CompanyLeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/CompanyLeadRepository.php
@@ -170,7 +170,7 @@ class CompanyLeadRepository extends CommonRepository
 
         $result = $q->executeQuery()->fetchAllAssociative();
 
-        return !empty($result) ? $result[0] : [];
+        return $result[0] ?? [];
     }
 
     /**

--- a/app/bundles/LeadBundle/Entity/Import.php
+++ b/app/bundles/LeadBundle/Entity/Import.php
@@ -108,12 +108,12 @@ class Import extends FormEntity
     /**
      * @var int
      */
-    private $priority;
+    private $priority = self::LOW;
 
     /**
      * @var int
      */
-    private $status;
+    private $status = self::QUEUED;
 
     private ?\DateTimeInterface $dateStarted = null;
 
@@ -135,8 +135,6 @@ class Import extends FormEntity
 
     public function __construct()
     {
-        $this->status   = self::QUEUED;
-        $this->priority = self::LOW;
     }
 
     public static function loadMetadata(ORM\ClassMetadata $metadata): void

--- a/app/bundles/LeadBundle/Entity/Import.php
+++ b/app/bundles/LeadBundle/Entity/Import.php
@@ -133,10 +133,6 @@ class Import extends FormEntity
         parent::__clone();
     }
 
-    public function __construct()
-    {
-    }
-
     public static function loadMetadata(ORM\ClassMetadata $metadata): void
     {
         $builder = new ClassMetadataBuilder($metadata);

--- a/app/bundles/LeadBundle/Entity/LeadDeviceRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadDeviceRepository.php
@@ -108,7 +108,7 @@ class LeadDeviceRepository extends CommonRepository
         // get totals
         $device = $selectQuery->executeQuery()->fetchAllAssociative();
 
-        return (!empty($device)) ? $device[0] : [];
+        return $device[0] ?? [];
     }
 
     /**

--- a/app/bundles/LeadBundle/Event/LeadBuildSearchEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadBuildSearchEvent.php
@@ -7,15 +7,15 @@ use Mautic\CoreBundle\Event\CommonEvent;
 
 class LeadBuildSearchEvent extends CommonEvent
 {
-    protected string $subQuery;
+    protected string $subQuery = '';
 
-    protected bool $isSearchDone;
+    protected bool $isSearchDone = false;
 
-    protected bool $returnParameters;
+    protected bool $returnParameters = false;
 
-    protected bool $strict;
+    protected bool $strict = false;
 
-    protected array $parameters;
+    protected array $parameters = [];
 
     /**
      * @param string $string
@@ -29,11 +29,6 @@ class LeadBuildSearchEvent extends CommonEvent
         protected bool $negate,
         protected QueryBuilder $queryBuilder,
     ) {
-        $this->subQuery         = '';
-        $this->isSearchDone     = false;
-        $this->strict           = false;
-        $this->returnParameters = false;
-        $this->parameters       = [];
     }
 
     /**

--- a/app/bundles/LeadBundle/Event/LeadListFilteringEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadListFilteringEvent.php
@@ -11,9 +11,9 @@ use Mautic\LeadBundle\Segment\Query\QueryBuilder;
  */
 final class LeadListFilteringEvent extends CommonEvent
 {
-    private bool $isFilteringDone;
+    private bool $isFilteringDone = false;
 
-    private string $subQuery;
+    private string $subQuery = '';
 
     private readonly string $leadsTableAlias;
 
@@ -33,8 +33,6 @@ final class LeadListFilteringEvent extends CommonEvent
         EntityManagerInterface $entityManager,
     ) {
         $this->em              = $entityManager;
-        $this->isFilteringDone = false;
-        $this->subQuery        = '';
         $this->leadsTableAlias = $queryBuilder->getTableAlias(MAUTIC_TABLE_PREFIX.'leads');
     }
 

--- a/app/bundles/LeadBundle/EventListener/ReportNormalizeSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/ReportNormalizeSubscriber.php
@@ -11,7 +11,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 final readonly class ReportNormalizeSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly LeadFieldRepository $leadFieldRepository,
+        private LeadFieldRepository $leadFieldRepository,
     ) {
     }
 

--- a/app/bundles/LeadBundle/EventListener/WebhookSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/WebhookSubscriber.php
@@ -21,7 +21,7 @@ final readonly class WebhookSubscriber implements EventSubscriberInterface
     public function __construct(
         private WebhookModel $webhookModel,
         private LeadModel $leadModel,
-        private readonly LeadRepository $leadRepository,
+        private LeadRepository $leadRepository,
     ) {
     }
 

--- a/app/bundles/LeadBundle/Model/CompanyModel.php
+++ b/app/bundles/LeadBundle/Model/CompanyModel.php
@@ -800,7 +800,7 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
             return null;
         }
 
-        $company = !empty($duplicateCompanies) ? $duplicateCompanies[0] : new Company();
+        $company = $duplicateCompanies[0] ?? new Company();
 
         if (!$company->isNew() && !$this->existDataForUpdate($fields, $data)) {
             return $company;

--- a/app/bundles/LeadBundle/Segment/Stat/SegmentDependencies.php
+++ b/app/bundles/LeadBundle/Segment/Stat/SegmentDependencies.php
@@ -23,43 +23,32 @@ final readonly class SegmentDependencies
 
     public function getChannelsIds($segmentId): array
     {
-        $usage   = [];
-        $usage[] = [
-            'label' => 'mautic.email.emails',
-            'route' => 'mautic_email_index',
-            'ids'   => $this->emailModel->getEmailsIdsWithDependenciesOnSegment($segmentId),
+        return [
+            [
+                'label' => 'mautic.email.emails',
+                'route' => 'mautic_email_index',
+                'ids'   => $this->emailModel->getEmailsIdsWithDependenciesOnSegment($segmentId),
+            ], [
+                'label' => 'mautic.campaign.campaigns',
+                'route' => 'mautic_campaign_index',
+                'ids'   => $this->campaignModel->getCampaignIdsWithDependenciesOnSegment($segmentId),
+            ], [
+                'label' => 'mautic.lead.lead.lists',
+                'route' => 'mautic_segment_index',
+                'ids'   => $this->listModel->getSegmentsWithDependenciesOnSegment($segmentId, 'id'),
+            ], [
+                'label' => 'mautic.report.reports',
+                'route' => 'mautic_report_index',
+                'ids'   => $this->reportModel->getReportsIdsWithDependenciesOnSegment($segmentId),
+            ], [
+                'label' => 'mautic.form.forms',
+                'route' => 'mautic_form_index',
+                'ids'   => $this->actionModel->getFormsIdsWithDependenciesOnSegment($segmentId),
+            ], [
+                'label' => 'mautic.point.trigger.header.index',
+                'route' => 'mautic_pointtrigger_index',
+                'ids'   => $this->triggerEventModel->getReportIdsWithDependenciesOnSegment($segmentId),
+            ],
         ];
-
-        $usage[] = [
-            'label' => 'mautic.campaign.campaigns',
-            'route' => 'mautic_campaign_index',
-            'ids'   => $this->campaignModel->getCampaignIdsWithDependenciesOnSegment($segmentId),
-        ];
-
-        $usage[] = [
-            'label' => 'mautic.lead.lead.lists',
-            'route' => 'mautic_segment_index',
-            'ids'   => $this->listModel->getSegmentsWithDependenciesOnSegment($segmentId, 'id'),
-        ];
-
-        $usage[] = [
-            'label' => 'mautic.report.reports',
-            'route' => 'mautic_report_index',
-            'ids'   => $this->reportModel->getReportsIdsWithDependenciesOnSegment($segmentId),
-        ];
-
-        $usage[] = [
-            'label' => 'mautic.form.forms',
-            'route' => 'mautic_form_index',
-            'ids'   => $this->actionModel->getFormsIdsWithDependenciesOnSegment($segmentId),
-        ];
-
-        $usage[] = [
-            'label' => 'mautic.point.trigger.header.index',
-            'route' => 'mautic_pointtrigger_index',
-            'ids'   => $this->triggerEventModel->getReportIdsWithDependenciesOnSegment($segmentId),
-        ];
-
-        return $usage;
     }
 }

--- a/app/bundles/LeadBundle/Segment/TableSchemaColumnsCache.php
+++ b/app/bundles/LeadBundle/Segment/TableSchemaColumnsCache.php
@@ -6,12 +6,11 @@ use Doctrine\ORM\EntityManagerInterface;
 
 class TableSchemaColumnsCache
 {
-    private array $cache;
+    private array $cache = [];
 
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
     ) {
-        $this->cache         = [];
     }
 
     /**

--- a/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
@@ -531,12 +531,7 @@ final class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
      */
     private function createContacts(): array
     {
-        $contacts   = [];
-        $contacts[] = $this->createContact('contact1@email.com', 'Isaac', 'Asimov');
-        $contacts[] = $this->createContact('contact2@email.com', 'Robert A.', 'Heinlein');
-        $contacts[] = $this->createContact('contact3@email.com', 'Arthur C.', 'Clarke', 1);
-
-        return $contacts;
+        return [$this->createContact('contact1@email.com', 'Isaac', 'Asimov'), $this->createContact('contact2@email.com', 'Robert A.', 'Heinlein'), $this->createContact('contact3@email.com', 'Arthur C.', 'Clarke', 1)];
     }
 
     /**

--- a/app/bundles/PointBundle/Entity/GroupContactScore.php
+++ b/app/bundles/PointBundle/Entity/GroupContactScore.php
@@ -19,13 +19,12 @@ class GroupContactScore extends CommonEntity
 
     private Group $group;
 
-    private int $score;
+    private int $score = 0;
 
     public function __construct()
     {
         $this->contact = new Lead();
         $this->group   = new Group();
-        $this->score   = 0;
     }
 
     /**

--- a/app/bundles/ReportBundle/Entity/Report.php
+++ b/app/bundles/ReportBundle/Entity/Report.php
@@ -702,11 +702,6 @@ class Report extends FormEntity implements SchedulerInterface, UuidInterface
      */
     public function getSchedule(): array
     {
-        $schedule                             = [];
-        $schedule['schedule_unit']            = $this->scheduleUnit;
-        $schedule['schedule_day']             = $this->scheduleDay;
-        $schedule['schedule_month_frequency'] = $this->scheduleMonthFrequency;
-
-        return $schedule;
+        return ['schedule_unit' => $this->scheduleUnit, 'schedule_day' => $this->scheduleDay, 'schedule_month_frequency' => $this->scheduleMonthFrequency];
     }
 }

--- a/app/bundles/ReportBundle/Event/ColumnCollectEvent.php
+++ b/app/bundles/ReportBundle/Event/ColumnCollectEvent.php
@@ -11,7 +11,7 @@ final class ColumnCollectEvent extends Event
     /**
      * @var array<string, mixed>
      */
-    private array $columns;
+    private array $columns = [];
 
     /**
      * @param array<string, mixed> $properties
@@ -20,7 +20,6 @@ final class ColumnCollectEvent extends Event
         private readonly string $object,
         private readonly array $properties = [],
     ) {
-        $this->columns = [];
     }
 
     public function getObject(): string

--- a/app/bundles/ReportBundle/Model/ReportExportOptions.php
+++ b/app/bundles/ReportBundle/Model/ReportExportOptions.php
@@ -8,7 +8,7 @@ final class ReportExportOptions
 {
     private readonly int $batchSize;
 
-    private int $page;
+    private int $page = 1;
 
     /**
      * @var \DateTimeInterface
@@ -23,7 +23,6 @@ final class ReportExportOptions
     public function __construct(CoreParametersHelper $coreParametersHelper)
     {
         $this->batchSize = $coreParametersHelper->get('report_export_batch_size');
-        $this->page      = 1;
     }
 
     public function beginExport(): void

--- a/app/bundles/SmsBundle/Sms/TransportChain.php
+++ b/app/bundles/SmsBundle/Sms/TransportChain.php
@@ -14,7 +14,7 @@ class TransportChain
     /**
      * @var array<string, array{alias: string, integrationAlias: string, service: TransportInterface, published?: bool}>
      */
-    private array $transports;
+    private array $transports = [];
 
     /**
      * @param string $primaryTransport
@@ -23,7 +23,6 @@ class TransportChain
         private $primaryTransport,
         private readonly IntegrationHelper $integrationHelper,
     ) {
-        $this->transports        = [];
     }
 
     /**

--- a/plugins/GrapesJsBuilderBundle/EventSubscriber/InjectCustomContentSubscriber.php
+++ b/plugins/GrapesJsBuilderBundle/EventSubscriber/InjectCustomContentSubscriber.php
@@ -25,7 +25,7 @@ final readonly class InjectCustomContentSubscriber implements EventSubscriberInt
         private Environment $twig,
         private RequestStack $requestStack,
         private RouterInterface $router,
-        private readonly GrapesJsBuilderRepository $grapesJsBuilderRepository,
+        private GrapesJsBuilderRepository $grapesJsBuilderRepository,
     ) {
     }
 

--- a/plugins/GrapesJsBuilderBundle/EventSubscriber/SerializerSubscriber.php
+++ b/plugins/GrapesJsBuilderBundle/EventSubscriber/SerializerSubscriber.php
@@ -17,7 +17,7 @@ final readonly class SerializerSubscriber implements EventSubscriberInterface
 {
     public function __construct(
         private Config $config,
-        private readonly GrapesJsBuilderRepository $grapesJsBuilderRepository,
+        private GrapesJsBuilderRepository $grapesJsBuilderRepository,
     ) {
     }
 

--- a/plugins/MauticFocusBundle/EventListener/FormSubscriber.php
+++ b/plugins/MauticFocusBundle/EventListener/FormSubscriber.php
@@ -12,7 +12,7 @@ final readonly class FormSubscriber implements EventSubscriberInterface
 {
     public function __construct(
         private FocusModel $model,
-        private readonly FocusRepository $focusRepository,
+        private FocusRepository $focusRepository,
     ) {
     }
 

--- a/rector.php
+++ b/rector.php
@@ -49,7 +49,7 @@ return RectorConfig::configure()
         Utils\Rector\ModelGetRepositoryToRepositoryServiceRector::class,
     ])
     ->reportUnusedSkips()
-    ->withCodeQualityLevel(45)
+    ->withCodeQualityLevel(60)
     ->withComposerBased(phpunit: true, symfony: true)
     ->withSkip([
         // @todo move to "twig" group
@@ -62,12 +62,10 @@ return RectorConfig::configure()
             __DIR__.'/app/bundles/PageBundle/Form/Type/PreferenceCenterListType.php',
         ],
 
+        // preference to compare null over object
+        Rector\CodeQuality\Rector\Identical\FlipTypeControlToUseExclusiveTypeRector::class,
+
         Rector\CodeQuality\Rector\Isset_\IssetOnPropertyObjectToPropertyExistsRector::class => [
-<<<<<<< HEAD
-=======
-            // handle in rector
-            __DIR__.'/plugins/GrapesJsBuilderBundle/Helper/FileManager.php',
->>>>>>> ab45e23259 ([solid] flip isset to direct property value check, as property exists and is explicitly defined)
             // doctrine magic
             __DIR__.'/app/bundles/CoreBundle/EventListener/DoctrineEventsSubscriber.php',
         ],

--- a/rector.php
+++ b/rector.php
@@ -49,7 +49,7 @@ return RectorConfig::configure()
         Utils\Rector\ModelGetRepositoryToRepositoryServiceRector::class,
     ])
     ->reportUnusedSkips()
-    ->withCodeQualityLevel(60)
+    ->withCodeQualityLevel(55)
     ->withComposerBased(phpunit: true, symfony: true)
     ->withSkip([
         // @todo move to "twig" group

--- a/rector.php
+++ b/rector.php
@@ -63,6 +63,11 @@ return RectorConfig::configure()
         ],
 
         Rector\CodeQuality\Rector\Isset_\IssetOnPropertyObjectToPropertyExistsRector::class => [
+<<<<<<< HEAD
+=======
+            // handle in rector
+            __DIR__.'/plugins/GrapesJsBuilderBundle/Helper/FileManager.php',
+>>>>>>> ab45e23259 ([solid] flip isset to direct property value check, as property exists and is explicitly defined)
             // doctrine magic
             __DIR__.'/app/bundles/CoreBundle/EventListener/DoctrineEventsSubscriber.php',
         ],


### PR DESCRIPTION
Rector code quality cleanups, bumped from `withCodeQualityLevel(45)` to `55`.

**Inline array assign of an instant return**:

```diff
-        $user = $repository->findOneBy(['username' => $userName]);
-        if (!$user instanceof User) {
-            return null;
-        }
-
-        return $user;
+        return $repository->findOneBy(['username' => $userName]);
```

**Move constructor default values directly to the property**:

```diff
-    protected array $allowedGrantTypes;
+    protected array $allowedGrantTypes = [
+        OAuth2::GRANT_TYPE_AUTH_CODE,
+        OAuth2::GRANT_TYPE_REFRESH_TOKEN,
+    ];

     public function __construct()
     {
-        $this->allowedGrantTypes = [
-            OAuth2::GRANT_TYPE_AUTH_CODE,
-            OAuth2::GRANT_TYPE_REFRESH_TOKEN,
-        ];
```

**Remove `readonly` on properties of already readonly classes**, where it is implied:

```diff
 final readonly class AssetSubscriber
 {
     public function __construct(
-        private readonly AssetRepository $assetRepository,
+        private AssetRepository $assetRepository,
```

Config also skips `FlipTypeControlToUseExclusiveTypeRector` (preference to compare null over object) and keeps the doctrine-magic skips for `IssetOnPropertyObjectToPropertyExistsRector`.

Split out of this PR into their own: #16956 (`static::` → `self::`) and #16957 (`empty()` → `[] === $array`).
