### PR TITLE
[solid] use self over static where local use

### DIFF
--- a/app/bundles/ApiBundle/Form/Validator/Constraints/OAuthCallbackValidator.php
+++ b/app/bundles/ApiBundle/Form/Validator/Constraints/OAuthCallbackValidator.php
@@ -28,7 +28,7 @@ final class OAuthCallbackValidator extends ConstraintValidator
         }
 
         $value = (string) $value;
-        if (!preg_match(static::PATTERN, $value)) {
+        if (!preg_match(self::PATTERN, $value)) {
             $this->context->buildViolation($constraint->message)
                 ->setParameter('{{ value }}', $this->formatValue($value))
                 ->addViolation();

--- a/app/bundles/ApiBundle/Tests/Functional/Controller/ClientControllerTest.php
+++ b/app/bundles/ApiBundle/Tests/Functional/Controller/ClientControllerTest.php
@@ -65,7 +65,7 @@ final class ClientControllerTest extends MauticMysqlTestCase
         $content = $this->client->getResponse()->getContent();
         $this->assertResponseIsSuccessful();
 
-        $translator = static::getContainer()->get(TranslatorInterface::class);
+        $translator = self::getContainer()->get(TranslatorInterface::class);
 
         // Check for total item count in pagination
         $this->assertStringContainsString(

--- a/app/bundles/ApiBundle/Tests/Functional/Controller/CommonApiControllerTest.php
+++ b/app/bundles/ApiBundle/Tests/Functional/Controller/CommonApiControllerTest.php
@@ -40,11 +40,11 @@ final class CommonApiControllerTest extends MauticMysqlTestCase
 
         $this->assertEquals(Response::HTTP_CONFLICT, $error['code']);
 
-        $translator = static::getContainer()->get(TranslatorInterface::class);
+        $translator = self::getContainer()->get(TranslatorInterface::class);
         $this->assertInstanceOf(TranslatorInterface::class, $translator);
 
         /** @var CoreParametersHelper $coreParametersHelper */
-        $coreParametersHelper = static::getContainer()->get(CoreParametersHelper::class);
+        $coreParametersHelper = self::getContainer()->get(CoreParametersHelper::class);
         $this->assertInstanceOf(CoreParametersHelper::class, $coreParametersHelper);
         $dateFormat = $coreParametersHelper->get('date_format_dateonly');
         $timeFormat = $coreParametersHelper->get('date_format_timeonly');
@@ -113,11 +113,11 @@ final class CommonApiControllerTest extends MauticMysqlTestCase
 
         $this->assertEquals(Response::HTTP_CONFLICT, $error['code']);
 
-        $translator = static::getContainer()->get(TranslatorInterface::class);
+        $translator = self::getContainer()->get(TranslatorInterface::class);
         $this->assertInstanceOf(TranslatorInterface::class, $translator);
 
         /** @var CoreParametersHelper $coreParametersHelper */
-        $coreParametersHelper = static::getContainer()->get(CoreParametersHelper::class);
+        $coreParametersHelper = self::getContainer()->get(CoreParametersHelper::class);
         $this->assertInstanceOf(CoreParametersHelper::class, $coreParametersHelper);
         $dateFormat = $coreParametersHelper->get('date_format_dateonly');
         $timeFormat = $coreParametersHelper->get('date_format_timeonly');
@@ -157,6 +157,6 @@ final class CommonApiControllerTest extends MauticMysqlTestCase
         $this->em->persist($user);
         $this->em->flush();
 
-        static::getContainer()->get(UserTokenSetter::class)->setUser($user->getId());
+        self::getContainer()->get(UserTokenSetter::class)->setUser($user->getId());
     }
 }

--- a/app/bundles/AssetBundle/Tests/Controller/AssetControllerFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Controller/AssetControllerFunctionalTest.php
@@ -412,7 +412,7 @@ final class AssetControllerFunctionalTest extends AbstractAssetTestCase
         // Set new permissions
         $role->setIsAdmin(false);
         /** @var RoleModel $roleModel */
-        $roleModel = static::getContainer()->get(RoleModel::class);
+        $roleModel = self::getContainer()->get(RoleModel::class);
         $this->assertInstanceOf(RoleModel::class, $roleModel);
         $roleModel->setRolePermissions($role, $permissions);
         $this->em->persist($role);

--- a/app/bundles/AssetBundle/Tests/Controller/PublicControllerFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Controller/PublicControllerFunctionalTest.php
@@ -137,7 +137,7 @@ final class PublicControllerFunctionalTest extends AbstractAssetTestCase
         $this->logoutUser();
         $asset                = $this->createAsset(['title' => 'Missing Local File Asset']);
         /** @var CoreParametersHelper $coreParametersHelper */
-        $coreParametersHelper = static::getContainer()->get(CoreParametersHelper::class);
+        $coreParametersHelper = self::getContainer()->get(CoreParametersHelper::class);
         $asset->setUploadDir($coreParametersHelper->get('upload_dir'));
         $this->em->flush();
 

--- a/app/bundles/AssetBundle/Tests/EventListener/LeadSubscriberFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/EventListener/LeadSubscriberFunctionalTest.php
@@ -99,7 +99,7 @@ final class LeadSubscriberFunctionalTest extends MauticMysqlTestCase
     private function getFirstAssetDownloadEvent(int $leadId): array
     {
         /** @var LeadModel $leadModel */
-        $leadModel = static::getContainer()->get(LeadModel::class);
+        $leadModel = self::getContainer()->get(LeadModel::class);
         $payload   = $leadModel->getEngagements($leadModel->getEntity($leadId), []);
 
         // LeadTimelineEvent::getEvents() flattens events across all types into

--- a/app/bundles/AssetBundle/Tests/Model/AssetModelFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Model/AssetModelFunctionalTest.php
@@ -48,7 +48,7 @@ final class AssetModelFunctionalTest extends MauticMysqlTestCase
         $expectedUrl = 'https://localhost/asset/'.$slug.$expectedQuery;
 
         /** @var AssetModel $assetModel */
-        $assetModel = static::getContainer()->get(AssetModel::class);
+        $assetModel = self::getContainer()->get(AssetModel::class);
         $this->assertInstanceOf(AssetModel::class, $assetModel);
         $generatedUrl = $assetModel->generateUrl($asset, $absolute, $clickthrough, $stream);
 
@@ -119,7 +119,7 @@ final class AssetModelFunctionalTest extends MauticMysqlTestCase
         $this->assertSame('1:the-alias', $asset->getSlug());
 
         /** @var AssetModel $assetModel */
-        $assetModel = static::getContainer()->get(AssetModel::class);
+        $assetModel = self::getContainer()->get(AssetModel::class);
         $this->assertInstanceOf(AssetModel::class, $assetModel);
         $generatedUrl = $assetModel->generateUrl($asset, true, []);
         $this->assertSame('https://localhost/asset/1:the-alias', $generatedUrl);
@@ -127,7 +127,7 @@ final class AssetModelFunctionalTest extends MauticMysqlTestCase
 
     public function testGetAssetListRespectsCanViewOthersOption(): void
     {
-        $currentUserId = static::getContainer()->get(UserHelper::class)->getUser()->getId();
+        $currentUserId = self::getContainer()->get(UserHelper::class)->getUser()->getId();
         $dateFrom      = new \DateTime('-1 day', new \DateTimeZone('UTC'));
         $dateTo        = new \DateTime('+1 day', new \DateTimeZone('UTC'));
 
@@ -160,7 +160,7 @@ final class AssetModelFunctionalTest extends MauticMysqlTestCase
         $this->em->flush();
 
         /** @var AssetModel $assetModel */
-        $assetModel = static::getContainer()->get(AssetModel::class);
+        $assetModel = self::getContainer()->get(AssetModel::class);
         $this->assertInstanceOf(AssetModel::class, $assetModel);
 
         $ownOnlyList = $assetModel->getAssetList(10, $dateFrom, $dateTo, [], ['canViewOthers' => false]);

--- a/app/bundles/CampaignBundle/Tests/Command/ExecuteEventCommandTest.php
+++ b/app/bundles/CampaignBundle/Tests/Command/ExecuteEventCommandTest.php
@@ -47,7 +47,7 @@ final class ExecuteEventCommandTest extends AbstractCampaignCommand
         $lastId = array_pop($logIds);
 
         // Wait 6 seconds to go past scheduled time
-        static::getContainer()->get(ScheduledExecutioner::class)->setNowTime(new \DateTime('+'.self::CONDITION_SECONDS.' seconds'));
+        self::getContainer()->get(ScheduledExecutioner::class)->setNowTime(new \DateTime('+'.self::CONDITION_SECONDS.' seconds'));
 
         $this->testSymfonyCommand('mautic:campaigns:execute', ['--scheduled-log-ids' => implode(',', $logIds)]);
 

--- a/app/bundles/CampaignBundle/Tests/Command/TriggerCampaignCommandTest.php
+++ b/app/bundles/CampaignBundle/Tests/Command/TriggerCampaignCommandTest.php
@@ -35,7 +35,7 @@ final class TriggerCampaignCommandTest extends AbstractCampaignCommand
 
         putenv('CAMPAIGN_EXECUTIONER_SCHEDULER_ACKNOWLEDGE_SECONDS=1');
 
-        $this->segmentCountCacheHelper = static::getContainer()->get(SegmentCountCacheHelper::class);
+        $this->segmentCountCacheHelper = self::getContainer()->get(SegmentCountCacheHelper::class);
     }
 
     public function beforeTearDown(): void
@@ -99,7 +99,7 @@ final class TriggerCampaignCommandTest extends AbstractCampaignCommand
         $this->assertCount(0, $stats);
 
         // Wait 6 seconds then execute the campaign again to send scheduled events
-        static::getContainer()->get(ScheduledExecutioner::class)->setNowTime(new \DateTime('+'.self::CONDITION_SECONDS.' seconds'));
+        self::getContainer()->get(ScheduledExecutioner::class)->setNowTime(new \DateTime('+'.self::CONDITION_SECONDS.' seconds'));
         $this->testSymfonyCommand('mautic:campaigns:trigger', ['-i' => 1, '-l' => 10]);
 
         // Send email 1 should no longer be scheduled
@@ -143,7 +143,7 @@ final class TriggerCampaignCommandTest extends AbstractCampaignCommand
         $this->assertCount(25, $byEvent[10]);
 
         // Wait another 6 seconds to go beyond the inaction timeframe
-        static::getContainer()->get(InactiveExecutioner::class)->setNowTime(new \DateTime('+'.(self::CONDITION_SECONDS * 2).' seconds'));
+        self::getContainer()->get(InactiveExecutioner::class)->setNowTime(new \DateTime('+'.(self::CONDITION_SECONDS * 2).' seconds'));
 
         // Execute the command again to trigger inaction related events
         $this->testSymfonyCommand('mautic:campaigns:trigger', ['-i' => 1, '-l' => 10]);
@@ -266,7 +266,7 @@ final class TriggerCampaignCommandTest extends AbstractCampaignCommand
         $this->assertCount(0, $stats);
 
         // Wait 6 seconds then execute the campaign again to send scheduled events
-        static::getContainer()->get(ScheduledExecutioner::class)->setNowTime(new \DateTime('+'.self::CONDITION_SECONDS.' seconds'));
+        self::getContainer()->get(ScheduledExecutioner::class)->setNowTime(new \DateTime('+'.self::CONDITION_SECONDS.' seconds'));
         $this->testSymfonyCommand('mautic:campaigns:trigger', ['-i' => 1, '--contact-id' => 1]);
 
         // Send email 1 should no longer be scheduled
@@ -310,7 +310,7 @@ final class TriggerCampaignCommandTest extends AbstractCampaignCommand
         $this->assertCount(1, $byEvent[10]);
 
         // Wait 6 seconds to go beyond the inaction timeframe
-        static::getContainer()->get(InactiveExecutioner::class)->setNowTime(new \DateTime('+'.(self::CONDITION_SECONDS * 2).' seconds'));
+        self::getContainer()->get(InactiveExecutioner::class)->setNowTime(new \DateTime('+'.(self::CONDITION_SECONDS * 2).' seconds'));
 
         // Execute the command again to trigger inaction related events
         $this->testSymfonyCommand('mautic:campaigns:trigger', ['-i' => 1, '--contact-id' => 1]);
@@ -427,7 +427,7 @@ final class TriggerCampaignCommandTest extends AbstractCampaignCommand
         $this->assertCount(0, $stats);
 
         // Wait 6 seconds then execute the campaign again to send scheduled events
-        static::getContainer()->get(ScheduledExecutioner::class)->setNowTime(new \DateTime('+'.self::CONDITION_SECONDS.' seconds'));
+        self::getContainer()->get(ScheduledExecutioner::class)->setNowTime(new \DateTime('+'.self::CONDITION_SECONDS.' seconds'));
         $this->testSymfonyCommand('mautic:campaigns:trigger', ['-i' => 1, '--contact-ids' => '1,2,3,4,19']);
 
         // Send email 1 should no longer be scheduled
@@ -470,7 +470,7 @@ final class TriggerCampaignCommandTest extends AbstractCampaignCommand
         $this->assertCount(2, $byEvent[10]);
 
         // Wait 6 seconds to go beyond the inaction timeframe
-        static::getContainer()->get(InactiveExecutioner::class)->setNowTime(new \DateTime('+'.(self::CONDITION_SECONDS * 2).' seconds'));
+        self::getContainer()->get(InactiveExecutioner::class)->setNowTime(new \DateTime('+'.(self::CONDITION_SECONDS * 2).' seconds'));
 
         // Execute the command again to trigger inaction related events
         $this->testSymfonyCommand('mautic:campaigns:trigger', ['-i' => 1, '--contact-ids' => '1,2,3,4,19']);

--- a/app/bundles/CampaignBundle/Tests/Command/ValidateEventCommandTest.php
+++ b/app/bundles/CampaignBundle/Tests/Command/ValidateEventCommandTest.php
@@ -14,7 +14,7 @@ final class ValidateEventCommandTest extends AbstractCampaignCommand
         $this->testSymfonyCommand('mautic:campaigns:trigger', ['-i' => 1, '--contact-id' => 1]);
 
         // Wait 6 seconds then execute the campaign again to send scheduled events
-        static::getContainer()->get(ScheduledExecutioner::class)->setNowTime(new \DateTime('+'.self::CONDITION_SECONDS.' seconds'));
+        self::getContainer()->get(ScheduledExecutioner::class)->setNowTime(new \DateTime('+'.self::CONDITION_SECONDS.' seconds'));
         $this->testSymfonyCommand('mautic:campaigns:trigger', ['-i' => 1, '--contact-id' => 1]);
 
         // No open email decisions should be recorded yet
@@ -22,7 +22,7 @@ final class ValidateEventCommandTest extends AbstractCampaignCommand
         $this->assertCount(0, $byEvent[3]);
 
         // Wait 6 seconds to go beyond the inaction timeframe
-        static::getContainer()->get(InactiveExecutioner::class)->setNowTime(new \DateTime('+'.(self::CONDITION_SECONDS * 2).' seconds'));
+        self::getContainer()->get(InactiveExecutioner::class)->setNowTime(new \DateTime('+'.(self::CONDITION_SECONDS * 2).' seconds'));
 
         // Now they should be inactive
         $this->testSymfonyCommand('mautic:campaigns:validate', ['--decision-id' => 3, '--contact-id' => 1]);
@@ -38,7 +38,7 @@ final class ValidateEventCommandTest extends AbstractCampaignCommand
         $this->testSymfonyCommand('mautic:campaigns:trigger', ['-i' => 1, '--contact-ids' => '1,2,3']);
 
         // Wait 6 seconds then execute the campaign again to send scheduled events
-        static::getContainer()->get(ScheduledExecutioner::class)->setNowTime(new \DateTime('+'.self::CONDITION_SECONDS.' seconds'));
+        self::getContainer()->get(ScheduledExecutioner::class)->setNowTime(new \DateTime('+'.self::CONDITION_SECONDS.' seconds'));
         $this->testSymfonyCommand('mautic:campaigns:trigger', ['-i' => 1, '--contact-ids' => '1,2,3']);
 
         // No open email decisions should be recorded yet
@@ -46,7 +46,7 @@ final class ValidateEventCommandTest extends AbstractCampaignCommand
         $this->assertCount(0, $byEvent[3]);
 
         // Wait 6 seconds to go beyond the inaction timeframe
-        static::getContainer()->get(InactiveExecutioner::class)->setNowTime(new \DateTime('+'.(self::CONDITION_SECONDS * 2).' seconds'));
+        self::getContainer()->get(InactiveExecutioner::class)->setNowTime(new \DateTime('+'.(self::CONDITION_SECONDS * 2).' seconds'));
 
         // Now they should be inactive
         $this->testSymfonyCommand('mautic:campaigns:validate', ['--decision-id' => 3, '--contact-ids' => '1,2,3']);
@@ -62,7 +62,7 @@ final class ValidateEventCommandTest extends AbstractCampaignCommand
         $this->testSymfonyCommand('mautic:campaigns:trigger', ['-i' => 1, '--contact-ids' => '1,2,3']);
 
         // Wait 6 seconds then execute the campaign again to send scheduled events
-        static::getContainer()->get(ScheduledExecutioner::class)->setNowTime(new \DateTime('+'.self::CONDITION_SECONDS.' seconds'));
+        self::getContainer()->get(ScheduledExecutioner::class)->setNowTime(new \DateTime('+'.self::CONDITION_SECONDS.' seconds'));
         $this->testSymfonyCommand('mautic:campaigns:trigger', ['-i' => 1, '--contact-ids' => '1,2,3']);
 
         // No open email decisions should be recorded yet
@@ -70,7 +70,7 @@ final class ValidateEventCommandTest extends AbstractCampaignCommand
         $this->assertCount(0, $byEvent[3]);
 
         // Wait 6 seconds to go beyond the inaction timeframe
-        static::getContainer()->get(InactiveExecutioner::class)->setNowTime(new \DateTime('+'.(self::CONDITION_SECONDS * 2).' seconds'));
+        self::getContainer()->get(InactiveExecutioner::class)->setNowTime(new \DateTime('+'.(self::CONDITION_SECONDS * 2).' seconds'));
 
         // Remove a contact from the campaign
         $this->db->createQueryBuilder()->update(MAUTIC_TABLE_PREFIX.'campaign_leads')

--- a/app/bundles/CampaignBundle/Tests/Controller/CampaignControllerFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/CampaignControllerFunctionalTest.php
@@ -40,10 +40,10 @@ final class CampaignControllerFunctionalTest extends AbstractCampaignTestCase
         $this->configParams[self::CAMPAIGN_RANGE_PARAM]   = in_array($this->name(), $functionForUseRange);
         parent::setUp();
 
-        $model = static::getContainer()->get(CampaignModel::class);
+        $model = self::getContainer()->get(CampaignModel::class);
 
         $this->campaignModel                                           = $model;
-        $this->campaignLeadsLabel                                      = static::getContainer()->get(TranslatorInterface::class)->trans('mautic.campaign.campaign.leads');
+        $this->campaignLeadsLabel                                      = self::getContainer()->get(TranslatorInterface::class)->trans('mautic.campaign.campaign.leads');
         $this->configParams['delete_campaign_event_log_in_background'] = false;
     }
 

--- a/app/bundles/CampaignBundle/Tests/Controller/CampaignUnpublishedWorkflowFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/CampaignUnpublishedWorkflowFunctionalTest.php
@@ -38,7 +38,7 @@ final class CampaignUnpublishedWorkflowFunctionalTest extends AbstractCampaignTe
     public function testCampaignEditPageCheckUnpublishWorkflowAttributesPresent(): void
     {
         $campaign   = $this->saveSomeCampaignLeadEventLogs();
-        $translator = static::getContainer()->get(TranslatorInterface::class);
+        $translator = self::getContainer()->get(TranslatorInterface::class);
 
         // Check the message in the Campaign edit page
         $crawler  = $this->client->request('GET', sprintf('/s/campaigns/edit/%d', $campaign->getId()));
@@ -70,7 +70,7 @@ final class CampaignUnpublishedWorkflowFunctionalTest extends AbstractCampaignTe
     public function testCampaignListPageCheckUnpublishWorkflowAttributesPresent(): void
     {
         $campaign   = $this->saveSomeCampaignLeadEventLogs();
-        $translator = static::getContainer()->get(TranslatorInterface::class);
+        $translator = self::getContainer()->get(TranslatorInterface::class);
 
         // Check the message in the Campaign listing page
         $crawler  = $this->client->request('GET', '/s/campaigns');
@@ -98,7 +98,7 @@ final class CampaignUnpublishedWorkflowFunctionalTest extends AbstractCampaignTe
     public function testCampaignUnpublishToggle(): void
     {
         $campaign   = $this->saveSomeCampaignLeadEventLogs();
-        $translator = static::getContainer()->get(TranslatorInterface::class);
+        $translator = self::getContainer()->get(TranslatorInterface::class);
 
         $this->client->request(Request::METHOD_POST, '/s/ajax', ['action' => 'togglePublishStatus', 'model' => 'campaign', 'id' => $campaign->getId()]);
         $response = $this->client->getResponse();

--- a/app/bundles/CampaignBundle/Tests/Entity/EventRepositoryFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Entity/EventRepositoryFunctionalTest.php
@@ -35,7 +35,7 @@ final class EventRepositoryFunctionalTest extends MauticMysqlTestCase
     public function testGetContactPendingEventsConsidersCampaignPublishUpAndDown(?\DateTime $publishUp, ?\DateTime $publishDown, int $expectedCount): void
     {
         /** @var EventRepository $repository */
-        $repository = static::getContainer()->get(EventRepository::class);
+        $repository = self::getContainer()->get(EventRepository::class);
         $this->assertInstanceOf(EventRepository::class, $repository);
 
         $campaign = $this->createCampaign();
@@ -54,7 +54,7 @@ final class EventRepositoryFunctionalTest extends MauticMysqlTestCase
     public function testSetEventsAsDeletedWithRedirectUpdatesChains(): void
     {
         /** @var EventRepository $repository */
-        $repository = static::getContainer()->get(EventRepository::class);
+        $repository = self::getContainer()->get(EventRepository::class);
         $this->assertInstanceOf(EventRepository::class, $repository);
 
         $campaign = $this->createCampaign();

--- a/app/bundles/CampaignBundle/Tests/EventListener/CampaignEventSubscriberFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/EventListener/CampaignEventSubscriberFunctionalTest.php
@@ -44,7 +44,7 @@ final class CampaignEventSubscriberFunctionalTest extends MauticMysqlTestCase
 
         $unpublishEvent = new NotifyOfUnpublishEvent($failedEvent);
         /** @var EventDispatcherInterface $dispatcher */
-        $dispatcher = static::getContainer()->get(EventDispatcherInterface::class);
+        $dispatcher = self::getContainer()->get(EventDispatcherInterface::class);
         $dispatcher->dispatch($unpublishEvent, CampaignEvents::ON_CAMPAIGN_UNPUBLISH_NOTIFY);
         $this->assertInstanceOf(Campaign::class, $campaign);
 

--- a/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignEventDetailsTimelineFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignEventDetailsTimelineFunctionalTest.php
@@ -80,7 +80,7 @@ final class CampaignEventDetailsTimelineFunctionalTest extends MauticMysqlTestCa
         $this->testSymfonyCommand('mautic:campaigns:update', ['--campaign-id' => $campaign->getId()]);
         $this->testSymfonyCommand('mautic:campaigns:trigger', ['--campaign-id' => $campaign->getId()]);
 
-        $translator = static::getContainer()->get(TranslatorInterface::class);
+        $translator = self::getContainer()->get(TranslatorInterface::class);
         $this->assertInstanceOf(TranslatorInterface::class, $translator);
         $operator = $translator->trans('mautic.lead.list.form.operator.in');
 

--- a/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignMembershipFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignMembershipFunctionalTest.php
@@ -56,7 +56,7 @@ final class CampaignMembershipFunctionalTest extends MauticMysqlTestCase
         $eventId    = $event->getId();
         $contactId  = $contact->getId();
         $db         = $this->em->getConnection();
-        $prefix     = static::getContainer()->getParameter('mautic.db_table_prefix');
+        $prefix     = self::getContainer()->getParameter('mautic.db_table_prefix');
 
         $this->em->clear();
 
@@ -80,7 +80,7 @@ final class CampaignMembershipFunctionalTest extends MauticMysqlTestCase
         );
         $this->em->clear();
 
-        $adder              = static::getContainer()->get(Adder::class);
+        $adder              = self::getContainer()->get(Adder::class);
         $campaignLeadEntity = $this->em->getRepository(CampaignLead::class)->findOneBy([
             'lead'     => $contactId,
             'campaign' => $campaignId,

--- a/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignRotationTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignRotationTest.php
@@ -45,12 +45,12 @@ final class CampaignRotationTest extends MauticMysqlTestCase
         $this->em->flush();
 
         /** @var ContactTracker $contactTracker */
-        $contactTracker               = static::getContainer()->get(ContactTracker::class);
-        $this->campaignLeadRepository = static::getContainer()->get(LeadRepository::class);
-        $this->leadEventLogRepository = static::getContainer()->get(LeadEventLogRepository::class);
+        $contactTracker               = self::getContainer()->get(ContactTracker::class);
+        $this->campaignLeadRepository = self::getContainer()->get(LeadRepository::class);
+        $this->leadEventLogRepository = self::getContainer()->get(LeadEventLogRepository::class);
 
         /** @var RequestStack $requestStack */
-        $requestStack = static::getContainer()->get(RequestStack::class);
+        $requestStack = self::getContainer()->get(RequestStack::class);
         $request      = new Request();
 
         $request->setSession($sessionMock = $this->createMock(Session::class));

--- a/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignAuditLogTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignAuditLogTest.php
@@ -91,7 +91,7 @@ final class CampaignAuditLogTest extends MauticMysqlTestCase
 
         // 2.c Save campaign through CampaignModel to trigger audit log creation
         /** @var CampaignModel $campaignModel */
-        $campaignModel = static::getContainer()->get(CampaignModel::class);
+        $campaignModel = self::getContainer()->get(CampaignModel::class);
         $campaign      = $campaignModel->getEntity($campaignId);
         $event         = $this->em->find(Event::class, $eventId);
         $this->assertInstanceOf(Event::class, $event);
@@ -106,7 +106,7 @@ final class CampaignAuditLogTest extends MauticMysqlTestCase
         $this->client->request(Request::METHOD_GET, $campaignViewUrl);
         $this->assertResponseIsSuccessful();
 
-        $translator = static::getContainer()->get(TranslatorInterface::class);
+        $translator = self::getContainer()->get(TranslatorInterface::class);
         $this->assertInstanceOf(TranslatorInterface::class, $translator);
 
         $this->assertStringContainsString(

--- a/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignControllerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignControllerTest.php
@@ -390,7 +390,7 @@ final class CampaignControllerTest extends MauticMysqlTestCase
         $exportHelperMock->method('writeToZipFile')->willReturn('');
 
         // Inject the mock into the container
-        static::getContainer()->set(ExportHelper::class, $exportHelperMock);
+        self::getContainer()->set(ExportHelper::class, $exportHelperMock);
 
         $this->loginOtherUser($nonAdminUser);
 
@@ -448,7 +448,7 @@ final class CampaignControllerTest extends MauticMysqlTestCase
         $exportHelperMock->method('writeToZipFile')->willReturn('/invalid/path/to/file.zip');
 
         // Use the test container to replace the service with the mock
-        static::getContainer()->set(ExportHelper::class, $exportHelperMock);
+        self::getContainer()->set(ExportHelper::class, $exportHelperMock);
 
         $this->loginOtherUser($nonAdminUser);
 

--- a/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignImportControllerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignImportControllerTest.php
@@ -137,7 +137,7 @@ final class CampaignImportControllerTest extends MauticMysqlTestCase
 
         $importHelper = $this->createMock(ImportHelper::class);
         $importHelper->method('readZipFile')->willReturn([]);
-        static::getContainer()->set(ImportHelper::class, $importHelper);
+        self::getContainer()->set(ImportHelper::class, $importHelper);
 
         $this->client->request('GET', '/s/campaign/import/progress');
         $response = $this->client->getResponse();
@@ -167,7 +167,7 @@ final class CampaignImportControllerTest extends MauticMysqlTestCase
 
         $importHelper = $this->createMock(ImportHelper::class);
         $importHelper->method('readZipFile')->willReturn(FixtureHelper::getPayload());
-        static::getContainer()->set(ImportHelper::class, $importHelper);
+        self::getContainer()->set(ImportHelper::class, $importHelper);
 
         $this->client->request('GET', '/s/campaign/import/progress');
         $response = $this->client->getResponse();
@@ -190,7 +190,7 @@ final class CampaignImportControllerTest extends MauticMysqlTestCase
 
         $importHelper = $this->createMock(ImportHelper::class);
         $importHelper->method('readZipFile')->willReturn([]);
-        static::getContainer()->set(ImportHelper::class, $importHelper);
+        self::getContainer()->set(ImportHelper::class, $importHelper);
 
         $this->client->request('GET', '/s/campaign/import/progress');
         $response = $this->client->getResponse();
@@ -220,7 +220,7 @@ final class CampaignImportControllerTest extends MauticMysqlTestCase
 
         $importHelper = $this->createMock(ImportHelper::class);
         $importHelper->method('readZipFile')->willReturn(FixtureHelper::getPayload());
-        static::getContainer()->set(ImportHelper::class, $importHelper);
+        self::getContainer()->set(ImportHelper::class, $importHelper);
 
         $this->client->request('GET', '/s/campaign/import/progress');
         $response = $this->client->getResponse();

--- a/app/bundles/CampaignBundle/Tests/Functional/Service/CampaignAuditServiceFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Service/CampaignAuditServiceFunctionalTest.php
@@ -32,7 +32,7 @@ final class CampaignAuditServiceFunctionalTest extends MauticMysqlTestCase
         $this->campaignAuditService = new CampaignAuditService(
             $this->flashBagMock,
             $this->urlGeneratorMock,
-            static::getContainer()->get(EventRepository::class)
+            self::getContainer()->get(EventRepository::class)
         );
     }
 

--- a/app/bundles/CategoryBundle/Tests/Controller/CategoryControllerFunctionalTest.php
+++ b/app/bundles/CategoryBundle/Tests/Controller/CategoryControllerFunctionalTest.php
@@ -40,7 +40,7 @@ final class CategoryControllerFunctionalTest extends MauticMysqlTestCase
             ],
         ];
         /** @var CategoryModel $model */
-        $model      = static::getContainer()->get(CategoryModel::class);
+        $model      = self::getContainer()->get(CategoryModel::class);
 
         foreach ($categoriesData as $categoryData) {
             $category = new Category();
@@ -50,7 +50,7 @@ final class CategoryControllerFunctionalTest extends MauticMysqlTestCase
             $model->saveEntity($category);
         }
 
-        $this->translator = static::getContainer()->get(TranslatorInterface::class);
+        $this->translator = self::getContainer()->get(TranslatorInterface::class);
     }
 
     /**
@@ -138,9 +138,9 @@ final class CategoryControllerFunctionalTest extends MauticMysqlTestCase
     public function testEditLockCategory(): void
     {
         /** @var CategoryModel $categoryModel */
-        $categoryModel      = static::getContainer()->get(CategoryModel::class);
+        $categoryModel      = self::getContainer()->get(CategoryModel::class);
         /** @var UserModel $userModel */
-        $userModel      = static::getContainer()->get(UserModel::class);
+        $userModel      = self::getContainer()->get(UserModel::class);
         $user           = $userModel->getEntity(2);
 
         $category = new Category();
@@ -296,7 +296,7 @@ final class CategoryControllerFunctionalTest extends MauticMysqlTestCase
         $category->setBundle($bundle);
         $category->setAlias($alias);
         /** @var CategoryModel $categoryModel */
-        $categoryModel      = static::getContainer()->get(CategoryModel::class);
+        $categoryModel      = self::getContainer()->get(CategoryModel::class);
         $categoryModel->saveEntity($category);
 
         return $category;

--- a/app/bundles/ConfigBundle/Tests/Controller/ConfigControllerFunctionalTest.php
+++ b/app/bundles/ConfigBundle/Tests/Controller/ConfigControllerFunctionalTest.php
@@ -89,7 +89,7 @@ final class ConfigControllerFunctionalTest extends MauticMysqlTestCase
     private function getConfigPath(): string
     {
         /** @var \AppKernel $kernel */
-        $kernel = static::getContainer()->get(KernelInterface::class);
+        $kernel = self::getContainer()->get(KernelInterface::class);
 
         return $kernel->getLocalConfigFile();
     }

--- a/app/bundles/ConfigBundle/Tests/Controller/SysinfoControllerTest.php
+++ b/app/bundles/ConfigBundle/Tests/Controller/SysinfoControllerTest.php
@@ -12,7 +12,7 @@ final class SysinfoControllerTest extends MauticMysqlTestCase
 {
     public function testDbInfoIsShown(): void
     {
-        $sysinfoModel = static::getContainer()->get(SysinfoModel::class);
+        $sysinfoModel = self::getContainer()->get(SysinfoModel::class);
         $this->assertInstanceOf(SysinfoModel::class, $sysinfoModel);
         $dbInfo = $sysinfoModel->getDbInfo();
 

--- a/app/bundles/CoreBundle/EventListener/EditorFontsSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/EditorFontsSubscriber.php
@@ -32,7 +32,7 @@ final readonly class EditorFontsSubscriber implements EventSubscriberInterface
 
     private function addEditorFonts(CustomAssetsEvent $customAssetsEvent): void
     {
-        $fonts = (array) $this->coreParametersHelper->get(static::PARAMETER_EDITOR_FONTS, []);
+        $fonts = (array) $this->coreParametersHelper->get(self::PARAMETER_EDITOR_FONTS, []);
         foreach ($fonts as $font) {
             if (empty($font['url'])) {
                 continue;

--- a/app/bundles/CoreBundle/Loader/ParameterLoader.php
+++ b/app/bundles/CoreBundle/Loader/ParameterLoader.php
@@ -28,7 +28,7 @@ final class ParameterLoader
     public function __construct(
         private readonly string $rootPath = __DIR__.'/../../../',
     ) {
-        $this->configBaseDir = static::getLocalConfigBaseDir($this->rootPath);
+        $this->configBaseDir = self::getLocalConfigBaseDir($this->rootPath);
 
         $this->loadDefaultParameters();
         $this->loadLocalParameters();

--- a/app/bundles/CoreBundle/Tests/Command/CleanupMaintenanceCommandTest.php
+++ b/app/bundles/CoreBundle/Tests/Command/CleanupMaintenanceCommandTest.php
@@ -23,7 +23,7 @@ final class CleanupMaintenanceCommandTest extends MauticMysqlTestCase
         $this->testSymfonyCommand('mautic:maintenance:cleanup', ['--days-old' => 180, '--no-interaction' => true]);
 
         $this->assertNull(
-            static::getContainer()->get(LeadModel::class)->getEntity($contactId),
+            self::getContainer()->get(LeadModel::class)->getEntity($contactId),
             'Purge an unidentified lead that is considered inactive'
         );
 
@@ -42,7 +42,7 @@ final class CleanupMaintenanceCommandTest extends MauticMysqlTestCase
         $this->testSymfonyCommand('mautic:maintenance:cleanup', ['--days-old' => 180, '--no-interaction' => true]);
 
         $this->assertNotNull(
-            static::getContainer()->get(LeadModel::class)->getEntity($contactId),
+            self::getContainer()->get(LeadModel::class)->getEntity($contactId),
             'Keep an unidentified lead that is still considered active'
         );
     }

--- a/app/bundles/CoreBundle/Tests/Command/PullTransifexCommandFunctionalTest.php
+++ b/app/bundles/CoreBundle/Tests/Command/PullTransifexCommandFunctionalTest.php
@@ -25,7 +25,7 @@ final class PullTransifexCommandFunctionalTest extends MauticMysqlTestCase
 
         parent::setUp();
 
-        $this->filesystem = static::getContainer()->get(Filesystem::class);
+        $this->filesystem = self::getContainer()->get(Filesystem::class);
         $this->filesystem->mkdir(self::FAKE_TRANSLATION_DIR);
     }
 

--- a/app/bundles/CoreBundle/Tests/Functional/Command/MessageOfTheDayCommandTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Command/MessageOfTheDayCommandTest.php
@@ -182,7 +182,7 @@ final class MessageOfTheDayCommandTest extends MauticMysqlTestCase
         file_put_contents($this->cachePath, 'stale-cache');
         touch($this->cachePath, time() - 7200);
 
-        $httpClient = static::getContainer()->get(HttpClientInterface::class);
+        $httpClient = self::getContainer()->get(HttpClientInterface::class);
         $this->assertInstanceOf(MockHttpClient::class, $httpClient);
         $httpClient->setResponseFactory([
             new MockResponse('', ['http_code' => 500]),

--- a/app/bundles/CoreBundle/Tests/Functional/Controller/FileControllerTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Controller/FileControllerTest.php
@@ -22,7 +22,7 @@ final class FileControllerTest extends MauticMysqlTestCase
         $this->arrayHasKey('url');
         $this->assertNotEmpty($responseData['url']);
         $uploadedFileName = basename($responseData['url']);
-        $uploadedImage    = static::getContainer()->getParameter('mautic.application_dir').'/media/images/'.$uploadedFileName;
+        $uploadedImage    = self::getContainer()->getParameter('mautic.application_dir').'/media/images/'.$uploadedFileName;
         $this->assertFileExists($uploadedImage);
     }
 

--- a/app/bundles/CoreBundle/Tests/Functional/DependencyInjection/Compiler/SystemThemeTemplatePathPassTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/DependencyInjection/Compiler/SystemThemeTemplatePathPassTest.php
@@ -20,7 +20,7 @@ final class SystemThemeTemplatePathPassTest extends MauticMysqlTestCase
         // This test require cache to be cleared
         // as the template override must exist before the cache is generated.
         /** @var PathsHelper $pathsHelper */
-        $pathsHelper = static::getContainer()->get(PathsHelper::class);
+        $pathsHelper = self::getContainer()->get(PathsHelper::class);
         $this->assertInstanceOf(PathsHelper::class, $pathsHelper);
         $cacheDir    = $pathsHelper->getCachePath();
 
@@ -60,7 +60,7 @@ final class SystemThemeTemplatePathPassTest extends MauticMysqlTestCase
     private function getOverridePath(): string
     {
         /** @var PathsHelper $pathsHelper */
-        $pathsHelper = static::getContainer()->get(PathsHelper::class);
+        $pathsHelper = self::getContainer()->get(PathsHelper::class);
 
         return $pathsHelper->getThemesPath().'/system/UserBundle/Resources/views/Profile';
     }

--- a/app/bundles/CoreBundle/Tests/Functional/Doctrine/Paginator/SimplePaginatorTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Doctrine/Paginator/SimplePaginatorTest.php
@@ -25,7 +25,7 @@ final class SimplePaginatorTest extends MauticMysqlTestCase
     {
         parent::setUp();
 
-        $debugDataHolder = static::getContainer()->get('doctrine.debug_data_holder');
+        $debugDataHolder = self::getContainer()->get('doctrine.debug_data_holder');
         $this->assertInstanceOf(DebugDataHolder::class, $debugDataHolder);
         $debugDataHolder->reset();
 
@@ -60,7 +60,7 @@ final class SimplePaginatorTest extends MauticMysqlTestCase
             $ipAddress3->getId() => $ipAddress3,
         ], iterator_to_array($paginator), 'Only 2 last records should be returned.');
 
-        $prefix  = static::getContainer()->getParameter('mautic.db_table_prefix');
+        $prefix  = self::getContainer()->getParameter('mautic.db_table_prefix');
         $queries = $this->debugDataHolder->getData()['default'];
 
         $this->assertCount(5, $queries, 'There should be exactly 5 queries executed.');

--- a/app/bundles/CoreBundle/Tests/Functional/EventListener/MigrationCommandSubscriberTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/EventListener/MigrationCommandSubscriberTest.php
@@ -27,8 +27,8 @@ final class MigrationCommandSubscriberTest extends MauticMysqlTestCase
     {
         parent::setUp();
 
-        $this->tablePrefix     = static::getContainer()->getParameter('mautic.db_table_prefix');
-        $this->eventDispatcher = static::getContainer()->get(EventDispatcherInterface::class);
+        $this->tablePrefix     = self::getContainer()->getParameter('mautic.db_table_prefix');
+        $this->eventDispatcher = self::getContainer()->get(EventDispatcherInterface::class);
     }
 
     protected function beforeTearDown(): void
@@ -121,7 +121,7 @@ ADD INDEX `{$this->tablePrefix}generated_name_three`(generated_name_three)
     {
         // intentionally not using AbstractMauticTestCase::testSymfonyCommand() as it does not dispatch 'console.terminate' event
         $params      = ['command' => 'doctrine:migration:migrate', '--no-interaction' => true];
-        $application = new Application(static::getContainer()->get(KernelInterface::class));
+        $application = new Application(self::getContainer()->get(KernelInterface::class));
         $application->setAutoExit(false);
         $application->setCatchExceptions(false);
         $output     = new BufferedOutput();

--- a/app/bundles/CoreBundle/Tests/Functional/Helper/CommandHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Helper/CommandHelperTest.php
@@ -14,7 +14,7 @@ final class CommandHelperTest extends MauticMysqlTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->commandHelper = static::getContainer()->get(CommandHelper::class);
+        $this->commandHelper = self::getContainer()->get(CommandHelper::class);
     }
 
     public function testRunCommandWithParam(): void

--- a/app/bundles/CoreBundle/Tests/Functional/Helper/LanguageHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Helper/LanguageHelperTest.php
@@ -12,7 +12,7 @@ final class LanguageHelperTest extends MauticMysqlTestCase
 {
     public function testGettingLanguageFiles(): void
     {
-        $languageHelper = static::getContainer()->get(LanguageHelper::class);
+        $languageHelper = self::getContainer()->get(LanguageHelper::class);
         $this->assertInstanceOf(LanguageHelper::class, $languageHelper);
 
         $languageFiles = $languageHelper->getLanguageFiles();

--- a/app/bundles/CoreBundle/Tests/Functional/ParametersTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/ParametersTest.php
@@ -10,6 +10,6 @@ final class ParametersTest extends AbstractMauticTestCase
 {
     public function testRememberMeParameterUsesIntProcessor(): void
     {
-        $this->assertSame(7_776_000, static::getContainer()->getParameter('mautic.rememberme_lifetime'));
+        $this->assertSame(7_776_000, self::getContainer()->getParameter('mautic.rememberme_lifetime'));
     }
 }

--- a/app/bundles/CoreBundle/Tests/Functional/SamlTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/SamlTest.php
@@ -21,7 +21,7 @@ final class SamlTest extends MauticMysqlTestCase
 
     public function testDiscoveryTemplateIsOverridden(): void
     {
-        $twig    = static::getContainer()->get(Environment::class);
+        $twig    = self::getContainer()->get(Environment::class);
         $content = $twig->render('@LightSamlSp/discovery.html.twig', ['parties' => []]);
 
         $this->assertStringContainsString('SAML not configured or configured incorrectly.', (string) $content);

--- a/app/bundles/CoreBundle/Tests/Functional/Service/LocalFileAdapterServiceTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Service/LocalFileAdapterServiceTest.php
@@ -19,7 +19,7 @@ final class LocalFileAdapterServiceTest extends MauticMysqlTestCase
     protected function beforeTearDown(): void
     {
         /** @var PathsHelper $pathsHelper */
-        $pathsHelper = static::getContainer()->get(PathsHelper::class);
+        $pathsHelper = self::getContainer()->get(PathsHelper::class);
         $folderPath  = "{$pathsHelper->getImagePath()}/{$this->folderName}";
 
         if (is_dir($folderPath)) {
@@ -29,7 +29,7 @@ final class LocalFileAdapterServiceTest extends MauticMysqlTestCase
 
     public function testElfinderCreateFolderPermissions(): void
     {
-        $elFinderLoader = new class(static::getContainer()) extends ElFinderLoader {
+        $elFinderLoader = new class(self::getContainer()) extends ElFinderLoader {
             public function __construct(ContainerInterface $container)
             {
                 /** @phpstan-ignore symfonyContainer.privateService */
@@ -51,7 +51,7 @@ final class LocalFileAdapterServiceTest extends MauticMysqlTestCase
             }
         };
 
-        static::getContainer()->set('fm_elfinder.loader', $elFinderLoader);
+        self::getContainer()->set('fm_elfinder.loader', $elFinderLoader);
 
         $this->folderName = (string) time();
         $user             = $this->em->getRepository(User::class)->findOneBy(['username' => 'admin']);
@@ -64,7 +64,7 @@ final class LocalFileAdapterServiceTest extends MauticMysqlTestCase
         );
         self::assertResponseIsSuccessful();
         /** @var PathsHelper $pathsHelper */
-        $pathsHelper = static::getContainer()->get(PathsHelper::class);
+        $pathsHelper = self::getContainer()->get(PathsHelper::class);
         $folderPath  = "{$pathsHelper->getImagePath()}/{$this->folderName}";
         $this->assertDirectoryExists($folderPath);
         $this->assertSame('777', substr(sprintf('%o', fileperms($folderPath)), -3));

--- a/app/bundles/CoreBundle/Tests/Unit/Twig/Extension/AssetExtensionTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Twig/Extension/AssetExtensionTest.php
@@ -11,7 +11,7 @@ final class AssetExtensionTest extends AbstractMauticTestCase
 {
     public function testGetCountryFlag(): void
     {
-        $assetExtension = static::getContainer()->get(AssetExtension::class);
+        $assetExtension = self::getContainer()->get(AssetExtension::class);
         $this->assertInstanceOf(AssetExtension::class, $assetExtension);
 
         $this->assertStringStartsWith('/./app/assets/images/flags/Belgium.png', $assetExtension->getCountryFlag('Belgium'));

--- a/app/bundles/CoreBundle/Tests/Unit/Twig/Extension/MenuExtensionTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Twig/Extension/MenuExtensionTest.php
@@ -13,7 +13,7 @@ final class MenuExtensionTest extends AbstractMauticTestCase
 {
     public function testParseMenuAttributes(): void
     {
-        $menuExtension = static::getContainer()->get(MenuExtension::class);
+        $menuExtension = self::getContainer()->get(MenuExtension::class);
         $this->assertInstanceOf(MenuExtension::class, $menuExtension);
 
         $menuAttributes = [
@@ -29,7 +29,7 @@ final class MenuExtensionTest extends AbstractMauticTestCase
 
     public function testBuildMenuClasses(): void
     {
-        $menuExtension = static::getContainer()->get(MenuExtension::class);
+        $menuExtension = self::getContainer()->get(MenuExtension::class);
         $this->assertInstanceOf(MenuExtension::class, $menuExtension);
 
         // create a menu and menu items to test with

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -1737,7 +1737,7 @@ final class EmailController extends FormController
         $user   = $this->user;
 
         // We have to add prefix to example emails
-        $subject = sprintf('%s %s', static::EXAMPLE_EMAIL_SUBJECT_PREFIX, $entity->getSubject());
+        $subject = sprintf('%s %s', self::EXAMPLE_EMAIL_SUBJECT_PREFIX, $entity->getSubject());
         $entity->setSubject($subject);
 
         $form = $this->createForm(ExampleSendType::class, ['emails' => ['list' => [$user->getEmail()]]], ['action' => $action]);

--- a/app/bundles/EmailBundle/MonitoredEmail/Processor/Bounce/Mapper/CategoryMapper.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Processor/Bounce/Mapper/CategoryMapper.php
@@ -37,11 +37,11 @@ final class CategoryMapper
      */
     public static function map($category): CategoryObject
     {
-        if (!isset(static::$mappings[$category])) {
+        if (!isset(self::$mappings[$category])) {
             throw new CategoryNotFound();
         }
 
-        $mapping = static::$mappings[$category];
+        $mapping = self::$mappings[$category];
 
         return new CategoryObject($category, $mapping['bounce_type'], $mapping['permanent']);
     }

--- a/app/bundles/EmailBundle/Tests/Controller/AjaxControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/AjaxControllerFunctionalTest.php
@@ -53,7 +53,7 @@ final class AjaxControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertArrayHasKey('sendToDncStatus', $content);
         $this->assertSame($sendToDnc, $content['sendToDncStatus']);
         $this->assertSame(
-            static::getContainer()->get(TranslatorInterface::class)->trans($expectedTranslationKey),
+            self::getContainer()->get(TranslatorInterface::class)->trans($expectedTranslationKey),
             $content['sendToDncText']
         );
     }
@@ -92,7 +92,7 @@ final class AjaxControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertInstanceOf(EmailMime::class, $email);
 
         /** @var UserHelper $userHelper */
-        $userHelper = static::getContainer()->get(UserHelper::class);
+        $userHelper = self::getContainer()->get(UserHelper::class);
         $user       = $userHelper->getUser();
 
         $this->assertSame('Mautic test email', $email->getSubject());

--- a/app/bundles/EmailBundle/Tests/Controller/Api/EmailApiControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/Api/EmailApiControllerFunctionalTest.php
@@ -45,7 +45,7 @@ final class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
     private function setUpMailer(): void
     {
         /** @var MailHelper $mailHelper */
-        $mailHelper = static::getContainer()->get(MailHelper::class);
+        $mailHelper = self::getContainer()->get(MailHelper::class);
         $transport  = new SmtpTransport();
         $mailer     = new Mailer($transport);
         ReflectionHelper::setValue($mailHelper, 'mailer', $mailer);
@@ -58,7 +58,7 @@ final class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
     {
         // Clear owners cache (to leave a clean environment for future tests):
         /** @var MailHelper $mailHelper */
-        $mailHelper = static::getContainer()->get(MailHelper::class);
+        $mailHelper = self::getContainer()->get(MailHelper::class);
         ReflectionHelper::setValue($mailHelper, 'leadOwners', []);
     }
 
@@ -485,7 +485,7 @@ final class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
         $trackingHash = 'tracking_hash_123';
 
         /** @var StatRepository $statRepository */
-        $statRepository = static::getContainer()->get(StatRepository::class);
+        $statRepository = self::getContainer()->get(StatRepository::class);
 
         // Create a test email stat.
         $stat = new Stat();
@@ -540,7 +540,7 @@ final class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
         $user->setSignature('Best regards, |FROM_NAME|');
         $user->setRole($role);
 
-        $hasher = static::getContainer()->get(PasswordHasherFactoryInterface::class)->getPasswordHasher($user);
+        $hasher = self::getContainer()->get(PasswordHasherFactoryInterface::class)->getPasswordHasher($user);
         $this->assertInstanceOf(PasswordHasherInterface::class, $hasher);
 
         $user->setPassword($hasher->hash('password'));

--- a/app/bundles/EmailBundle/Tests/Controller/EmailControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailControllerFunctionalTest.php
@@ -208,7 +208,7 @@ final class EmailControllerFunctionalTest extends MauticMysqlTestCase
         /** @var DoctrineDataCollector $dbCollector */
         $dbCollector = $profile->getCollector('db');
         $queries     = $dbCollector->getQueries();
-        $prefix      = static::getContainer()->getParameter('mautic.db_table_prefix');
+        $prefix      = self::getContainer()->getParameter('mautic.db_table_prefix');
 
         $dncQueries = array_filter(
             $queries['default'],

--- a/app/bundles/EmailBundle/Tests/Controller/PublicControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/PublicControllerFunctionalTest.php
@@ -143,7 +143,7 @@ final class PublicControllerFunctionalTest extends MauticMysqlTestCase
         self::assertResponseIsSuccessful();
 
         $this->assertCount(1, $crawler->filter('#success-message-text'), $this->client->getResponse()->getContent());
-        $expectedMessage = static::getContainer()->get(TranslatorInterface::class)->trans('mautic.email.preferences_center_success_message.text');
+        $expectedMessage = self::getContainer()->get(TranslatorInterface::class)->trans('mautic.email.preferences_center_success_message.text');
         $this->assertEquals($expectedMessage, trim($crawler->filter('#success-message-text')->text(null, false)));
         $this->assertResponseIsSuccessful();
 
@@ -329,7 +329,7 @@ final class PublicControllerFunctionalTest extends MauticMysqlTestCase
         $crawler = $this->client->request('GET', '/email/unsubscribe/'.$stat->getTrackingHash());
         $this->assertResponseIsSuccessful();
 
-        $translator = static::getContainer()->get(TranslatorInterface::class);
+        $translator = self::getContainer()->get(TranslatorInterface::class);
         $needle     = $translator->trans('mautic.page.form.saveprefs', [], null, $expectedLocale);
 
         $this->assertStringContainsString($needle, $crawler->html());

--- a/app/bundles/EmailBundle/Tests/Entity/PendingQueryFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Entity/PendingQueryFunctionalTest.php
@@ -59,7 +59,7 @@ final class PendingQueryFunctionalTest extends MauticMysqlTestCase
         }
 
         /** @var LeadModel $contactModel */
-        $contactModel = static::getContainer()->get(LeadModel::class);
+        $contactModel = self::getContainer()->get(LeadModel::class);
         $this->assertInstanceOf(LeadModel::class, $contactModel);
         $contactModel->saveEntities($contacts);
 

--- a/app/bundles/EmailBundle/Tests/EventListener/CampaignSubscriberActionEmailToContactFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/CampaignSubscriberActionEmailToContactFunctionalTest.php
@@ -45,7 +45,7 @@ final class CampaignSubscriberActionEmailToContactFunctionalTest extends MauticM
         $this->testSymfonyCommand('mautic:campaigns:trigger', ['--campaign-id' => $campaign->getId()]);
 
         /** @var LeadEventLogRepository $logRepo */
-        $logRepo  = static::getContainer()->get(LeadEventLogRepository::class);
+        $logRepo  = self::getContainer()->get(LeadEventLogRepository::class);
         $metaData = [];
         foreach ($logRepo->getLeadLogs() as $leadLog) {
             if ($leadLog['metadata']) {
@@ -53,7 +53,7 @@ final class CampaignSubscriberActionEmailToContactFunctionalTest extends MauticM
             }
         }
 
-        $translator = static::getContainer()->get(TranslatorInterface::class);
+        $translator = self::getContainer()->get(TranslatorInterface::class);
         $noEmailLog = $translator->trans(
             'mautic.email.contact_has_no_email',
             ['%contact%' => $leadB->getPrimaryIdentifier()]

--- a/app/bundles/EmailBundle/Tests/EventListener/EmailImportExportSubscriberFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/EmailImportExportSubscriberFunctionalTest.php
@@ -16,7 +16,7 @@ final class EmailImportExportSubscriberFunctionalTest extends MauticMysqlTestCas
     protected function setUp(): void
     {
         parent::setUp();
-        $this->dispatcher = static::getContainer()->get(EventDispatcherInterface::class);
+        $this->dispatcher = self::getContainer()->get(EventDispatcherInterface::class);
     }
 
     public function testExportEmailWithNullParentReferences(): void

--- a/app/bundles/EmailBundle/Tests/EventListener/SegmentSubscriberFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/SegmentSubscriberFunctionalTest.php
@@ -12,7 +12,7 @@ final class SegmentSubscriberFunctionalTest extends MauticMysqlTestCase
 {
     public function testLeadListChangeEventHasListeners(): void
     {
-        $dispatcher = static::getContainer()->get(EventDispatcherInterface::class);
+        $dispatcher = self::getContainer()->get(EventDispatcherInterface::class);
 
         $this->assertTrue($dispatcher->hasListeners(LeadEvents::LEAD_LIST_CHANGE));
         $this->assertTrue($dispatcher->hasListeners(LeadEvents::LEAD_LIST_BATCH_CHANGE));

--- a/app/bundles/EmailBundle/Tests/EventListener/WebhookSubscriberFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/WebhookSubscriberFunctionalTest.php
@@ -109,7 +109,7 @@ final class WebhookSubscriberFunctionalTest extends MauticMysqlTestCase
         $this->em->flush();
 
         /** @var EmailModel $emailModel */
-        $emailModel = static::getContainer()->get(EmailModel::class);
+        $emailModel = self::getContainer()->get(EmailModel::class);
         $emailModel->sendEmailToLists($email);
 
         $stat = $this->em->getRepository(Stat::class)->findOneBy([]);

--- a/app/bundles/EmailBundle/Tests/Functional/Form/Type/EmailTypeTest.php
+++ b/app/bundles/EmailBundle/Tests/Functional/Form/Type/EmailTypeTest.php
@@ -170,7 +170,7 @@ final class EmailTypeTest extends MauticMysqlTestCase
     private function addContactToDnc(array $contactIds): void
     {
         /** @var DoNotContactModel $dncModel */
-        $dncModel = static::getContainer()->get(DoNotContactModel::class);
+        $dncModel = self::getContainer()->get(DoNotContactModel::class);
 
         foreach ($contactIds as $contactId) {
             $dncModel->addDncForContact($contactId, 'email', DoNotContact::MANUAL, 'Some comment');

--- a/app/bundles/EmailBundle/Tests/Functional/Stats/Helper/BouncedHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Functional/Stats/Helper/BouncedHelperTest.php
@@ -42,7 +42,7 @@ final class BouncedHelperTest extends MauticMysqlTestCase
     {
         parent::setUp();
 
-        $this->bouncedHelper = static::getContainer()->get(BouncedHelper::class);
+        $this->bouncedHelper = self::getContainer()->get(BouncedHelper::class);
 
         $this->createUsers();
         $this->createEmailAndCampaign();

--- a/app/bundles/EmailBundle/Tests/Functional/Stats/Helper/UnsubscribedHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Functional/Stats/Helper/UnsubscribedHelperTest.php
@@ -42,7 +42,7 @@ final class UnsubscribedHelperTest extends MauticMysqlTestCase
     {
         parent::setUp();
 
-        $this->unsubscribedHelper = static::getContainer()->get(UnsubscribedHelper::class);
+        $this->unsubscribedHelper = self::getContainer()->get(UnsubscribedHelper::class);
 
         $this->createUsers();
         $this->createEmailAndCampaign();

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelBuildUrlTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelBuildUrlTest.php
@@ -18,7 +18,7 @@ final class EmailModelBuildUrlTest extends MauticMysqlTestCase
     public function testSiteUrlAlwaysTakesPrecedenceWhenBuildingUrls(): void
     {
         /** @var EmailModel $emailModel */
-        $emailModel = static::getContainer()->get(EmailModel::class);
+        $emailModel = self::getContainer()->get(EmailModel::class);
         $idHash     = uniqid();
         $url        = $emailModel->buildUrl('mautic_email_unsubscribe', ['idHash' => $idHash]);
 

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelFunctionalTest.php
@@ -50,7 +50,7 @@ final class EmailModelFunctionalTest extends MauticMysqlTestCase
         parent::setUp();
 
         /** @var EmailModel $emailModel */
-        $emailModel = static::getContainer()->get(EmailModel::class);
+        $emailModel = self::getContainer()->get(EmailModel::class);
         $this->assertInstanceOf(EmailModel::class, $emailModel);
         $this->emailModel = $emailModel;
     }
@@ -145,7 +145,7 @@ final class EmailModelFunctionalTest extends MauticMysqlTestCase
         }
 
         /** @var LeadModel $contactModel */
-        $contactModel = static::getContainer()->get(LeadModel::class);
+        $contactModel = self::getContainer()->get(LeadModel::class);
         $this->assertInstanceOf(LeadModel::class, $contactModel);
         $contactModel->saveEntities($contacts);
 
@@ -570,7 +570,7 @@ final class EmailModelFunctionalTest extends MauticMysqlTestCase
 
         $this->addContactsToSegment(array_slice($contacts, 2, 3), $segment);
 
-        static::getContainer()->get(EventDispatcherInterface::class)->dispatch(
+        self::getContainer()->get(EventDispatcherInterface::class)->dispatch(
             new ListChangeEvent($contacts[2], $segment, true),
             LeadEvents::LEAD_LIST_CHANGE
         );
@@ -590,7 +590,7 @@ final class EmailModelFunctionalTest extends MauticMysqlTestCase
 
         $this->emailModel->getPendingLeads($email, null, true);
 
-        $listModel = static::getContainer()->get(ListModel::class);
+        $listModel = self::getContainer()->get(ListModel::class);
         $this->assertInstanceOf(ListModel::class, $listModel);
 
         foreach (array_slice($contacts, 2, 3) as $contact) {
@@ -612,7 +612,7 @@ final class EmailModelFunctionalTest extends MauticMysqlTestCase
 
         $this->emailModel->getPendingLeads($email, null, true);
 
-        $listModel = static::getContainer()->get(ListModel::class);
+        $listModel = self::getContainer()->get(ListModel::class);
         $this->assertInstanceOf(ListModel::class, $listModel);
 
         foreach (array_slice($contacts, 2, 3) as $contact) {

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelTranslationCountFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelTranslationCountFunctionalTest.php
@@ -31,7 +31,7 @@ final class EmailModelTranslationCountFunctionalTest extends MauticMysqlTestCase
         $this->em->clear();
 
         /** @var EmailModel $emailModel */
-        $emailModel = static::getContainer()->get(EmailModel::class);
+        $emailModel = self::getContainer()->get(EmailModel::class);
         $this->assertInstanceOf(EmailModel::class, $emailModel);
 
         // Re-fetch the email to get the updated stats
@@ -64,7 +64,7 @@ final class EmailModelTranslationCountFunctionalTest extends MauticMysqlTestCase
     private function createContacts(): array
     {
         /** @var LeadModel $contactModel */
-        $contactModel = static::getContainer()->get(LeadModel::class);
+        $contactModel = self::getContainer()->get(LeadModel::class);
         $this->assertInstanceOf(LeadModel::class, $contactModel);
 
         $contacts = [];

--- a/app/bundles/FormBundle/Tests/Controller/ResultControllerFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/ResultControllerFunctionalTest.php
@@ -18,9 +18,9 @@ final class ResultControllerFunctionalTest extends MauticMysqlTestCase
     public function testDownloadFileByFileNameAction(): void
     {
         /** @var FieldModel $fieldModel */
-        $fieldModel   = static::getContainer()->get(FieldModel::class);
+        $fieldModel   = self::getContainer()->get(FieldModel::class);
         /** @var FormUploader $formUploader */
-        $formUploader = static::getContainer()->get(FormUploader::class);
+        $formUploader = self::getContainer()->get(FormUploader::class);
         $fileName     = 'image.png';
 
         $this->createFile($fileName);

--- a/app/bundles/FormBundle/Tests/Controller/SubmissionFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/SubmissionFunctionalTest.php
@@ -469,7 +469,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         $campaignSources = ['forms' => [$formId => $formId]];
 
         /** @var CampaignModel $campaignModel */
-        $campaignModel = static::getContainer()->get(CampaignModel::class);
+        $campaignModel = self::getContainer()->get(CampaignModel::class);
 
         $campaign = new Campaign();
         $campaign->setName('Test Campaign');
@@ -1349,7 +1349,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         $this->assertCount(1, $submissionsData['submissions']);
 
         // The denormalised counter must match the single submission that was just created.
-        $prefix   = static::getContainer()->getParameter('mautic.db_table_prefix');
+        $prefix   = self::getContainer()->getParameter('mautic.db_table_prefix');
         $countSql = "SELECT submission_count FROM {$prefix}forms WHERE id = ?";
         $this->assertSame(1, (int) $this->connection->fetchOne($countSql, [$formId]));
 
@@ -1390,7 +1390,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
         // Deleting the submission decrements the counter symmetrically (via the postRemove listener).
         $submissionId    = $finalSubmissionsData['submissions'][0]['id'];
         /** @var SubmissionModel $submissionModel */
-        $submissionModel = static::getContainer()->get(SubmissionModel::class);
+        $submissionModel = self::getContainer()->get(SubmissionModel::class);
         $submission      = $submissionModel->getEntity($submissionId);
         $submissionModel->deleteEntity($submission);
 
@@ -1466,7 +1466,7 @@ final class SubmissionFunctionalTest extends MauticMysqlTestCase
 
         $this->assertResponseIsSuccessful();
 
-        $tablePrefix = static::getContainer()->getParameter('mautic.db_table_prefix');
+        $tablePrefix = self::getContainer()->getParameter('mautic.db_table_prefix');
 
         // we are expecting form results table to be deleted in background, so the table should exists
         $this->assertTrue($this->connection->createSchemaManager()->tablesExist("{$tablePrefix}form_results_{$formId}_{$formAlias}"));

--- a/app/bundles/FormBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
@@ -116,7 +116,7 @@ final class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
         );
 
         /** @var EventDispatcherInterface $dispatcher */
-        $dispatcher = static::getContainer()->get(EventDispatcherInterface::class);
+        $dispatcher = self::getContainer()->get(EventDispatcherInterface::class);
 
         $dispatcher->dispatch($event, FormEvents::ON_CAMPAIGN_TRIGGER_CONDITION);
 
@@ -155,7 +155,7 @@ final class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
 
     protected function beforeTearDown(): void
     {
-        $tablePrefix = static::getContainer()->getParameter('mautic.db_table_prefix');
+        $tablePrefix = self::getContainer()->getParameter('mautic.db_table_prefix');
 
         if ($this->connection->createSchemaManager()->tablesExist("{$tablePrefix}form_results_1_test_form")) {
             $this->connection->executeStatement("DROP TABLE {$tablePrefix}form_results_1_test_form");

--- a/app/bundles/FormBundle/Tests/Functional/FormSubmissionFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Functional/FormSubmissionFunctionalTest.php
@@ -81,7 +81,7 @@ final class FormSubmissionFunctionalTest extends MauticMysqlTestCase
         $this->em->flush();
 
         /** @var EmailModel $emailModel */
-        $emailModel = static::getContainer()->get(EmailModel::class);
+        $emailModel = self::getContainer()->get(EmailModel::class);
         $emailModel->sendEmail($email, [[
             'id'        => $lead->getId(),
             'email'     => $lead->getEmail(),

--- a/app/bundles/FormBundle/Tests/Model/FormCaptchaHoneypotFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Model/FormCaptchaHoneypotFunctionalTest.php
@@ -19,7 +19,7 @@ final class FormCaptchaHoneypotFunctionalTest extends MauticMysqlTestCase
         $formId = $this->createFormWithHoneypotCaptcha();
 
         /** @var FormModel $formModel */
-        $formModel = static::getContainer()->get(FormModel::class);
+        $formModel = self::getContainer()->get(FormModel::class);
         $form      = $formModel->getEntity($formId);
         $this->assertInstanceOf(Form::class, $form);
 
@@ -51,7 +51,7 @@ final class FormCaptchaHoneypotFunctionalTest extends MauticMysqlTestCase
         $formId = $this->createFormWithHoneypotCaptcha('class="custom-class"');
 
         /** @var FormModel $formModel */
-        $formModel = static::getContainer()->get(FormModel::class);
+        $formModel = self::getContainer()->get(FormModel::class);
         $form      = $formModel->getEntity($formId);
         $this->assertInstanceOf(Form::class, $form);
 

--- a/app/bundles/FormBundle/Tests/Model/FormModelFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Model/FormModelFunctionalTest.php
@@ -22,7 +22,7 @@ final class FormModelFunctionalTest extends MauticMysqlTestCase
     public function testConditionalFieldsPreserveOrderAfterDatabaseSave(): void
     {
         /** @var FormModel $formModel */
-        $formModel = static::getContainer()->get(FormModel::class);
+        $formModel = self::getContainer()->get(FormModel::class);
 
         // Parent session key must contain 'new' so FormConditionalSubscriber resolves it to a persisted field ID.
         $sessionFields = ConditionalFieldOrderTestData::createSessionFields([

--- a/app/bundles/InstallBundle/Configurator/Step/DoctrineStep.php
+++ b/app/bundles/InstallBundle/Configurator/Step/DoctrineStep.php
@@ -139,7 +139,7 @@ final class DoctrineStep implements StepInterface
      */
     public static function getDriverKeys(): array
     {
-        return array_keys(static::getDrivers());
+        return array_keys(self::getDrivers());
     }
 
     /**

--- a/app/bundles/InstallBundle/Tests/Functional/InstallWorkflowTest.php
+++ b/app/bundles/InstallBundle/Tests/Functional/InstallWorkflowTest.php
@@ -33,7 +33,7 @@ final class InstallWorkflowTest extends MauticMysqlTestCase
     {
         parent::setUp();
         /** @var \AppKernel $kernel */
-        $kernel                   = static::getContainer()->get(KernelInterface::class);
+        $kernel                   = self::getContainer()->get(KernelInterface::class);
         $this->localConfigPath    = $kernel->getLocalConfigFile();
         $this->defaultMemoryLimit = ini_get('memory_limit');
 
@@ -112,7 +112,7 @@ final class InstallWorkflowTest extends MauticMysqlTestCase
     public function testInstallRequirementsAndRecommendations(): void
     {
         $limit                 = FileHelper::convertPHPSizeToBytes(CheckStep::RECOMMENDED_MEMORY_LIMIT);
-        $expectedMemoryMessage = static::getContainer()->get(TranslatorInterface::class)->trans('mautic.install.memory.limit', ['%min_memory_limit%' => CheckStep::RECOMMENDED_MEMORY_LIMIT]);
+        $expectedMemoryMessage = self::getContainer()->get(TranslatorInterface::class)->trans('mautic.install.memory.limit', ['%min_memory_limit%' => CheckStep::RECOMMENDED_MEMORY_LIMIT]);
 
         // set the memory limit lower than the recommended value.
         ini_set('memory_limit', (string) ($limit - 1));

--- a/app/bundles/IntegrationsBundle/Tests/Functional/Entity/FieldChangeRepositoryTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Functional/Entity/FieldChangeRepositoryTest.php
@@ -46,7 +46,7 @@ final class FieldChangeRepositoryTest extends MauticMysqlTestCase
         $this->deleteLead($lead2);
 
         $changes = $this->repository->findChangesBefore(
-            static::INTEGRATION,
+            self::INTEGRATION,
             Lead::class,
             $this->getNow()->modify('+30 seconds'),
             null,
@@ -71,9 +71,9 @@ final class FieldChangeRepositoryTest extends MauticMysqlTestCase
         $this->em->flush();
 
         $this->repository->deleteEntitiesForObject(
-            static::OBJECT_ID,
+            self::OBJECT_ID,
             Lead::class,
-            static::INTEGRATION,
+            self::INTEGRATION,
             $now->modify('+30 seconds')
         );
 
@@ -91,11 +91,11 @@ final class FieldChangeRepositoryTest extends MauticMysqlTestCase
         $now          = $this->getNow();
         for ($i = 1; $i <= $quantity; ++$i) {
             $fieldChange = new FieldChange();
-            $fieldChange->setIntegration(static::INTEGRATION);
-            $fieldChange->setObjectId(static::OBJECT_ID);
+            $fieldChange->setIntegration(self::INTEGRATION);
+            $fieldChange->setObjectId(self::OBJECT_ID);
             $fieldChange->setObjectType(Lead::class);
             $fieldChange->setModifiedAt($now);
-            $fieldChange->setColumnName(static::COLUMN_NAME);
+            $fieldChange->setColumnName(self::COLUMN_NAME);
             $fieldChange->setColumnType('string');
             $fieldChange->setColumnValue((string) $i);
 

--- a/app/bundles/IntegrationsBundle/Tests/Functional/Entity/ObjectMappingRepositoryTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Functional/Entity/ObjectMappingRepositoryTest.php
@@ -27,7 +27,7 @@ final class ObjectMappingRepositoryTest extends MauticMysqlTestCase
     {
         parent::setUp();
 
-        $this->repository = static::getContainer()->get(ObjectMappingRepository::class);
+        $this->repository = self::getContainer()->get(ObjectMappingRepository::class);
     }
 
     public function testGetInternalObject(): void

--- a/app/bundles/IntegrationsBundle/Tests/Functional/EventListener/LeadSubscriberTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Functional/EventListener/LeadSubscriberTest.php
@@ -22,10 +22,10 @@ final class LeadSubscriberTest extends MauticMysqlTestCase
     {
         parent::setUp();
 
-        $this->dispatcher            = static::getContainer()->get(EventDispatcherInterface::class);
+        $this->dispatcher            = self::getContainer()->get(EventDispatcherInterface::class);
         $this->fieldChangeRepository = self::getContainer()->get(FieldChangeRepository::class);
 
-        static::getContainer()->set(
+        self::getContainer()->set(
             SyncIntegrationsHelper::class,
             new class() extends SyncIntegrationsHelper {
                 public function __construct()

--- a/app/bundles/IntegrationsBundle/Tests/Functional/Services/SyncDataExchange/Internal/ObjectHelper/CompanyObjectHelperTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Functional/Services/SyncDataExchange/Internal/ObjectHelper/CompanyObjectHelperTest.php
@@ -20,7 +20,7 @@ final class CompanyObjectHelperTest extends MauticMysqlTestCase
     public function testUpdateEmpty(): void
     {
         /** @var CompanyObjectHelper $companyObjectHelper */
-        $companyObjectHelper  = static::getContainer()->get(CompanyObjectHelper::class);
+        $companyObjectHelper  = self::getContainer()->get(CompanyObjectHelper::class);
         $updatedMappedObjects = $companyObjectHelper->update([], []);
         $this->assertSame([], $updatedMappedObjects);
     }
@@ -28,7 +28,7 @@ final class CompanyObjectHelperTest extends MauticMysqlTestCase
     public function testUpdate(): void
     {
         /** @var UserModel $userModel */
-        $userModel = static::getContainer()->get(UserModel::class);
+        $userModel = self::getContainer()->get(UserModel::class);
         $users     = $userModel->getRepository()->findAll();
         $user      = reset($users);
         $now       = new \DateTime();
@@ -42,7 +42,7 @@ final class CompanyObjectHelperTest extends MauticMysqlTestCase
         $company2->setOwner($user);
 
         /** @var CompanyModel $companyModel */
-        $companyModel = static::getContainer()->get(CompanyModel::class);
+        $companyModel = self::getContainer()->get(CompanyModel::class);
         $companyModel->saveEntity($company1);
         $companyModel->saveEntity($company2);
 
@@ -50,7 +50,7 @@ final class CompanyObjectHelperTest extends MauticMysqlTestCase
         $city  = 'Boston';
 
         /** @var CompanyObjectHelper $companyObjectHelper */
-        $companyObjectHelper = static::getContainer()->get(CompanyObjectHelper::class);
+        $companyObjectHelper = self::getContainer()->get(CompanyObjectHelper::class);
         $companyObjectHelper->update([
             $company1->getId(),
             $company2->getId(),

--- a/app/bundles/IntegrationsBundle/Tests/Functional/Sync/Notification/BulkNotificationTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Functional/Sync/Notification/BulkNotificationTest.php
@@ -16,7 +16,7 @@ final class BulkNotificationTest extends MauticMysqlTestCase
     {
         parent::setUp();
 
-        $this->bulkNotification = static::getContainer()->get(BulkNotification::class);
+        $this->bulkNotification = self::getContainer()->get(BulkNotification::class);
     }
 
     public function testNotifications(): void

--- a/app/bundles/IntegrationsBundle/Tests/Functional/Sync/Notification/Helper/UserNotificationBuilderTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Functional/Sync/Notification/Helper/UserNotificationBuilderTest.php
@@ -17,7 +17,7 @@ final class UserNotificationBuilderTest extends MauticMysqlTestCase
     {
         parent::setUp();
 
-        $this->notificationBuilder = static::getContainer()->get(UserNotificationBuilder::class);
+        $this->notificationBuilder = self::getContainer()->get(UserNotificationBuilder::class);
     }
 
     public function testGetUserIdsWithNonExistentObject(): void

--- a/app/bundles/IntegrationsBundle/Tests/Functional/Sync/Notification/NotifierTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Functional/Sync/Notification/NotifierTest.php
@@ -27,11 +27,11 @@ final class NotifierTest extends MauticMysqlTestCase
         $leads = $leadRepository->findBy([], [], 2);
 
         /** @var SyncIntegrationsHelper $syncIntegrationsHelper */
-        $syncIntegrationsHelper = static::getContainer()->get(SyncIntegrationsHelper::class);
+        $syncIntegrationsHelper = self::getContainer()->get(SyncIntegrationsHelper::class);
         $syncIntegrationsHelper->addIntegration(new ExampleIntegration(new ExampleSyncDataExchange()));
 
         /** @var Notifier $notifier */
-        $notifier = static::getContainer()->get(Notifier::class);
+        $notifier = self::getContainer()->get(Notifier::class);
 
         $contactNotification = new NotificationDAO(
             new ObjectChangeDAO(

--- a/app/bundles/LeadBundle/Tests/Command/DeduplicateCommandFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/DeduplicateCommandFunctionalTest.php
@@ -29,7 +29,7 @@ final class DeduplicateCommandFunctionalTest extends MauticMysqlTestCase
         $contactRepository = $this->em->getRepository(Lead::class);
 
         /** @var ContactDeduper $contactDeduper */
-        $contactDeduper = static::getContainer()->get(ContactDeduper::class);
+        $contactDeduper = self::getContainer()->get(ContactDeduper::class);
 
         $this->assertSame(0, $contactRepository->count([]), 'Some contacts were forgotten to remove from other tests');
 

--- a/app/bundles/LeadBundle/Tests/Command/SegmentCountCacheCommandFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/SegmentCountCacheCommandFunctionalTest.php
@@ -32,7 +32,7 @@ final class SegmentCountCacheCommandFunctionalTest extends MauticMysqlTestCase
 
         // Check segment cached contact count using the SegmentCountCacheHelper directly
         /** @var SegmentCountCacheHelper $segmentCountCacheHelper */
-        $segmentCountCacheHelper = static::getContainer()->get(SegmentCountCacheHelper::class);
+        $segmentCountCacheHelper = self::getContainer()->get(SegmentCountCacheHelper::class);
         $count                   = $segmentCountCacheHelper->getSegmentContactCount($segmentId);
         $this->assertEquals(5, $count, "Expected segment {$segmentId} to have 5 contacts");
 
@@ -46,7 +46,7 @@ final class SegmentCountCacheCommandFunctionalTest extends MauticMysqlTestCase
 
         // Check segment cached contact count using the SegmentCountCacheHelper directly
         /** @var SegmentCountCacheHelper $segmentCountCacheHelper */
-        $segmentCountCacheHelper = static::getContainer()->get(SegmentCountCacheHelper::class);
+        $segmentCountCacheHelper = self::getContainer()->get(SegmentCountCacheHelper::class);
         $count                   = $segmentCountCacheHelper->getSegmentContactCount($segmentId);
         $this->assertEquals(4, $count, "Expected segment {$segmentId} to have 4 contacts");
     }

--- a/app/bundles/LeadBundle/Tests/Command/SegmentFiltersFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/SegmentFiltersFunctionalTest.php
@@ -90,7 +90,7 @@ final class SegmentFiltersFunctionalTest extends MauticMysqlTestCase
         $field->setProperties($fieldDetails['properties']);
 
         /** @var FieldModel $fieldModel */
-        $fieldModel = static::getContainer()->get(FieldModel::class);
+        $fieldModel = self::getContainer()->get(FieldModel::class);
         $fieldModel->saveEntity($field);
     }
 
@@ -123,7 +123,7 @@ final class SegmentFiltersFunctionalTest extends MauticMysqlTestCase
                     ],
                 ]);
                 /** @var LeadModel $leadModel */
-                $leadModel = static::getContainer()->get(LeadModel::class);
+                $leadModel = self::getContainer()->get(LeadModel::class);
                 $leadModel->setFieldValues($contact, [self::FIELD_NAME => [$cars[$i % 3]]]);
             }
             $contacts[] = $contact;

--- a/app/bundles/LeadBundle/Tests/Controller/AjaxControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/AjaxControllerFunctionalTest.php
@@ -106,7 +106,7 @@ final class AjaxControllerFunctionalTest extends MauticMysqlTestCase
         $user->setUsername('no-campaign-edit-user');
         $user->setRole($role);
 
-        $hasher = static::getContainer()->get(PasswordHasherFactoryInterface::class)->getPasswordHasher($user);
+        $hasher = self::getContainer()->get(PasswordHasherFactoryInterface::class)->getPasswordHasher($user);
 
         $user->setPassword($hasher->hash('mautic'));
         $userRepository->saveEntity($user);
@@ -570,7 +570,7 @@ final class AjaxControllerFunctionalTest extends MauticMysqlTestCase
         $user->setRole($role);
 
         /** @var PasswordHasherInterface $hasher */
-        $hasher = static::getContainer()->get(PasswordHasherFactoryInterface::class)->getPasswordHasher($user);
+        $hasher = self::getContainer()->get(PasswordHasherFactoryInterface::class)->getPasswordHasher($user);
 
         $passwordNonAdmin = 'Maut1cR0cks!';
         $user->setPassword($hasher->hash($passwordNonAdmin));

--- a/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerFunctionalTest.php
@@ -36,7 +36,7 @@ final class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         // Disable API just for specific test.
         $this->configParams['api_enabled'] = 'testDisabledApi' !== $this->name();
 
-        static::getContainer()->set(
+        self::getContainer()->set(
             'session',
             new Session(
                 new class() extends FixedMockFileSessionStorage {
@@ -166,7 +166,7 @@ final class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->flush();
 
         /** @var ContactMerger $contactMerger */
-        $contactMerger = static::getContainer()->get(ContactMerger::class);
+        $contactMerger = self::getContainer()->get(ContactMerger::class);
 
         $contactMerger->merge($contact1, $contact2);
 
@@ -228,7 +228,7 @@ final class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         $contactId4Created = $response['contacts'][3]['id'];
 
         /** @var ContactMerger $contactMerger */
-        $contactMerger = static::getContainer()->get(ContactMerger::class);
+        $contactMerger = self::getContainer()->get(ContactMerger::class);
 
         // Merge contact 102 into 101.
         $contactMerger->merge(

--- a/app/bundles/LeadBundle/Tests/Controller/Api/ListApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/ListApiControllerFunctionalTest.php
@@ -37,9 +37,9 @@ final class ListApiControllerFunctionalTest extends MauticMysqlTestCase
     {
         parent::setUp();
 
-        $this->listModel  = static::getContainer()->get(ListModel::class);
-        $this->prefix     = static::getContainer()->getParameter('mautic.db_table_prefix');
-        $this->translator = static::getContainer()->get(TranslatorInterface::class);
+        $this->listModel  = self::getContainer()->get(ListModel::class);
+        $this->prefix     = self::getContainer()->getParameter('mautic.db_table_prefix');
+        $this->translator = self::getContainer()->get(TranslatorInterface::class);
     }
 
     protected function beforeBeginTransaction(): void

--- a/app/bundles/LeadBundle/Tests/Controller/FieldFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/FieldFunctionalTest.php
@@ -21,11 +21,11 @@ final class FieldFunctionalTest extends MauticMysqlTestCase
     public function testNewFieldVarcharFieldLength(int $expectedLength, ?int $inputLength = null): void
     {
         /** @var FieldModel $fieldModel */
-        $fieldModel = static::getContainer()->get(FieldModel::class);
+        $fieldModel = self::getContainer()->get(FieldModel::class);
         $field      = $this->createField('a', 'text', [], $inputLength);
         $fieldModel->saveEntity($field);
 
-        $tablePrefix = static::getContainer()->getParameter('mautic.db_table_prefix');
+        $tablePrefix = self::getContainer()->getParameter('mautic.db_table_prefix');
         $columns     = $this->connection->createSchemaManager()->listTableColumns("{$tablePrefix}leads");
         $this->assertEquals($expectedLength, $columns[$field->getAlias()]->getLength());
     }
@@ -33,11 +33,11 @@ final class FieldFunctionalTest extends MauticMysqlTestCase
     public function testNewMultiSelectField(): void
     {
         /** @var FieldModel $fieldModel */
-        $fieldModel = static::getContainer()->get(FieldModel::class);
+        $fieldModel = self::getContainer()->get(FieldModel::class);
         $field      = $this->createField('s', 'select', ['properties' => ['list' => ['choice_a' => 'Choice A']]]);
         $fieldModel->saveEntity($field);
 
-        $tablePrefix = static::getContainer()->getParameter('mautic.db_table_prefix');
+        $tablePrefix = self::getContainer()->getParameter('mautic.db_table_prefix');
         $columns     = $this->connection->createSchemaManager()->listTableColumns("{$tablePrefix}leads");
         $this->assertArrayHasKey('field_s', $columns);
     }
@@ -66,7 +66,7 @@ final class FieldFunctionalTest extends MauticMysqlTestCase
     public function testFieldDeleteValidationUsedInSegment(): void
     {
         /** @var FieldModel $fieldModel */
-        $fieldModel       = static::getContainer()->get(FieldModel::class);
+        $fieldModel       = self::getContainer()->get(FieldModel::class);
         $field_first      = $this->createField('First');
         $fieldModel->saveEntity($field_first);
 

--- a/app/bundles/LeadBundle/Tests/Controller/ImportControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/ImportControllerTest.php
@@ -447,8 +447,8 @@ final class ImportControllerTest extends MauticMysqlTestCase
     private function addCancellationNotification(?Import $import = null): void
     {
         /** @var NotificationModel $notificationModel */
-        $notificationModel = static::getContainer()->get(NotificationModel::class);
-        $translator        = static::getContainer()->get(TranslatorInterface::class);
+        $notificationModel = self::getContainer()->get(NotificationModel::class);
+        $translator        = self::getContainer()->get(TranslatorInterface::class);
 
         $fileName = basename('/tmp/test.csv');
         $message  = $import && $import->getId()

--- a/app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
@@ -263,7 +263,7 @@ final class LeadControllerTest extends MauticMysqlTestCase
         $contactC = $this->createContact(self::CONTACT_C_EMAIL);
 
         /** @var LeadModel $contactModel */
-        $contactModel = static::getContainer()->get(LeadModel::class);
+        $contactModel = self::getContainer()->get(LeadModel::class);
 
         foreach ([$contactA, $contactB] as $contact) {
             $contactModel->setFieldValues($contact, ['preferred_locale' => 'en_GB'], true, false);
@@ -316,7 +316,7 @@ final class LeadControllerTest extends MauticMysqlTestCase
         $contactG = $this->createContact('fifth@matching.email');
 
         /** @var LeadModel $contactModel */
-        $contactModel = static::getContainer()->get(LeadModel::class);
+        $contactModel = self::getContainer()->get(LeadModel::class);
 
         foreach ([$contactA, $contactB, $contactC, $contactE, $contactF, $contactG] as $contact) {
             $contactModel->setFieldValues($contact, ['preferred_locale' => 'en_GB'], true, false);
@@ -430,7 +430,7 @@ final class LeadControllerTest extends MauticMysqlTestCase
         $this->assertInstanceOf(ContactExportScheduler::class, $contactExportScheduler);
         $data                   = $contactExportScheduler->getData();
         /** @var CoreParametersHelper $coreParametersHelper */
-        $coreParametersHelper = static::getContainer()->get(CoreParametersHelper::class);
+        $coreParametersHelper = self::getContainer()->get(CoreParametersHelper::class);
 
         $this->assertSame([
             'start'  => 0,
@@ -539,7 +539,7 @@ final class LeadControllerTest extends MauticMysqlTestCase
     {
         $crawler             = $this->client->request('GET', '/s/contacts/new');
         $elementPlaceholder  = $crawler->filter('#lead_timezone')->filter('select')->attr('data-placeholder');
-        $expectedPlaceholder = static::getContainer()->get(TranslatorInterface::class)->trans('mautic.lead.field.timezone');
+        $expectedPlaceholder = self::getContainer()->get(TranslatorInterface::class)->trans('mautic.lead.field.timezone');
         $this->assertEquals($expectedPlaceholder, $elementPlaceholder);
 
         // Test that a locale option is present correctly.
@@ -642,7 +642,7 @@ final class LeadControllerTest extends MauticMysqlTestCase
         $email = $this->getMailerMessage();
         $this->assertInstanceOf(MauticMessage::class, $email);
 
-        $userHelper = static::getContainer()->get(UserHelper::class);
+        $userHelper = self::getContainer()->get(UserHelper::class);
         $user       = $userHelper->getUser();
 
         $this->assertSame('Ahoy contact@an.email', $email->getSubject());
@@ -692,7 +692,7 @@ final class LeadControllerTest extends MauticMysqlTestCase
         $email = $this->getMailerMessage();
         $this->assertInstanceOf(MauticMessage::class, $email);
 
-        $userHelper = static::getContainer()->get(UserHelper::class);
+        $userHelper = self::getContainer()->get(UserHelper::class);
         $user       = $userHelper->getUser();
 
         $this->assertSame('Ahoy contact@an.email', $email->getSubject());
@@ -879,9 +879,9 @@ EMAIL;
     public function testContactCompanyEditShowsOldCompanyNameInAuditLog(): void
     {
         /** @var CompanyModel $companyModel */
-        $companyModel = static::getContainer()->get(CompanyModel::class);
+        $companyModel = self::getContainer()->get(CompanyModel::class);
         /** @var LeadModel $contactModel */
-        $contactModel = static::getContainer()->get(LeadModel::class);
+        $contactModel = self::getContainer()->get(LeadModel::class);
 
         // Create companies
         $company = (new Company())
@@ -922,7 +922,7 @@ EMAIL;
     public function testSetNullCompanyToContact(): void
     {
         /** @var LeadModel $contactModel */
-        $contactModel = static::getContainer()->get(LeadModel::class);
+        $contactModel = self::getContainer()->get(LeadModel::class);
 
         $company = new Company();
         $company->setName('Doe Corp');

--- a/app/bundles/LeadBundle/Tests/Controller/LeadDetailFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/LeadDetailFunctionalTest.php
@@ -125,7 +125,7 @@ final class LeadDetailFunctionalTest extends MauticMysqlTestCase
         $data    = $crawler->filterXPath('//div[@id="social"]//td');
         $this->assertCount(1, $data);
 
-        $translator = static::getContainer()->get(TranslatorInterface::class);
+        $translator = self::getContainer()->get(TranslatorInterface::class);
         $this->assertStringContainsString($translator->trans('mautic.lead.field.group.no_data'), $data->text());
     }
 

--- a/app/bundles/LeadBundle/Tests/Controller/LeadListSearchFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/LeadListSearchFunctionalTest.php
@@ -41,7 +41,7 @@ final class LeadListSearchFunctionalTest extends MauticMysqlTestCase
         $this->em->clear();
 
         $this->client->enableProfiler();
-        $prefix          = static::getContainer()->getParameter('mautic.db_table_prefix');
+        $prefix          = self::getContainer()->getParameter('mautic.db_table_prefix');
         $previousQueries = [];
 
         // non-existent segment search

--- a/app/bundles/LeadBundle/Tests/Controller/ListControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/ListControllerFunctionalTest.php
@@ -43,14 +43,14 @@ final class ListControllerFunctionalTest extends MauticMysqlTestCase
         $this->configParams['update_segment_contact_count_in_background'] = 'testSegmentCountInBackground' === $this->name();
         $this->configParams['delete_segment_in_background']               = false;
         parent::setUp();
-        $this->listModel = static::getContainer()->get(ListModel::class);
+        $this->listModel = self::getContainer()->get(ListModel::class);
         $this->assertInstanceOf(ListModel::class, $this->listModel);
         $this->listRepo = $this->listModel->getRepository();
         $this->assertInstanceOf(LeadListRepository::class, $this->listRepo);
         /** @var LeadModel $leadModel */
-        $leadModel = static::getContainer()->get(LeadModel::class);
+        $leadModel = self::getContainer()->get(LeadModel::class);
         $this->assertInstanceOf(LeadModel::class, $leadModel);
-        $this->segmentCountCacheHelper = static::getContainer()->get(SegmentCountCacheHelper::class);
+        $this->segmentCountCacheHelper = self::getContainer()->get(SegmentCountCacheHelper::class);
         $this->leadRepo                = $leadModel->getRepository();
         $this->assertInstanceOf(LeadRepository::class, $this->leadRepo);
         $this->prefix                  = self::getContainer()->getParameter('mautic.db_table_prefix');

--- a/app/bundles/LeadBundle/Tests/Controller/NoteControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/NoteControllerTest.php
@@ -240,7 +240,7 @@ final class NoteControllerTest extends MauticMysqlTestCase
         $this->em->persist($role);
         $this->em->flush();
 
-        $roleModel = static::getContainer()->get(RoleModel::class);
+        $roleModel = self::getContainer()->get(RoleModel::class);
         $roleModel->setRolePermissions($role, $permissions);
         $this->em->persist($role);
 
@@ -251,7 +251,7 @@ final class NoteControllerTest extends MauticMysqlTestCase
         $user->setEmail('note.controller.'.uniqid().'@example.com');
         $user->setRole($role);
 
-        $hasher = static::getContainer()->get(PasswordHasherFactoryInterface::class)->getPasswordHasher($user);
+        $hasher = self::getContainer()->get(PasswordHasherFactoryInterface::class)->getPasswordHasher($user);
         $this->assertInstanceOf(PasswordHasherInterface::class, $hasher);
         $user->setPassword($hasher->hash('Maut1cR0cks!'));
         $this->em->persist($user);
@@ -292,7 +292,7 @@ final class NoteControllerTest extends MauticMysqlTestCase
         $this->em->persist($role);
         $this->em->flush();
 
-        $roleModel = static::getContainer()->get(RoleModel::class);
+        $roleModel = self::getContainer()->get(RoleModel::class);
         $roleModel->setRolePermissions($role, $permissions);
         $this->em->persist($role);
 
@@ -303,7 +303,7 @@ final class NoteControllerTest extends MauticMysqlTestCase
         $user->setEmail('note.user.'.uniqid().'@example.com');
         $user->setRole($role);
 
-        $hasher = static::getContainer()->get(PasswordHasherFactoryInterface::class)->getPasswordHasher($user);
+        $hasher = self::getContainer()->get(PasswordHasherFactoryInterface::class)->getPasswordHasher($user);
         $this->assertInstanceOf(PasswordHasherInterface::class, $hasher);
         $user->setPassword($hasher->hash('Maut1cR0cks!'));
         $this->em->persist($user);

--- a/app/bundles/LeadBundle/Tests/Deduplicate/ContactMergerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Deduplicate/ContactMergerFunctionalTest.php
@@ -19,11 +19,11 @@ final class ContactMergerFunctionalTest extends MauticMysqlTestCase
     public function testMergedContactFound(): void
     {
         /** @var LeadModel $model */
-        $model = static::getContainer()->get(LeadModel::class);
+        $model = self::getContainer()->get(LeadModel::class);
         $this->assertInstanceOf(LeadModel::class, $model);
 
         /** @var ContactMerger $merger */
-        $merger = static::getContainer()->get(ContactMerger::class);
+        $merger = self::getContainer()->get(ContactMerger::class);
         $this->assertInstanceOf(ContactMerger::class, $merger);
 
         $bob = new Lead();
@@ -78,14 +78,14 @@ final class ContactMergerFunctionalTest extends MauticMysqlTestCase
     public function testMergedContactsPointsAreAccurate(): void
     {
         /** @var LeadModel $model */
-        $model = static::getContainer()->get(LeadModel::class);
+        $model = self::getContainer()->get(LeadModel::class);
         $this->assertInstanceOf(LeadModel::class, $model);
 
-        $em = static::getContainer()->get(EntityManagerInterface::class);
+        $em = self::getContainer()->get(EntityManagerInterface::class);
         $this->assertInstanceOf(EntityManager::class, $em);
 
         /** @var ContactMerger $merger */
-        $merger = static::getContainer()->get(ContactMerger::class);
+        $merger = self::getContainer()->get(ContactMerger::class);
         $this->assertInstanceOf(ContactMerger::class, $merger);
 
         // Startout Jane with 50 points
@@ -155,19 +155,19 @@ final class ContactMergerFunctionalTest extends MauticMysqlTestCase
     public function testMergedContactKeepsCompanyAssociations(): void
     {
         /** @var LeadModel $model */
-        $model = static::getContainer()->get(LeadModel::class);
+        $model = self::getContainer()->get(LeadModel::class);
         $this->assertInstanceOf(LeadModel::class, $model);
 
         /** @var CompanyModel $companyModel */
-        $companyModel = static::getContainer()->get(CompanyModel::class);
+        $companyModel = self::getContainer()->get(CompanyModel::class);
         $this->assertInstanceOf(CompanyModel::class, $companyModel);
 
         /** @var ContactMerger $merger */
-        $merger = static::getContainer()->get(ContactMerger::class);
+        $merger = self::getContainer()->get(ContactMerger::class);
         $this->assertInstanceOf(ContactMerger::class, $merger);
 
         /** @var CompanyLeadRepository $companyLeadRepository */
-        $companyLeadRepository = static::getContainer()->get(CompanyLeadRepository::class);
+        $companyLeadRepository = self::getContainer()->get(CompanyLeadRepository::class);
         $this->assertInstanceOf(CompanyLeadRepository::class, $companyLeadRepository);
 
         // Jane is a known contact associated with a primary company

--- a/app/bundles/LeadBundle/Tests/Entity/FrequencyRuleRepositoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/FrequencyRuleRepositoryTest.php
@@ -20,7 +20,7 @@ final class FrequencyRuleRepositoryTest extends MauticMysqlTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->frequencyRuleRepository = static::getContainer()->get(FrequencyRuleRepository::class);
+        $this->frequencyRuleRepository = self::getContainer()->get(FrequencyRuleRepository::class);
     }
 
     /**

--- a/app/bundles/LeadBundle/Tests/Entity/LeadFieldRepositoryFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadFieldRepositoryFunctionalTest.php
@@ -23,7 +23,7 @@ final class LeadFieldRepositoryFunctionalTest extends MauticMysqlTestCase
         $this->em->persist($lead);
         $this->em->flush();
 
-        $repository = static::getContainer()->get(FieldModel::class)->getRepository();
+        $repository = self::getContainer()->get(FieldModel::class)->getRepository();
 
         $this->assertTrue($repository->compareValue($lead->getId(), 'firstname', 'John', 'eq'));
         $this->assertFalse($repository->compareValue($lead->getId(), 'firstname', 'Jack', 'eq'));
@@ -36,7 +36,7 @@ final class LeadFieldRepositoryFunctionalTest extends MauticMysqlTestCase
         $this->em->persist($lead);
         $this->em->flush();
 
-        $repository = static::getContainer()->get(FieldModel::class)->getRepository();
+        $repository = self::getContainer()->get(FieldModel::class)->getRepository();
 
         $this->assertTrue($repository->compareValue($lead->getId(), 'firstname', 'Annie', 'neq'));
         $this->assertFalse($repository->compareValue($lead->getId(), 'firstname', 'Ada', 'neq'));
@@ -49,7 +49,7 @@ final class LeadFieldRepositoryFunctionalTest extends MauticMysqlTestCase
         $this->em->persist($lead);
         $this->em->flush();
 
-        $repository = static::getContainer()->get(FieldModel::class)->getRepository();
+        $repository = self::getContainer()->get(FieldModel::class)->getRepository();
 
         $this->assertTrue($repository->compareValue($lead->getId(), 'lastname', null, 'empty'));
         $this->assertFalse($repository->compareValue($lead->getId(), 'firstname', null, 'empty'));
@@ -62,7 +62,7 @@ final class LeadFieldRepositoryFunctionalTest extends MauticMysqlTestCase
         $this->em->persist($lead);
         $this->em->flush();
 
-        $repository = static::getContainer()->get(FieldModel::class)->getRepository();
+        $repository = self::getContainer()->get(FieldModel::class)->getRepository();
 
         $this->assertTrue($repository->compareValue($lead->getId(), 'firstname', null, 'notEmpty'));
         $this->assertFalse($repository->compareValue($lead->getId(), 'lastname', null, 'notEmpty'));
@@ -75,7 +75,7 @@ final class LeadFieldRepositoryFunctionalTest extends MauticMysqlTestCase
         $this->em->persist($lead);
         $this->em->flush();
 
-        $repository = static::getContainer()->get(FieldModel::class)->getRepository();
+        $repository = self::getContainer()->get(FieldModel::class)->getRepository();
 
         $this->assertTrue($repository->compareValue($lead->getId(), 'email', 'Mary', 'startsWith'));
         $this->assertFalse($repository->compareValue($lead->getId(), 'email', 'Unicorn', 'startsWith'));
@@ -88,7 +88,7 @@ final class LeadFieldRepositoryFunctionalTest extends MauticMysqlTestCase
         $this->em->persist($lead);
         $this->em->flush();
 
-        $repository = static::getContainer()->get(FieldModel::class)->getRepository();
+        $repository = self::getContainer()->get(FieldModel::class)->getRepository();
 
         $this->assertTrue($repository->compareValue($lead->getId(), 'email', 'armyspy.com', 'endsWith'));
         $this->assertFalse($repository->compareValue($lead->getId(), 'email', 'Unicorn', 'endsWith'));
@@ -101,7 +101,7 @@ final class LeadFieldRepositoryFunctionalTest extends MauticMysqlTestCase
         $this->em->persist($lead);
         $this->em->flush();
 
-        $repository = static::getContainer()->get(FieldModel::class)->getRepository();
+        $repository = self::getContainer()->get(FieldModel::class)->getRepository();
 
         $this->assertTrue($repository->compareValue($lead->getId(), 'email', 'Nevarez', 'contains'));
         $this->assertFalse($repository->compareValue($lead->getId(), 'email', 'Unicorn', 'contains'));
@@ -114,7 +114,7 @@ final class LeadFieldRepositoryFunctionalTest extends MauticMysqlTestCase
         $this->em->persist($lead);
         $this->em->flush();
 
-        $repository = static::getContainer()->get(FieldModel::class)->getRepository();
+        $repository = self::getContainer()->get(FieldModel::class)->getRepository();
 
         $this->assertTrue($repository->compareValue($lead->getId(), 'country', ['United Kingdom', 'South Africa'], 'in'));
         $this->assertFalse($repository->compareValue($lead->getId(), 'country', ['Poland', 'Canada'], 'in'));
@@ -127,7 +127,7 @@ final class LeadFieldRepositoryFunctionalTest extends MauticMysqlTestCase
         $this->em->persist($lead);
         $this->em->flush();
 
-        $repository = static::getContainer()->get(FieldModel::class)->getRepository();
+        $repository = self::getContainer()->get(FieldModel::class)->getRepository();
 
         $this->assertTrue($repository->compareValue($lead->getId(), 'country', ['Australia', 'Poland'], 'notIn'));
         $this->assertFalse($repository->compareValue($lead->getId(), 'country', ['United Kingdom'], 'notIn'));

--- a/app/bundles/LeadBundle/Tests/Entity/LeadRepositoryFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadRepositoryFunctionalTest.php
@@ -25,7 +25,7 @@ final class LeadRepositoryFunctionalTest extends MauticMysqlTestCase
     public function testPointsAreAdded(): void
     {
         /** @var LeadModel $model */
-        $model = static::getContainer()->get(LeadModel::class);
+        $model = self::getContainer()->get(LeadModel::class);
 
         $this->lead->adjustPoints(100);
 
@@ -40,7 +40,7 @@ final class LeadRepositoryFunctionalTest extends MauticMysqlTestCase
     public function testPointsAreSubtracted(): void
     {
         /** @var LeadModel $model */
-        $model = static::getContainer()->get(LeadModel::class);
+        $model = self::getContainer()->get(LeadModel::class);
 
         $this->lead->adjustPoints(100, Lead::POINTS_SUBTRACT);
 
@@ -55,7 +55,7 @@ final class LeadRepositoryFunctionalTest extends MauticMysqlTestCase
     public function testPointsAreMultiplied(): void
     {
         /** @var LeadModel $model */
-        $model = static::getContainer()->get(LeadModel::class);
+        $model = self::getContainer()->get(LeadModel::class);
 
         $this->lead->adjustPoints(2, Lead::POINTS_MULTIPLY);
 
@@ -70,7 +70,7 @@ final class LeadRepositoryFunctionalTest extends MauticMysqlTestCase
     public function testPointsAreDivided(): void
     {
         /** @var LeadModel $model */
-        $model = static::getContainer()->get(LeadModel::class);
+        $model = self::getContainer()->get(LeadModel::class);
 
         $this->lead->adjustPoints(2, Lead::POINTS_DIVIDE);
 
@@ -85,7 +85,7 @@ final class LeadRepositoryFunctionalTest extends MauticMysqlTestCase
     public function testMixedOperatorPointsAreCalculated(): void
     {
         /** @var LeadModel $model */
-        $model = static::getContainer()->get(LeadModel::class);
+        $model = self::getContainer()->get(LeadModel::class);
 
         $this->lead->adjustPoints(100, Lead::POINTS_SUBTRACT);
         $this->lead->adjustPoints(120, Lead::POINTS_ADD);
@@ -103,7 +103,7 @@ final class LeadRepositoryFunctionalTest extends MauticMysqlTestCase
     public function testMixedModelAndRepositorySavesDoNotDoublePoints(): void
     {
         /** @var LeadModel $model */
-        $model = static::getContainer()->get(LeadModel::class);
+        $model = self::getContainer()->get(LeadModel::class);
         $this->lead->adjustPoints(120, Lead::POINTS_ADD);
         $model->saveEntity($this->lead);
         // Changes should be stored with points

--- a/app/bundles/LeadBundle/Tests/Entity/ListLeadRepositoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/ListLeadRepositoryTest.php
@@ -18,7 +18,7 @@ final class ListLeadRepositoryTest extends MauticMysqlTestCase
     {
         parent::setUp();
 
-        $this->listLeadRepository = static::getContainer()->get(ListLeadRepository::class);
+        $this->listLeadRepository = self::getContainer()->get(ListLeadRepository::class);
     }
 
     public function testGetContactsCountBySegment(): void

--- a/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
@@ -146,7 +146,7 @@ final class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
         // Execute the campaign.
         $this->testSymfonyCommand('mautic:campaigns:trigger', ['--campaign-id' => $campaign->getId()]);
 
-        $prefix = static::getContainer()->getParameter('mautic.db_table_prefix');
+        $prefix = self::getContainer()->getParameter('mautic.db_table_prefix');
 
         foreach ($listLeads as $contactId) {
             $points = $this->connection->fetchOne("SELECT points FROM {$prefix}leads WHERE id = :id", ['id' => $contactId]);
@@ -262,7 +262,7 @@ final class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
             $args['lead'] = $this->contactRepository->getEntity($contact->getId());
 
             $event      = new CampaignExecutionEvent($args, true);
-            $dispatcher = static::getContainer()->get(EventDispatcherInterface::class);
+            $dispatcher = self::getContainer()->get(EventDispatcherInterface::class);
             $result     = $dispatcher->dispatch(
                 $event,
                 LeadEvents::ON_CAMPAIGN_TRIGGER_CONDITION
@@ -1059,7 +1059,7 @@ final class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
         ];
 
         $event           = new CampaignExecutionEvent($args, false, $log);
-        $eventDispatcher = static::getContainer()->get(EventDispatcherInterface::class);
+        $eventDispatcher = self::getContainer()->get(EventDispatcherInterface::class);
         $eventDispatcher->dispatch($event, 'mautic.lead.on_campaign_trigger_action');
 
         $leadManipulator = $lead->getManipulator();
@@ -1094,7 +1094,7 @@ final class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
         // Create a contact and set the custom field value
         $contact   = $this->createContact('john.doe@example.com');
         /** @var LeadModel $leadModel */
-        $leadModel = static::getContainer()->get(LeadModel::class);
+        $leadModel = self::getContainer()->get(LeadModel::class);
         $leadModel->setFieldValues($contact, ['test_date' => $fieldValue]);
         $leadModel->saveEntity($contact);
 
@@ -1122,7 +1122,7 @@ final class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
         // @phpstan-ignore-next-line new.deprecated
         $event = new CampaignExecutionEvent($eventArgs, true);
 
-        $dispatcher = static::getContainer()->get(EventDispatcherInterface::class);
+        $dispatcher = self::getContainer()->get(EventDispatcherInterface::class);
 
         // The test passes if no exception is thrown and the result is as expected
         $dispatcher->dispatch($event, LeadEvents::ON_CAMPAIGN_TRIGGER_CONDITION);
@@ -1131,7 +1131,7 @@ final class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
 
         // Clean up
         /** @var FieldModel $fieldModel */
-        $fieldModel = static::getContainer()->get(FieldModel::class);
+        $fieldModel = self::getContainer()->get(FieldModel::class);
         $field      = $fieldModel->getEntityByAlias('test_date');
         if ($field) {
             $fieldModel->deleteEntity($field);

--- a/app/bundles/LeadBundle/Tests/EventListener/ReportNormalizeSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/ReportNormalizeSubscriberTest.php
@@ -25,7 +25,7 @@ final class ReportNormalizeSubscriberTest extends MauticMysqlTestCase
     public function testOnReportDisplay(string $value, string $type, array $properties, string $expected): void
     {
         /** @var FieldModel $fieldModel */
-        $fieldModel = static::getContainer()->get(FieldModel::class);
+        $fieldModel = self::getContainer()->get(FieldModel::class);
         $this->assertInstanceOf(FieldModel::class, $fieldModel);
         $field = new LeadField();
         $field->setType($type);

--- a/app/bundles/LeadBundle/Tests/EventListener/WebhookSubscriberFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/WebhookSubscriberFunctionalTest.php
@@ -38,7 +38,7 @@ final class WebhookSubscriberFunctionalTest extends MauticMysqlTestCase
         $this->assertInstanceOf(LeadRepository::class, $contactRepository);
 
         /** @var ListModel $segmentModel */
-        $segmentModel = static::getContainer()->get(ListModel::class);
+        $segmentModel = self::getContainer()->get(ListModel::class);
         $this->assertInstanceOf(ListModel::class, $segmentModel);
 
         $webhookQueueRepository = $this->em->getRepository(WebhookQueue::class);

--- a/app/bundles/LeadBundle/Tests/Functional/Command/CreateCustomFieldCommandTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Command/CreateCustomFieldCommandTest.php
@@ -35,7 +35,7 @@ final class CreateCustomFieldCommandTest extends MauticMysqlTestCase
         $this->em->persist($leadField);
         $this->em->flush();
 
-        $kernel = static::getContainer()->get(KernelInterface::class);
+        $kernel = self::getContainer()->get(KernelInterface::class);
         $this->assertInstanceOf(KernelInterface::class, $kernel);
 
         $expectedUserId          = 1;
@@ -89,7 +89,7 @@ final class CreateCustomFieldCommandTest extends MauticMysqlTestCase
         $this->em->persist($leadField2);
         $this->em->flush();
 
-        $kernel = static::getContainer()->get(KernelInterface::class);
+        $kernel = self::getContainer()->get(KernelInterface::class);
         $this->assertInstanceOf(KernelInterface::class, $kernel);
 
         $expectedUserId          = 1;

--- a/app/bundles/LeadBundle/Tests/Functional/Command/ImportCommandTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Command/ImportCommandTest.php
@@ -118,7 +118,7 @@ final class ImportCommandTest extends MauticMysqlTestCase
         $import->setProperties($properties);
 
         /** @var ImportModel $importModel */
-        $importModel = static::getContainer()->get(ImportModel::class);
+        $importModel = self::getContainer()->get(ImportModel::class);
         $importModel->saveEntity($import);
 
         return $import;

--- a/app/bundles/LeadBundle/Tests/Functional/Controller/ContactExportAdminNotificationsDisabledTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Controller/ContactExportAdminNotificationsDisabledTest.php
@@ -109,7 +109,7 @@ final class ContactExportAdminNotificationsDisabledTest extends MauticMysqlTestC
         $this->assertInstanceOf(AuditLog::class, $sendEmailAuditLog);
 
         /** @var CoreParametersHelper $coreParametersHelper */
-        $coreParametersHelper = static::getContainer()->get(CoreParametersHelper::class);
+        $coreParametersHelper = self::getContainer()->get(CoreParametersHelper::class);
         $zipFileName          = 'contacts_export_'.$contactExportScheduler->getScheduledDateTime()->format('Y_m_d_H_i_s').'.zip';
         $this->filePaths[]    = $filePath = $coreParametersHelper->get('contact_export_dir').'/'.$zipFileName;
         $downloadLink         = $this->router->generate(
@@ -144,7 +144,7 @@ final class ContactExportAdminNotificationsDisabledTest extends MauticMysqlTestC
             $contacts[] = $contact;
         }
 
-        $leadModel = static::getContainer()->get(LeadModel::class);
+        $leadModel = self::getContainer()->get(LeadModel::class);
         $leadModel->saveEntities($contacts);
     }
 

--- a/app/bundles/LeadBundle/Tests/Functional/Controller/ImportControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Controller/ImportControllerFunctionalTest.php
@@ -345,7 +345,7 @@ final class ImportControllerFunctionalTest extends MauticMysqlTestCase
         $field->setProperties($properties);
 
         /** @var FieldModel $fieldModel */
-        $fieldModel = static::getContainer()->get(FieldModel::class);
+        $fieldModel = self::getContainer()->get(FieldModel::class);
         $fieldModel->saveEntity($field);
     }
 
@@ -401,7 +401,7 @@ final class ImportControllerFunctionalTest extends MauticMysqlTestCase
 
         $this->getContainer()->get(UserTokenSetter::class)->setUser($import->getCreatedBy());
         /** @var ImportModel $importModel */
-        $importModel = static::getContainer()->get(ImportModel::class);
+        $importModel = self::getContainer()->get(ImportModel::class);
         $importModel->saveEntity($import);
 
         return $import;
@@ -457,7 +457,7 @@ final class ImportControllerFunctionalTest extends MauticMysqlTestCase
         $tag->setTag($tagName);
 
         /** @var TagModel $tagModel */
-        $tagModel = static::getContainer()->get(TagModel::class);
+        $tagModel = self::getContainer()->get(TagModel::class);
         $tagModel->saveEntity($tag);
 
         return $tag;

--- a/app/bundles/LeadBundle/Tests/Functional/Controller/LeadControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Controller/LeadControllerTest.php
@@ -63,7 +63,7 @@ final class LeadControllerTest extends MauticMysqlTestCase
         $this->testSymfonyCommand(ContactScheduledExportCommand::COMMAND_NAME, ['--ids' => $contactExportScheduler->getId()]);
         $this->checkContactExportScheduler(0);
         /** @var CoreParametersHelper $coreParametersHelper */
-        $coreParametersHelper    = static::getContainer()->get(CoreParametersHelper::class);
+        $coreParametersHelper    = self::getContainer()->get(CoreParametersHelper::class);
         $zipFileName             = 'contacts_export_'.$contactExportScheduler->getScheduledDateTime()
                 ->format('Y_m_d_H_i_s').'.zip';
         $this->filePaths[] = $filePath = $coreParametersHelper->get('contact_export_dir').'/'.$zipFileName;
@@ -116,7 +116,7 @@ final class LeadControllerTest extends MauticMysqlTestCase
         /** @var ContactExportScheduler $contactExportScheduler */
         $contactExportScheduler = $this->checkContactExportScheduler(1)[0];
         /** @var DateHelper $dateHelper */
-        $dateHelper             = static::getContainer()->get(DateHelper::class);
+        $dateHelper             = self::getContainer()->get(DateHelper::class);
         $requestedAt            = $dateHelper->toFull($this->getScheduledDateTimeForDisplay($contactExportScheduler));
         $requestingAdmin        = $this->em->getRepository(User::class)->findOneBy(['username' => 'admin']);
 
@@ -190,14 +190,14 @@ final class LeadControllerTest extends MauticMysqlTestCase
         $contactExportScheduler = $this->checkContactExportScheduler(1)[0];
         $requestingAdmin        = $this->em->getRepository(User::class)->findOneBy(['username' => 'admin']);
         /** @var DateHelper $dateHelper */
-        $dateHelper      = static::getContainer()->get(DateHelper::class);
+        $dateHelper      = self::getContainer()->get(DateHelper::class);
         $requestedAt     = $dateHelper->toFull($this->getScheduledDateTimeForDisplay($contactExportScheduler));
 
         $this->testSymfonyCommand(ContactScheduledExportCommand::COMMAND_NAME, ['--ids' => $contactExportScheduler->getId()]);
         $this->checkContactExportScheduler(0);
 
         /** @var CoreParametersHelper $coreParametersHelper */
-        $coreParametersHelper = static::getContainer()->get(CoreParametersHelper::class);
+        $coreParametersHelper = self::getContainer()->get(CoreParametersHelper::class);
         $zipFileName          = 'contacts_export_'.$contactExportScheduler->getScheduledDateTime()->format('Y_m_d_H_i_s').'.zip';
         $this->filePaths[]    = $filePath = $coreParametersHelper->get('contact_export_dir').'/'.$zipFileName;
         $downloadLink         = $this->router->generate(
@@ -257,7 +257,7 @@ final class LeadControllerTest extends MauticMysqlTestCase
         }
 
         /** @var LeadModel $leadModel */
-        $leadModel = static::getContainer()->get(LeadModel::class);
+        $leadModel = self::getContainer()->get(LeadModel::class);
         $leadModel->saveEntities($contacts);
     }
 

--- a/app/bundles/LeadBundle/Tests/Functional/Entity/CompanyRepositoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Entity/CompanyRepositoryTest.php
@@ -30,7 +30,7 @@ final class CompanyRepositoryTest extends MauticMysqlTestCase
     {
         // Clear owners cache (to leave a clean environment for future tests):
         /** @var MailHelper $mailHelper */
-        $mailHelper = static::getContainer()->get(MailHelper::class);
+        $mailHelper = self::getContainer()->get(MailHelper::class);
         ReflectionHelper::setValue($mailHelper, 'leadOwners', []);
     }
 
@@ -61,7 +61,7 @@ final class CompanyRepositoryTest extends MauticMysqlTestCase
     private function createCompany(string $name, string $address1 = ''): Company
     {
         /** @var CompanyModel $model */
-        $model   = static::getContainer()->get(CompanyModel::class);
+        $model   = self::getContainer()->get(CompanyModel::class);
         $company = new Company();
         $company->setIsPublished(true)->setName($name)->setAddress1($address1);
         $model->saveEntity($company);
@@ -159,7 +159,7 @@ final class CompanyRepositoryTest extends MauticMysqlTestCase
     private function setUpMailer(): void
     {
         /** @var MailHelper $mailHelper */
-        $mailHelper = static::getContainer()->get(MailHelper::class);
+        $mailHelper = self::getContainer()->get(MailHelper::class);
         $transport  = new SmtpTransport();
         $mailer     = new Mailer($transport);
         ReflectionHelper::setValue($mailHelper, 'mailer', $mailer);

--- a/app/bundles/LeadBundle/Tests/Functional/EventListener/CompanySubscriberFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/EventListener/CompanySubscriberFunctionalTest.php
@@ -24,7 +24,7 @@ final class CompanySubscriberFunctionalTest extends MauticMysqlTestCase
     public function testCreateCompany(): void
     {
         /** @var UserModel $userModel */
-        $userModel = static::getContainer()->get(UserModel::class);
+        $userModel = self::getContainer()->get(UserModel::class);
         $users     = $userModel->getRepository()->findAll();
         $user      = reset($users);
         $this->assertInstanceOf(User::class, $user);
@@ -33,7 +33,7 @@ final class CompanySubscriberFunctionalTest extends MauticMysqlTestCase
         $company->setName('Test company');
         $company->setOwner($user);
         /** @var CompanyModel $companyModel */
-        $companyModel = static::getContainer()->get(CompanyModel::class);
+        $companyModel = self::getContainer()->get(CompanyModel::class);
         $companyModel->saveEntity($company);
 
         $auditLogRepository = $this->em->getRepository(AuditLog::class);
@@ -49,13 +49,13 @@ final class CompanySubscriberFunctionalTest extends MauticMysqlTestCase
         $company = new Company();
         $company->setName('Test Delete Company');
         /** @var CompanyModel $companyModel */
-        $companyModel = static::getContainer()->get(CompanyModel::class);
+        $companyModel = self::getContainer()->get(CompanyModel::class);
         $companyModel->saveEntity($company);
 
         $lead = new Lead();
         $lead->setFirstname('Test name');
         /** @var LeadModel $leadModel */
-        $leadModel = static::getContainer()->get(LeadModel::class);
+        $leadModel = self::getContainer()->get(LeadModel::class);
         $leadModel->saveEntity($lead);
         $companyModel->addLeadToCompany($company, $lead);
         $leadModel->saveEntity($lead);

--- a/app/bundles/LeadBundle/Tests/Functional/SearchWithCustomFieldDataFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/SearchWithCustomFieldDataFunctionalTest.php
@@ -123,7 +123,7 @@ final class SearchWithCustomFieldDataFunctionalTest extends AbstractSearchTestCa
         $this->assertStringContainsString('ABC', $crawler->html());
         $this->assertStringNotContainsString('XYZ', $crawler->html());
 
-        $translator = static::getContainer()->get(TranslatorInterface::class);
+        $translator = self::getContainer()->get(TranslatorInterface::class);
 
         $this->assertStringContainsString(
             $translator->trans('mautic.core.pagination.items', ['%count%' => 1]),

--- a/app/bundles/LeadBundle/Tests/Model/FieldModelDeleteTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/FieldModelDeleteTest.php
@@ -58,7 +58,7 @@ final class FieldModelDeleteTest extends MauticMysqlTestCase
 
     private function columnExists(string $table, string $column): bool
     {
-        $prefix = static::getContainer()->getParameter('mautic.db_table_prefix');
+        $prefix = self::getContainer()->getParameter('mautic.db_table_prefix');
 
         return (bool) $this->connection->createQueryBuilder()
             ->select('1')

--- a/app/bundles/LeadBundle/Tests/Model/FieldModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/FieldModelTest.php
@@ -100,7 +100,7 @@ final class FieldModelTest extends MauticMysqlTestCase
     public function testSingleContactFieldIsCreatedAndDeleted(): void
     {
         /** @var FieldModel $fieldModel */
-        $fieldModel = static::getContainer()->get(FieldModel::class);
+        $fieldModel = self::getContainer()->get(FieldModel::class);
 
         $field = new LeadField();
         $field->setName('Test Field')
@@ -117,7 +117,7 @@ final class FieldModelTest extends MauticMysqlTestCase
     public function testSingleCompanyFieldIsCreatedAndDeleted(): void
     {
         /** @var FieldModel $fieldModel */
-        $fieldModel = static::getContainer()->get(FieldModel::class);
+        $fieldModel = self::getContainer()->get(FieldModel::class);
 
         $field = new LeadField();
         $field->setName('Test Field')
@@ -134,7 +134,7 @@ final class FieldModelTest extends MauticMysqlTestCase
     public function testMultipleFieldsAreCreatedAndDeleted(): void
     {
         /** @var FieldModel $fieldModel */
-        $fieldModel = static::getContainer()->get(FieldModel::class);
+        $fieldModel = self::getContainer()->get(FieldModel::class);
 
         $leadField = new LeadField();
         $leadField->setName('Test Field')

--- a/app/bundles/LeadBundle/Tests/Model/LeadModelFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/LeadModelFunctionalTest.php
@@ -31,13 +31,13 @@ final class LeadModelFunctionalTest extends MauticMysqlTestCase
     public function testSavingPrimaryCompanyAfterPointsAreSetByListenerAreNotResetToDefaultOf0BecauseOfPointsFieldDefaultIs0(): void
     {
         /** @var EventDispatcher $eventDispatcher */
-        $eventDispatcher = static::getContainer()->get(EventDispatcherInterface::class);
+        $eventDispatcher = self::getContainer()->get(EventDispatcherInterface::class);
         $eventDispatcher->addListener(LeadEvents::LEAD_POST_SAVE, $this->addPointsListener(...));
 
         /** @var LeadModel $model */
-        $model = static::getContainer()->get(LeadModel::class);
+        $model = self::getContainer()->get(LeadModel::class);
         /** @var EntityManager $em */
-        $em   = static::getContainer()->get(EntityManagerInterface::class);
+        $em   = self::getContainer()->get(EntityManagerInterface::class);
 
         // Set company to trigger setPrimaryCompany()
         $lead = new Lead();
@@ -71,7 +71,7 @@ final class LeadModelFunctionalTest extends MauticMysqlTestCase
         $lead->adjustPoints(10);
 
         /** @var LeadModel $model */
-        $model = static::getContainer()->get(LeadModel::class);
+        $model = self::getContainer()->get(LeadModel::class);
         $model->saveEntity($lead);
     }
 

--- a/app/bundles/LeadBundle/Tests/Model/ListModelFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/ListModelFunctionalTest.php
@@ -35,7 +35,7 @@ final class ListModelFunctionalTest extends MauticMysqlTestCase
     public function testSegmentLineChartData(): void
     {
         /** @var ListModel $segmentModel */
-        $segmentModel = static::getContainer()->get(ListModel::class);
+        $segmentModel = self::getContainer()->get(ListModel::class);
 
         /** @var LeadRepository $contactRepository */
         $contactRepository = $this->em->getRepository(Lead::class);
@@ -90,7 +90,7 @@ final class ListModelFunctionalTest extends MauticMysqlTestCase
     public function testSegmentLineChartDataWithoutFetchDataFromLeadListTable(): void
     {
         /** @var ListModel $segmentModel */
-        $segmentModel = static::getContainer()->get(ListModel::class);
+        $segmentModel = self::getContainer()->get(ListModel::class);
 
         /** @var LeadRepository $contactRepository */
         $contactRepository = $this->em->getRepository(Lead::class);

--- a/app/bundles/LeadBundle/Tests/Model/SetFrequencyRulesFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/SetFrequencyRulesFunctionalTest.php
@@ -45,7 +45,7 @@ final class SetFrequencyRulesFunctionalTest extends MauticMysqlTestCase
         ];
 
         /** @var LeadModel $model */
-        $model = static::getContainer()->get(LeadModel::class);
+        $model = self::getContainer()->get(LeadModel::class);
         $model->setFrequencyRules($lead, $data, [], []);
 
         $subscribedCategories   = $model->getLeadCategories($lead);

--- a/app/bundles/LeadBundle/Tests/Segment/ContactSegmentServiceFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/ContactSegmentServiceFunctionalTest.php
@@ -54,7 +54,7 @@ final class ContactSegmentServiceFunctionalTest extends MauticMysqlTestCase
             false
         )->getReferenceRepository();
 
-        $this->contactSegmentService = static::getContainer()->get(ContactSegmentService::class);
+        $this->contactSegmentService = self::getContainer()->get(ContactSegmentService::class);
     }
 
     protected function beforeBeginTransaction(): void

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/RelativeDateFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/RelativeDateFunctionalTest.php
@@ -150,7 +150,7 @@ final class RelativeDateFunctionalTest extends MauticMysqlTestCase
     private function checkSegmentResult(string $name, Lead $lead): void
     {
         /** @var ContactSegmentService $contactSegmentService */
-        $contactSegmentService = static::getContainer()->get(ContactSegmentService::class);
+        $contactSegmentService = self::getContainer()->get(ContactSegmentService::class);
 
         $alias = strtolower(InputHelper::alphanum($name, false, '-'));
 
@@ -174,7 +174,7 @@ final class RelativeDateFunctionalTest extends MauticMysqlTestCase
     private function createLead(string $name, string $initialTime, string $dateModifier): Lead
     {
         /** @var LeadRepository $leadRepository */
-        $leadRepository = static::getContainer()->get(EntityManagerInterface::class)->getRepository(Lead::class);
+        $leadRepository = self::getContainer()->get(EntityManagerInterface::class)->getRepository(Lead::class);
 
         $date = new \DateTime($initialTime, new \DateTimeZone('UTC'));
         $date->modify($dateModifier);

--- a/app/bundles/LeadBundle/Tests/Segment/Query/Filter/SegmentReferenceFilterQueryBuilderGlueTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Query/Filter/SegmentReferenceFilterQueryBuilderGlueTest.php
@@ -67,7 +67,7 @@ final class SegmentReferenceFilterQueryBuilderGlueTest extends MauticMysqlTestCa
         $this->testSymfonyCommand('mautic:segments:update', ['--list-id' => $segmentD->getId()]);
 
         /** @var ListModel $listModel */
-        $listModel = static::getContainer()->get(ListModel::class);
+        $listModel = self::getContainer()->get(ListModel::class);
 
         $leadCount = $listModel->getListLeadRepository()->getContactsCountBySegment($segmentD->getId());
         $this->assertSame(4, $leadCount, 'Segment must contain all the leads.');

--- a/app/bundles/LeadBundle/Tests/Segment/SegmentFilterFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/SegmentFilterFunctionalTest.php
@@ -125,7 +125,7 @@ final class SegmentFilterFunctionalTest extends MauticMysqlTestCase
     private function buildSegment(LeadList $segment, int $expectedCountInSegment): void
     {
         /** @var ContactSegmentService $contactSegmentService */
-        $contactSegmentService = static::getContainer()->get(ContactSegmentService::class);
+        $contactSegmentService = self::getContainer()->get(ContactSegmentService::class);
 
         $this->testSymfonyCommand('mautic:segments:update', [
             '-i'    => $segment->getId(),

--- a/app/bundles/LeadBundle/Tests/Tracker/ContactTrackerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Tracker/ContactTrackerFunctionalTest.php
@@ -22,13 +22,13 @@ final class ContactTrackerFunctionalTest extends MauticMysqlTestCase
     {
         parent::setUp();
 
-        $this->contactTracker = static::getContainer()->get(ContactTracker::class);
-        $this->requestStack   = static::getContainer()->get(RequestStack::class);
+        $this->contactTracker = self::getContainer()->get(ContactTracker::class);
+        $this->requestStack   = self::getContainer()->get(RequestStack::class);
     }
 
     public function testReset(): void
     {
-        static::getContainer()->get(TokenStorageInterface::class)->setToken(null);
+        self::getContainer()->get(TokenStorageInterface::class)->setToken(null);
         $this->contactTracker->setUseSystemContact(false);
 
         $contactOne = $this->createContact('test-one@domain.tld');

--- a/app/bundles/LeadBundle/Tests/Validator/Constraints/EmailAddressValidatorTest.php
+++ b/app/bundles/LeadBundle/Tests/Validator/Constraints/EmailAddressValidatorTest.php
@@ -18,10 +18,10 @@ final class EmailAddressValidatorTest extends AbstractMauticTestCase
     public function testValidate(?string $value, int $expectedViolationCount): void
     {
         /** @var EmailAddressValidator $emailAddressValidator */
-        $emailAddressValidator = static::getContainer()->get(EmailAddressValidator::class);
+        $emailAddressValidator = self::getContainer()->get(EmailAddressValidator::class);
         $this->assertInstanceOf(EmailAddressValidator::class, $emailAddressValidator);
 
-        $translator = static::getContainer()->get(TranslatorInterface::class);
+        $translator = self::getContainer()->get(TranslatorInterface::class);
         $this->assertInstanceOf(TranslatorInterface::class, $translator);
 
         $context = new ExecutionContext($this->createStub(ValidatorInterface::class), null, $translator);

--- a/app/bundles/LeadBundle/Validator/Constraints/SegmentUsedInCampaigns.php
+++ b/app/bundles/LeadBundle/Validator/Constraints/SegmentUsedInCampaigns.php
@@ -10,6 +10,6 @@ final class SegmentUsedInCampaigns extends Constraint
 {
     public function getTargets(): string
     {
-        return static::CLASS_CONSTRAINT;
+        return self::CLASS_CONSTRAINT;
     }
 }

--- a/app/bundles/MarketplaceBundle/Service/RouteProvider.php
+++ b/app/bundles/MarketplaceBundle/Service/RouteProvider.php
@@ -25,13 +25,13 @@ final readonly class RouteProvider
 
     public function buildListRoute(int $page = 1): string
     {
-        return $this->router->generate(static::ROUTE_LIST, ['page' => $page]);
+        return $this->router->generate(self::ROUTE_LIST, ['page' => $page]);
     }
 
     public function buildDetailRoute(string $vendor, string $package): string
     {
         return $this->router->generate(
-            static::ROUTE_DETAIL,
+            self::ROUTE_DETAIL,
             ['vendor' => $vendor, 'package' => $package]
         );
     }
@@ -39,7 +39,7 @@ final readonly class RouteProvider
     public function buildInstallRoute(string $vendor, string $package): string
     {
         return $this->router->generate(
-            static::ROUTE_DETAIL,
+            self::ROUTE_DETAIL,
             ['vendor' => $vendor, 'package' => $package]
         );
     }
@@ -47,7 +47,7 @@ final readonly class RouteProvider
     public function buildRemoveRoute(string $vendor, string $package): string
     {
         return $this->router->generate(
-            static::ROUTE_REMOVE,
+            self::ROUTE_REMOVE,
             ['vendor' => $vendor, 'package' => $package]
         );
     }
@@ -55,7 +55,7 @@ final readonly class RouteProvider
     public function buildClearCacheRoute(): string
     {
         return $this->router->generate(
-            static::ROUTE_CLEAR_CACHE
+            self::ROUTE_CLEAR_CACHE
         );
     }
 }

--- a/app/bundles/MarketplaceBundle/Tests/Functional/Controller/AjaxControllerTest.php
+++ b/app/bundles/MarketplaceBundle/Tests/Functional/Controller/AjaxControllerTest.php
@@ -107,7 +107,7 @@ final class AjaxControllerTest extends AbstractMauticTestCase
             $this->createStub(LoggerInterface::class),
             $this->marketplaceConfig
         );
-        $controller->setContainer(static::getContainer());
+        $controller->setContainer(self::getContainer());
 
         return $controller;
     }

--- a/app/bundles/MarketplaceBundle/Tests/Functional/Controller/DetailControllerTest.php
+++ b/app/bundles/MarketplaceBundle/Tests/Functional/Controller/DetailControllerTest.php
@@ -25,7 +25,7 @@ final class DetailControllerTest extends MauticMysqlTestCase
         );
 
         /** @var Allowlist $allowlist */
-        $allowlist = static::getContainer()->get(Allowlist::class);
+        $allowlist = self::getContainer()->get(Allowlist::class);
         $allowlist->clearCache();
 
         $this->client->request('GET', "s/marketplace/detail/{$requestedPackage}");

--- a/app/bundles/MarketplaceBundle/Tests/Functional/Controller/ListControllerTest.php
+++ b/app/bundles/MarketplaceBundle/Tests/Functional/Controller/ListControllerTest.php
@@ -32,7 +32,7 @@ final class ListControllerTest extends MauticMysqlTestCase
         );
 
         /** @var Allowlist $allowlist */
-        $allowlist = static::getContainer()->get(Allowlist::class);
+        $allowlist = self::getContainer()->get(Allowlist::class);
         $allowlist->clearCache();
 
         $crawler = $this->client->request('GET', 's/marketplace');
@@ -63,7 +63,7 @@ final class ListControllerTest extends MauticMysqlTestCase
         );
 
         /** @var Allowlist $allowlist */
-        $allowlist = static::getContainer()->get(Allowlist::class);
+        $allowlist = self::getContainer()->get(Allowlist::class);
         $allowlist->clearCache();
 
         $crawler = $this->client->request('GET', 's/marketplace');

--- a/app/bundles/NotificationBundle/Tests/Functional/EventListener/CampaignSubscriberTest.php
+++ b/app/bundles/NotificationBundle/Tests/Functional/EventListener/CampaignSubscriberTest.php
@@ -421,10 +421,10 @@ final class CampaignSubscriberTest extends MauticMysqlTestCase
 
     public function testNotificationsSentInBatches(): void
     {
-        $subscriber = new class(static::getContainer()->get(IntegrationHelper::class), static::getContainer()->get(NotificationModel::class), static::getContainer()->get(OneSignalApi::class), static::getContainer()->get(EventDispatcherInterface::class), static::getContainer()->get(DoNotContactModel::class), static::getContainer()->get(TranslatorInterface::class), static::getContainer()->get(NotificationRepository::class)) extends CampaignSubscriber {
+        $subscriber = new class(self::getContainer()->get(IntegrationHelper::class), self::getContainer()->get(NotificationModel::class), self::getContainer()->get(OneSignalApi::class), self::getContainer()->get(EventDispatcherInterface::class), self::getContainer()->get(DoNotContactModel::class), self::getContainer()->get(TranslatorInterface::class), self::getContainer()->get(NotificationRepository::class)) extends CampaignSubscriber {
             protected const MAX_PLAYER_IDS_PER_REQUEST = 2;
         };
-        static::getContainer()->set('mautic.notification.campaignbundle.subscriber', $subscriber);
+        self::getContainer()->set('mautic.notification.campaignbundle.subscriber', $subscriber);
 
         $notification = $this->createNotification($this->em);
         $this->em->flush();
@@ -557,7 +557,7 @@ final class CampaignSubscriberTest extends MauticMysqlTestCase
     private function convertToTrackedUrl(Notification $notification, Lead $leadOne): string
     {
         /** @var AbstractNotificationApi $api */
-        $api          = static::getContainer()->get(OneSignalApi::class);
+        $api          = self::getContainer()->get(OneSignalApi::class);
         $clickThrough = [
             'notification' => $notification->getId(),
             'lead'         => $leadOne->getId(),

--- a/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
@@ -83,7 +83,7 @@ final class BuilderSubscriber implements EventSubscriberInterface
 
     public function onEmailBuild(EmailBuilderEvent $event): void
     {
-        if ($event->tokensRequested([static::pageTokenRegex])) {
+        if ($event->tokensRequested([self::pageTokenRegex])) {
             $tokenHelper = $this->builderTokenHelperFactory->getBuilderTokenHelper('page');
             $tokenFilter = $event->getTokenFilter();
             $tokens      = $tokenHelper->getFormattedTokens(
@@ -133,7 +133,7 @@ final class BuilderSubscriber implements EventSubscriberInterface
             $event->addAbTestWinnerCriteria('page.dwelltime', $dwellTime);
         }
 
-        if ($event->tokensRequested([static::pageTokenRegex, static::dwcTokenRegex])) {
+        if ($event->tokensRequested([self::pageTokenRegex, self::dwcTokenRegex])) {
             $tokenFilter = $event->getTokenFilter();
             $labelFilter = 'label' === $tokenFilter['target'] ? $tokenFilter['filter'] : '';
             $tokens      = $tokenHelper->getFormattedTokens(
@@ -150,7 +150,7 @@ final class BuilderSubscriber implements EventSubscriberInterface
             $dwcTokenHelper = $this->builderTokenHelperFactory->getBuilderTokenHelper('dynamicContent', 'dynamiccontent:dynamiccontents');
             $expr           = $this->connection->createExpressionBuilder()->and('e.is_campaign_based <> 1 and e.slot_name is not null');
             $dwcTokens      = $dwcTokenHelper->getFormattedTokens(
-                static::dwcTokenRegex,
+                self::dwcTokenRegex,
                 TokenFormatOptions::simplePrefix('mautic.page.token.dwc'),
                 $labelFilter,
                 'name',
@@ -165,18 +165,18 @@ final class BuilderSubscriber implements EventSubscriberInterface
             $event->addTokens(
                 $event->filterTokens(
                     [
-                        static::langBarRegex      => $thisPagePrefix.$this->translator->trans('mautic.page.token.lang'),
-                        static::shareButtonsRegex => $thisPagePrefix.$this->translator->trans('mautic.page.token.share'),
-                        static::titleRegex        => $thisPagePrefix.$this->translator->trans('mautic.core.title'),
-                        static::brandName         => $thisPagePrefix.$this->translator->trans('mautic.core.token.brand_name'),
-                        static::descriptionRegex  => $thisPagePrefix.$this->translator->trans('mautic.page.form.metadescription'),
-                        static::segmentListRegex  => $thisPagePrefix.$this->translator->trans('mautic.page.form.segmentlist'),
-                        static::categoryListRegex => $thisPagePrefix.$this->translator->trans('mautic.page.form.categorylist'),
-                        static::preferredchannel  => $thisPagePrefix.$this->translator->trans('mautic.page.form.preferredchannel'),
-                        static::channelfrequency  => $thisPagePrefix.$this->translator->trans('mautic.page.form.channelfrequency'),
-                        static::saveprefsRegex    => $thisPagePrefix.$this->translator->trans('mautic.page.form.saveprefs'),
-                        static::successmessage    => $thisPagePrefix.$this->translator->trans('mautic.page.form.successmessage'),
-                        static::identifierToken   => $thisPagePrefix.$this->translator->trans('mautic.page.form.leadidentifier'),
+                        self::langBarRegex      => $thisPagePrefix.$this->translator->trans('mautic.page.token.lang'),
+                        self::shareButtonsRegex => $thisPagePrefix.$this->translator->trans('mautic.page.token.share'),
+                        self::titleRegex        => $thisPagePrefix.$this->translator->trans('mautic.core.title'),
+                        self::brandName         => $thisPagePrefix.$this->translator->trans('mautic.core.token.brand_name'),
+                        self::descriptionRegex  => $thisPagePrefix.$this->translator->trans('mautic.page.form.metadescription'),
+                        self::segmentListRegex  => $thisPagePrefix.$this->translator->trans('mautic.page.form.segmentlist'),
+                        self::categoryListRegex => $thisPagePrefix.$this->translator->trans('mautic.page.form.categorylist'),
+                        self::preferredchannel  => $thisPagePrefix.$this->translator->trans('mautic.page.form.preferredchannel'),
+                        self::channelfrequency  => $thisPagePrefix.$this->translator->trans('mautic.page.form.channelfrequency'),
+                        self::saveprefsRegex    => $thisPagePrefix.$this->translator->trans('mautic.page.form.saveprefs'),
+                        self::successmessage    => $thisPagePrefix.$this->translator->trans('mautic.page.form.successmessage'),
+                        self::identifierToken   => $thisPagePrefix.$this->translator->trans('mautic.page.form.leadidentifier'),
                     ]
                 )
             );
@@ -217,17 +217,17 @@ final class BuilderSubscriber implements EventSubscriberInterface
     private function replaceCommonTokens(string $content, Page $page): string
     {
         return str_ireplace([
-            static::langBarRegex,
-            static::shareButtonsRegex,
-            static::titleRegex,
-            static::brandName,
-            static::descriptionRegex,
+            self::langBarRegex,
+            self::shareButtonsRegex,
+            self::titleRegex,
+            self::brandName,
+            self::descriptionRegex,
         ], [
-            str_contains($content, static::langBarRegex) ? $this->renderLanguageBar($page) : '',
-            str_contains($content, static::shareButtonsRegex) ? $this->renderSocialShareButtons() : '',
-            str_contains($content, static::titleRegex) ? $page->getTitle() : '',
-            str_contains($content, static::brandName) ? $this->coreParametersHelper->get('brand_name') : '',
-            str_contains($content, static::descriptionRegex) ? $page->getMetaDescription() : '',
+            str_contains($content, self::langBarRegex) ? $this->renderLanguageBar($page) : '',
+            str_contains($content, self::shareButtonsRegex) ? $this->renderSocialShareButtons() : '',
+            str_contains($content, self::titleRegex) ? $page->getTitle() : '',
+            str_contains($content, self::brandName) ? $this->coreParametersHelper->get('brand_name') : '',
+            str_contains($content, self::descriptionRegex) ? $page->getMetaDescription() : '',
         ], $content);
     }
 
@@ -249,19 +249,19 @@ final class BuilderSubscriber implements EventSubscriberInterface
     private function replacePreferenceCenterTokens(string $content, array $params): string
     {
         return str_ireplace([
-            static::segmentListRegex,
-            static::categoryListRegex,
-            static::preferredchannel,
-            static::channelfrequency,
-            static::saveprefsRegex,
-            static::successmessage,
+            self::segmentListRegex,
+            self::categoryListRegex,
+            self::preferredchannel,
+            self::channelfrequency,
+            self::saveprefsRegex,
+            self::successmessage,
         ], [
-            str_contains($content, static::segmentListRegex) ? $this->renderSegmentList($params) : '',
-            str_contains($content, static::categoryListRegex) ? $this->renderCategoryList($params) : '',
-            str_contains($content, static::preferredchannel) ? $this->renderPreferredChannel($params) : '',
-            str_contains($content, static::channelfrequency) ? $this->renderChannelFrequency($params) : '',
-            str_contains($content, static::saveprefsRegex) ? $this->renderSavePrefs($params) : '',
-            str_contains($content, static::successmessage) ? $this->renderSuccessMessage($params) : '',
+            str_contains($content, self::segmentListRegex) ? $this->renderSegmentList($params) : '',
+            str_contains($content, self::categoryListRegex) ? $this->renderCategoryList($params) : '',
+            str_contains($content, self::preferredchannel) ? $this->renderPreferredChannel($params) : '',
+            str_contains($content, self::channelfrequency) ? $this->renderChannelFrequency($params) : '',
+            str_contains($content, self::saveprefsRegex) ? $this->renderSavePrefs($params) : '',
+            str_contains($content, self::successmessage) ? $this->renderSuccessMessage($params) : '',
         ], $content);
     }
 
@@ -304,7 +304,7 @@ final class BuilderSubscriber implements EventSubscriberInterface
             '@MauticCore/Slots/segmentlist.html.twig',
             $params,
             '<div class="pref-segmentlist"%s>{templateContent}</div>',
-            static::firstSlotAttribute
+            self::firstSlotAttribute
         );
     }
 
@@ -314,7 +314,7 @@ final class BuilderSubscriber implements EventSubscriberInterface
             '@MauticCore/Slots/categorylist.html.twig',
             $params,
             '<div class="pref-categorylist"%s>{templateContent}</div>',
-            static::firstSlotAttribute
+            self::firstSlotAttribute
         );
     }
 
@@ -333,7 +333,7 @@ final class BuilderSubscriber implements EventSubscriberInterface
             '@MauticCore/Slots/channelfrequency.html.twig',
             $params,
             '<div class="pref-channelfrequency"%s>{templateContent}</div>',
-            static::firstSlotAttribute
+            self::firstSlotAttribute
         );
     }
 
@@ -343,8 +343,8 @@ final class BuilderSubscriber implements EventSubscriberInterface
             '@MauticCore/Slots/saveprefsbutton.html.twig',
             $params,
             '<div class="%s"%s>{templateContent}</div>',
-            static::saveButtonContainerClass,
-            static::firstSlotAttribute
+            self::saveButtonContainerClass,
+            self::firstSlotAttribute
         );
     }
 
@@ -472,7 +472,7 @@ final class BuilderSubscriber implements EventSubscriberInterface
         $content = implode('', array_map([$node->ownerDocument, 'saveHTML'], iterator_to_array($node->childNodes)));
 
         // Check if the save button exists in the content. If not, try again with the parentNode.
-        if (!str_contains($content, static::saveButtonContainerClass)) {
+        if (!str_contains($content, self::saveButtonContainerClass)) {
             if (null === $node->parentNode) {
                 throw new \RuntimeException("Can't get parent node of #document. Did you forget to insert a save button in your preference center form?");
             }

--- a/app/bundles/PageBundle/Tests/Controller/PageControllerTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PageControllerTest.php
@@ -28,7 +28,7 @@ final class PageControllerTest extends MauticMysqlTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->prefix = static::getContainer()->getParameter('mautic.db_table_prefix');
+        $this->prefix = self::getContainer()->getParameter('mautic.db_table_prefix');
 
         $pageData = [
             'title'    => 'Test Page',
@@ -36,7 +36,7 @@ final class PageControllerTest extends MauticMysqlTestCase
         ];
 
         /** @var PageModel $model */
-        $model = static::getContainer()->get(PageModel::class);
+        $model = self::getContainer()->get(PageModel::class);
         $page  = new Page();
         $page->setTitle($pageData['title'])
             ->setTemplate($pageData['template']);
@@ -203,7 +203,7 @@ final class PageControllerTest extends MauticMysqlTestCase
         $clientResponse         = $this->client->getResponse();
         $clientResponseContent  = $clientResponse->getContent();
         /** @var PageModel $model */
-        $model                  = static::getContainer()->get(PageModel::class);
+        $model                  = self::getContainer()->get(PageModel::class);
         $page                   = $model->getEntity($this->id);
         $this->assertEquals(Response::HTTP_OK, $clientResponse->getStatusCode());
         $this->assertInstanceOf(Page::class, $page);
@@ -277,7 +277,7 @@ final class PageControllerTest extends MauticMysqlTestCase
     public function testSavePageAliasWithUnderscores(): void
     {
         /** @var PageModel $pageModel */
-        $pageModel = static::getContainer()->get(PageModel::class);
+        $pageModel = self::getContainer()->get(PageModel::class);
 
         $parentPage = new Page();
         $parentPage->setTitle('This is My Page');

--- a/app/bundles/PageBundle/Tests/Functional/EventListener/BuilderSubscriberTest.php
+++ b/app/bundles/PageBundle/Tests/Functional/EventListener/BuilderSubscriberTest.php
@@ -80,7 +80,7 @@ final class BuilderSubscriberTest extends MauticMysqlTestCase
 
         $this->em->flush();
 
-        $mailHashHelper = static::getContainer()->get(MailHashHelper::class);
+        $mailHashHelper = self::getContainer()->get(MailHashHelper::class);
         $this->assertInstanceOf(MailHashHelper::class, $mailHashHelper);
 
         $unsubscribeUrl = $this->router->generate('mautic_email_unsubscribe', [
@@ -93,7 +93,7 @@ final class BuilderSubscriberTest extends MauticMysqlTestCase
 
         $this->assertTrue($this->client->getResponse()->isSuccessful(), $this->client->getResponse()->getContent());
 
-        $form = $crawler->filter(static::FORM_SELECTOR);
+        $form = $crawler->filter(self::FORM_SELECTOR);
         $html = $form->html();
 
         foreach ($selectorsAndExpectedCounts as $selector => $expectedCount) {
@@ -108,12 +108,12 @@ final class BuilderSubscriberTest extends MauticMysqlTestCase
         }
 
         // Ensure the token and save button are always included within the <form> tag
-        $this->assertCount(1, $form->filter(static::TOKEN_SELECTOR), sprintf('The following HTML does not contain the _token. %s', $html));
+        $this->assertCount(1, $form->filter(self::TOKEN_SELECTOR), sprintf('The following HTML does not contain the _token. %s', $html));
 
         if ($hasPreferenceCenter) {
-            $this->assertCount(1, $form->filter(static::CUSTOM_SAVE_BUTTON_SELECTOR), sprintf('The following HTML does not contain the save button. %s', $html));
+            $this->assertCount(1, $form->filter(self::CUSTOM_SAVE_BUTTON_SELECTOR), sprintf('The following HTML does not contain the save button. %s', $html));
         } else {
-            $this->assertCount(1, $form->filter(static::DEFAULT_SAVE_BUTTON_SELECTOR), sprintf('The following HTML does not contain the save button. %s', $html));
+            $this->assertCount(1, $form->filter(self::DEFAULT_SAVE_BUTTON_SELECTOR), sprintf('The following HTML does not contain the save button. %s', $html));
         }
     }
 
@@ -128,10 +128,10 @@ final class BuilderSubscriberTest extends MauticMysqlTestCase
                 'show_contact_pause_dates'        => 1,
             ],
             [
-                static::CUSTOM_SEGMENT_SELECTOR           => 1, // determined by show_contact_segments
-                static::CUSTOM_CATEGORY_SELECTOR          => 1, // determined by show_contact_categories
-                static::CUSTOM_PREFERRED_CHANNEL_SELECTOR => 1, // determined by show_contact_preferred_channels
-                static::CUSTOM_CHANNEL_FREQ_SELECTOR      => 1, // determined by EITHER show_contact_frequency & show_contact_pause_dates
+                self::CUSTOM_SEGMENT_SELECTOR           => 1, // determined by show_contact_segments
+                self::CUSTOM_CATEGORY_SELECTOR          => 1, // determined by show_contact_categories
+                self::CUSTOM_PREFERRED_CHANNEL_SELECTOR => 1, // determined by show_contact_preferred_channels
+                self::CUSTOM_CHANNEL_FREQ_SELECTOR      => 1, // determined by EITHER show_contact_frequency & show_contact_pause_dates
             ],
             true,
         ];
@@ -145,10 +145,10 @@ final class BuilderSubscriberTest extends MauticMysqlTestCase
                 'show_contact_pause_dates'        => 1,
             ],
             [
-                static::CUSTOM_SEGMENT_SELECTOR           => 0, // determined by show_contact_segments
-                static::CUSTOM_CATEGORY_SELECTOR          => 0, // determined by show_contact_categories
-                static::CUSTOM_PREFERRED_CHANNEL_SELECTOR => 1, // determined by show_contact_preferred_channels
-                static::CUSTOM_CHANNEL_FREQ_SELECTOR      => 1, // determined by EITHER show_contact_frequency & show_contact_pause_dates
+                self::CUSTOM_SEGMENT_SELECTOR           => 0, // determined by show_contact_segments
+                self::CUSTOM_CATEGORY_SELECTOR          => 0, // determined by show_contact_categories
+                self::CUSTOM_PREFERRED_CHANNEL_SELECTOR => 1, // determined by show_contact_preferred_channels
+                self::CUSTOM_CHANNEL_FREQ_SELECTOR      => 1, // determined by EITHER show_contact_frequency & show_contact_pause_dates
             ],
             true,
         ];
@@ -162,10 +162,10 @@ final class BuilderSubscriberTest extends MauticMysqlTestCase
                 'show_contact_pause_dates'        => 0,
             ],
             [
-                static::CUSTOM_SEGMENT_SELECTOR           => 1, // determined by show_contact_segments
-                static::CUSTOM_CATEGORY_SELECTOR          => 1, // determined by show_contact_categories
-                static::CUSTOM_PREFERRED_CHANNEL_SELECTOR => 0, // determined by show_contact_preferred_channels
-                static::CUSTOM_CHANNEL_FREQ_SELECTOR      => 0, // determined by EITHER show_contact_frequency & show_contact_pause_dates
+                self::CUSTOM_SEGMENT_SELECTOR           => 1, // determined by show_contact_segments
+                self::CUSTOM_CATEGORY_SELECTOR          => 1, // determined by show_contact_categories
+                self::CUSTOM_PREFERRED_CHANNEL_SELECTOR => 0, // determined by show_contact_preferred_channels
+                self::CUSTOM_CHANNEL_FREQ_SELECTOR      => 0, // determined by EITHER show_contact_frequency & show_contact_pause_dates
             ],
             true,
         ];
@@ -179,10 +179,10 @@ final class BuilderSubscriberTest extends MauticMysqlTestCase
                 'show_contact_pause_dates'        => 0,
             ],
             [
-                static::CUSTOM_SEGMENT_SELECTOR           => 0, // determined by show_contact_segments
-                static::CUSTOM_CATEGORY_SELECTOR          => 0, // determined by show_contact_categories
-                static::CUSTOM_PREFERRED_CHANNEL_SELECTOR => 0, // determined by show_contact_preferred_channels
-                static::CUSTOM_CHANNEL_FREQ_SELECTOR      => 1, // determined by EITHER show_contact_frequency & show_contact_pause_dates
+                self::CUSTOM_SEGMENT_SELECTOR           => 0, // determined by show_contact_segments
+                self::CUSTOM_CATEGORY_SELECTOR          => 0, // determined by show_contact_categories
+                self::CUSTOM_PREFERRED_CHANNEL_SELECTOR => 0, // determined by show_contact_preferred_channels
+                self::CUSTOM_CHANNEL_FREQ_SELECTOR      => 1, // determined by EITHER show_contact_frequency & show_contact_pause_dates
             ],
             true,
         ];
@@ -196,11 +196,11 @@ final class BuilderSubscriberTest extends MauticMysqlTestCase
                 'show_contact_pause_dates'        => 1,
             ],
             [
-                static::CUSTOM_SEGMENT_SELECTOR           => 0, // determined by show_contact_segments
-                static::CUSTOM_CATEGORY_SELECTOR          => 0, // determined by show_contact_categories
-                static::CUSTOM_PREFERRED_CHANNEL_SELECTOR => 0, // determined by show_contact_preferred_channels
-                static::CUSTOM_CHANNEL_FREQ_SELECTOR      => 0, // determined by show_contact_frequency
-                static::DEFAULT_PAUSE_DATES_SELECTOR      => 1, // determined by show_contact_pause_dates
+                self::CUSTOM_SEGMENT_SELECTOR           => 0, // determined by show_contact_segments
+                self::CUSTOM_CATEGORY_SELECTOR          => 0, // determined by show_contact_categories
+                self::CUSTOM_PREFERRED_CHANNEL_SELECTOR => 0, // determined by show_contact_preferred_channels
+                self::CUSTOM_CHANNEL_FREQ_SELECTOR      => 0, // determined by show_contact_frequency
+                self::DEFAULT_PAUSE_DATES_SELECTOR      => 1, // determined by show_contact_pause_dates
             ],
             true,
         ];
@@ -214,10 +214,10 @@ final class BuilderSubscriberTest extends MauticMysqlTestCase
                 'show_contact_pause_dates'        => 0,
             ],
             [
-                static::CUSTOM_SEGMENT_SELECTOR           => 0, // determined by show_contact_segments
-                static::CUSTOM_CATEGORY_SELECTOR          => 0, // determined by show_contact_categories
-                static::CUSTOM_PREFERRED_CHANNEL_SELECTOR => 0, // determined by show_contact_preferred_channels
-                static::CUSTOM_CHANNEL_FREQ_SELECTOR      => 0, // determined by EITHER show_contact_frequency & show_contact_pause_dates
+                self::CUSTOM_SEGMENT_SELECTOR           => 0, // determined by show_contact_segments
+                self::CUSTOM_CATEGORY_SELECTOR          => 0, // determined by show_contact_categories
+                self::CUSTOM_PREFERRED_CHANNEL_SELECTOR => 0, // determined by show_contact_preferred_channels
+                self::CUSTOM_CHANNEL_FREQ_SELECTOR      => 0, // determined by EITHER show_contact_frequency & show_contact_pause_dates
             ],
             true,
         ];
@@ -231,11 +231,11 @@ final class BuilderSubscriberTest extends MauticMysqlTestCase
                 'show_contact_pause_dates'        => 1,
             ],
             [
-                static::DEFAULT_SEGMENT_SELECTOR           => 1, // determined by show_contact_segments
-                static::DEFAULT_CATEGORY_SELECTOR          => 1, // determined by show_contact_categories
-                static::DEFAULT_PREFERRED_CHANNEL_SELECTOR => 1, // determined by show_contact_preferred_channels
-                static::DEFAULT_CHANNEL_FREQ_SELECTOR      => 1, // determined by show_contact_frequency. This differs from a custom page.
-                static::DEFAULT_PAUSE_DATES_SELECTOR       => 1, // determined FIRST by show_contact_frequency, then by show_contact_pause_dates
+                self::DEFAULT_SEGMENT_SELECTOR           => 1, // determined by show_contact_segments
+                self::DEFAULT_CATEGORY_SELECTOR          => 1, // determined by show_contact_categories
+                self::DEFAULT_PREFERRED_CHANNEL_SELECTOR => 1, // determined by show_contact_preferred_channels
+                self::DEFAULT_CHANNEL_FREQ_SELECTOR      => 1, // determined by show_contact_frequency. This differs from a custom page.
+                self::DEFAULT_PAUSE_DATES_SELECTOR       => 1, // determined FIRST by show_contact_frequency, then by show_contact_pause_dates
             ],
             false,
         ];
@@ -249,11 +249,11 @@ final class BuilderSubscriberTest extends MauticMysqlTestCase
                 'show_contact_pause_dates'        => 1,
             ],
             [
-                static::DEFAULT_SEGMENT_SELECTOR           => 0, // determined by show_contact_segments
-                static::DEFAULT_CATEGORY_SELECTOR          => 0, // determined by show_contact_categories
-                static::DEFAULT_PREFERRED_CHANNEL_SELECTOR => 1, // determined by show_contact_preferred_channels
-                static::DEFAULT_CHANNEL_FREQ_SELECTOR      => 1, // determined by show_contact_frequency. This differs from a custom page.
-                static::DEFAULT_PAUSE_DATES_SELECTOR       => 1, // determined FIRST by show_contact_frequency, then by show_contact_pause_dates
+                self::DEFAULT_SEGMENT_SELECTOR           => 0, // determined by show_contact_segments
+                self::DEFAULT_CATEGORY_SELECTOR          => 0, // determined by show_contact_categories
+                self::DEFAULT_PREFERRED_CHANNEL_SELECTOR => 1, // determined by show_contact_preferred_channels
+                self::DEFAULT_CHANNEL_FREQ_SELECTOR      => 1, // determined by show_contact_frequency. This differs from a custom page.
+                self::DEFAULT_PAUSE_DATES_SELECTOR       => 1, // determined FIRST by show_contact_frequency, then by show_contact_pause_dates
             ],
             false,
         ];
@@ -267,11 +267,11 @@ final class BuilderSubscriberTest extends MauticMysqlTestCase
                 'show_contact_pause_dates'        => 0,
             ],
             [
-                static::DEFAULT_SEGMENT_SELECTOR           => 1, // determined by show_contact_segments
-                static::DEFAULT_CATEGORY_SELECTOR          => 1, // determined by show_contact_categories
-                static::DEFAULT_PREFERRED_CHANNEL_SELECTOR => 0, // determined by show_contact_preferred_channels
-                static::DEFAULT_CHANNEL_FREQ_SELECTOR      => 0, // determined by show_contact_frequency. This differs from a custom page.
-                static::DEFAULT_PAUSE_DATES_SELECTOR       => 0, // determined FIRST by show_contact_frequency, then by show_contact_pause_dates
+                self::DEFAULT_SEGMENT_SELECTOR           => 1, // determined by show_contact_segments
+                self::DEFAULT_CATEGORY_SELECTOR          => 1, // determined by show_contact_categories
+                self::DEFAULT_PREFERRED_CHANNEL_SELECTOR => 0, // determined by show_contact_preferred_channels
+                self::DEFAULT_CHANNEL_FREQ_SELECTOR      => 0, // determined by show_contact_frequency. This differs from a custom page.
+                self::DEFAULT_PAUSE_DATES_SELECTOR       => 0, // determined FIRST by show_contact_frequency, then by show_contact_pause_dates
             ],
             false,
         ];
@@ -285,11 +285,11 @@ final class BuilderSubscriberTest extends MauticMysqlTestCase
                 'show_contact_pause_dates'        => 0,
             ],
             [
-                static::DEFAULT_SEGMENT_SELECTOR           => 0, // determined by show_contact_segments
-                static::DEFAULT_CATEGORY_SELECTOR          => 0, // determined by show_contact_categories
-                static::DEFAULT_PREFERRED_CHANNEL_SELECTOR => 0, // determined by show_contact_preferred_channels
-                static::DEFAULT_CHANNEL_FREQ_SELECTOR      => 1, // determined by show_contact_frequency. This differs from a custom page.
-                static::DEFAULT_PAUSE_DATES_SELECTOR       => 0, // determined FIRST by show_contact_frequency, then by show_contact_pause_dates
+                self::DEFAULT_SEGMENT_SELECTOR           => 0, // determined by show_contact_segments
+                self::DEFAULT_CATEGORY_SELECTOR          => 0, // determined by show_contact_categories
+                self::DEFAULT_PREFERRED_CHANNEL_SELECTOR => 0, // determined by show_contact_preferred_channels
+                self::DEFAULT_CHANNEL_FREQ_SELECTOR      => 1, // determined by show_contact_frequency. This differs from a custom page.
+                self::DEFAULT_PAUSE_DATES_SELECTOR       => 0, // determined FIRST by show_contact_frequency, then by show_contact_pause_dates
             ],
             false,
         ];
@@ -303,11 +303,11 @@ final class BuilderSubscriberTest extends MauticMysqlTestCase
                 'show_contact_pause_dates'        => 1,
             ],
             [
-                static::DEFAULT_SEGMENT_SELECTOR           => 0, // determined by show_contact_segments
-                static::DEFAULT_CATEGORY_SELECTOR          => 0, // determined by show_contact_categories
-                static::DEFAULT_PREFERRED_CHANNEL_SELECTOR => 0, // determined by show_contact_preferred_channels
-                static::DEFAULT_CHANNEL_FREQ_SELECTOR      => 0, // determined by show_contact_frequency. This differs from a custom page.
-                static::DEFAULT_PAUSE_DATES_SELECTOR       => 0, // determined FIRST by show_contact_frequency, then by show_contact_pause_dates
+                self::DEFAULT_SEGMENT_SELECTOR           => 0, // determined by show_contact_segments
+                self::DEFAULT_CATEGORY_SELECTOR          => 0, // determined by show_contact_categories
+                self::DEFAULT_PREFERRED_CHANNEL_SELECTOR => 0, // determined by show_contact_preferred_channels
+                self::DEFAULT_CHANNEL_FREQ_SELECTOR      => 0, // determined by show_contact_frequency. This differs from a custom page.
+                self::DEFAULT_PAUSE_DATES_SELECTOR       => 0, // determined FIRST by show_contact_frequency, then by show_contact_pause_dates
             ],
             false,
         ];
@@ -321,11 +321,11 @@ final class BuilderSubscriberTest extends MauticMysqlTestCase
                 'show_contact_pause_dates'        => 0,
             ],
             [
-                static::DEFAULT_SEGMENT_SELECTOR           => 0, // determined by show_contact_segments
-                static::DEFAULT_CATEGORY_SELECTOR          => 0, // determined by show_contact_categories
-                static::DEFAULT_PREFERRED_CHANNEL_SELECTOR => 0, // determined by show_contact_preferred_channels
-                static::DEFAULT_CHANNEL_FREQ_SELECTOR      => 0, // determined by show_contact_frequency. This differs from a custom page.
-                static::DEFAULT_PAUSE_DATES_SELECTOR       => 0, // determined FIRST by show_contact_frequency, then by show_contact_pause_dates
+                self::DEFAULT_SEGMENT_SELECTOR           => 0, // determined by show_contact_segments
+                self::DEFAULT_CATEGORY_SELECTOR          => 0, // determined by show_contact_categories
+                self::DEFAULT_PREFERRED_CHANNEL_SELECTOR => 0, // determined by show_contact_preferred_channels
+                self::DEFAULT_CHANNEL_FREQ_SELECTOR      => 0, // determined by show_contact_frequency. This differs from a custom page.
+                self::DEFAULT_PAUSE_DATES_SELECTOR       => 0, // determined FIRST by show_contact_frequency, then by show_contact_pause_dates
             ],
             false,
         ];

--- a/app/bundles/PluginBundle/Helper/EventHelper.php
+++ b/app/bundles/PluginBundle/Helper/EventHelper.php
@@ -16,9 +16,9 @@ final class EventHelper
     {
         $contact = $leadRepository->getEntityWithPrimaryCompany($lead);
 
-        static::setStaticIntegrationHelper($integrationHelper);
+        self::setStaticIntegrationHelper($integrationHelper);
         $errors  = [];
 
-        return static::pushIt($config, $contact, $errors);
+        return self::pushIt($config, $contact, $errors);
     }
 }

--- a/app/bundles/PluginBundle/Tests/ConfigFormTest.php
+++ b/app/bundles/PluginBundle/Tests/ConfigFormTest.php
@@ -132,8 +132,8 @@ final class ConfigFormTest extends KernelTestCase
         $pluginModel          = $this->createMock(PluginModel::class);
         $coreParametersHelper = new CoreParametersHelper(self::$kernel->getContainer());
 
-        $registeredPluginBundles = static::getContainer()->getParameter('mautic.plugin.bundles');
-        $mauticPlugins           = static::getContainer()->getParameter('mautic.bundles');
+        $registeredPluginBundles = self::getContainer()->getParameter('mautic.plugin.bundles');
+        $mauticPlugins           = self::getContainer()->getParameter('mautic.bundles');
         $bundleHelper->method('getPluginBundles')->willReturn($registeredPluginBundles);
 
         $bundleHelper->method('getMauticBundles')->willReturn(array_merge($mauticPlugins, $registeredPluginBundles));

--- a/app/bundles/PluginBundle/Tests/Entity/IntegrationEntityRepositoryTest.php
+++ b/app/bundles/PluginBundle/Tests/Entity/IntegrationEntityRepositoryTest.php
@@ -27,7 +27,7 @@ final class IntegrationEntityRepositoryTest extends MauticMysqlTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->prefix                      = static::getContainer()->getParameter('mautic.db_table_prefix');
+        $this->prefix                      = self::getContainer()->getParameter('mautic.db_table_prefix');
         $this->integrationEntityRepository = self::getContainer()->get(IntegrationEntityRepository::class);
     }
 
@@ -115,7 +115,7 @@ final class IntegrationEntityRepositoryTest extends MauticMysqlTestCase
 
     public function testGetIntegrationEntityByLeadWhenNoIntegrationNamePassed(): void
     {
-        $prefix = static::getContainer()->getParameter('mautic.db_table_prefix');
+        $prefix = self::getContainer()->getParameter('mautic.db_table_prefix');
 
         $this->connection->executeQuery('SET FOREIGN_KEY_CHECKS=0;');
         $this->connection->executeQuery("INSERT INTO {$prefix}plugin_integration_settings(plugin_id, name, is_published, api_keys) VALUES (:id, :name, :isPublished, '')", ['id' => 1, 'name' => self::INTEGRATION, 'isPublished' => 1]);

--- a/app/bundles/PointBundle/Tests/Controller/Api/PointGroupsApiControllerTest.php
+++ b/app/bundles/PointBundle/Tests/Controller/Api/PointGroupsApiControllerTest.php
@@ -17,7 +17,7 @@ final class PointGroupsApiControllerTest extends MauticMysqlTestCase
     public function testPointGroupCRUDActions(): void
     {
         /** @var Translator $translator */
-        $translator = static::getContainer()->get(TranslatorInterface::class);
+        $translator = self::getContainer()->get(TranslatorInterface::class);
 
         // Create a new point group
         $this->client->request('POST', '/api/points/groups/new', [
@@ -89,7 +89,7 @@ final class PointGroupsApiControllerTest extends MauticMysqlTestCase
     public function testContactGroupPointsActions(): void
     {
         /** @var Translator $translator */
-        $translator = static::getContainer()->get(TranslatorInterface::class);
+        $translator = self::getContainer()->get(TranslatorInterface::class);
 
         // Arrange
         $contact     = $this->createContact('test@example.com');

--- a/app/bundles/PointBundle/Tests/Controller/Api/PointInsightApiControllerTest.php
+++ b/app/bundles/PointBundle/Tests/Controller/Api/PointInsightApiControllerTest.php
@@ -17,7 +17,7 @@ final class PointInsightApiControllerTest extends MauticMysqlTestCase
     public function testPointInsightCRUDActions(): void
     {
         /** @var Translator $translator */
-        $translator = static::getContainer()->get(TranslatorInterface::class);
+        $translator = self::getContainer()->get(TranslatorInterface::class);
 
         $this->client->request('POST', '/api/points/insights/new', [
             'name'          => 'New Point Insight',

--- a/app/bundles/PointBundle/Tests/Functional/PointActionFunctionalTest.php
+++ b/app/bundles/PointBundle/Tests/Functional/PointActionFunctionalTest.php
@@ -20,7 +20,7 @@ final class PointActionFunctionalTest extends MauticMysqlTestCase
         $this->logoutUser();
 
         /** @var LeadModel $leadModel */
-        $leadModel = static::getContainer()->get(LeadModel::class);
+        $leadModel = self::getContainer()->get(LeadModel::class);
 
         $lead  = $this->createLead('john@doe.email');
         $email = $this->createEmail();
@@ -41,7 +41,7 @@ final class PointActionFunctionalTest extends MauticMysqlTestCase
         $this->logoutUser();
 
         /** @var LeadModel $leadModel */
-        $leadModel = static::getContainer()->get(LeadModel::class);
+        $leadModel = self::getContainer()->get(LeadModel::class);
 
         $lead   = $this->createLead('john@doe.email');
         $email  = $this->createEmail();
@@ -65,7 +65,7 @@ final class PointActionFunctionalTest extends MauticMysqlTestCase
     public function testPointActionEarlyReturnWhenNoPointsAvailable(): void
     {
         /** @var LeadModel $leadModel */
-        $leadModel = static::getContainer()->get(LeadModel::class);
+        $leadModel = self::getContainer()->get(LeadModel::class);
 
         $lead  = $this->createLead('jane@doe.email');
         $email = $this->createEmail();
@@ -107,7 +107,7 @@ final class PointActionFunctionalTest extends MauticMysqlTestCase
         string $trackingHash,
     ): Stat {
         /** @var StatRepository $statRepository */
-        $statRepository = static::getContainer()->get(StatRepository::class);
+        $statRepository = self::getContainer()->get(StatRepository::class);
 
         $stat = new Stat();
         $stat->setTrackingHash($trackingHash);

--- a/app/bundles/PointBundle/Tests/Functional/ReportSubscriberFunctionalTest.php
+++ b/app/bundles/PointBundle/Tests/Functional/ReportSubscriberFunctionalTest.php
@@ -165,7 +165,7 @@ final class ReportSubscriberFunctionalTest extends MauticMysqlTestCase
     private function createTestContactWithGroupPoints(): void
     {
         /** @var LeadModel $contactModel */
-        $contactModel = static::getContainer()->get(LeadModel::class);
+        $contactModel = self::getContainer()->get(LeadModel::class);
 
         $groupA = $this->createGroup('Group A');
         $groupB = $this->createGroup('Group B');

--- a/app/bundles/ReportBundle/Tests/Controller/Api/ReportApiControllerTest.php
+++ b/app/bundles/ReportBundle/Tests/Controller/Api/ReportApiControllerTest.php
@@ -98,7 +98,7 @@ final class ReportApiControllerTest extends MauticMysqlTestCase
         // Set new permissions
         $role->setIsAdmin(false);
         /** @var RoleModel $roleModel */
-        $roleModel = static::getContainer()->get(RoleModel::class);
+        $roleModel = self::getContainer()->get(RoleModel::class);
         $this->assertInstanceOf(RoleModel::class, $roleModel);
         $roleModel->setRolePermissions($role, $permissions);
         $this->em->persist($role);

--- a/app/bundles/ReportBundle/Tests/Controller/ReportControllerFunctionalTest.php
+++ b/app/bundles/ReportBundle/Tests/Controller/ReportControllerFunctionalTest.php
@@ -177,7 +177,7 @@ final class ReportControllerFunctionalTest extends MauticMysqlTestCase
         ];
         $report->setColumns($coulmns);
 
-        static::getContainer()->get(ReportModel::class)->saveEntity($report);
+        self::getContainer()->get(ReportModel::class)->saveEntity($report);
 
         // Check the details page
         $this->client->request('GET', '/s/reports/view/'.$report->getId());
@@ -187,7 +187,7 @@ final class ReportControllerFunctionalTest extends MauticMysqlTestCase
     public function testEmailReportWithAggregatedColumnsAndTotals(): void
     {
         /** @var LeadModel $contactModel */
-        $contactModel = static::getContainer()->get(LeadModel::class);
+        $contactModel = self::getContainer()->get(LeadModel::class);
 
         // Create and save contacts
         $payload = [
@@ -269,7 +269,7 @@ final class ReportControllerFunctionalTest extends MauticMysqlTestCase
                 'function'  => 'AVG',
             ],
         ]);
-        static::getContainer()->get(ReportModel::class)->saveEntity($report);
+        self::getContainer()->get(ReportModel::class)->saveEntity($report);
 
         // Expected report table values [ID, Company name, MIN Points, Max Points, SUM Points, COUNT Points, AVG Points]
         $expected = [
@@ -447,7 +447,7 @@ final class ReportControllerFunctionalTest extends MauticMysqlTestCase
         $report->setName('HTML Test');
         $report->setDescription('<b>This is allowed HTML</b>');
         $report->setSource('email');
-        static::getContainer()->get(ReportModel::class)->saveEntity($report);
+        self::getContainer()->get(ReportModel::class)->saveEntity($report);
 
         // Check the details page
         $this->client->request('GET', '/s/reports/'.$report->getId());
@@ -707,7 +707,7 @@ final class ReportControllerFunctionalTest extends MauticMysqlTestCase
         ];
 
         $reportModel->method('getFilterList')->willReturn($filterDefinitions);
-        static::getContainer()->set('mautic.report.model.report', $reportModel);
+        self::getContainer()->set('mautic.report.model.report', $reportModel);
 
         $this->client->request('GET', '/s/reports/view/'.$report->getId());
         self::assertResponseIsSuccessful();

--- a/app/bundles/SmsBundle/Tests/Sms/TransportChainTest.php
+++ b/app/bundles/SmsBundle/Tests/Sms/TransportChainTest.php
@@ -48,7 +48,7 @@ final class TransportChainTest extends MauticMysqlTestCase
 
         $this->transportChain = new TransportChain(
             'mautic.test.twilio.mock',
-            static::getContainer()->get(IntegrationHelper::class)
+            self::getContainer()->get(IntegrationHelper::class)
         );
 
         $this->twilioTransport = $this->createMock(TwilioTransport::class);
@@ -62,7 +62,7 @@ final class TransportChainTest extends MauticMysqlTestCase
     {
         $count = count($this->transportChain->getTransports());
 
-        $this->transportChain->addTransport('mautic.transport.test', static::getContainer()->get(TwilioTransport::class), 'mautic.transport.test', 'Twilio');
+        $this->transportChain->addTransport('mautic.transport.test', self::getContainer()->get(TwilioTransport::class), 'mautic.transport.test', 'Twilio');
 
         $this->assertCount($count + 1, $this->transportChain->getTransports());
     }

--- a/app/bundles/StageBundle/Tests/Functional/Controller/StageControllerFunctionalTest.php
+++ b/app/bundles/StageBundle/Tests/Functional/Controller/StageControllerFunctionalTest.php
@@ -101,7 +101,7 @@ final class StageControllerFunctionalTest extends MauticMysqlTestCase
         ]);
 
         /** @var StageModel $stageModel */
-        $stageModel = static::getContainer()->get(StageModel::class);
+        $stageModel = self::getContainer()->get(StageModel::class);
         $stageModel->stageMerge($primaryStage, $mergedStage);
         $this->em->clear();
 

--- a/app/bundles/UserBundle/Tests/Functional/UserLogoutFunctionalTest.php
+++ b/app/bundles/UserBundle/Tests/Functional/UserLogoutFunctionalTest.php
@@ -26,7 +26,7 @@ final class UserLogoutFunctionalTest extends MauticMysqlTestCase
         $user->setUsername('john.doe');
         $user->setEmail('john.doe@email.com');
         $user->setRole($role);
-        $hasher = static::getContainer()->get(PasswordHasherFactoryInterface::class)->getPasswordHasher($user);
+        $hasher = self::getContainer()->get(PasswordHasherFactoryInterface::class)->getPasswordHasher($user);
         $this->assertInstanceOf(PasswordHasherInterface::class, $hasher);
         $user->setPassword($hasher->hash('Maut1cR0cks!'));
         $this->em->persist($user);

--- a/app/bundles/UserBundle/Tests/Model/PasswordStrengthEstimatorModelTest.php
+++ b/app/bundles/UserBundle/Tests/Model/PasswordStrengthEstimatorModelTest.php
@@ -25,7 +25,7 @@ final class PasswordStrengthEstimatorModelTest extends MauticMysqlTestCase
         parent::setUp();
         $this->passwordHasher = self::getContainer()->get(PasswordHasherFactoryInterface::class);
         $this->roleRepository = self::getContainer()->get(RoleRepository::class);
-        $this->validator      = static::getContainer()->get(ValidatorInterface::class);
+        $this->validator      = self::getContainer()->get(ValidatorInterface::class);
     }
 
     public function testThatItIsNotPossibleToCreateAnUserWithAWeakPassword(): void

--- a/app/bundles/WebhookBundle/Tests/Functional/Command/DeleteWebhookLogsCommandTest.php
+++ b/app/bundles/WebhookBundle/Tests/Functional/Command/DeleteWebhookLogsCommandTest.php
@@ -21,7 +21,7 @@ final class DeleteWebhookLogsCommandTest extends MauticMysqlTestCase
         $this->configParams['webhook_log_max']                      = 5;
         parent::setUp();
 
-        $this->webhookModel = static::getContainer()->get(WebhookModel::class);
+        $this->webhookModel = self::getContainer()->get(WebhookModel::class);
     }
 
     public function testRemoveLogInstantly(): void

--- a/app/bundles/WebhookBundle/Tests/Functional/Entity/WebhookQueueFunctionalTest.php
+++ b/app/bundles/WebhookBundle/Tests/Functional/Entity/WebhookQueueFunctionalTest.php
@@ -59,7 +59,7 @@ final class WebhookQueueFunctionalTest extends MauticMysqlTestCase
      */
     private function fetchPayloadDbValues(WebhookQueue $webhookQueue): array
     {
-        $prefix = static::getContainer()->getParameter('mautic.db_table_prefix');
+        $prefix = self::getContainer()->getParameter('mautic.db_table_prefix');
         $query  = sprintf('SELECT payload_compressed FROM %swebhook_queue WHERE id = ?', $prefix);
 
         return $this->connection->executeQuery($query, [$webhookQueue->getId()])

--- a/app/bundles/WebhookBundle/Tests/Functional/Model/WebhookModelTest.php
+++ b/app/bundles/WebhookBundle/Tests/Functional/Model/WebhookModelTest.php
@@ -114,6 +114,6 @@ final class WebhookModelTest extends MauticMysqlTestCase
 
         $this->setUpSymfony($webhookParams);
 
-        return static::getContainer()->get(WebhookModel::class);
+        return self::getContainer()->get(WebhookModel::class);
     }
 }

--- a/plugins/MauticClearbitBundle/Tests/Functional/Controller/ConfigControllerTest.php
+++ b/plugins/MauticClearbitBundle/Tests/Functional/Controller/ConfigControllerTest.php
@@ -35,7 +35,7 @@ final class ConfigControllerTest extends MauticMysqlTestCase
 
         $this->em->flush();
 
-        $this->configRoute = static::getContainer()->get(RouterInterface::class)->generate('mautic_plugin_config', ['name' => 'Clearbit']);
+        $this->configRoute = self::getContainer()->get(RouterInterface::class)->generate('mautic_plugin_config', ['name' => 'Clearbit']);
     }
 
     public function testSavedIntegrationIsPublishedAndApiKeyIsEncryptedAtRest(): void
@@ -55,9 +55,9 @@ final class ConfigControllerTest extends MauticMysqlTestCase
         $this->em->clear();
 
         /** @var IntegrationsHelper $integrationsHelper */
-        $integrationsHelper = static::getContainer()->get(IntegrationsHelper::class);
+        $integrationsHelper = self::getContainer()->get(IntegrationsHelper::class);
         /** @var ConfigSupport $configSupport */
-        $configSupport = static::getContainer()->get(ConfigSupport::class);
+        $configSupport = self::getContainer()->get(ConfigSupport::class);
         $decrypted     = $integrationsHelper->getIntegrationConfiguration($configSupport);
 
         $this->assertSame(self::API_KEY, $decrypted->getApiKeys()['apikey']);

--- a/plugins/MauticFocusBundle/Tests/Controller/FocusAjaxControllerFunctionalTest.php
+++ b/plugins/MauticFocusBundle/Tests/Controller/FocusAjaxControllerFunctionalTest.php
@@ -17,7 +17,7 @@ final class FocusAjaxControllerFunctionalTest extends MauticMysqlTestCase
     public function testViewsCount(): void
     {
         /** @var FocusModel $focusModel */
-        $focusModel = static::getContainer()->get(FocusModel::class);
+        $focusModel = self::getContainer()->get(FocusModel::class);
         $focus      = $this->createFocus('popup');
         $focusModel->saveEntity($focus);
 
@@ -43,7 +43,7 @@ final class FocusAjaxControllerFunctionalTest extends MauticMysqlTestCase
     public function testClickThroughCount(): void
     {
         /** @var FocusModel $focusModel */
-        $focusModel = static::getContainer()->get(FocusModel::class);
+        $focusModel = self::getContainer()->get(FocusModel::class);
         $focus      = $this->createFocus('popup');
         $focusModel->saveEntity($focus);
 

--- a/plugins/MauticFocusBundle/Tests/Controller/FocusControllerTest.php
+++ b/plugins/MauticFocusBundle/Tests/Controller/FocusControllerTest.php
@@ -74,7 +74,7 @@ final class FocusControllerTest extends MauticMysqlTestCase
         ]);
 
         /** @var FocusModel $focusModel */
-        $focusModel = static::getContainer()->get(FocusModel::class);
+        $focusModel = self::getContainer()->get(FocusModel::class);
         $focusModel->saveEntity($focus);
 
         $this->em->clear();

--- a/plugins/MauticFocusBundle/Tests/Controller/FocusPublicControllerFunctionalTest.php
+++ b/plugins/MauticFocusBundle/Tests/Controller/FocusPublicControllerFunctionalTest.php
@@ -18,7 +18,7 @@ final class FocusPublicControllerFunctionalTest extends MauticMysqlTestCase
     public function testGenerateFocusItemScript(): void
     {
         /** @var FocusModel $focusModel */
-        $focusModel = static::getContainer()->get(FocusModel::class);
+        $focusModel = self::getContainer()->get(FocusModel::class);
         $focus      = $this->createFocus('popup');
         $focus->setStyle('bar');
         $focusModel->saveEntity($focus);
@@ -46,7 +46,7 @@ final class FocusPublicControllerFunctionalTest extends MauticMysqlTestCase
     public function testInactiveFocusItemScript(): void
     {
         /** @var FocusModel $focusModel */
-        $focusModel = static::getContainer()->get(FocusModel::class);
+        $focusModel = self::getContainer()->get(FocusModel::class);
         $focus      = $this->createFocus('popup');
         $focus->setIsPublished(false);
         $focusModel->saveEntity($focus);

--- a/plugins/MauticFocusBundle/Tests/Entity/StatRepositoryFunctionalTest.php
+++ b/plugins/MauticFocusBundle/Tests/Entity/StatRepositoryFunctionalTest.php
@@ -19,7 +19,7 @@ final class StatRepositoryFunctionalTest extends MauticMysqlTestCase
     {
         parent::setUp();
 
-        $this->focusModel = static::$kernel->getContainer()->get(FocusModel::class);
+        $this->focusModel = self::$kernel->getContainer()->get(FocusModel::class);
         $this->setTestsData($this->createLead());
     }
 

--- a/plugins/MauticFocusBundle/Tests/EventListener/LeadSubscriberFunctionalTest.php
+++ b/plugins/MauticFocusBundle/Tests/EventListener/LeadSubscriberFunctionalTest.php
@@ -21,7 +21,7 @@ final class LeadSubscriberFunctionalTest extends MauticMysqlTestCase
     {
         parent::setUp();
 
-        $this->focusModel = static::getContainer()->get(FocusModel::class);
+        $this->focusModel = self::getContainer()->get(FocusModel::class);
         $this->lead       = $this->createLead();
 
         $this->setTestsData($this->lead);

--- a/plugins/MauticFocusBundle/Tests/Model/FocusModelFunctionalTest.php
+++ b/plugins/MauticFocusBundle/Tests/Model/FocusModelFunctionalTest.php
@@ -21,7 +21,7 @@ final class FocusModelFunctionalTest extends MauticMysqlTestCase
     {
         parent::setUp();
 
-        $this->focusModel = static::getContainer()->get(FocusModel::class);
+        $this->focusModel = self::getContainer()->get(FocusModel::class);
         $this->lead       = $this->createLead();
     }
 

--- a/plugins/MauticSocialBundle/Tests/Functional/Controller/TweetControllerTest.php
+++ b/plugins/MauticSocialBundle/Tests/Functional/Controller/TweetControllerTest.php
@@ -19,7 +19,7 @@ final class TweetControllerTest extends MauticMysqlTestCase
         parent::setUp();
 
         /** @var TweetModel $tweetsModel */
-        $tweetsModel      = static::getContainer()->get(TweetModel::class);
+        $tweetsModel      = self::getContainer()->get(TweetModel::class);
         $this->tweetsRepo = $tweetsModel->getRepository();
 
         $tweet = new Tweet();

--- a/plugins/MauticTagManagerBundle/Tests/Functional/Controller/BatchControllerTest.php
+++ b/plugins/MauticTagManagerBundle/Tests/Functional/Controller/BatchControllerTest.php
@@ -36,7 +36,7 @@ final class BatchControllerTest extends MauticMysqlTestCase
         ];
 
         /** @var TagModel $tagModel */
-        $tagModel            = static::getContainer()->get(TagModel::class);
+        $tagModel            = self::getContainer()->get(TagModel::class);
         $this->tagRepository = $tagModel->getRepository();
         $this->tags          = $this->addTags($tags);
         $this->leads         = $this->addLeads();
@@ -65,7 +65,7 @@ final class BatchControllerTest extends MauticMysqlTestCase
         $this->assertStringContainsString('3 contacts affected', (string) $this->client->getResponse()->getContent());
 
         /** @var LeadModel $leadModel */
-        $leadModel = static::getContainer()->get(LeadModel::class);
+        $leadModel = self::getContainer()->get(LeadModel::class);
         $lead1     = $leadModel->getEntity($this->leads[0]->getId());
         $this->assertInstanceOf(Lead::class, $lead1);
         $this->assertContains($this->tags[0], $lead1->getTags()->toArray());
@@ -76,7 +76,7 @@ final class BatchControllerTest extends MauticMysqlTestCase
     public function testAddAndRemoveBatchSetAction(): void
     {
         /** @var LeadModel $leadModel */
-        $leadModel = static::getContainer()->get(LeadModel::class);
+        $leadModel = self::getContainer()->get(LeadModel::class);
         $this->leads[0]->addTag($this->tags[1]);
         $this->leads[0]->addTag($this->tags[2]);
         $leadModel->saveEntity($this->leads[0]);
@@ -119,7 +119,7 @@ final class BatchControllerTest extends MauticMysqlTestCase
     public function addLeads(): array
     {
         /** @var LeadModel $leadModel */
-        $leadModel = static::getContainer()->get(LeadModel::class);
+        $leadModel = self::getContainer()->get(LeadModel::class);
         $lead      = $leadModel->getEntity();
 
         $lead->setEmail('example1@example.com');

--- a/plugins/MauticTagManagerBundle/Tests/Functional/Controller/TagControllerTest.php
+++ b/plugins/MauticTagManagerBundle/Tests/Functional/Controller/TagControllerTest.php
@@ -33,7 +33,7 @@ final class TagControllerTest extends MauticMysqlTestCase
     {
         parent::setUp();
         /** @var TagModel $tagModel */
-        $tagModel            = static::getContainer()->get(TagModel::class);
+        $tagModel            = self::getContainer()->get(TagModel::class);
         $this->tagRepository = $tagModel->getRepository();
 
         $tags = ['tag1', 'tag2', 'tag3', 'tag4', 'tag5'];
@@ -356,7 +356,7 @@ final class TagControllerTest extends MauticMysqlTestCase
 
         // Test the actual merge functionality by calling the model directly
         /** @var TagModel $tagModel */
-        $tagModel = static::getContainer()->get(TagModel::class);
+        $tagModel = self::getContainer()->get(TagModel::class);
         $tagModel->tagMerge($primaryTag, $secondaryTag);
 
         $this->em->clear();
@@ -396,7 +396,7 @@ final class TagControllerTest extends MauticMysqlTestCase
         $reportId              = (int) $report->getId();
 
         /** @var TagModel $tagModel */
-        $tagModel = static::getContainer()->get(TagModel::class);
+        $tagModel = self::getContainer()->get(TagModel::class);
         $tagModel->tagMerge($primaryTag, $secondaryTag);
 
         $this->em->clear();


### PR DESCRIPTION
The `static::` should be used only on purpose to magically pass values between parent/child classes (pretty anti-pattern, TBH). 
For clear access (same class, right here), the clear 1-way `self::` should be used instead :+1: 

---

Use `self::` instead of `static::` where the call is local and no child overriding is intended.

```diff
-        if (!preg_match(static::PATTERN, $value)) {
+        if (!preg_match(self::PATTERN, $value)) {
```

```diff
-        $this->configBaseDir = static::getLocalConfigBaseDir($this->rootPath);
+        $this->configBaseDir = self::getLocalConfigBaseDir($this->rootPath);
```

Split out of #16955 to keep the diff reviewable.
