### PR TITLE
[solid] compare empty array directly to []

### DIFF
--- a/app/bundles/ApiBundle/Controller/CommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/CommonApiController.php
@@ -118,7 +118,7 @@ class CommonApiController extends FetchCommonApiController
             $this->doctrine->getManager()->detach($entity);
         }
 
-        if (!empty($errors)) {
+        if ([] !== $errors) {
             $content           = json_decode($response->getContent(), true);
             $content['errors'] = $errors;
             $response->setContent(json_encode($content));
@@ -223,7 +223,7 @@ class CommonApiController extends FetchCommonApiController
             'statusCodes'          => $statusCodes,
         ];
 
-        if (!empty($errors)) {
+        if ([] !== $errors) {
             $payload['errors'] = $errors;
         }
 
@@ -320,7 +320,7 @@ class CommonApiController extends FetchCommonApiController
             'statusCodes'          => $statusCodes,
         ];
 
-        if (!empty($errors)) {
+        if ([] !== $errors) {
             $payload['errors'] = $errors;
         }
 

--- a/app/bundles/ApiBundle/Controller/FetchCommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/FetchCommonApiController.php
@@ -316,7 +316,7 @@ class FetchCommonApiController extends AbstractFOSRestController implements Maut
             $this->customSelectRequested = true;
         }
 
-        if (!empty($args)) {
+        if ([] !== $args) {
             $args['id'] = $id;
             $entity     = $this->model->getEntity($args);
         } else {
@@ -689,7 +689,7 @@ class FetchCommonApiController extends AbstractFOSRestController implements Maut
             $context = $apiSerializationContextEvent->getContext();
         }
 
-        if (!empty($this->serializerGroups)) {
+        if ([] !== $this->serializerGroups) {
             $context->setGroups($this->serializerGroups);
         }
 

--- a/app/bundles/ApiBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/ApiBundle/EventListener/SearchSubscriber.php
@@ -38,7 +38,7 @@ final readonly class SearchSubscriber implements EventSubscriberInterface
             '@MauticApi/SubscribedEvents/Search/global.html.twig'
         );
 
-        if (!empty($results)) {
+        if ([] !== $results) {
             $event->addResults('mautic.api.client.menu.index', $results);
         }
     }

--- a/app/bundles/ApiBundle/Helper/BatchIdToEntityHelper.php
+++ b/app/bundles/ApiBundle/Helper/BatchIdToEntityHelper.php
@@ -26,7 +26,7 @@ final class BatchIdToEntityHelper
 
     public function hasIds(): bool
     {
-        return !empty($this->ids);
+        return [] !== $this->ids;
     }
 
     public function getIds(): array
@@ -36,7 +36,7 @@ final class BatchIdToEntityHelper
 
     public function hasErrors(): bool
     {
-        return !empty($this->errors);
+        return [] !== $this->errors;
     }
 
     public function getErrors(): array
@@ -155,7 +155,7 @@ final class BatchIdToEntityHelper
 
     private function isAssociativeArray(array $array): bool
     {
-        if (empty($array)) {
+        if ([] === $array) {
             return false;
         }
         $firstKey = array_key_first($array);

--- a/app/bundles/ApiBundle/Helper/EntityResultHelper.php
+++ b/app/bundles/ApiBundle/Helper/EntityResultHelper.php
@@ -27,7 +27,7 @@ class EntityResultHelper
         }
 
         // solving array/object discrepancy for empty values
-        if ($this->isKeyedById($results) && empty($entities)) {
+        if ($this->isKeyedById($results) && [] === $entities) {
             $entities = new \ArrayObject();
         }
 

--- a/app/bundles/AssetBundle/Controller/AssetController.php
+++ b/app/bundles/AssetBundle/Controller/AssetController.php
@@ -697,7 +697,7 @@ final class AssetController extends FormController
             }
 
             // Delete everything we are able to
-            if (!empty($deleteIds)) {
+            if ([] !== $deleteIds) {
                 $entities = $model->deleteEntities($deleteIds);
 
                 $flashes[] = [

--- a/app/bundles/AssetBundle/Controller/UploadController.php
+++ b/app/bundles/AssetBundle/Controller/UploadController.php
@@ -19,7 +19,7 @@ final class UploadController extends DropzoneController
         $response = new EmptyResponse();
         $files    = $this->getFiles($request->files);
 
-        if (!empty($files)) {
+        if ([] !== $files) {
             foreach ($files as $file) {
                 try {
                     $this->handleUpload($file, $response, $request);

--- a/app/bundles/AssetBundle/EventListener/AssetExportListEventSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/AssetExportListEventSubscriber.php
@@ -27,7 +27,7 @@ final readonly class AssetExportListEventSubscriber implements EventSubscriberIn
     {
         $data = $event->getEntityData();
 
-        if (empty($data)) {
+        if ([] === $data) {
             return;
         }
 

--- a/app/bundles/AssetBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/SearchSubscriber.php
@@ -38,7 +38,7 @@ final readonly class SearchSubscriber implements EventSubscriberInterface
             '@MauticAsset/SubscribedEvents/Search/global.html.twig'
         );
 
-        if (!empty($results)) {
+        if ([] !== $results) {
             $event->addResults('mautic.asset.assets', $results);
         }
     }

--- a/app/bundles/AssetBundle/Model/AssetModel.php
+++ b/app/bundles/AssetBundle/Model/AssetModel.php
@@ -419,7 +419,7 @@ class AssetModel extends FormModel implements GlobalSearchInterface
         $referenceType = ($absolute) ? UrlGeneratorInterface::ABSOLUTE_URL : UrlGeneratorInterface::ABSOLUTE_PATH;
         $url           = $this->router->generate('mautic_asset_download', $routeParams, $referenceType);
 
-        if (empty($clickthrough)) {
+        if ([] === $clickthrough) {
             return $url;
         }
 
@@ -470,7 +470,7 @@ class AssetModel extends FormModel implements GlobalSearchInterface
             $assets = [$assets];
         }
 
-        if (empty($assets)) {
+        if ([] === $assets) {
             return 0;
         }
 

--- a/app/bundles/CampaignBundle/Command/ResumeStuckCampaignCommand.php
+++ b/app/bundles/CampaignBundle/Command/ResumeStuckCampaignCommand.php
@@ -294,7 +294,7 @@ final class ResumeStuckCampaignCommand extends Command
             }
         }
 
-        if (empty($contacts)) {
+        if ([] === $contacts) {
             return;
         }
 

--- a/app/bundles/CampaignBundle/Controller/Api/CampaignApiController.php
+++ b/app/bundles/CampaignBundle/Controller/Api/CampaignApiController.php
@@ -293,7 +293,7 @@ final class CampaignApiController extends CommonApiController
             $this->model->setCanvasSettings($entity, $parameters['canvasSettings']);
         }
 
-        if (Request::METHOD_PUT === $method && !empty($deletedEvents)) {
+        if (Request::METHOD_PUT === $method && [] !== $deletedEvents) {
             $this->eventModel->deleteEvents($entity->getEvents()->toArray(), $deletedEvents);
         }
     }

--- a/app/bundles/CampaignBundle/Controller/Api/EventLogApiController.php
+++ b/app/bundles/CampaignBundle/Controller/Api/EventLogApiController.php
@@ -240,7 +240,7 @@ final class EventLogApiController extends FetchCommonApiController
             $this->entityNameMulti => $events,
         ];
 
-        if (!empty($errors)) {
+        if ([] !== $errors) {
             $payload['errors'] = $errors;
         }
 

--- a/app/bundles/CampaignBundle/Controller/CampaignController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignController.php
@@ -755,7 +755,7 @@ class CampaignController extends AbstractStandardFormController
      */
     protected function beforeEntitySave($entity, FormInterface $form, $action, $objectId = null, $isClone = false): bool
     {
-        if (empty($this->campaignEvents)) {
+        if ([] === $this->campaignEvents) {
             // set the error
             $form->addError(
                 new FormError(
@@ -794,7 +794,7 @@ class CampaignController extends AbstractStandardFormController
         $this->campaignModel->setEvents($entity, $this->campaignEvents, $this->connections, $this->deletedEvents);
 
         if ('edit' === $action && null !== $this->connections) {
-            if (!empty($this->deletedEvents)) {
+            if ([] !== $this->deletedEvents) {
                 $this->eventModel->deleteEvents($entity->getEvents()->toArray(), $this->deletedEvents);
             }
         }
@@ -907,12 +907,12 @@ class CampaignController extends AbstractStandardFormController
             $filter['string'] = $this->stripQuickFilterTokensFromSearch((string) ($filter['string'] ?? ''), $searchFilterTerms);
             $session->set('mautic.campaign.filter', $filter['string']);
 
-            if (!empty($listAliases)) {
+            if ([] !== $listAliases) {
                 $joinLists         = true;
                 $filter['force'][] = ['column' => 'l.alias', 'expr' => 'in', 'value' => array_values(array_unique($listAliases))];
             }
 
-            if (!empty($formIds)) {
+            if ([] !== $formIds) {
                 $joinForms         = true;
                 $filter['force'][] = ['column' => 'f.id', 'expr' => 'in', 'value' => $formIds];
             }

--- a/app/bundles/CampaignBundle/Controller/ImportController.php
+++ b/app/bundles/CampaignBundle/Controller/ImportController.php
@@ -257,7 +257,7 @@ final class ImportController extends AbstractFormController
         if (self::STEP_PROGRESS_BAR === $step) {
             $analyzeSummary = $this->analyzeData($importHelper, $fullPath);
 
-            if (empty($analyzeSummary)) {
+            if ([] === $analyzeSummary) {
                 $this->addFlashMessage('mautic.campaign.import.nofile', [], FlashBag::LEVEL_ERROR, 'validators');
                 $this->removeImportFile($fullPath);
                 $this->resetImport();
@@ -331,7 +331,7 @@ final class ImportController extends AbstractFormController
                 $event  = new EntityImportEvent(Campaign::ENTITY_NAME, $entity, $userId);
                 $this->dispatcher->dispatch($event);
                 $summary = $event->getStatus();
-                if (!empty($summary)) {
+                if ([] !== $summary) {
                     $importSummary[] = $summary;
                 }
             }
@@ -439,7 +439,7 @@ final class ImportController extends AbstractFormController
                     }
                 }
             }
-            if (!empty($mergedSummary)) {
+            if ([] !== $mergedSummary) {
                 $allData[] = $mergedSummary;
             }
         }

--- a/app/bundles/CampaignBundle/Entity/Campaign.php
+++ b/app/bundles/CampaignBundle/Entity/Campaign.php
@@ -645,7 +645,7 @@ class Campaign extends FormEntity implements OptimisticLockInterface, UuidInterf
             fn ($id): bool => !in_array($id, ['lists', 'forms'])
         );
 
-        if (empty($eventIds)) {
+        if ([] === $eventIds) {
             return false;
         }
 

--- a/app/bundles/CampaignBundle/Entity/CampaignRepository.php
+++ b/app/bundles/CampaignBundle/Entity/CampaignRepository.php
@@ -627,7 +627,7 @@ class CampaignRepository extends CommonRepository
             );
         $q->groupBy('c.id');
 
-        if (!empty($campaignIds)) {
+        if ([] !== $campaignIds) {
             $q->where($q->expr()->in('c.id', ':campaignIds'));
             $q->setParameter('campaignIds', $campaignIds, ArrayParameterType::INTEGER);
         }

--- a/app/bundles/CampaignBundle/Entity/EventRepository.php
+++ b/app/bundles/CampaignBundle/Entity/EventRepository.php
@@ -310,7 +310,7 @@ class EventRepository extends CommonRepository
      */
     public function setEventsAsDeletedWithRedirect(array $eventData): void
     {
-        if (empty($eventData)) {
+        if ([] === $eventData) {
             return;
         }
 
@@ -354,7 +354,7 @@ class EventRepository extends CommonRepository
                ->executeStatement();
         }
 
-        if (!empty($eventData)) {
+        if ([] !== $eventData) {
             $this->updateRedirectionChains($eventData);
         }
     }

--- a/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
@@ -354,7 +354,7 @@ class LeadEventLogRepository extends CommonRepository
             ->set('lead_id', (int) $toLeadId)
             ->where('lead_id = '.(int) $fromLeadId);
 
-        if (!empty($exists)) {
+        if ([] !== $exists) {
             $q->andWhere(
                 $q->expr()->notIn('event_id', ':ids')
             )

--- a/app/bundles/CampaignBundle/Entity/LeadRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadRepository.php
@@ -109,7 +109,7 @@ class LeadRepository extends CommonRepository
             ->set('lead_id', (int) $toLeadId)
             ->where('lead_id = '.(int) $fromLeadId);
 
-        if (!empty($campaigns)) {
+        if ([] !== $campaigns) {
             $q->andWhere(
                 $q->expr()->notIn('campaign_id', ':ids')
             )

--- a/app/bundles/CampaignBundle/EventCollector/EventCollector.php
+++ b/app/bundles/CampaignBundle/EventCollector/EventCollector.php
@@ -25,7 +25,7 @@ class EventCollector
 
     public function getEvents(): EventAccessor
     {
-        if (empty($this->eventsArray)) {
+        if ([] === $this->eventsArray) {
             $this->buildEventList();
         }
 
@@ -55,7 +55,7 @@ class EventCollector
      */
     public function getEventsArray($type = null)
     {
-        if (empty($this->eventsArray)) {
+        if ([] === $this->eventsArray) {
             $this->buildEventList();
         }
 

--- a/app/bundles/CampaignBundle/EventListener/CampaignActionChangeMembershipSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/CampaignActionChangeMembershipSubscriber.php
@@ -122,7 +122,7 @@ final readonly class CampaignActionChangeMembershipSubscriber implements EventSu
         }
 
         $campaignEntities = [];
-        if (!empty($campaigns)) {
+        if ([] !== $campaigns) {
             $campaignEntities = $this->campaignModel->getEntities(['ids' => $campaigns, 'ignore_paginator' => true]);
         }
 

--- a/app/bundles/CampaignBundle/EventListener/CampaignImportExportSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/CampaignImportExportSubscriber.php
@@ -535,7 +535,7 @@ final class CampaignImportExportSubscriber implements EventSubscriberInterface
         }
 
         $eventDependencies = $this->getSubDependencies($dependencies, Event::ENTITY_NAME);
-        if (empty($eventDependencies)) {
+        if ([] === $eventDependencies) {
             return;
         }
 
@@ -561,7 +561,7 @@ final class CampaignImportExportSubscriber implements EventSubscriberInterface
         }
 
         $emailDependencies = $this->getSubDependencies($dependencies, Email::ENTITY_NAME);
-        if (empty($emailDependencies)) {
+        if ([] === $emailDependencies) {
             return;
         }
 
@@ -591,7 +591,7 @@ final class CampaignImportExportSubscriber implements EventSubscriberInterface
         }
 
         $formDependencies = $this->getSubDependencies($dependencies, Form::ENTITY_NAME);
-        if (empty($formDependencies)) {
+        if ([] === $formDependencies) {
             return;
         }
 

--- a/app/bundles/CampaignBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/SearchSubscriber.php
@@ -38,7 +38,7 @@ final readonly class SearchSubscriber implements EventSubscriberInterface
             '@MauticCampaign/SubscribedEvents/Search/global.html.twig'
         );
 
-        if (!empty($results)) {
+        if ([] !== $results) {
             $event->addResults('mautic.campaign.campaigns', $results);
         }
     }

--- a/app/bundles/CampaignBundle/Executioner/ContactFinder/KickoffContactFinder.php
+++ b/app/bundles/CampaignBundle/Executioner/ContactFinder/KickoffContactFinder.php
@@ -32,7 +32,7 @@ class KickoffContactFinder
         // Get list of all campaign leads; start is always zero in practice because of $pendingOnly
         $campaignContacts = $this->campaignRepository->getPendingContactIds($campaignId, $limiter);
 
-        if (empty($campaignContacts)) {
+        if ([] === $campaignContacts) {
             // No new contacts found in the campaign
 
             throw new NoContactsFoundException();

--- a/app/bundles/CampaignBundle/Helper/CampaignContactCountHelper.php
+++ b/app/bundles/CampaignBundle/Helper/CampaignContactCountHelper.php
@@ -37,7 +37,7 @@ final readonly class CampaignContactCountHelper
             }
         }
 
-        if (empty($campaignIdsForCountFromDb)) {
+        if ([] === $campaignIdsForCountFromDb) {
             return $contactCounts;
         }
 

--- a/app/bundles/CampaignBundle/Model/CampaignModel.php
+++ b/app/bundles/CampaignBundle/Model/CampaignModel.php
@@ -941,7 +941,7 @@ class CampaignModel extends CommonFormModel implements GlobalSearchInterface
      */
     private function handleDeletedEventsWithRedirect(array $deletedEvents): void
     {
-        if (empty($deletedEvents)) {
+        if ([] === $deletedEvents) {
             return;
         }
 

--- a/app/bundles/CampaignBundle/Service/PublishStateService.php
+++ b/app/bundles/CampaignBundle/Service/PublishStateService.php
@@ -73,7 +73,7 @@ class PublishStateService
         $eventLogCreatedDateRanges        = $this->generatePublishStateDateRanges($campaign);
         $publishOnlyStates                = $this->filterRangesForState($eventLogCreatedDateRanges, true);
 
-        if (empty($publishOnlyStates)) {
+        if ([] === $publishOnlyStates) {
             return null; // The campaign has never been published
         }
 

--- a/app/bundles/CampaignBundle/Tests/Controller/CampaignMapStatsControllerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/CampaignMapStatsControllerTest.php
@@ -253,7 +253,7 @@ final class CampaignMapStatsControllerTest extends MauticMysqlTestCase
         // Add events to campaign
         $campaign->addEvent(0, $event);
 
-        if (!empty($leadsPayload)) {
+        if ([] !== $leadsPayload) {
             $this->emulateEmailCampaignStat($event, $email, $leadsPayload);
         }
 

--- a/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignEntitiesTrait.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignEntitiesTrait.php
@@ -67,7 +67,7 @@ trait CampaignEntitiesTrait
         array $additionalValue,
         int $index,
     ): Lead {
-        $fieldValue      = !empty($fieldDetails) ?
+        $fieldValue      = [] !== $fieldDetails ?
             array_merge($fieldDetails, ['value' => array_merge(['v'.$index], $additionalValue)]) : [];
         $leadFieldValue  = 'lead' === $object ? $fieldValue : [];
         $lead            = $this->createLead('l'.$index, $leadFieldValue);
@@ -89,7 +89,7 @@ trait CampaignEntitiesTrait
         \assert($contactRepo instanceof LeadRepository);
         $lead        = new Lead();
         $lead->setFirstname($leadName);
-        if (!empty($customField)) {
+        if ([] !== $customField) {
             $lead->setFields([
                 $customField['group'] => [
                     $customField['alias'] => [
@@ -117,7 +117,7 @@ trait CampaignEntitiesTrait
         \assert($companyRepo instanceof CompanyRepository);
         $company = new Company();
         $company->setName($name);
-        if (!empty($customField)) {
+        if ([] !== $customField) {
             $company->setFields([
                 $customField['group'] => [
                     $customField['alias'] => [

--- a/app/bundles/CategoryBundle/Controller/CategoryController.php
+++ b/app/bundles/CategoryBundle/Controller/CategoryController.php
@@ -545,7 +545,7 @@ final class CategoryController extends AbstractFormController
                 }
             }
 
-            if (!empty($deleteIds)) {
+            if ([] !== $deleteIds) {
                 $flashes[] = [
                     'type'    => 'notice',
                     'msg'     => 'mautic.category.notice.batch_deleted',

--- a/app/bundles/ChannelBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/ChannelBundle/EventListener/SearchSubscriber.php
@@ -34,7 +34,7 @@ final readonly class SearchSubscriber implements EventSubscriberInterface
             '@MauticChannel/SubscribedEvents/Search/global.html.twig'
         );
 
-        if (!empty($results)) {
+        if ([] !== $results) {
             $event->addResults('mautic.messages.header', $results);
         }
     }

--- a/app/bundles/ChannelBundle/Helper/ChannelListHelper.php
+++ b/app/bundles/ChannelBundle/Helper/ChannelListHelper.php
@@ -101,7 +101,7 @@ class ChannelListHelper
      */
     private function setupChannels(): void
     {
-        if (!empty($this->channels)) {
+        if ([] !== $this->channels) {
             return;
         }
 

--- a/app/bundles/ChannelBundle/Model/MessageQueueModel.php
+++ b/app/bundles/ChannelBundle/Model/MessageQueueModel.php
@@ -216,7 +216,7 @@ class MessageQueueModel extends FormModel
                 $contacts[$message->getId()] = $message->getLead()->getId();
             }
         }
-        if (!empty($contacts)) {
+        if ([] !== $contacts) {
             $contactData = $this->leadRepository->getContacts($contacts);
             foreach ($contacts as $messageId => $contactId) {
                 $queue[$messageId]->getLead()->setFields($contactData[$contactId]);

--- a/app/bundles/ConfigBundle/Service/ConfigChangeLogger.php
+++ b/app/bundles/ConfigBundle/Service/ConfigChangeLogger.php
@@ -65,7 +65,7 @@ class ConfigChangeLogger
             }
         }
 
-        if (empty($diff)) {
+        if ([] === $diff) {
             return;
         }
 

--- a/app/bundles/CoreBundle/Command/EntityExportCommand.php
+++ b/app/bundles/CoreBundle/Command/EntityExportCommand.php
@@ -50,7 +50,7 @@ final class EntityExportCommand extends ModeratedCommand
 
         $entityIds = array_filter(array_map(intval(...), explode(',', (string) $idOption)));
 
-        if (empty($entityName) || empty($entityIds)) {
+        if (empty($entityName) || [] === $entityIds) {
             $output->writeln('<error>You must specify the entity and at least one valid entity ID.</error>');
 
             return self::FAILURE;
@@ -62,12 +62,12 @@ final class EntityExportCommand extends ModeratedCommand
             $event = $this->dispatchEntityExportEvent($entityName, $entityId);
             $data  = $event->getEntities();
 
-            if (!empty($data)) {
+            if ([] !== $data) {
                 $allData[] = $data;
             }
         }
 
-        if (empty($allData)) {
+        if ([] === $allData) {
             $output->writeln('<error>No data found for export.</error>');
 
             return self::FAILURE;

--- a/app/bundles/CoreBundle/Controller/AbstractStandardFormController.php
+++ b/app/bundles/CoreBundle/Controller/AbstractStandardFormController.php
@@ -144,7 +144,7 @@ abstract class AbstractStandardFormController extends AbstractFormController
             }
 
             // Delete everything we are able to
-            if (!empty($deleteIds)) {
+            if ([] !== $deleteIds) {
                 $entities = $model->deleteEntities($deleteIds);
 
                 $flashes[] = [

--- a/app/bundles/CoreBundle/Controller/AjaxController.php
+++ b/app/bundles/CoreBundle/Controller/AjaxController.php
@@ -227,7 +227,7 @@ class AjaxController extends CommonController
 
         $post = $request->request->all();
         unset($post['model'], $post['id'], $post['action']);
-        if (!empty($post)) {
+        if ([] !== $post) {
             $extra = http_build_query($post);
         } else {
             $extra = '';

--- a/app/bundles/CoreBundle/DependencyInjection/Builder/Metadata/EntityMetadata.php
+++ b/app/bundles/CoreBundle/DependencyInjection/Builder/Metadata/EntityMetadata.php
@@ -48,7 +48,7 @@ final class EntityMetadata
             }
 
             // The bundle leverages the static loadApiMetadata method
-            if (empty($this->serializerConfig) && $reflectionClass->hasMethod('loadApiMetadata')) {
+            if ([] === $this->serializerConfig && $reflectionClass->hasMethod('loadApiMetadata')) {
                 $this->serializerConfig = [
                     'namespace_prefix' => $bundleNamespace.'\\Entity',
                     'path'             => "@{$bundleName}/Entity",
@@ -56,7 +56,7 @@ final class EntityMetadata
             }
 
             // The bundle leverages the static loadMetadata method
-            if (empty($this->ormConfig) && $reflectionClass->hasMethod('loadMetadata')) {
+            if ([] === $this->ormConfig && $reflectionClass->hasMethod('loadMetadata')) {
                 $this->ormConfig = [
                     'dir'       => 'Entity',
                     'type'      => 'staticphp',

--- a/app/bundles/CoreBundle/Doctrine/Helper/IndexSchemaHelper.php
+++ b/app/bundles/CoreBundle/Doctrine/Helper/IndexSchemaHelper.php
@@ -85,7 +85,7 @@ class IndexSchemaHelper
     {
         $textColumns = $this->getTextColumns($columns);
 
-        if (empty($textColumns)) {
+        if ([] === $textColumns) {
             return $this;
         }
 

--- a/app/bundles/CoreBundle/Entity/CommonRepository.php
+++ b/app/bundles/CoreBundle/Entity/CommonRepository.php
@@ -1533,7 +1533,7 @@ class CommonRepository extends ServiceEntityRepository
                 $advancedFilterStrings[] = $filter;
             }
 
-            if (!empty($advancedFilterStrings)) {
+            if ([] !== $advancedFilterStrings) {
                 foreach ($advancedFilterStrings as $parseString) {
                     $parsed = $filterHelper->parseString($parseString);
 

--- a/app/bundles/CoreBundle/ErrorHandler/ErrorHandler.php
+++ b/app/bundles/CoreBundle/ErrorHandler/ErrorHandler.php
@@ -548,7 +548,7 @@ namespace {
                 if (1 === count($context) && true === $context[0]) {
                     ErrorHandler::logDebugEntry($log, $context, true);
                 } else {
-                    ErrorHandler::logDebugEntry($log, (empty($context)) ? [] : $context);
+                    ErrorHandler::logDebugEntry($log, ([] === $context) ? [] : $context);
                 }
             }
         }

--- a/app/bundles/CoreBundle/ErrorHandler/ErrorHandler.php
+++ b/app/bundles/CoreBundle/ErrorHandler/ErrorHandler.php
@@ -548,7 +548,7 @@ namespace {
                 if (1 === count($context) && true === $context[0]) {
                     ErrorHandler::logDebugEntry($log, $context, true);
                 } else {
-                    ErrorHandler::logDebugEntry($log, ([] === $context) ? [] : $context);
+                    ErrorHandler::logDebugEntry($log, $context);
                 }
             }
         }

--- a/app/bundles/CoreBundle/Form/ChoiceLoader/EntityLookupChoiceLoader.php
+++ b/app/bundles/CoreBundle/Form/ChoiceLoader/EntityLookupChoiceLoader.php
@@ -105,7 +105,7 @@ final class EntityLookupChoiceLoader implements ChoiceLoaderInterface
                 $this->formatChoices($choices);
             }
 
-            if ($includeNew && !empty($data)) {
+            if ($includeNew && [] !== $data) {
                 // Fetch some extra choices
                 $extraChoices = $this->fetchChoices($modelName);
 
@@ -202,7 +202,7 @@ final class EntityLookupChoiceLoader implements ChoiceLoaderInterface
 
         // Default to 100 records if no data is populated
         if (!isset($args['limit'])) {
-            $args['limit'] = empty($data) ? 100 : count($data);
+            $args['limit'] = [] === $data ? 100 : count($data);
         } elseif (0 !== $args['limit']) {
             $args['limit'] = max($args['limit'], count($data));
         }

--- a/app/bundles/CoreBundle/Form/RequestTrait.php
+++ b/app/bundles/CoreBundle/Form/RequestTrait.php
@@ -71,7 +71,7 @@ trait RequestTrait
                     }
 
                     // find property by value
-                    if (!empty($fields)) {
+                    if ([] !== $fields) {
                         $properties = ArrayHelper::getValue('properties', $fields[$name]);
                         if (is_array($properties)) {
                             $valuesAsKeys = array_flip(array_values($properties));

--- a/app/bundles/CoreBundle/Helper/BuilderTokenHelper.php
+++ b/app/bundles/CoreBundle/Helper/BuilderTokenHelper.php
@@ -134,7 +134,7 @@ final class BuilderTokenHelper
     ): array {
         $tokens = $this->getTokens($tokenRegex, $filter, $labelColumn, $valueColumn, $expr) ?? [];
 
-        if (empty($tokens)) {
+        if ([] === $tokens) {
             return [];
         }
 

--- a/app/bundles/CoreBundle/Helper/EmailAddressHelper.php
+++ b/app/bundles/CoreBundle/Helper/EmailAddressHelper.php
@@ -22,7 +22,7 @@ final class EmailAddressHelper
         $emails = [$email, $this->cleanEmail($email)];
         // email without suffix
         preg_match('#^(.*?)\+(.*?)@(.*?)$#', $email, $parts);
-        if (!empty($parts)) {
+        if ([] !== $parts) {
             $emails[] = $parts[1].'@'.$parts[3];
         }
 

--- a/app/bundles/CoreBundle/Helper/ImportHelper.php
+++ b/app/bundles/CoreBundle/Helper/ImportHelper.php
@@ -216,7 +216,7 @@ class ImportHelper
                 continue;
             }
             if ('..' === $segment) {
-                if (!empty($parts)) {
+                if ([] !== $parts) {
                     array_pop($parts);
                 } else {
                     // Cannot resolve upward — preserve so callers detect traversal.

--- a/app/bundles/CoreBundle/Helper/InputHelper.php
+++ b/app/bundles/CoreBundle/Helper/InputHelper.php
@@ -205,7 +205,7 @@ final class InputHelper
 
         $delimiter = '~';
 
-        if (!empty($allowedCharacters)) {
+        if ([] !== $allowedCharacters) {
             $regex = $delimiter.'[^0-9a-z'.preg_quote(implode('', $allowedCharacters), $delimiter).']+'.$delimiter.'i';
         } else {
             $regex = $delimiter.'[^0-9a-z]+'.$delimiter.'i';

--- a/app/bundles/CoreBundle/Helper/LanguageHelper.php
+++ b/app/bundles/CoreBundle/Helper/LanguageHelper.php
@@ -44,7 +44,7 @@ class LanguageHelper
      */
     public function getSupportedLanguages(): array
     {
-        if (!empty($this->supportedLanguages)) {
+        if ([] !== $this->supportedLanguages) {
             return $this->supportedLanguages;
         }
 
@@ -298,7 +298,7 @@ class LanguageHelper
 
         foreach (array_merge($mauticBundles, $pluginBundles) as $bundle) {
             // Apply the bundle filter.
-            if (!empty($forBundles) && !in_array($bundle['bundle'], $forBundles)) {
+            if ([] !== $forBundles && !in_array($bundle['bundle'], $forBundles)) {
                 continue;
             }
 

--- a/app/bundles/CoreBundle/Helper/PrivateAddressChecker.php
+++ b/app/bundles/CoreBundle/Helper/PrivateAddressChecker.php
@@ -130,7 +130,7 @@ final class PrivateAddressChecker
             }
 
             // If no allowed private addresses are set, all private URLs are forbidden
-            if (empty($this->allowedPrivateAddresses)) {
+            if ([] === $this->allowedPrivateAddresses) {
                 return false;
             }
 

--- a/app/bundles/CoreBundle/Helper/SearchStringHelper.php
+++ b/app/bundles/CoreBundle/Helper/SearchStringHelper.php
@@ -133,7 +133,7 @@ final class SearchStringHelper
                     $command                              = substr($command, 1);
                 }
 
-                if (empty($chars)) {
+                if ([] === $chars) {
                     // Command hasn't been defined so don't allow empty or could end up searching entire table
                     $filters->{$baseName}[$keyCount]->command      = $command;
                     $filters->{$baseName}[$keyCount]->missingValue = true;
@@ -147,7 +147,7 @@ final class SearchStringHelper
                 if (' ' !== $string) {
                     $string = trim($string);
                     $type   = ('OR' === $string || 'AND' === $string) ? $string : '';
-                    $this->setFilter($filters, $baseName, $keyCount, $string, $command, $overrideCommand, true, $type, !empty($chars));
+                    $this->setFilter($filters, $baseName, $keyCount, $string, $command, $overrideCommand, true, $type, [] !== $chars);
                 }
                 continue;
             } elseif (in_array($char, $this->needsClosing)) {
@@ -205,7 +205,7 @@ final class SearchStringHelper
                         ++$closingCount;
                     }
                 }
-            } elseif (empty($chars)) {
+            } elseif ([] === $chars) {
                 $filters->{$baseName}[$keyCount]->command = $command;
                 $this->setFilter($filters, $baseName, $keyCount, $string, $command, $overrideCommand, true, null, false);
             }// else keep concocting chars

--- a/app/bundles/CoreBundle/Helper/ThemeHelper.php
+++ b/app/bundles/CoreBundle/Helper/ThemeHelper.php
@@ -731,7 +731,7 @@ class ThemeHelper implements ThemeHelperInterface
         if (false !== $keyToRemove) {
             unset($hiddenThemes[$keyToRemove]);
 
-            if (empty($hiddenThemes)) {
+            if ([] === $hiddenThemes) {
                 $this->filesystem->remove($hidden);
             } else {
                 $this->filesystem->dumpFile($hidden, sprintf('|%s', implode('|', $hiddenThemes)));

--- a/app/bundles/CoreBundle/Helper/UpdateHelper.php
+++ b/app/bundles/CoreBundle/Helper/UpdateHelper.php
@@ -178,7 +178,7 @@ class UpdateHelper
             $checkResults[] = new PreUpdateCheckResult(false, null, [new PreUpdateCheckError('mautic.core.update.check.error.release_data')]);
         }
 
-        if (!empty($checkResults)) {
+        if ([] !== $checkResults) {
             return $checkResults;
         }
 

--- a/app/bundles/CoreBundle/Menu/MenuHelper.php
+++ b/app/bundles/CoreBundle/Menu/MenuHelper.php
@@ -32,7 +32,7 @@ final class MenuHelper
     public function createMenuStructure(array &$items, $depth = 0, $defaultPriority = 9999, $type = 'main'): void
     {
         foreach ($items as $k => &$i) {
-            if (!is_array($i) || empty($i)) {
+            if (!is_array($i) || [] === $i) {
                 continue;
             }
 

--- a/app/bundles/CoreBundle/Security/Permissions/CorePermissions.php
+++ b/app/bundles/CoreBundle/Security/Permissions/CorePermissions.php
@@ -435,7 +435,7 @@ class CorePermissions implements ResetInterface
 
     protected function getPermissionClasses(): array
     {
-        if (empty($this->permissionClasses)) {
+        if ([] === $this->permissionClasses) {
             $this->registerPermissionClasses();
         }
 

--- a/app/bundles/CoreBundle/Service/SearchCommandList.php
+++ b/app/bundles/CoreBundle/Service/SearchCommandList.php
@@ -22,7 +22,7 @@ final class SearchCommandList implements SearchCommandListInterface
 
     public function getList(): array
     {
-        if (!empty($this->searchCommands)) {
+        if ([] !== $this->searchCommands) {
             return $this->searchCommands;
         }
 

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/UpdateHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/UpdateHelperTest.php
@@ -840,7 +840,7 @@ final class UpdateHelperTest extends TestCase
         $errors  = [];
 
         foreach ($results as $result) {
-            if (!empty($result->errors)) {
+            if ([] !== $result->errors) {
                 $errors = array_merge($errors, array_map(fn (PreUpdateCheckError $error): string => $error->key, $result->errors));
             }
         }
@@ -865,7 +865,7 @@ final class UpdateHelperTest extends TestCase
         $errors  = [];
 
         foreach ($results as $result) {
-            if (!empty($result->errors)) {
+            if ([] !== $result->errors) {
                 $errors = array_merge($errors, array_map(fn (PreUpdateCheckError $error): string => $error->key, $result->errors));
             }
         }

--- a/app/bundles/CoreBundle/Twig/Helper/DateHelper.php
+++ b/app/bundles/CoreBundle/Twig/Helper/DateHelper.php
@@ -173,7 +173,7 @@ final class DateHelper
             }
         }
 
-        if (empty($formated)) {
+        if ([] === $formated) {
             return $this->translator->trans('mautic.core.date.less.than.second');
         }
 

--- a/app/bundles/CoreBundle/Update/Step/PreUpdateChecksStep.php
+++ b/app/bundles/CoreBundle/Update/Step/PreUpdateChecksStep.php
@@ -55,7 +55,7 @@ final readonly class PreUpdateChecksStep implements StepInterface
             }
         }
 
-        if (!empty($errors)) {
+        if ([] !== $errors) {
             $errorString = '';
 
             foreach ($errors as $error) {

--- a/app/bundles/DynamicContentBundle/Controller/DynamicContentController.php
+++ b/app/bundles/DynamicContentBundle/Controller/DynamicContentController.php
@@ -552,7 +552,7 @@ final class DynamicContentController extends FormController
             }
 
             // Delete everything we are able to
-            if (!empty($deleteIds)) {
+            if ([] !== $deleteIds) {
                 $entities = $this->dynamicContentModel->deleteEntities($deleteIds);
 
                 $flashes[] = [

--- a/app/bundles/DynamicContentBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/DynamicContentBundle/EventListener/SearchSubscriber.php
@@ -35,7 +35,7 @@ final readonly class SearchSubscriber implements EventSubscriberInterface
             '@MauticDynamicContent/SubscribedEvents/Search/global.html.twig'
         );
 
-        if (!empty($results)) {
+        if ([] !== $results) {
             $event->addResults('mautic.dynamicContent.dynamicContent', $results);
         }
     }

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -206,16 +206,16 @@ final class EmailController extends FormController
             $session->set('mautic.email.filter', $search);
             $filter['string'] = $search;
 
-            if (!empty($listAliases)) {
+            if ([] !== $listAliases) {
                 $filter['force'][] = ['column' => 'l.alias', 'expr' => 'in', 'value' => array_values(array_unique($listAliases))];
                 $ignoreListJoin    = false;
             }
 
-            if (!empty($catIds)) {
+            if ([] !== $catIds) {
                 $filter['force'][] = ['column' => 'c.id', 'expr' => 'in', 'value' => $catIds];
             }
 
-            if (!empty($templates)) {
+            if ([] !== $templates) {
                 $filter['force'][] = ['column' => 'e.template', 'expr' => 'in', 'value' => $templates];
             }
         }
@@ -1597,7 +1597,7 @@ final class EmailController extends FormController
             }
 
             // Delete everything we are able to
-            if (!empty($deleteIds)) {
+            if ([] !== $deleteIds) {
                 $entities = $this->emailModel->deleteEntities($deleteIds);
 
                 $flashes[] = [

--- a/app/bundles/EmailBundle/Entity/EmailRepository.php
+++ b/app/bundles/EmailBundle/Entity/EmailRepository.php
@@ -240,7 +240,7 @@ class EmailRepository extends CommonRepository
 
             $listIds = array_column($lists, 'leadlist_id');
 
-            if (empty($listIds)) {
+            if ([] === $listIds) {
                 // Prevent fatal error
                 return ($countOnly) ? 0 : [];
             }
@@ -456,7 +456,7 @@ class EmailRepository extends CommonRepository
             );
         }
 
-        if (!empty($ignoreIds)) {
+        if ([] !== $ignoreIds) {
             $q->andWhere($q->expr()->notIn('e.id', ':emailIds'))
                 ->setParameter('emailIds', $ignoreIds);
         }

--- a/app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/CampaignSubscriber.php
@@ -315,7 +315,7 @@ final readonly class CampaignSubscriber implements EventSubscriberInterface
 
             if (!$options['ignoreDNC']) {
                 $categories = $this->leadModel->getUnsubscribedLeadCategoriesIds($contact);
-                if ($emailCategory && !empty($categories) && in_array($emailCategory, $categories)) {
+                if ($emailCategory && [] !== $categories && in_array($emailCategory, $categories)) {
                     // Pass with a note to the UI because no use retrying
                     $event->passWithError(
                         $pending->get($logId),

--- a/app/bundles/EmailBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/SearchSubscriber.php
@@ -38,7 +38,7 @@ final readonly class SearchSubscriber implements EventSubscriberInterface
             '@MauticEmail/SubscribedEvents/Search/global.html.twig'
         );
 
-        if (!empty($results)) {
+        if ([] !== $results) {
             $event->addResults('mautic.email.emails', $results);
         }
     }

--- a/app/bundles/EmailBundle/Form/Type/EmailType.php
+++ b/app/bundles/EmailBundle/Form/Type/EmailType.php
@@ -563,7 +563,7 @@ final class EmailType extends AbstractType
         ];
 
         $draftActionButtons = $this->getDraftActionButtons($emailEntity);
-        if (!empty($draftActionButtons)) {
+        if ([] !== $draftActionButtons) {
             $extraButtons['post_extra_buttons'] = $draftActionButtons;
         }
         $builder->add(

--- a/app/bundles/EmailBundle/Helper/EmailDefaultsHelper.php
+++ b/app/bundles/EmailBundle/Helper/EmailDefaultsHelper.php
@@ -56,7 +56,7 @@ class EmailDefaultsHelper
     private function applyUtmTagDefaults(Email $email): void
     {
         $existingTags = array_filter($email->getUtmTags(), static fn ($tag): bool => null !== $tag && '' !== $tag);
-        if (!empty($existingTags)) {
+        if ([] !== $existingTags) {
             return;
         }
 

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -1579,7 +1579,7 @@ class MailHelper
     protected function createAssetDownloadEntries(): void
     {
         // Nothing was sent out so bail
-        if ($this->fatal || empty($this->assetStats)) {
+        if ($this->fatal || [] === $this->assetStats) {
             return;
         }
 
@@ -1591,7 +1591,7 @@ class MailHelper
         }
 
         // Create a download entry if there is an Asset attachment
-        if (!empty($this->assetStats)) {
+        if ([] !== $this->assetStats) {
             foreach ($this->assets as $asset) {
                 foreach ($this->assetStats as $stat) {
                     $this->assetModel->trackDownload(
@@ -1615,7 +1615,7 @@ class MailHelper
      */
     protected function queueAssetDownloadEntry($contactEmail = null, ?array $metadata = null): void
     {
-        if ($this->internalSend || empty($this->assets)) {
+        if ($this->internalSend || [] === $this->assets) {
             return;
         }
 
@@ -1870,7 +1870,7 @@ class MailHelper
         $headers = $this->getCustomHeaders();
 
         // Set custom headers
-        if (!empty($headers)) {
+        if ([] !== $headers) {
             $tokens = $this->getTokens();
             // Replace tokens
             $messageHeaders = $this->message->getHeaders();
@@ -2094,7 +2094,7 @@ class MailHelper
         $this->skip               = $event->isSkip();
         $this->fatal              = $event->isFatal();
         $errors                   = $event->getErrors();
-        if (!empty($errors)) {
+        if ([] !== $errors) {
             $currentErrors = [];
             if (isset($this->errors['failures']) && is_array($this->errors['failures'])) {
                 $currentErrors = $this->errors['failures'];

--- a/app/bundles/EmailBundle/Model/AbTest/SendWinnerService.php
+++ b/app/bundles/EmailBundle/Model/AbTest/SendWinnerService.php
@@ -47,7 +47,7 @@ final class SendWinnerService
             $emails = [$emailEntity];
         }
 
-        if (empty($emails)) {
+        if ([] === $emails) {
             $this->addOutputMessage('No emails to send');
 
             return;

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -1415,7 +1415,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
 
         // Process frequency rules for email
         if (!$email->getSendToDnc() && count($sendTo)) {
-            $campaignEventId = (is_array($channel) && !empty($channel) && 'campaign.event' === $channel[0] && !empty($channel[1])) ? $channel[1]
+            $campaignEventId = (is_array($channel) && [] !== $channel && 'campaign.event' === $channel[0] && !empty($channel[1])) ? $channel[1]
                 : null;
 
             $this->messageQueueModel->processFrequencyRules(
@@ -1567,7 +1567,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
 
         unset($emailSettings, $options, $sendTo);
 
-        $success = empty($failedContacts);
+        $success = [] === $failedContacts;
         if (!$success && $returnErrorMessages) {
             return $singleEmail ? $errorMessages[$singleEmail] : $errorMessages;
         }
@@ -1609,7 +1609,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
         $emailSettings = &$this->getEmailSettings($email, false);
 
         // No one to send to so bail
-        if (empty($users) && empty($to)) {
+        if ([] === $users && [] === $to) {
             return false;
         }
 
@@ -2048,7 +2048,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
             $dateTo
         );
 
-        if (empty($deviceStats)) {
+        if ([] === $deviceStats) {
             $deviceStats[] = [
                 'count'   => 0,
                 'device'  => $this->translator->trans('mautic.report.report.noresults'),
@@ -2238,7 +2238,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
         $emailSettings = &$this->getEmailSettings($email, false);
 
         // noone to send to so bail
-        if (empty($users)) {
+        if ([] === $users) {
             return false;
         }
 

--- a/app/bundles/EmailBundle/Tests/Functional/Fixtures/EmailFixturesHelper.php
+++ b/app/bundles/EmailBundle/Tests/Functional/Fixtures/EmailFixturesHelper.php
@@ -40,7 +40,7 @@ final readonly class EmailFixturesHelper
             ->setTemplate($template)
             ->setCustomHtml($customHtml);
 
-        if (!empty($segments)) {
+        if ([] !== $segments) {
             $email->setLists($segments);
         }
 

--- a/app/bundles/FormBundle/Controller/FormController.php
+++ b/app/bundles/FormBundle/Controller/FormController.php
@@ -315,7 +315,7 @@ class FormController extends CommonFormController
                     $fields = array_diff_key($modifiedFields, array_flip($deletedFields));
 
                     // make sure that at least one field is selected
-                    if (empty($fields)) {
+                    if ([] === $fields) {
                         // set the error
                         $form->addError(
                             new FormError(
@@ -571,7 +571,7 @@ class FormController extends CommonFormController
 
                 if ($valid = $this->isFormValid($form)) {
                     // make sure that at least one field is selected
-                    if (empty($fields)) {
+                    if ([] === $fields) {
                         // set the error
                         $form->addError(
                             new FormError(
@@ -1071,7 +1071,7 @@ class FormController extends CommonFormController
             }
 
             // Delete everything we are able to
-            if (!empty($deleteIds)) {
+            if ([] !== $deleteIds) {
                 $entities = $this->formModel->deleteEntities($deleteIds);
 
                 $flashes[] = [

--- a/app/bundles/FormBundle/Entity/SubmissionRepository.php
+++ b/app/bundles/FormBundle/Entity/SubmissionRepository.php
@@ -101,7 +101,7 @@ class SubmissionRepository extends CommonRepository
         // Quote reserved keywords in field aliases
         $fieldAliases = array_map($databasePlatform->quoteIdentifier(...), $fieldAliases);
 
-        $fieldAliasSql = (!empty($fieldAliases)) ? ', r.'.implode(',r.', $fieldAliases) : '';
+        $fieldAliasSql = ([] !== $fieldAliases) ? ', r.'.implode(',r.', $fieldAliases) : '';
         $dq->select('r.submission_id, s.date_submitted as dateSubmitted, s.lead_id as leadId, s.referer, i.ip_address as ipAddress'.$fieldAliasSql);
         $results = $dq->executeQuery()->fetchAllAssociative();
 
@@ -562,7 +562,7 @@ class SubmissionRepository extends CommonRepository
      */
     public function batchDeleteFormResultsTableRecord(array $submissionIds): void
     {
-        if (!empty($submissionIds)) {
+        if ([] !== $submissionIds) {
             $entity = $this->getEntity((int) $submissionIds[0]);
             $form   = $entity->getForm();
 

--- a/app/bundles/FormBundle/Event/FormBuilderEvent.php
+++ b/app/bundles/FormBundle/Event/FormBuilderEvent.php
@@ -172,7 +172,7 @@ final class FormBuilderEvent extends Event
      */
     public function addValidatorsToBuilder(FormInterface $form): void
     {
-        if (!empty($this->validators)) {
+        if ([] !== $this->validators) {
             $validationData = $form->getData()['validation'] ?? [];
             foreach ($this->validators as $validator) {
                 if (isset($validator['formType']) && isset($validator['fieldType']) && $validator['fieldType'] == $form->getData()['type']) {

--- a/app/bundles/FormBundle/EventListener/FormConditionalSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/FormConditionalSubscriber.php
@@ -54,7 +54,7 @@ final readonly class FormConditionalSubscriber implements EventSubscriberInterfa
             }
         }
 
-        if (!empty($deleteIds)) {
+        if ([] !== $deleteIds) {
             $this->formModel->deleteFields($form, $deleteIds);
         }
     }

--- a/app/bundles/FormBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/SearchSubscriber.php
@@ -38,7 +38,7 @@ final readonly class SearchSubscriber implements EventSubscriberInterface
             '@MauticForm/SubscribedEvents/Search/global.html.twig'
         );
 
-        if (!empty($results)) {
+        if ([] !== $results) {
             $event->addResults('mautic.campaign.campaigns', $results);
         }
     }

--- a/app/bundles/FormBundle/Model/SubmissionModel.php
+++ b/app/bundles/FormBundle/Model/SubmissionModel.php
@@ -180,7 +180,7 @@ final class SubmissionModel extends CommonFormModel
 
             if ($f->isCaptchaType()) {
                 $captcha = $this->fieldHelper->validateFieldValue($type, $value, $f);
-                if (!empty($captcha)) {
+                if ([] !== $captcha) {
                     $props = $f->getProperties();
                     // check for a custom message
                     $validationErrors[$alias] = (!empty($props['errorMessage'])) ? $props['errorMessage'] : implode('<br />', $captcha);
@@ -319,12 +319,12 @@ final class SubmissionModel extends CommonFormModel
         }
 
         // return errors if there any
-        if (!empty($validationErrors)) {
+        if ([] !== $validationErrors) {
             return ['errors' => $validationErrors];
         }
 
         // Create/update lead
-        if (!empty($leadFieldMatches)) {
+        if ([] !== $leadFieldMatches) {
             $lead = $this->createLeadFromSubmit($form, $leadFieldMatches, $leadFields, $company);
         }
 
@@ -1146,7 +1146,7 @@ final class SubmissionModel extends CommonFormModel
         }
 
         $companyFieldMatches = $getCompanyData($leadFieldMatches);
-        if (!empty($companyFieldMatches)) {
+        if ([] !== $companyFieldMatches) {
             [$company, $leadAdded, $companyEntity] = IdentifyCompanyHelper::identifyLeadsCompany($companyFieldMatches, $lead, $this->companyModel);
             $companyChangeLog                      = null;
             if ($leadAdded) {
@@ -1177,7 +1177,7 @@ final class SubmissionModel extends CommonFormModel
     protected function validateFieldValue(Field $field, $value)
     {
         $standardValidation = $this->fieldHelper->validateFieldValue($field->getType(), $value, $field);
-        if (!empty($standardValidation)) {
+        if ([] !== $standardValidation) {
             return $standardValidation;
         }
 

--- a/app/bundles/FormBundle/Twig/Extension/FormFieldExtension.php
+++ b/app/bundles/FormBundle/Twig/Extension/FormFieldExtension.php
@@ -38,7 +38,7 @@ final class FormFieldExtension extends AbstractExtension
         $value = htmlspecialchars($value, ENT_SUBSTITUTE, 'UTF-8', false);
         // Remove any attribute starting with "on" or javascript used in href, src, value, data, etc.
         preg_match('/(on[A-Za-z]*\s*=|javascript:)/i', $value, $result);
-        if (!empty($result)) {
+        if ([] !== $result) {
             return '';
         }
 

--- a/app/bundles/InstallBundle/Command/InstallCommand.php
+++ b/app/bundles/InstallBundle/Command/InstallCommand.php
@@ -233,7 +233,7 @@ final class InstallCommand extends Command
             case InstallService::CHECK_STEP:
                 $output->writeln($step.' - Checking installation requirements...');
                 $messages = $this->stepAction(['site_url' => $siteUrl], $step);
-                if (!empty($messages)) {
+                if ([] !== $messages) {
                     if (isset($messages['requirements']) && !empty($messages['requirements'])) {
                         // Stop install if requirements not met
                         $output->writeln('Missing requirements:');
@@ -274,7 +274,7 @@ final class InstallCommand extends Command
                 $connectionWrapper->initConnection($dbParams);
 
                 $messages = $this->stepAction($dbParams, $step);
-                if (!empty($messages)) {
+                if ([] !== $messages) {
                     $output->writeln('Errors in database configuration/installation:');
                     $this->handleInstallerErrors($output, $messages);
 
@@ -286,7 +286,7 @@ final class InstallCommand extends Command
                 $step = InstallService::DOCTRINE_STEP + .1;
                 $output->writeln($step.' - Creating schema...');
                 $messages = $this->stepAction($dbParams, $step);
-                if (!empty($messages)) {
+                if ([] !== $messages) {
                     $output->writeln('Errors in schema configuration/installation:');
                     $this->handleInstallerErrors($output, $messages);
 
@@ -298,7 +298,7 @@ final class InstallCommand extends Command
                 $step = InstallService::DOCTRINE_STEP + .2;
                 $output->writeln($step.' - Loading fixtures...');
                 $messages = $this->stepAction($dbParams, $step);
-                if (!empty($messages)) {
+                if ([] !== $messages) {
                     $output->writeln('Errors in fixtures configuration/installation:');
                     $this->handleInstallerErrors($output, $messages);
 
@@ -314,7 +314,7 @@ final class InstallCommand extends Command
             case InstallService::USER_STEP:
                 $output->writeln($step.' - Creating admin user...');
                 $messages = $this->stepAction($adminParam, $step);
-                if (!empty($messages)) {
+                if ([] !== $messages) {
                     $output->writeln('Errors in admin user configuration/installation:');
                     $this->handleInstallerErrors($output, $messages);
 
@@ -329,7 +329,7 @@ final class InstallCommand extends Command
             case InstallService::FINAL_STEP:
                 $output->writeln($step.' - Final steps...');
                 $messages = $this->stepAction($allParams, $step);
-                if (!empty($messages)) {
+                if ([] !== $messages) {
                     $output->writeln('Errors in final step:');
                     $this->handleInstallerErrors($output, $messages);
 
@@ -420,7 +420,7 @@ final class InstallCommand extends Command
                 // Save final configuration
                 $siteUrl  = $params['site_url'];
                 $messages = $this->installer->createFinalConfigStep($siteUrl);
-                if (empty($messages)) {
+                if ([] === $messages) {
                     $this->installer->finalMigrationStep();
                 }
                 break;

--- a/app/bundles/InstallBundle/Controller/InstallController.php
+++ b/app/bundles/InstallBundle/Controller/InstallController.php
@@ -56,7 +56,7 @@ final class InstallController extends CommonController
         $completedSteps = $session->get('mautic.installer.completedsteps', []);
 
         // Check to ensure the installer is in the right place
-        if ((empty($params) || empty($params['db_driver'])) && $index > 1) {
+        if (([] === $params || empty($params['db_driver'])) && $index > 1) {
             $session->set('mautic.installer.completedsteps', [0]);
 
             return $this->redirectToRoute('mautic_installer_step', ['index' => 1]);
@@ -88,7 +88,7 @@ final class InstallController extends CommonController
                             $formData['password'] = $params['db_password'];
                         }
                         $messages = $this->installer->createDatabaseStep($step, $formData);
-                        if (!empty($messages)) {
+                        if ([] !== $messages) {
                             $this->handleInstallerErrors($form, $messages);
                             break;
                         }
@@ -106,7 +106,7 @@ final class InstallController extends CommonController
                     case InstallService::USER_STEP:
                         $messages = $this->installer->createAdminUserStep($formData);
 
-                        if (!empty($messages)) {
+                        if ([] !== $messages) {
                             $this->handleInstallerErrors($form, $messages);
                             break;
                         }
@@ -125,7 +125,7 @@ final class InstallController extends CommonController
                 switch ($subIndex) {
                     case 1:
                         $messages = $this->installer->createSchemaStep($dbParams);
-                        if (!empty($messages)) {
+                        if ([] !== $messages) {
                             $this->handleInstallerErrors($form, $messages);
 
                             return $this->redirectToRoute('mautic_installer_step', ['index' => 1]);
@@ -134,7 +134,7 @@ final class InstallController extends CommonController
                         return $this->redirectToRoute('mautic_installer_step', ['index' => 1.2]);
                     case 2:
                         $messages = $this->installer->createFixturesStep();
-                        if (!empty($messages)) {
+                        if ([] !== $messages) {
                             $this->handleInstallerErrors($form, $messages);
 
                             return $this->redirectToRoute('mautic_installer_step', ['index' => 1]);
@@ -159,7 +159,7 @@ final class InstallController extends CommonController
             $siteUrl  = $request->getSchemeAndHttpHost().$request->getBaseUrl();
             $messages = $this->installer->createFinalConfigStep($siteUrl);
 
-            if (!empty($messages)) {
+            if ([] !== $messages) {
                 $this->handleInstallerErrors($form, $messages);
             }
 

--- a/app/bundles/InstallBundle/Install/InstallService.php
+++ b/app/bundles/InstallBundle/Install/InstallService.php
@@ -76,7 +76,7 @@ class InstallService
         $params = $this->configurator->getParameters();
 
         // Check to ensure the installer is in the right place
-        if ((empty($params)
+        if (([] === $params
                 || !isset($params['db_driver'])
                 || empty($params['db_driver'])) && $index > 1) {
             return $this->configurator->getStep(self::DOCTRINE_STEP)[0];
@@ -138,7 +138,7 @@ class InstallService
      */
     private function translateMessages(array $messages): array
     {
-        if (empty($messages)) {
+        if ([] === $messages) {
             return $messages;
         }
 
@@ -246,7 +246,7 @@ class InstallService
     {
         $messages = $this->validateDatabaseParams($dbParams);
 
-        if (!empty($messages)) {
+        if ([] !== $messages) {
             return $messages;
         }
 
@@ -259,7 +259,7 @@ class InstallService
 
             if ($schemaHelper->createDatabase()) {
                 $messages = $this->saveConfiguration($dbParams, $step, true);
-                if (empty($messages)) {
+                if ([] === $messages) {
                     return $messages;
                 }
             }
@@ -402,7 +402,7 @@ class InstallService
             }
         }
 
-        if (!empty($messages)) {
+        if ([] !== $messages) {
             return $messages;
         }
 
@@ -424,7 +424,7 @@ class InstallService
             }
         }
 
-        if (!empty($messages)) {
+        if ([] !== $messages) {
             return $messages;
         }
 

--- a/app/bundles/IntegrationsBundle/Form/Type/IntegrationSyncSettingsObjectFieldType.php
+++ b/app/bundles/IntegrationsBundle/Form/Type/IntegrationSyncSettingsObjectFieldType.php
@@ -57,7 +57,7 @@ final class IntegrationSyncSettingsObjectFieldType extends AbstractType
             $choices['mautic.integration.sync_direction_mautic'] = ObjectMappingDAO::SYNC_TO_MAUTIC;
         }
 
-        if (empty($choices)) {
+        if ([] === $choices) {
             throw new InvalidFormOptionException('field "'.$field->getName().'" must allow at least 1 direction for sync');
         }
 

--- a/app/bundles/IntegrationsBundle/Helper/FieldMergerHelper.php
+++ b/app/bundles/IntegrationsBundle/Helper/FieldMergerHelper.php
@@ -131,7 +131,7 @@ final class FieldMergerHelper
             $supportedDirections[] = ObjectMappingDAO::SYNC_TO_MAUTIC;
         }
 
-        if (empty($supportedDirections)) {
+        if ([] === $supportedDirections) {
             throw new InvalidFormOptionException('field "'.$field->getName().'" must allow at least 1 direction for sync');
         }
 

--- a/app/bundles/IntegrationsBundle/Helper/FieldValidationHelper.php
+++ b/app/bundles/IntegrationsBundle/Helper/FieldValidationHelper.php
@@ -63,7 +63,7 @@ final class FieldValidationHelper
         $hasMissingFields  = false;
         $errorsOnGivenPage = false;
 
-        if (!empty($missingFields)) {
+        if ([] !== $missingFields) {
             $hasMissingFields = true;
         }
 
@@ -113,7 +113,7 @@ final class FieldValidationHelper
     private function validateMauticRequiredFields(FormInterface $fieldMappingsForm, string $object, array $objectFieldMappings): void
     {
         $missingFields = $this->findMissingInternalRequiredFieldMappings($object, $objectFieldMappings);
-        if (empty($missingFields)) {
+        if ([] === $missingFields) {
             return;
         }
 

--- a/app/bundles/IntegrationsBundle/Sync/DAO/Sync/Order/OrderDAO.php
+++ b/app/bundles/IntegrationsBundle/Sync/DAO/Sync/Order/OrderDAO.php
@@ -290,7 +290,7 @@ class OrderDAO
 
     public function shouldSync(): bool
     {
-        return !empty($this->changedObjects);
+        return [] !== $this->changedObjects;
     }
 
     public function getObjectCount(): int

--- a/app/bundles/IntegrationsBundle/Sync/DAO/Sync/Report/ReportDAO.php
+++ b/app/bundles/IntegrationsBundle/Sync/DAO/Sync/Report/ReportDAO.php
@@ -133,7 +133,7 @@ class ReportDAO
 
     public function shouldSync(): bool
     {
-        return !empty($this->objects);
+        return [] !== $this->objects;
     }
 
     public function getRelations(): RelationsDAO

--- a/app/bundles/IntegrationsBundle/Sync/DAO/Sync/Request/RequestDAO.php
+++ b/app/bundles/IntegrationsBundle/Sync/DAO/Sync/Request/RequestDAO.php
@@ -66,6 +66,6 @@ final class RequestDAO
      */
     public function shouldSync(): bool
     {
-        return !empty($this->objects);
+        return [] !== $this->objects;
     }
 }

--- a/app/bundles/IntegrationsBundle/Sync/Helper/MappingHelper.php
+++ b/app/bundles/IntegrationsBundle/Sync/Helper/MappingHelper.php
@@ -70,7 +70,7 @@ class MappingHelper
             }
         }
 
-        if (empty($identifiers)) {
+        if ([] === $identifiers) {
             // No fields found to search for contact so return null
             return new ObjectDAO($internalObjectName, null);
         }

--- a/app/bundles/IntegrationsBundle/Sync/Notification/Helper/OwnerProvider.php
+++ b/app/bundles/IntegrationsBundle/Sync/Notification/Helper/OwnerProvider.php
@@ -27,7 +27,7 @@ class OwnerProvider
      */
     public function getOwnersForObjectIds(string $objectName, array $objectIds): array
     {
-        if (empty($objectIds)) {
+        if ([] === $objectIds) {
             return [];
         }
 

--- a/app/bundles/IntegrationsBundle/Sync/Notification/Helper/UserSummaryNotificationHelper.php
+++ b/app/bundles/IntegrationsBundle/Sync/Notification/Helper/UserSummaryNotificationHelper.php
@@ -41,7 +41,7 @@ final class UserSummaryNotificationHelper
         $this->mauticObject       = $mauticObject;
         $this->listTranslationKey = $listTranslationKey;
 
-        if (empty($this->userNotifications)) {
+        if ([] === $this->userNotifications) {
             return;
         }
 

--- a/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ObjectHelper/CompanyObjectHelper.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ObjectHelper/CompanyObjectHelper.php
@@ -208,7 +208,7 @@ class CompanyObjectHelper implements ObjectHelperInterface
 
     public function findOwnerIds(array $objectIds): array
     {
-        if (empty($objectIds)) {
+        if ([] === $objectIds) {
             return [];
         }
 

--- a/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ObjectHelper/ContactObjectHelper.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ObjectHelper/ContactObjectHelper.php
@@ -271,7 +271,7 @@ class ContactObjectHelper implements ObjectHelperInterface
 
     public function findOwnerIds(array $objectIds): array
     {
-        if (empty($objectIds)) {
+        if ([] === $objectIds) {
             return [];
         }
 

--- a/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ObjectProvider.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ObjectProvider.php
@@ -62,7 +62,7 @@ class ObjectProvider
      */
     private function collectObjects(): void
     {
-        if (empty($this->objects)) {
+        if ([] === $this->objects) {
             $event = new InternalObjectEvent();
             $this->dispatcher->dispatch($event, IntegrationEvents::INTEGRATION_COLLECT_INTERNAL_OBJECTS);
             $this->objects = $event->getObjects();

--- a/app/bundles/IntegrationsBundle/Sync/SyncProcess/SyncProcess.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncProcess/SyncProcess.php
@@ -218,7 +218,7 @@ final class SyncProcess
         // Relation objects we need to synchronize
         $objectsToSynchronize = $this->relationsHelper->getObjectsToSynchronize();
 
-        if (!empty($objectsToSynchronize)) {
+        if ([] !== $objectsToSynchronize) {
             $this->synchronizeMissingObjects($objectsToSynchronize, $syncReport);
         }
     }

--- a/app/bundles/LeadBundle/Controller/AjaxController.php
+++ b/app/bundles/LeadBundle/Controller/AjaxController.php
@@ -583,7 +583,7 @@ final class AjaxController extends CommonAjaxController
                 }
             }
 
-            if (!empty($newTags)) {
+            if ([] !== $newTags) {
                 $leadModel->getTagRepository()->saveEntities($newTags);
             }
 
@@ -626,7 +626,7 @@ final class AjaxController extends CommonAjaxController
                 }
             }
 
-            if (!empty($newUtmTags)) {
+            if ([] !== $newUtmTags) {
                 $leadModel->getUtmTagRepository()->saveEntities($newUtmTags);
             }
 

--- a/app/bundles/LeadBundle/Controller/CompanyController.php
+++ b/app/bundles/LeadBundle/Controller/CompanyController.php
@@ -117,7 +117,7 @@ final class CompanyController extends FormController
 
         $tmpl  = $request->isXmlHttpRequest() ? $request->get('tmpl', 'index') : 'index';
         $companyIds = array_keys($companies);
-        $leadCounts = (!empty($companyIds)) ? $this->companyRepository->getLeadCount($companyIds) : [];
+        $leadCounts = ([] !== $companyIds) ? $this->companyRepository->getLeadCount($companyIds) : [];
 
         return $this->delegateView(
             [
@@ -794,7 +794,7 @@ final class CompanyController extends FormController
             }
 
             // Delete everything we are able to
-            if (!empty($deleteIds)) {
+            if ([] !== $deleteIds) {
                 $entities = $this->companyModel->deleteEntities($deleteIds);
                 $deleted  = count($entities);
                 $this->addFlashMessage(

--- a/app/bundles/LeadBundle/Controller/ImportController.php
+++ b/app/bundles/LeadBundle/Controller/ImportController.php
@@ -397,7 +397,7 @@ final class ImportController extends FormController
 
                     $matchedFields = $validateEvent->getMatchedFields();
 
-                    if (empty($matchedFields)) {
+                    if ([] === $matchedFields) {
                         $this->resetImport($object);
                         $this->removeImportFile($fullPath);
                         $this->logger->log(LogLevel::WARNING, "Import for file {$fullPath} was aborted as there were no matched files found.");

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -587,7 +587,7 @@ final class LeadController extends FormController
                     // Save here as we need the entity with an ID for the company code bellow.
                     $this->leadRepository->saveEntity($lead);
 
-                    if (!empty($companies)) {
+                    if ([] !== $companies) {
                         $this->leadModel->modifyCompanies($lead, $companies);
                     }
 
@@ -1270,7 +1270,7 @@ final class LeadController extends FormController
             }
 
             // Delete everything we are able to
-            if (!empty($deleteIds)) {
+            if ([] !== $deleteIds) {
                 $entities = $this->leadModel->deleteEntities($deleteIds);
 
                 $flashes[] = [

--- a/app/bundles/LeadBundle/Controller/ListController.php
+++ b/app/bundles/LeadBundle/Controller/ListController.php
@@ -149,7 +149,7 @@ final class ListController extends FormController
         $session->set('mautic.segment.page', $page);
 
         $listIds    = array_keys($items->getIterator()->getArrayCopy());
-        $leadCounts = (!empty($listIds)) ? $this->listModel->getSegmentContactCountFromCache($listIds) : [];
+        $leadCounts = ([] !== $listIds) ? $this->listModel->getSegmentContactCountFromCache($listIds) : [];
 
         $parameters = [
             'items'                          => $items,
@@ -899,7 +899,7 @@ final class ListController extends FormController
             $filter['string'] = $this->stripQuickFilterTokensFromSearch((string) ($filter['string'] ?? ''), $searchFilterTerms);
             $session->set('mautic.lead.list.filter', $filter['string']);
 
-            if (!empty($catAliases)) {
+            if ([] !== $catAliases) {
                 $joinCategories    = true;
                 $filter['force'][] = ['column' => 'cat.alias', 'expr' => 'in', 'value' => array_values(array_unique($catAliases))];
             }
@@ -951,7 +951,7 @@ final class ListController extends FormController
             $filters = [];
         }
 
-        if (!empty($filters)) {
+        if ([] !== $filters) {
             if (in_array('manually_added', $filters['includeEvents'])) {
                 $listFilters = array_merge($listFilters, ['manually_added' => 1]);
             }

--- a/app/bundles/LeadBundle/Deduplicate/CompanyDeduper.php
+++ b/app/bundles/LeadBundle/Deduplicate/CompanyDeduper.php
@@ -30,7 +30,7 @@ class CompanyDeduper
     public function checkForDuplicateCompanies(array $queryFields): array
     {
         $uniqueData = $this->getUniqueData($queryFields);
-        if (empty($uniqueData)) {
+        if ([] === $uniqueData) {
             throw new UniqueFieldNotFoundException();
         }
 

--- a/app/bundles/LeadBundle/Deduplicate/ContactDeduper.php
+++ b/app/bundles/LeadBundle/Deduplicate/ContactDeduper.php
@@ -92,7 +92,7 @@ final class ContactDeduper
      */
     public function mergeContacts(array $duplicates): void
     {
-        if (empty($duplicates)) {
+        if ([] === $duplicates) {
             return;
         }
 
@@ -114,7 +114,7 @@ final class ContactDeduper
     {
         $duplicates = [];
         $uniqueData = $this->getUniqueData($queryFields);
-        if (!empty($uniqueData)) {
+        if ([] !== $uniqueData) {
             $duplicates = $this->leadRepository->getLeadsByUniqueFields($uniqueData);
 
             // By default, duplicates are ordered by newest first

--- a/app/bundles/LeadBundle/Entity/CompanyRepository.php
+++ b/app/bundles/LeadBundle/Entity/CompanyRepository.php
@@ -223,7 +223,7 @@ class CompanyRepository extends CommonRepository implements CustomFieldRepositor
     public function getSearchCommands(): array
     {
         $commands = array_merge(['mautic.project.searchcommand.name'], $this->getStandardSearchCommands());
-        if (!empty($this->availableSearchFields)) {
+        if ([] !== $this->availableSearchFields) {
             $commands = array_merge($commands, $this->availableSearchFields);
         }
 
@@ -468,7 +468,7 @@ class CompanyRepository extends CommonRepository implements CustomFieldRepositor
             $q->where($expr);
         }
 
-        if (!empty($parameters)) {
+        if ([] !== $parameters) {
             $q->setParameters($parameters);
         }
 

--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -615,7 +615,7 @@ SQL;
     {
         $segmentIds = $this->fetchContactToSegmentIdsRelationships($contactId, $expectedSegmentIds);
 
-        return !empty($segmentIds);
+        return [] !== $segmentIds;
     }
 
     /**
@@ -625,7 +625,7 @@ SQL;
     {
         $segmentIds = $this->fetchContactToSegmentIdsRelationships($contactId, $expectedSegmentIds);
 
-        if (empty($segmentIds)) {
+        if ([] === $segmentIds) {
             return true; // Contact is not associated wit any segment
         }
 

--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -1051,7 +1051,7 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
             'mautic.lead.lead.searchcommand.form',
         ];
 
-        if (!empty($this->availableSearchFields)) {
+        if ([] !== $this->availableSearchFields) {
             $commands = array_merge($commands, $this->availableSearchFields);
         }
 
@@ -1141,7 +1141,7 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
      */
     public function isContactInOneOfStages(Lead $lead, array $stages = []): bool
     {
-        if (empty($stages)) {
+        if ([] === $stages) {
             return false;
         }
 
@@ -1215,7 +1215,7 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
      */
     public function getContactCollection(array $ids): ArrayCollection
     {
-        if (empty($ids)) {
+        if ([] === $ids) {
             return new ArrayCollection();
         }
 

--- a/app/bundles/LeadBundle/Entity/ListLeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/ListLeadRepository.php
@@ -35,7 +35,7 @@ class ListLeadRepository extends CommonRepository
             ->set('lead_id', (int) $toLeadId)
             ->where('lead_id = '.(int) $fromLeadId);
 
-        if (!empty($lists)) {
+        if ([] !== $lists) {
             $q->andWhere(
                 $q->expr()->notIn('leadlist_id', ':ids')
             )

--- a/app/bundles/LeadBundle/Entity/TagRepository.php
+++ b/app/bundles/LeadBundle/Entity/TagRepository.php
@@ -71,7 +71,7 @@ class TagRepository extends CommonRepository
      */
     public function getTagsByName(array $tags): array
     {
-        if (empty($tags)) {
+        if ([] === $tags) {
             return [];
         }
 
@@ -163,13 +163,13 @@ class TagRepository extends CommonRepository
     {
         $result = [];
 
-        if (empty($leadIds) || empty($tagIds)) {
+        if ([] === $leadIds || [] === $tagIds) {
             return $result;
         }
 
         $tags = $this->getTagById($tagIds);
 
-        if (empty($tags)) {
+        if ([] === $tags) {
             return $result;
         }
 

--- a/app/bundles/LeadBundle/Event/LeadTimelineEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadTimelineEvent.php
@@ -76,7 +76,7 @@ final class LeadTimelineEvent extends Event
         private $forTimeline = true,
         private $siteDomain = null,
     ) {
-        $this->filters = !empty($filters)
+        $this->filters = [] !== $filters
             ? $filters
             :
             [
@@ -175,7 +175,7 @@ final class LeadTimelineEvent extends Event
      */
     public function getEvents()
     {
-        if (empty($this->events)) {
+        if ([] === $this->events) {
             return [];
         }
 

--- a/app/bundles/LeadBundle/EventListener/DashboardSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/DashboardSubscriber.php
@@ -401,7 +401,7 @@ final class DashboardSubscriber extends MainDashboardSubscriber
                 $leads = $this->leadModel->getLeadList($limit, $params['dateFrom'], $params['dateTo'], $canViewOthers, []);
                 $items = [];
 
-                if (empty($leads)) {
+                if ([] === $leads) {
                     $leads[] = [
                         'name' => $this->translator->trans('mautic.report.report.noresults'),
                     ];

--- a/app/bundles/LeadBundle/EventListener/ImportCompanySubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/ImportCompanySubscriber.php
@@ -104,7 +104,7 @@ final readonly class ImportCompanySubscriber implements EventSubscriberInterface
             array_filter($matchedFields)
         );
 
-        if (empty($matchedFields)) {
+        if ([] === $matchedFields) {
             $event->getForm()->addError(
                 new FormError(
                     $this->translator->trans('mautic.lead.import.matchfields', [], 'validators')

--- a/app/bundles/LeadBundle/EventListener/ImportContactSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/ImportContactSubscriber.php
@@ -124,7 +124,7 @@ final readonly class ImportContactSubscriber implements EventSubscriberInterface
             array_filter($matchedFields)
         );
 
-        if (empty($matchedFields)) {
+        if ([] === $matchedFields) {
             $event->getForm()->addError(
                 new FormError(
                     $this->translator->trans('mautic.lead.import.matchfields', [], 'validators')

--- a/app/bundles/LeadBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/SearchSubscriber.php
@@ -104,7 +104,7 @@ final class SearchSubscriber implements EventSubscriberInterface
             '@MauticLead/SubscribedEvents/Search/global_segment.html.twig'
         );
 
-        if (!empty($results)) {
+        if ([] !== $results) {
             $event->addResults('mautic.segment.segment', $results);
         }
     }

--- a/app/bundles/LeadBundle/Field/Command/AnalyseCustomFieldCommand.php
+++ b/app/bundles/LeadBundle/Field/Command/AnalyseCustomFieldCommand.php
@@ -45,7 +45,7 @@ final class AnalyseCustomFieldCommand extends Command
         $displayAsTable = $input->getOption('display-table');
 
         $fieldDetails = $this->getCustomFieldDetails();
-        if (empty($fieldDetails)) {
+        if ([] === $fieldDetails) {
             $output->writeln('No custom field(s) to analyse!!!');
 
             return Command::SUCCESS;

--- a/app/bundles/LeadBundle/Field/Command/ModifyCustomFieldCommand.php
+++ b/app/bundles/LeadBundle/Field/Command/ModifyCustomFieldCommand.php
@@ -64,7 +64,7 @@ final class ModifyCustomFieldCommand extends Command
             $fieldsNeedsToBeUpdated[$field['alias']] = $field;
         }
 
-        if (empty($fieldsNeedsToBeUpdated)) {
+        if ([] === $fieldsNeedsToBeUpdated) {
             $output->writeln('<info>No custom field(s) to update!!!</info>');
 
             return Command::SUCCESS;

--- a/app/bundles/LeadBundle/Form/DataTransformer/FieldFilterTransformer.php
+++ b/app/bundles/LeadBundle/Form/DataTransformer/FieldFilterTransformer.php
@@ -48,7 +48,7 @@ final class FieldFilterTransformer implements DataTransformerInterface
         }
 
         foreach ($rawFilters as $key => $filter) {
-            if (!empty($this->default)) {
+            if ([] !== $this->default) {
                 $rawFilters[$key] = array_merge($this->default, $rawFilters[$key]);
             }
             $operator = $filter['operator'] ?? '';

--- a/app/bundles/LeadBundle/Form/Type/FieldType.php
+++ b/app/bundles/LeadBundle/Form/Type/FieldType.php
@@ -484,7 +484,7 @@ final class FieldType extends AbstractType
             function (FormEvent $event) use ($formModifier, $disableDefaultValue, $setupOrderField): void {
                 $data          = $event->getData();
                 $cleaningRules = $formModifier($event);
-                $masks         = !empty($cleaningRules) ? $cleaningRules : 'clean';
+                $masks         = [] !== $cleaningRules ? $cleaningRules : 'clean';
                 // clean the data
                 $data = InputHelper::_($data, $masks);
 

--- a/app/bundles/LeadBundle/Helper/ContactRequestHelper.php
+++ b/app/bundles/LeadBundle/Helper/ContactRequestHelper.php
@@ -118,7 +118,7 @@ class ContactRequestHelper
         } catch (ContactNotFoundException) {
         }
 
-        if (!empty($this->queryFields)) {
+        if ([] !== $this->queryFields) {
             /** @var Lead $foundContact */
             [$foundContact, $this->publiclyUpdatableFieldValues] = $this->leadModel->checkForDuplicateContact(
                 $this->queryFields,
@@ -174,7 +174,7 @@ class ContactRequestHelper
             $this->trackedContact->addIpAddress($ipAddress);
         }
 
-        if (!empty($this->publiclyUpdatableFieldValues)) {
+        if ([] !== $this->publiclyUpdatableFieldValues) {
             $this->leadModel->setFieldValues(
                 $this->trackedContact,
                 $this->publiclyUpdatableFieldValues,

--- a/app/bundles/LeadBundle/Helper/IdentifyCompanyHelper.php
+++ b/app/bundles/LeadBundle/Helper/IdentifyCompanyHelper.php
@@ -27,14 +27,14 @@ final class IdentifyCompanyHelper
             return [null, false, null];
         }
 
-        if (!empty($companies)) {
+        if ([] !== $companies) {
             $companyEntity = end($companies);
             $companyData   = $companyEntity->getProfileFields();
 
             if ($lead) {
                 $companyLeadRepo = $companyModel->getCompanyLeadRepository();
                 $companyLead     = $companyLeadRepo->getCompaniesByLeadId($lead->getId(), $companyEntity->getId());
-                if (!empty($companyLead)) {
+                if ([] !== $companyLead) {
                     $addContactToCompany = false;
                 }
             }
@@ -66,7 +66,7 @@ final class IdentifyCompanyHelper
         }
 
         $companyData     = $parameters;
-        if (!empty($companyEntities)) {
+        if ([] !== $companyEntities) {
             $key               = array_key_last($companyEntities);
             $companyData['id'] = $companyEntities[$key]->getId();
         }

--- a/app/bundles/LeadBundle/Model/CompanyModel.php
+++ b/app/bundles/LeadBundle/Model/CompanyModel.php
@@ -305,7 +305,7 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
             }
         }
 
-        if (!empty($searchForCompanies)) {
+        if ([] !== $searchForCompanies) {
             $companyEntities = $this->getEntities([
                 'filter' => [
                     'force' => [
@@ -362,7 +362,7 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
             }
         }
 
-        if (!empty($persistCompany)) {
+        if ([] !== $persistCompany) {
             $this->companyLeadRepository->saveEntities($persistCompany);
         }
 
@@ -378,7 +378,7 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
             }
         }
 
-        if (!empty($dispatchEvents) && $this->dispatcher->hasListeners(LeadEvents::LEAD_COMPANY_CHANGE)) {
+        if ([] !== $dispatchEvents && $this->dispatcher->hasListeners(LeadEvents::LEAD_COMPANY_CHANGE)) {
             foreach ($dispatchEvents as $companyId) {
                 $event = new LeadChangeCompanyEvent($lead, $companyLeadAdd[$companyId]);
                 $this->dispatcher->dispatch($event, LeadEvents::LEAD_COMPANY_CHANGE);
@@ -411,7 +411,7 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
                 $l                    = (int) $l;
                 $searchForCompanies[] = $l;
             }
-            if (!empty($searchForCompanies)) {
+            if ([] !== $searchForCompanies) {
                 $companyEntities = $this->getEntities(
                     [
                         'filter' => [
@@ -477,7 +477,7 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
             unset($companyLead);
         }
 
-        if (!empty($deleteCompanyLead)) {
+        if ([] !== $deleteCompanyLead) {
             $this->companyLeadRepository->deleteEntities($deleteCompanyLead);
         }
 
@@ -490,7 +490,7 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
         // Clear CompanyLead entities from Doctrine memory
         $this->companyLeadRepository->detachEntities($deleteCompanyLead);
 
-        if (!empty($dispatchEvents) && $this->dispatcher->hasListeners(LeadEvents::LEAD_COMPANY_CHANGE)) {
+        if ([] !== $dispatchEvents && $this->dispatcher->hasListeners(LeadEvents::LEAD_COMPANY_CHANGE)) {
             foreach ($dispatchEvents as $companyId) {
                 $event = new LeadChangeCompanyEvent($lead, $companyLeadRemove[$companyId], false);
                 $this->dispatcher->dispatch($event, LeadEvents::LEAD_COMPANY_CHANGE);

--- a/app/bundles/LeadBundle/Model/FieldModel.php
+++ b/app/bundles/LeadBundle/Model/FieldModel.php
@@ -817,7 +817,7 @@ class FieldModel extends FormModel
      */
     public function setFieldProperties(LeadField $entity, array $properties)
     {
-        if (!empty($properties) && is_array($properties)) {
+        if ([] !== $properties && is_array($properties)) {
             $properties = InputHelper::clean($properties);
         } else {
             $properties = [];

--- a/app/bundles/LeadBundle/Model/ImportModel.php
+++ b/app/bundles/LeadBundle/Model/ImportModel.php
@@ -457,7 +457,7 @@ class ImportModel extends FormModel
      */
     public function isEmptyCsvRow($row): bool
     {
-        if (!is_array($row) || empty($row)) {
+        if (!is_array($row) || [] === $row) {
             return true;
         }
 

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -600,7 +600,7 @@ class LeadModel extends FormModel
 
         if (empty($fieldValues) || $bindWithForm) {
             // Lead is new or they haven't been populated so let's build the fields now
-            if (empty($this->flattenedFields)) {
+            if ([] === $this->flattenedFields) {
                 /** @var Paginator<mixed[]> $paginator */
                 $paginator = $this->leadFieldModel->getEntities(
                     [
@@ -875,7 +875,7 @@ class LeadModel extends FormModel
     public function checkForDuplicateContact(array $queryFields, $returnWithQueryFields = false, $onlyPubliclyUpdateable = false)
     {
         // Search for lead by request and/or update lead fields if some data were sent in the URL query
-        if (empty($this->availableLeadFields)) {
+        if ([] === $this->availableLeadFields) {
             $filter = ['isPublished' => true, 'object' => 'lead'];
 
             if ($onlyPubliclyUpdateable) {
@@ -1025,7 +1025,7 @@ class LeadModel extends FormModel
 
         $frequencyRules = $this->frequencyRuleRepository->getFrequencyRules($channel, $lead->getId());
 
-        if (empty($frequencyRules)) {
+        if ([] === $frequencyRules) {
             return [];
         }
 
@@ -1076,7 +1076,7 @@ class LeadModel extends FormModel
             }
         }
 
-        if (!empty($entities)) {
+        if ([] !== $entities) {
             $this->frequencyRuleRepository->saveEntities($entities);
         }
 
@@ -1087,7 +1087,7 @@ class LeadModel extends FormModel
         }
         // Delete lists that were removed
         $deletedLists = array_diff(array_keys($leadLists), $data['lead_lists']);
-        if (!empty($deletedLists)) {
+        if ([] !== $deletedLists) {
             $this->removeFromLists($lead, $deletedLists);
         }
 
@@ -1099,7 +1099,7 @@ class LeadModel extends FormModel
         // Update categories relations as removed those are removed.
         $unsubscribedCategories = array_diff($leadCategories, $data['global_categories']);
 
-        if (!empty($unsubscribedCategories)) {
+        if ([] !== $unsubscribedCategories) {
             $this->unsubscribeCategories($unsubscribedCategories);
         }
 
@@ -1107,13 +1107,13 @@ class LeadModel extends FormModel
         $nonAssociatedCategories = $this->leadCategoryRepository->getNonAssociatedCategoryIdsForAContact($lead, ['global', 'email']);
 
         $unsubscribeNewCategories = array_diff($nonAssociatedCategories, $data['global_categories']);
-        if (!empty($unsubscribeNewCategories)) {
+        if ([] !== $unsubscribeNewCategories) {
             $this->addToCategory($lead, $unsubscribeNewCategories, false);
         }
 
         // Delete channels that were removed
         $deleted = array_diff_key($frequencyRules, $entities);
-        if (!empty($deleted)) {
+        if ([] !== $deleted) {
             $this->frequencyRuleRepository->deleteEntities($deleted);
         }
 
@@ -1163,7 +1163,7 @@ class LeadModel extends FormModel
             }
         }
 
-        if (!empty($results)) {
+        if ([] !== $results) {
             $this->leadCategoryRepository->saveEntities($results);
         }
 
@@ -1190,7 +1190,7 @@ class LeadModel extends FormModel
             }
         }
 
-        if (!empty($unsubscribedCats)) {
+        if ([] !== $unsubscribedCats) {
             $this->leadCategoryRepository->saveEntities($unsubscribedCats);
         }
     }
@@ -1216,7 +1216,7 @@ class LeadModel extends FormModel
             }
         }
 
-        if (!empty($deleteCats)) {
+        if ([] !== $deleteCats) {
             $this->leadCategoryRepository->deleteEntities($deleteCats);
         }
     }
@@ -1587,7 +1587,7 @@ class LeadModel extends FormModel
             }
         }
 
-        if (!empty($tags)) {
+        if ([] !== $tags) {
             foreach ($tags as $tag) {
                 if (is_numeric($tag)) {
                     // Existing tag being added to this lead
@@ -1636,7 +1636,7 @@ class LeadModel extends FormModel
         if (isset($params['query']) && !is_array($params['query'])) {
             // assume it's a query string; convert it to array
             parse_str($params['query'], $queryResult);
-            if (!empty($queryResult)) {
+            if ([] !== $queryResult) {
                 $params['query'] = $queryResult;
             } else {
                 // Something wrong with, remove it
@@ -1731,7 +1731,7 @@ class LeadModel extends FormModel
             $tags = explode(',', $tags);
         }
 
-        if (empty($tags) && empty($removeTags)) {
+        if ([] === $tags && empty($removeTags)) {
             return false;
         }
 
@@ -2173,7 +2173,7 @@ class LeadModel extends FormModel
 
         $companyLead = $this->companyModel->getCompanyLeadRepository()->getCompaniesByLeadId($lead->getId(), $company->getId());
 
-        if (empty($companyLead)) {
+        if ([] === $companyLead) {
             $this->companyModel->addLeadToCompany($company, $lead);
 
             return true;
@@ -2224,7 +2224,7 @@ class LeadModel extends FormModel
     public function getPreferredChannel(Lead $lead)
     {
         $preferredChannel = $this->frequencyRuleRepository->getPreferredChannel($lead->getId());
-        if (!empty($preferredChannel)) {
+        if ([] !== $preferredChannel) {
             return $preferredChannel[0];
         }
 
@@ -2270,7 +2270,7 @@ class LeadModel extends FormModel
             }
         }
 
-        if (!empty($companyArray)) {
+        if ([] !== $companyArray) {
             $this->leadRepository->saveEntity($lead);
             $this->companyModel->getCompanyLeadRepository()->saveEntities($companyArray, false);
         }
@@ -2296,7 +2296,7 @@ class LeadModel extends FormModel
             $success    = true;
         }
 
-        if (!empty($entities)) {
+        if ([] !== $entities) {
             $this->companyRepository->saveEntities($entities);
         }
 

--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -626,7 +626,7 @@ class ListModel extends FormModel implements GlobalSearchInterface
                 }
             }
 
-            if (!empty($searchForLists)) {
+            if ([] !== $searchForLists) {
                 $listEntities = $this->getEntities([
                     'filter' => [
                         'force' => [
@@ -713,7 +713,7 @@ class ListModel extends FormModel implements GlobalSearchInterface
             }
         }
 
-        if (!empty($persistLists)) {
+        if ([] !== $persistLists) {
             $this->getRepository()->saveEntities($persistLists);
         }
 
@@ -723,7 +723,7 @@ class ListModel extends FormModel implements GlobalSearchInterface
         if ($batchProcess) {
             // Detach for batch processing to preserve memory
             $this->em->detach($lead);
-        } elseif (!empty($dispatchEvents) && $this->dispatcher->hasListeners(LeadEvents::LEAD_LIST_CHANGE)) {
+        } elseif ([] !== $dispatchEvents && $this->dispatcher->hasListeners(LeadEvents::LEAD_LIST_CHANGE)) {
             foreach ($dispatchEvents as $listId) {
                 $event = new ListChangeEvent($lead, $this->leadChangeLists[$listId]);
                 $this->dispatcher->dispatch($event, LeadEvents::LEAD_LIST_CHANGE);
@@ -763,7 +763,7 @@ class ListModel extends FormModel implements GlobalSearchInterface
                 }
             }
 
-            if (!empty($searchForLists)) {
+            if ([] !== $searchForLists) {
                 $listEntities = $this->getEntities([
                     'filter' => [
                         'force' => [
@@ -837,11 +837,11 @@ class ListModel extends FormModel implements GlobalSearchInterface
             unset($listLead);
         }
 
-        if (!empty($persistLists)) {
+        if ([] !== $persistLists) {
             $this->getRepository()->saveEntities($persistLists);
         }
 
-        if (!empty($deleteLists)) {
+        if ([] !== $deleteLists) {
             $this->getRepository()->deleteEntities($deleteLists);
         }
 
@@ -852,7 +852,7 @@ class ListModel extends FormModel implements GlobalSearchInterface
         if ($batchProcess) {
             // Detach for batch processing to preserve memory
             $this->em->detach($lead);
-        } elseif (!empty($dispatchEvents) && $this->dispatcher->hasListeners(LeadEvents::LEAD_LIST_CHANGE)) {
+        } elseif ([] !== $dispatchEvents && $this->dispatcher->hasListeners(LeadEvents::LEAD_LIST_CHANGE)) {
             foreach ($dispatchEvents as $listId) {
                 $event = new ListChangeEvent($lead, $this->leadChangeLists[$listId], false);
                 $this->dispatcher->dispatch($event, LeadEvents::LEAD_LIST_CHANGE);
@@ -1440,7 +1440,7 @@ class ListModel extends FormModel implements GlobalSearchInterface
             $criteria['createdBy'] = $this->userHelper->getUser()->getId();
         }
 
-        if (!empty($segmentsFilter)) {
+        if ([] !== $segmentsFilter) {
             $criteria['id'] = $segmentsFilter;
         }
 

--- a/app/bundles/LeadBundle/Provider/FieldChoicesProvider.php
+++ b/app/bundles/LeadBundle/Provider/FieldChoicesProvider.php
@@ -67,7 +67,7 @@ final class FieldChoicesProvider implements FieldChoicesProviderInterface
 
     private function lookForFieldChoices(string $search = ''): void
     {
-        if (empty($this->cachedTypeChoices)) {
+        if ([] === $this->cachedTypeChoices) {
             $event = new ListFieldChoicesEvent();
             $event->setSearchTerm($search);
             $this->dispatcher->dispatch($event, LeadEvents::COLLECT_FILTER_CHOICES_FOR_LIST_FIELD_TYPE);

--- a/app/bundles/LeadBundle/Provider/FilterOperatorProvider.php
+++ b/app/bundles/LeadBundle/Provider/FilterOperatorProvider.php
@@ -27,7 +27,7 @@ final class FilterOperatorProvider implements FilterOperatorProviderInterface
      */
     public function getAllOperators(): array
     {
-        if (empty($this->cachedOperators)) {
+        if ([] === $this->cachedOperators) {
             $event = new LeadListFiltersOperatorsEvent([]);
 
             $this->dispatcher->dispatch($event, LeadEvents::LIST_FILTERS_OPERATORS_ON_GENERATE);

--- a/app/bundles/LeadBundle/Provider/TypeOperatorProvider.php
+++ b/app/bundles/LeadBundle/Provider/TypeOperatorProvider.php
@@ -76,7 +76,7 @@ final class TypeOperatorProvider implements TypeOperatorProviderInterface
 
     public function getAllTypeOperators(): array
     {
-        if (empty($this->cachedTypeOperators)) {
+        if ([] === $this->cachedTypeOperators) {
             $event = new TypeOperatorsEvent($this->context);
 
             $this->dispatcher->dispatch($event, LeadEvents::COLLECT_OPERATORS_FOR_FIELD_TYPE);

--- a/app/bundles/LeadBundle/Report/DncReportService.php
+++ b/app/bundles/LeadBundle/Report/DncReportService.php
@@ -83,7 +83,7 @@ class DncReportService
      */
     public function processDncStatusDisplay(array $data): array
     {
-        if (empty($data) || !array_key_exists('dnc_preferences', $data[0])) {
+        if ([] === $data || !array_key_exists('dnc_preferences', $data[0])) {
             return $data;
         }
 

--- a/app/bundles/LeadBundle/Segment/ContactSegmentFilterFactory.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentFilterFactory.php
@@ -145,7 +145,7 @@ final class ContactSegmentFilterFactory
         // add all grouped conditions back
         foreach ($arrStacks as $stack) {
             $groupedFilter = $this->groupFilters($stack);
-            if (!empty($groupedFilter)) {
+            if ([] !== $groupedFilter) {
                 $shrinkedFilters[] = $groupedFilter;
             }
         }
@@ -160,7 +160,7 @@ final class ContactSegmentFilterFactory
      */
     private function groupFilters(array $stack): array
     {
-        if (empty($stack)) {
+        if ([] === $stack) {
             return [];
         }
 

--- a/app/bundles/LeadBundle/Segment/Query/Filter/ComplexRelationValueFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/ComplexRelationValueFilterQueryBuilder.php
@@ -141,7 +141,7 @@ final class ComplexRelationValueFilterQueryBuilder extends BaseFilterQueryBuilde
                     $expressions[] = $queryBuilder->expr()->{$operator}($tableAlias.'.'.$filter->getField(), $parameter);
                 }
 
-                if (empty($expressions)) {
+                if ([] === $expressions) {
                     $expression = $queryBuilder->expr()->and($applyIsNull ? '1 = 1' : '1 = 0');
                     break;
                 }

--- a/app/bundles/LeadBundle/Services/ContactSegmentFilterDictionary.php
+++ b/app/bundles/LeadBundle/Services/ContactSegmentFilterDictionary.php
@@ -31,7 +31,7 @@ class ContactSegmentFilterDictionary
      */
     public function getFilters(): array
     {
-        if (empty($this->filters)) {
+        if ([] === $this->filters) {
             $this->setDefaultFilters();
             $this->fetchFiltersFromSubscribers();
         }

--- a/app/bundles/LeadBundle/Services/PeakInteractionTimer.php
+++ b/app/bundles/LeadBundle/Services/PeakInteractionTimer.php
@@ -130,7 +130,7 @@ class PeakInteractionTimer
         $this->bestHourStart  = $this->bestDefaultHourStart;
         $this->bestHourEnd    = $this->bestDefaultHourEnd;
         $bestDays             = array_map(intval(...), $this->bestDefaultDays);
-        $this->bestDays       = !empty($bestDays) ? $bestDays : self::DEFAULT_BEST_DAYS;
+        $this->bestDays       = [] !== $bestDays ? $bestDays : self::DEFAULT_BEST_DAYS;
         $this->maxOptimalDays = count($this->bestDays);
     }
 

--- a/app/bundles/LeadBundle/Tests/Controller/AjaxControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/AjaxControllerFunctionalTest.php
@@ -648,7 +648,7 @@ final class AjaxControllerFunctionalTest extends MauticMysqlTestCase
             }
         }
         // Assert that the actual options match the expected options
-        if (empty($expectedOptions)) {
+        if ([] === $expectedOptions) {
             $this->assertEmpty($actualOptions);
         }
         foreach ($expectedOptions as $expectedValue) {

--- a/app/bundles/NotificationBundle/Controller/MobileNotificationController.php
+++ b/app/bundles/NotificationBundle/Controller/MobileNotificationController.php
@@ -687,7 +687,7 @@ final class MobileNotificationController extends FormController
             }
 
             // Delete everything we are able to
-            if (!empty($deleteIds)) {
+            if ([] !== $deleteIds) {
                 $entities = $this->notificationModel->deleteEntities($deleteIds);
 
                 $flashes[] = [

--- a/app/bundles/NotificationBundle/Controller/NotificationController.php
+++ b/app/bundles/NotificationBundle/Controller/NotificationController.php
@@ -675,7 +675,7 @@ final class NotificationController extends AbstractFormController
             }
 
             // Delete everything we are able to
-            if (!empty($deleteIds)) {
+            if ([] !== $deleteIds) {
                 $entities = $this->notificationModel->deleteEntities($deleteIds);
 
                 $flashes[] = [

--- a/app/bundles/NotificationBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/NotificationBundle/EventListener/SearchSubscriber.php
@@ -47,7 +47,7 @@ final readonly class SearchSubscriber implements EventSubscriberInterface
             '@MauticNotification/SubscribedEvents/Search/global-web.html.twig'
         );
 
-        if (!empty($results)) {
+        if ([] !== $results) {
             $event->addResults('mautic.notification.notification.header', $results);
         }
     }
@@ -70,7 +70,7 @@ final readonly class SearchSubscriber implements EventSubscriberInterface
             '@MauticNotification/SubscribedEvents/Search/global-mobile.html.twig'
         );
 
-        if (!empty($results)) {
+        if ([] !== $results) {
             $event->addResults('mautic.notification.mobile_notification.header', $results);
         }
     }

--- a/app/bundles/PageBundle/Controller/PageController.php
+++ b/app/bundles/PageBundle/Controller/PageController.php
@@ -816,7 +816,7 @@ final class PageController extends FormController
             }
 
             // Delete everything we are able to
-            if (!empty($deleteIds)) {
+            if ([] !== $deleteIds) {
                 $entities = $this->pageModel->deleteEntities($deleteIds);
 
                 $flashes[] = [

--- a/app/bundles/PageBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/CampaignSubscriber.php
@@ -67,7 +67,7 @@ final readonly class CampaignSubscriber implements EventSubscriberInterface
         $event->addDecision('page.devicehit', $deviceHitTrigger);
 
         $trackingServices = $this->trackingHelper->getEnabledServices();
-        if (!empty($trackingServices)) {
+        if ([] !== $trackingServices) {
             $action = [
                 'label'                  => 'mautic.page.tracking.pixel.event.send',
                 'description'            => 'mautic.page.tracking.pixel.event.send_desc',

--- a/app/bundles/PageBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/SearchSubscriber.php
@@ -38,7 +38,7 @@ final readonly class SearchSubscriber implements EventSubscriberInterface
             '@MauticPage/SubscribedEvents/Search/global.html.twig'
         );
 
-        if (!empty($results)) {
+        if ([] !== $results) {
             $event->addResults('mautic.page.pages', $results);
         }
     }

--- a/app/bundles/PageBundle/Form/Type/PageType.php
+++ b/app/bundles/PageBundle/Form/Type/PageType.php
@@ -345,7 +345,7 @@ final class PageType extends AbstractType
         ];
 
         $draftActionButtons = $this->getDraftActionButtons($options['data']);
-        if (!empty($draftActionButtons)) {
+        if ([] !== $draftActionButtons) {
             $extraButtons['post_extra_buttons'] = $draftActionButtons;
         }
         $builder->add('buttons',

--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -1155,7 +1155,7 @@ class PageModel extends FormModel implements GlobalSearchInterface
                     $decoded = true;
                 }
 
-                if (is_array($query) && !empty($query)) {
+                if (is_array($query) && [] !== $query) {
                     if (isset($query['page_url'])) {
                         $pageURL = $query['page_url'];
                         if (!$decoded) {

--- a/app/bundles/PageBundle/Tests/Controller/PageControllerTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PageControllerTest.php
@@ -82,7 +82,7 @@ final class PageControllerTest extends MauticMysqlTestCase
         $this->assertResponseIsSuccessful();
 
         $sql = 'SELECT `id` FROM `'.$this->prefix.'leads`';
-        if (!empty($leadIdsBeforeTest)) {
+        if ([] !== $leadIdsBeforeTest) {
             $sql .= ' WHERE `id` NOT IN ('.implode(',', $leadIdsBeforeTest).');';
         }
         $newLeads = $this->connection->fetchAllAssociative($sql);
@@ -120,7 +120,7 @@ final class PageControllerTest extends MauticMysqlTestCase
         $this->client->request('GET', '/page-page-landingPageTrackingSecondVisit');
         $this->assertResponseIsSuccessful();
         $sql = 'SELECT `id` FROM `'.$this->prefix.'leads`';
-        if (!empty($leadIdsBeforeTest)) {
+        if ([] !== $leadIdsBeforeTest) {
             $sql .= ' WHERE `id` NOT IN ('.implode(',', $leadIdsBeforeTest).');';
         }
         $newLeadsAfterFirstVisit = $this->connection->fetchAllAssociative($sql);

--- a/app/bundles/PageBundle/Tests/Model/TrackableModelFunctionalTest.php
+++ b/app/bundles/PageBundle/Tests/Model/TrackableModelFunctionalTest.php
@@ -45,7 +45,7 @@ final class TrackableModelFunctionalTest extends MauticMysqlTestCase
             $this->assertStringContainsString($untrackedHtml, (string) $newContent);
         }
 
-        if (empty($expectedTrackedUrls)) {
+        if ([] === $expectedTrackedUrls) {
             $this->assertStringNotContainsString('{trackable=', (string) $newContent);
         } else {
             $this->assertStringContainsString('{trackable=', (string) $newContent);

--- a/app/bundles/PluginBundle/Helper/IntegrationHelper.php
+++ b/app/bundles/PluginBundle/Helper/IntegrationHelper.php
@@ -207,7 +207,7 @@ class IntegrationHelper
             }
 
             // Save newly found integrations
-            if (!empty($newIntegrations)) {
+            if ([] !== $newIntegrations) {
                 $this->integrationRepository->saveEntities($newIntegrations);
                 unset($newIntegrations);
             }

--- a/app/bundles/PluginBundle/Integration/AbstractIntegration.php
+++ b/app/bundles/PluginBundle/Integration/AbstractIntegration.php
@@ -1469,7 +1469,7 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
             $leadFields = $availableIntegrationFields;
         }
 
-        if (!empty($leadFields)) {
+        if ([] !== $leadFields) {
             $cleanup($submittedFields, $leadFields, $mauticLeadFields, 'leadFields');
             $featureSettings['leadFields'] = $submittedFields;
         }
@@ -2373,7 +2373,7 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
             }
         }
 
-        if (!empty($formattedFields)) {
+        if ([] !== $formattedFields) {
             $fields = $formattedFields;
         }
 

--- a/app/bundles/PointBundle/Controller/PointController.php
+++ b/app/bundles/PointBundle/Controller/PointController.php
@@ -451,7 +451,7 @@ final class PointController extends AbstractFormController
             }
 
             // Delete everything we are able to
-            if (!empty($deleteIds)) {
+            if ([] !== $deleteIds) {
                 $entities = $this->pointModel->deleteEntities($deleteIds);
 
                 $flashes[] = [

--- a/app/bundles/PointBundle/Controller/TriggerController.php
+++ b/app/bundles/PointBundle/Controller/TriggerController.php
@@ -189,7 +189,7 @@ final class TriggerController extends FormController
 
         // set added/updated events
         $addEvents     = $session->get('mautic.point.'.$sessionId.'.triggerevents.modified', []);
-        if (!empty($triggerEvents)) {
+        if ([] !== $triggerEvents) {
             $addEvents += $triggerEvents;
             $session->set('mautic.point.'.$sessionId.'.triggerevents.modified', $triggerEvents);
         }
@@ -208,7 +208,7 @@ final class TriggerController extends FormController
                     $events = array_diff_key($addEvents, array_flip($deletedEvents));
 
                     // make sure that at least one action is selected
-                    if (empty($events)) {
+                    if ([] === $events) {
                         // set the error
                         $form->addError(new FormError(
                             $this->translator->trans('mautic.core.value.required', [], 'validators')
@@ -257,7 +257,7 @@ final class TriggerController extends FormController
                     ],
                 ]);
             }
-        } elseif (!empty($triggerEvents)) {
+        } elseif ([] !== $triggerEvents) {
             // The clone part, no need to clear session here.
             $addEvents     = $triggerEvents;
             $deletedEvents = [];
@@ -354,7 +354,7 @@ final class TriggerController extends FormController
 
                 if ($valid = $this->isFormValid($form)) {
                     // make sure that at least one field is selected
-                    if (empty($events)) {
+                    if ([] === $events) {
                         // set the error
                         $form->addError(new FormError(
                             $this->translator->trans('mautic.core.value.required', [], 'validators')
@@ -590,7 +590,7 @@ final class TriggerController extends FormController
             }
 
             // Delete everything we are able to
-            if (!empty($deleteIds)) {
+            if ([] !== $deleteIds) {
                 $entities = $this->triggerModel->deleteEntities($deleteIds);
 
                 $flashes[] = [

--- a/app/bundles/PointBundle/Entity/LeadPointLogRepository.php
+++ b/app/bundles/PointBundle/Entity/LeadPointLogRepository.php
@@ -33,7 +33,7 @@ final class LeadPointLogRepository extends CommonRepository
             ->set('lead_id', (int) $toLeadId)
             ->where('lead_id = '.(int) $fromLeadId);
 
-        if (!empty($actions)) {
+        if ([] !== $actions) {
             $q->andWhere(
                 $q->expr()->notIn('point_id', ':actions')
             )

--- a/app/bundles/PointBundle/Entity/LeadTriggerLogRepository.php
+++ b/app/bundles/PointBundle/Entity/LeadTriggerLogRepository.php
@@ -33,7 +33,7 @@ final class LeadTriggerLogRepository extends CommonRepository
             ->set('lead_id', (int) $toLeadId)
             ->where('lead_id = '.(int) $fromLeadId);
 
-        if (!empty($events)) {
+        if ([] !== $events) {
             $q->andWhere(
                 $q->expr()->notIn('event_id', ':events')
             )

--- a/app/bundles/PointBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/PointBundle/EventListener/SearchSubscriber.php
@@ -46,7 +46,7 @@ final readonly class SearchSubscriber implements EventSubscriberInterface
             '@MauticPoint/SubscribedEvents/Search/global_point.html.twig'
         );
 
-        if (!empty($results)) {
+        if ([] !== $results) {
             $event->addResults('mautic.point.actions.header.index', $results);
         }
     }
@@ -60,7 +60,7 @@ final readonly class SearchSubscriber implements EventSubscriberInterface
             '@MauticPoint/SubscribedEvents/Search/global_group.html.twig'
         );
 
-        if (!empty($results)) {
+        if ([] !== $results) {
             $event->addResults('mautic.point.group.header.index', $results);
         }
     }
@@ -74,7 +74,7 @@ final readonly class SearchSubscriber implements EventSubscriberInterface
             '@MauticPoint/SubscribedEvents/Search/global_trigger.html.twig'
         );
 
-        if (!empty($results)) {
+        if ([] !== $results) {
             $event->addResults('mautic.point.trigger.header.index', $results);
         }
     }

--- a/app/bundles/PointBundle/Model/PointModel.php
+++ b/app/bundles/PointBundle/Model/PointModel.php
@@ -299,7 +299,7 @@ class PointModel extends CommonFormModel implements GlobalSearchInterface, Reset
             }
         }
 
-        if (!empty($persist)) {
+        if ([] !== $persist) {
             $this->pointRepository->saveEntities($persist);
             $this->pointRepository->detachEntities($persist);
         }

--- a/app/bundles/PointBundle/Model/TriggerModel.php
+++ b/app/bundles/PointBundle/Model/TriggerModel.php
@@ -154,7 +154,7 @@ class TriggerModel extends CommonFormModel implements GlobalSearchInterface
                 if (!$isNew) {
                     // get a list of leads that has already had this event applied
                     $leadIds = $this->triggerEventRepository->getLeadsForEvent($event->getId());
-                    if (!empty($leadIds)) {
+                    if ([] !== $leadIds) {
                         $args['filter']['force'][] = [
                             'column' => 'l.id',
                             'expr'   => 'notIn',
@@ -180,7 +180,7 @@ class TriggerModel extends CommonFormModel implements GlobalSearchInterface
                 }
             }
 
-            if (!empty($persist)) {
+            if ([] !== $persist) {
                 $this->triggerEventRepository->saveEntities($persist);
             }
         }
@@ -275,7 +275,7 @@ class TriggerModel extends CommonFormModel implements GlobalSearchInterface
      */
     public function getEvents(): array
     {
-        if (empty($this->cachedEvents)) {
+        if ([] === $this->cachedEvents) {
             $event = new TriggerBuilderEvent($this->translator);
             $this->dispatcher->dispatch($event, PointEvents::TRIGGER_ON_BUILD);
             $this->cachedEvents = $event->getEvents();
@@ -393,7 +393,7 @@ class TriggerModel extends CommonFormModel implements GlobalSearchInterface
         $groupEvents  = $this->triggerEventRepository->getPublishedByGroupScore($lead->getGroupScores());
         $events       = array_merge($events, $groupEvents);
 
-        if (!empty($events)) {
+        if ([] !== $events) {
             // get a list of actions that has already been applied to this lead
             $appliedEvents = $this->triggerEventRepository->getLeadTriggeredEvents($lead->getId());
             $ipAddress     = $this->ipLookupHelper->getIpAddress();
@@ -415,7 +415,7 @@ class TriggerModel extends CommonFormModel implements GlobalSearchInterface
                 }
             }
 
-            if (!empty($persist)) {
+            if ([] !== $persist) {
                 $this->triggerEventRepository->saveEntities($persist);
                 $this->triggerEventRepository->detachEntities($persist);
             }

--- a/app/bundles/ProjectBundle/Controller/ProjectController.php
+++ b/app/bundles/ProjectBundle/Controller/ProjectController.php
@@ -451,7 +451,7 @@ final class ProjectController extends AbstractFormController
             }
 
             // Delete everything we are able to
-            if (!empty($deleteIds)) {
+            if ([] !== $deleteIds) {
                 try {
                     $entities = $projectModel->deleteEntities($deleteIds);
                 } catch (ForeignKeyConstraintViolationException) {

--- a/app/bundles/ProjectBundle/Service/ProjectEntityLoaderService.php
+++ b/app/bundles/ProjectBundle/Service/ProjectEntityLoaderService.php
@@ -180,7 +180,7 @@ final class ProjectEntityLoaderService
      */
     private function getEntityTypes(): array
     {
-        if (!empty($this->entityTypesCache)) {
+        if ([] !== $this->entityTypesCache) {
             return $this->entityTypesCache;
         }
 

--- a/app/bundles/ReportBundle/Builder/MauticReportBuilder.php
+++ b/app/bundles/ReportBundle/Builder/MauticReportBuilder.php
@@ -552,7 +552,7 @@ final class MauticReportBuilder implements ReportBuilderInterface
             $filter['value']
         );
 
-        if (empty($conditions)) {
+        if ([] === $conditions) {
             return null;
         }
 

--- a/app/bundles/ReportBundle/Controller/ReportController.php
+++ b/app/bundles/ReportBundle/Controller/ReportController.php
@@ -256,7 +256,7 @@ final class ReportController extends FormController
             }
 
             // Delete everything we are able to
-            if (!empty($deleteIds)) {
+            if ([] !== $deleteIds) {
                 $entities = $this->reportModel->deleteEntities($deleteIds);
 
                 $flashes[] = [

--- a/app/bundles/ReportBundle/Crate/ReportDataResult.php
+++ b/app/bundles/ReportBundle/Crate/ReportDataResult.php
@@ -131,7 +131,7 @@ final class ReportDataResult
      */
     public function getTotalsToExport(FormatterHelper $formatterHelper): array
     {
-        if (empty($this->totals)) {
+        if ([] === $this->totals) {
             return [];
         }
 

--- a/app/bundles/ReportBundle/Entity/Report.php
+++ b/app/bundles/ReportBundle/Entity/Report.php
@@ -404,7 +404,7 @@ class Report extends FormEntity implements SchedulerInterface, UuidInterface
             }
         }
 
-        if (empty($values)) {
+        if ([] === $values) {
             throw new \UnexpectedValueException("Column {$column} doesn't have any filter.");
         }
 

--- a/app/bundles/ReportBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/ReportBundle/EventListener/SearchSubscriber.php
@@ -38,7 +38,7 @@ final readonly class SearchSubscriber implements EventSubscriberInterface
             '@MauticReport/SubscribedEvents/Search/global.html.twig'
         );
 
-        if (!empty($results)) {
+        if ([] !== $results) {
             $event->addResults('mautic.report.reports', $results);
         }
     }

--- a/app/bundles/ReportBundle/Model/CsvExporter.php
+++ b/app/bundles/ReportBundle/Model/CsvExporter.php
@@ -40,7 +40,7 @@ class CsvExporter
         if ($reportDataResult->isLastPage()) {
             $totalsRow = $reportDataResult->getTotalsToExport($this->formatterHelper);
 
-            if (!empty($totalsRow)) {
+            if ([] !== $totalsRow) {
                 $this->putTotals($totalsRow, $handle);
             }
         }

--- a/app/bundles/ReportBundle/Model/ExcelExporter.php
+++ b/app/bundles/ReportBundle/Model/ExcelExporter.php
@@ -60,7 +60,7 @@ class ExcelExporter
 
             // Add totals to export
             $totalsRow = $reportDataResult->getTotalsToExport($this->formatterHelper);
-            if (!empty($totalsRow)) {
+            if ([] !== $totalsRow) {
                 $this->putTotals($totalsRow, $objPHPExcelSheet, 'A'.++$rowCount);
             }
 

--- a/app/bundles/SmsBundle/Broadcast/BroadcastExecutioner.php
+++ b/app/bundles/SmsBundle/Broadcast/BroadcastExecutioner.php
@@ -50,7 +50,7 @@ final class BroadcastExecutioner
     private function send(Sms $sms): void
     {
         $contacts = $this->broadcastQuery->getPendingContacts($sms, $this->contactLimiter);
-        while (!empty($contacts)) {
+        while ([] !== $contacts) {
             $reduction = 0;
             $leads     = [];
             foreach ($contacts as $contact) {

--- a/app/bundles/SmsBundle/Controller/SmsController.php
+++ b/app/bundles/SmsBundle/Controller/SmsController.php
@@ -683,7 +683,7 @@ final class SmsController extends FormController
             }
 
             // Delete everything we are able to
-            if (!empty($deleteIds)) {
+            if ([] !== $deleteIds) {
                 $entities = $this->smsModel->deleteEntities($deleteIds);
 
                 $flashes[] = [

--- a/app/bundles/SmsBundle/Entity/SmsRepository.php
+++ b/app/bundles/SmsBundle/Entity/SmsRepository.php
@@ -255,7 +255,7 @@ class SmsRepository extends CommonRepository
             $q->andWhere($q->expr()->isNull('e.translationParent'));
         }
 
-        if (!empty($ignoreIds)) {
+        if ([] !== $ignoreIds) {
             $q->andWhere($q->expr()->notIn('e.id', ':smsIds'))
                 ->setParameter('smsIds', $ignoreIds);
         }

--- a/app/bundles/SmsBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/SmsBundle/EventListener/SearchSubscriber.php
@@ -35,7 +35,7 @@ final readonly class SearchSubscriber implements EventSubscriberInterface
             '@MauticSms/SubscribedEvents/Search/global.html.twig'
         );
 
-        if (!empty($results)) {
+        if ([] !== $results) {
             $event->addResults('mautic.sms.smses.header', $results);
         }
     }

--- a/app/bundles/SmsBundle/Model/SmsModel.php
+++ b/app/bundles/SmsBundle/Model/SmsModel.php
@@ -241,7 +241,7 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface, GlobalSear
         $contacts = $dncEvent->getContacts(); // The contacts param is reset here too, no?
 
         // Check if any contacts remain. If not, return early.
-        if (empty($contacts)) {
+        if ([] === $contacts) {
             return $results;
         }
 

--- a/app/bundles/StageBundle/Controller/StageController.php
+++ b/app/bundles/StageBundle/Controller/StageController.php
@@ -586,7 +586,7 @@ final class StageController extends AbstractFormController
             }
 
             // Delete everything we are able to
-            if (!empty($deleteIds)) {
+            if ([] !== $deleteIds) {
                 $entities = $this->stageModel->deleteEntities($deleteIds);
 
                 $flashes[] = [

--- a/app/bundles/StageBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/StageBundle/EventListener/SearchSubscriber.php
@@ -38,7 +38,7 @@ final readonly class SearchSubscriber implements EventSubscriberInterface
             '@MauticStage/SubscribedEvents/Search/global.html.twig'
         );
 
-        if (!empty($results)) {
+        if ([] !== $results) {
             $event->addResults('mautic.stage.actions.header.index', $results);
         }
     }

--- a/app/bundles/UserBundle/Controller/RoleController.php
+++ b/app/bundles/UserBundle/Controller/RoleController.php
@@ -613,7 +613,7 @@ final class RoleController extends FormController
             }
 
             // Delete everything we are able to
-            if (!empty($deleteIds)) {
+            if ([] !== $deleteIds) {
                 $entities = $model->deleteEntities($deleteIds);
 
                 $flashes[] = [

--- a/app/bundles/UserBundle/Controller/UserController.php
+++ b/app/bundles/UserBundle/Controller/UserController.php
@@ -691,7 +691,7 @@ final class UserController extends FormController
             }
 
             // Delete everything we are able to
-            if (!empty($deleteIds)) {
+            if ([] !== $deleteIds) {
                 $entities = $this->userModel->deleteEntities($deleteIds);
 
                 $flashes[] = [

--- a/app/bundles/UserBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/UserBundle/EventListener/SearchSubscriber.php
@@ -41,7 +41,7 @@ final readonly class SearchSubscriber implements EventSubscriberInterface
             '@MauticUser/SubscribedEvents/Search/global_user.html.twig'
         );
 
-        if (!empty($results)) {
+        if ([] !== $results) {
             $event->addResults('mautic.user.users', $results);
         }
     }
@@ -55,7 +55,7 @@ final readonly class SearchSubscriber implements EventSubscriberInterface
             '@MauticUser/SubscribedEvents/Search/global_role.html.twig'
         );
 
-        if (!empty($results)) {
+        if ([] !== $results) {
             $event->addResults('mautic.user.roles', $results);
         }
     }

--- a/app/bundles/UserBundle/Model/RoleModel.php
+++ b/app/bundles/UserBundle/Model/RoleModel.php
@@ -81,7 +81,7 @@ final class RoleModel extends FormModel implements GlobalSearchInterface
         }
 
         // set permissions if applicable and if the user is not an admin
-        $permissions = (!$entity->isAdmin() && !empty($rawPermissions)) ?
+        $permissions = (!$entity->isAdmin() && [] !== $rawPermissions) ?
             $this->security->generatePermissions($rawPermissions) :
             [];
 

--- a/plugins/MauticCrmBundle/Api/ConnectwiseApi.php
+++ b/plugins/MauticCrmBundle/Api/ConnectwiseApi.php
@@ -52,7 +52,7 @@ class ConnectwiseApi extends CrmApi
                 }
             }
         }
-        if (!empty($errors)) {
+        if ([] !== $errors) {
             throw new ApiErrorException(implode(' ', $errors), $code);
         }
 

--- a/plugins/MauticCrmBundle/Api/SalesforceApi.php
+++ b/plugins/MauticCrmBundle/Api/SalesforceApi.php
@@ -253,7 +253,7 @@ final class SalesforceApi extends CrmApi
         $mActivityObjectName = $namespace.'mautic_timeline__c';
         $activityData        = [];
 
-        if (!empty($activity)) {
+        if ([] !== $activity) {
             foreach ($activity as $sfId => $records) {
                 foreach ($records['records'] as $record) {
                     $body = [
@@ -279,7 +279,7 @@ final class SalesforceApi extends CrmApi
                 }
             }
 
-            if (!empty($activityData)) {
+            if ([] !== $activityData) {
                 $request              = [];
                 $request['allOrNone'] = 'false';
                 $chunked              = array_chunk($activityData, 25);
@@ -445,7 +445,7 @@ final class SalesforceApi extends CrmApi
     public function checkCampaignMembership($campaignId, $object, array $people): array
     {
         $campaignMembers = [];
-        if (!empty($people)) {
+        if ([] !== $people) {
             $idField = "{$object}Id";
             $query   = "Select Id, {$idField} from CampaignMember where CampaignId = '".$campaignId
                 ."' and {$idField} in ('".implode("','", $people)."')";

--- a/plugins/MauticCrmBundle/Api/SugarcrmApi.php
+++ b/plugins/MauticCrmBundle/Api/SugarcrmApi.php
@@ -314,7 +314,7 @@ final class SugarcrmApi extends CrmApi
         $s7_records = [];
         // Send activities and get back sugar activities id
 
-        if (!empty($activity)) {
+        if ([] !== $activity) {
             foreach ($activity as $sugarId => $records) {
                 foreach ($records['records'] as $record) {
                     $rec   = [];
@@ -580,7 +580,7 @@ final class SugarcrmApi extends CrmApi
         if ('6' == $tokenData['version']) {
             $result = [];
 
-            if (!empty($fields)) {
+            if ([] !== $fields) {
                 $q   = '';
                 $qry = [];
                 if (isset($query['start'])) {
@@ -637,7 +637,7 @@ final class SugarcrmApi extends CrmApi
                 return $this->request('get_entry_list', $parameters, 'GET', $object);
             }
         } else {
-            if (!empty($fields)) {
+            if ([] !== $fields) {
                 $q      = '';
                 $qry    = [];
                 $filter = [];

--- a/plugins/MauticCrmBundle/Api/VtigerApi.php
+++ b/plugins/MauticCrmBundle/Api/VtigerApi.php
@@ -19,7 +19,7 @@ final class VtigerApi extends CrmApi
             'elementType' => $element,
         ];
 
-        if (!empty($elementData)) {
+        if ([] !== $elementData) {
             $parameters['element'] = json_encode($elementData);
         }
         $response = $this->integration->makeRequest($request_url, $parameters, $method);

--- a/plugins/MauticCrmBundle/EventListener/LeadListSubscriber.php
+++ b/plugins/MauticCrmBundle/EventListener/LeadListSubscriber.php
@@ -63,7 +63,7 @@ final readonly class LeadListSubscriber implements EventSubscriberInterface
             }
         }
 
-        if (!empty($choices)) {
+        if ([] !== $choices) {
             $config = [
                 'label'      => $this->translator->trans('mautic.plugin.integration.campaign_members'),
                 'properties' => ['type' => 'select', 'list' => $choices],

--- a/plugins/MauticCrmBundle/Integration/ConnectwiseIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/ConnectwiseIntegration.php
@@ -588,7 +588,7 @@ class ConnectwiseIntegration extends CrmAbstractIntegration
                 foreach ($cwContactExists as $cwContact) { // go through array of contacts found since Connectwise lets you duplicate records with same email address
                     $mappedData = $this->getMappedFields($object, $lead, $personFound, $config, $cwContact);
 
-                    if (!empty($mappedData)) {
+                    if ([] !== $mappedData) {
                         $personData = $this->getApiHelper()->updateContact($mappedData, $cwContact['id']);
                     } else {
                         $personData['id'] = $cwContact['id'];
@@ -712,7 +712,7 @@ class ConnectwiseIntegration extends CrmAbstractIntegration
                 if ($config['update']) {
                     $communicationItems = array_merge($config['communicationItems'], $communicationItems);
                 }
-                if (!empty($communicationItems)) {
+                if ([] !== $communicationItems) {
                     $matched[$integrationKey] = $communicationItems;
                 }
             }
@@ -854,7 +854,7 @@ class ConnectwiseIntegration extends CrmAbstractIntegration
 
                 $contactsToFetch = array_diff_key($recordList, array_flip($existingContactsIds));
 
-                if (!empty($contactsToFetch)) {
+                if ([] !== $contactsToFetch) {
                     $listOfContactsToFetch = implode(',', array_keys($contactsToFetch));
                     $params['Ids']         = $listOfContactsToFetch;
 
@@ -896,7 +896,7 @@ class ConnectwiseIntegration extends CrmAbstractIntegration
         // first find existing campaign members.
         foreach ($contacts as $contact) {
             $existingCampaignMember = $this->integrationEntityModel->getSyncedRecords($campaignMemberObject, $this->getName(), $campaignId, $contact['internal_entity_id']);
-            if (empty($existingCampaignMember)) {
+            if ([] === $existingCampaignMember) {
                 $persistEntities[] = $this->createIntegrationEntity(
                     $campaignMemberObject->getType(),
                     $campaignId,

--- a/plugins/MauticCrmBundle/Integration/DynamicsIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/DynamicsIntegration.php
@@ -315,7 +315,7 @@ final class DynamicsIntegration extends CrmAbstractIntegration
             if ($this->isAuthorized()) {
                 $object = 'contacts';
                 $integrationId = $this->integrationEntityRepository->getIntegrationsEntityId('Dynamics', $object, 'lead', $lead->getId());
-                if (!empty($integrationId)) {
+                if ([] !== $integrationId) {
                     $integrationEntityId = $integrationId[0]['integration_entity_id'];
                     $this->getApiHelper()->updateLead($mappedData, $integrationEntityId);
 
@@ -697,7 +697,7 @@ final class DynamicsIntegration extends CrmAbstractIntegration
             unset($leadFields[$key]);
         }
 
-        if (empty($leadFields)) {
+        if ([] === $leadFields) {
             return [0, 0, 0];
         }
 

--- a/plugins/MauticCrmBundle/Integration/HubspotIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/HubspotIntegration.php
@@ -562,7 +562,7 @@ class HubspotIntegration extends CrmAbstractIntegration
 
             if (!empty($leadData['vid'])) {
                 $integrationId     = $this->integrationEntityRepository->getIntegrationsEntityId($this->getName(), $object, 'lead', $lead->getId());
-                $integrationEntity = (empty($integrationId)) ?
+                $integrationEntity = ([] === $integrationId) ?
                     $this->createIntegrationEntity(
                         $object,
                         $leadData['vid'],

--- a/plugins/MauticCrmBundle/Integration/Salesforce/QueryBuilder.php
+++ b/plugins/MauticCrmBundle/Integration/Salesforce/QueryBuilder.php
@@ -11,7 +11,7 @@ final class QueryBuilder
      */
     public static function getLeadQuery(array $fields, array $ids): string
     {
-        if (empty($ids)) {
+        if ([] === $ids) {
             throw new NoObjectsToFetchException();
         }
 
@@ -26,7 +26,7 @@ final class QueryBuilder
      */
     public static function getContactQuery(array $fields, array $ids): string
     {
-        if (empty($ids)) {
+        if ([] === $ids) {
             throw new NoObjectsToFetchException();
         }
 

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -691,7 +691,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
         $mappedData = $this->mapContactDataForPush($lead, $config);
 
         // No fields are mapped so bail
-        if (empty($mappedData)) {
+        if ([] === $mappedData) {
             return false;
         }
 
@@ -750,7 +750,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
                     if (isset($personData['Id'])) {
                         $integrationId = $this->integrationEntityRepository->getIntegrationsEntityId('Salesforce', $object, 'lead', $lead->getId());
 
-                        $integrationEntity = (empty($integrationId))
+                        $integrationEntity = ([] === $integrationId)
                             ? $this->createIntegrationEntity($object, $personData['Id'], 'lead', $lead->getId(), [], false)
                             :
                             $this->em->getReference(IntegrationEntity::class, $integrationId[0]['id']);
@@ -1026,7 +1026,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
                         $start,
                         $limit
                     );
-                    while (!empty($salesForceIds)) {
+                    while ([] !== $salesForceIds) {
                         $executed += count($salesForceIds);
 
                         // Extract a list of lead Ids
@@ -1065,7 +1065,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
                             }
                         }
 
-                        if (!empty($salesForceLeadData)) {
+                        if ([] !== $salesForceLeadData) {
                             $apiHelper->createLeadActivity($salesForceLeadData, $object);
                         } else {
                             $this->logger->debug('SALESFORCE: No contact activity to sync');
@@ -1750,7 +1750,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
                         $lead = $this->leadModel->getEntity($entity['internal_entity_id']);
                         if ($lead) {
                             $companies = $this->leadModel->getCompanies($lead);
-                            if (!empty($companies)) {
+                            if ([] !== $companies) {
                                 foreach ($companies as $companyData) {
                                     if ($companyData['is_primary']) {
                                         $company = $this->companyModel->getEntity($companyData['company_id']);
@@ -2766,7 +2766,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
                 break;
             }
 
-            if (!empty($sfEntityRecords) && isset($sfEntityRecords['records'])) {
+            if ([] !== $sfEntityRecords && isset($sfEntityRecords['records'])) {
                 $this->prepareMauticCompaniesToUpdate(
                     $mauticData,
                     $checkCompaniesInSF,
@@ -3025,7 +3025,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
 
         $resultsByName = $this->getApiHelper()->getCompaniesByName($searchForNames, $requiredFieldString);
         $resultsById   = [];
-        if (!empty($searchForIds)) {
+        if ([] !== $searchForIds) {
             $resultsById = $this->getApiHelper()->getCompaniesById($searchForIds, $requiredFieldString);
 
             // mark as deleleted

--- a/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
@@ -450,7 +450,7 @@ final class SugarcrmIntegration extends CrmAbstractIntegration
                         $limit
                     );
 
-                    while (!empty($sugarIds)) {
+                    while ([] !== $sugarIds) {
                         $executed += count($sugarIds);
 
                         // Extract a list of lead Ids
@@ -482,7 +482,7 @@ final class SugarcrmIntegration extends CrmAbstractIntegration
                             }
                         }
 
-                        if (!empty($sugarLeadData)) {
+                        if ([] !== $sugarLeadData) {
                             $apiHelper->createLeadActivity($sugarLeadData, $object);
                         }
 
@@ -698,7 +698,7 @@ final class SugarcrmIntegration extends CrmAbstractIntegration
                     }
                 }
             }
-            if (!empty($assignedUserIds)) {
+            if ([] !== $assignedUserIds) {
                 $assignedUserIds            = array_unique($assignedUserIds);
                 $onwerEmailByAssignedUserId = $this->getApiHelper()->getEmailBySugarUserId(['ids' => $assignedUserIds]);
             }
@@ -720,7 +720,7 @@ final class SugarcrmIntegration extends CrmAbstractIntegration
                     }
                 }
             }
-            if (!empty($checkEmailsInSugar)) {
+            if ([] !== $checkEmailsInSugar) {
                 $sugarLeads = $this->getApiHelper()->getLeads(['checkemail_contacts' => $checkEmailsInSugar, 'offset' => 0, 'max_results' => 1000], 'Contacts');
                 if (isset($sugarLeads[$RECORDS_LIST_NAME])) {
                     foreach ($sugarLeads[$RECORDS_LIST_NAME] as $record) {
@@ -779,7 +779,7 @@ final class SugarcrmIntegration extends CrmAbstractIntegration
                     continue; // Lead email is already in Sugar Contacts. Do not carry on
                 }
 
-                if (!empty($dataObject)) {
+                if ([] !== $dataObject) {
                     if ('Leads' == $object || 'Contacts' == $object) {
                         if (isset($dataObject['assigned_user_id__'.$object])) {
                             $auid = $dataObject['assigned_user_id__'.$object];
@@ -997,14 +997,14 @@ final class SugarcrmIntegration extends CrmAbstractIntegration
         // Check if lead has alredy been synched
         // Check if it is a sugar CRM alredy synched lead
         $integrationId = $this->integrationEntityRepository->getIntegrationsEntityId('Sugarcrm', $object, 'lead', $lead->getId());
-        if (empty($integrationId)) {
+        if ([] === $integrationId) {
             // Check if it is a sugar CRM alredy synched lead
             $integrationId = $this->integrationEntityRepository->getIntegrationsEntityId('Sugarcrm', 'Contacts', 'lead', $lead->getId());
-            if (!empty($integrationId)) {
+            if ([] !== $integrationId) {
                 $object = 'Contacts';
             }
         }
-        if (!empty($integrationId)) {
+        if ([] !== $integrationId) {
             $integrationEntity = $this->integrationEntityRepository->getEntity($integrationId[0]['id']);
             $lastSyncDate      = $integrationEntity->getLastSyncDate();
             $addedSyncDate     = $integrationEntity->getDateAdded();
@@ -1037,7 +1037,7 @@ final class SugarcrmIntegration extends CrmAbstractIntegration
             return false;
         }
 
-        if (!empty($integrationId)) {
+        if ([] !== $integrationId) {
             $integrationEntity = $this->integrationEntityRepository->findOneBy(
                 [
                     'integration'       => 'Sugarcrm',
@@ -1059,7 +1059,7 @@ final class SugarcrmIntegration extends CrmAbstractIntegration
                 }
                 $createdLeadData = $this->getApiHelper()->createLead($mappedData[$object], $lead);
                 if (isset($createdLeadData['id'])) {
-                    if (empty($integrationId)) {
+                    if ([] === $integrationId) {
                         $integrationEntity = new IntegrationEntity();
                         $integrationEntity->setDateAdded(new \DateTime());
                         $integrationEntity->setLastSyncDate(new \DateTime());
@@ -1228,7 +1228,7 @@ final class SugarcrmIntegration extends CrmAbstractIntegration
         }
         /** @var SugarcrmApi $apiHelper */
         $apiHelper = $this->getApiHelper();
-        if (!empty($mauticData)) {
+        if ([] !== $mauticData) {
             $result = $apiHelper->syncLeadsToSugar($mauticData);
         }
 
@@ -1250,7 +1250,7 @@ final class SugarcrmIntegration extends CrmAbstractIntegration
         $dncEntries   = $this->doNotContactModel->getDncRepo()->getEntriesByLeadAndChannel($leadEntity, 'email');
         $sugarDncKeys = array_combine(array_values($this->sugarDncKeys), $this->sugarDncKeys);
         foreach ($dncEntries as $dncEntry) {
-            if (empty($sugarDncKeys)) {
+            if ([] === $sugarDncKeys) {
                 continue;
             }
             // If DNC exists set to 1
@@ -1450,7 +1450,7 @@ final class SugarcrmIntegration extends CrmAbstractIntegration
                 }
             }
 
-            if (!empty($body)) {
+            if ([] !== $body) {
                 $id = $lead['internal_entity_id'].'-'.$object.(!empty($lead['id']) ? '-'.$lead['id'] : '');
 
                 $body[] = ['name' => 'reference_id', 'value' => $id];
@@ -1650,7 +1650,7 @@ final class SugarcrmIntegration extends CrmAbstractIntegration
 
         $contactFields = $this->cleanSugarData($config, array_keys($config['leadFields']), 'Contacts');
         $leadFields    = $this->cleanSugarData($config, array_keys($config['leadFields']), 'Leads');
-        if (!empty($contactFields)) {
+        if ([] !== $contactFields) {
             foreach ($fields['Contacts'] as $key => $field) {
                 if ($field['required']) {
                     $required[$key] = $field;
@@ -1661,7 +1661,7 @@ final class SugarcrmIntegration extends CrmAbstractIntegration
             ];
             $fieldMappings['Contacts']['create'] = $contactFields;
         }
-        if (!empty($leadFields)) {
+        if ([] !== $leadFields) {
             foreach ($fields['Leads'] as $key => $field) {
                 if ($field['required']) {
                     $required[$key] = $field;

--- a/plugins/MauticCrmBundle/Integration/ZohoIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/ZohoIntegration.php
@@ -789,7 +789,7 @@ final class ZohoIntegration extends CrmAbstractIntegration
         if ($key = array_search('mauticContactIsContactableByEmail', $leadFields)) {
             unset($leadFields[$key]);
         }
-        if (empty($leadFields)) {
+        if ([] === $leadFields) {
             return [0, 0, 0];
         }
 
@@ -1031,7 +1031,7 @@ final class ZohoIntegration extends CrmAbstractIntegration
 
         try {
             if ($this->isAuthorized()) {
-                if (!empty($existingPerson) && empty($integrationId)) {
+                if ([] !== $existingPerson && [] === $integrationId) {
                     $this->createIntegrationEntity($zObject, $existingPerson['id'], 'lead', $lead->getId());
 
                     $mapper
@@ -1039,7 +1039,7 @@ final class ZohoIntegration extends CrmAbstractIntegration
                         ->setContact($lead->getProfileFields())
                         ->map($lead->getId(), $existingPerson['id']);
                     $this->updateContactInZoho($mapper, $zObject, $counter, $errorCounter);
-                } elseif (!empty($existingPerson) && !empty($integrationId)) { // contact exists, then update
+                } elseif ([] !== $existingPerson && [] !== $integrationId) { // contact exists, then update
                     $mapper
                         ->setMappedFields($fieldsToUpdate[$zObject])
                         ->setContact($lead->getProfileFields())

--- a/plugins/MauticEmailMarketingBundle/Integration/ConstantContactIntegration.php
+++ b/plugins/MauticEmailMarketingBundle/Integration/ConstantContactIntegration.php
@@ -139,12 +139,12 @@ final class ConstantContactIntegration extends EmailAbstractIntegration
                     }
                 }
 
-                if (!empty($addresses)) {
+                if ([] !== $addresses) {
                     $addresses['address_type'] = 'PERSONAL';
                     $mappedData['addresses']   = $addresses;
                 }
 
-                if (!empty($customfields)) {
+                if ([] !== $customfields) {
                     $mappedData['custom_fields'] = $customfields;
                 }
 

--- a/plugins/MauticEmailMarketingBundle/Integration/IcontactIntegration.php
+++ b/plugins/MauticEmailMarketingBundle/Integration/IcontactIntegration.php
@@ -203,7 +203,7 @@ final class IcontactIntegration extends EmailAbstractIntegration
 
                 $listId = $config['list_settings']['list'];
 
-                if (!empty($customfields)) {
+                if ([] !== $customfields) {
                     $mappedData += $customfields;
                 }
 

--- a/plugins/MauticFocusBundle/EventListener/SearchSubscriber.php
+++ b/plugins/MauticFocusBundle/EventListener/SearchSubscriber.php
@@ -35,7 +35,7 @@ final readonly class SearchSubscriber implements EventSubscriberInterface
             '@MauticFocus/SubscribedEvents/Search/global.html.twig'
         );
 
-        if (!empty($results)) {
+        if ([] !== $results) {
             $event->addResults('mautic.focus.header', $results);
         }
     }

--- a/plugins/MauticFocusBundle/Form/Type/FocusPropertiesType.php
+++ b/plugins/MauticFocusBundle/Form/Type/FocusPropertiesType.php
@@ -101,7 +101,7 @@ final class FocusPropertiesType extends AbstractType
                 break;
         }
 
-        if (!empty($choices)) {
+        if ([] !== $choices) {
             $builder->add(
                 'placement',
                 ChoiceType::class,

--- a/plugins/MauticSocialBundle/Controller/MonitoringController.php
+++ b/plugins/MauticSocialBundle/Controller/MonitoringController.php
@@ -603,7 +603,7 @@ final class MonitoringController extends FormController
             }
 
             // Delete everything we are able to
-            if (!empty($deleteIds)) {
+            if ([] !== $deleteIds) {
                 $entities = $this->monitoringModel->deleteEntities($deleteIds);
 
                 $flashes[] = [

--- a/plugins/MauticSocialBundle/Entity/TweetRepository.php
+++ b/plugins/MauticSocialBundle/Entity/TweetRepository.php
@@ -38,7 +38,7 @@ final class TweetRepository extends CommonRepository
                 ->setParameter('id', $this->currentUser->getId());
         }
 
-        if (!empty($ignoreIds)) {
+        if ([] !== $ignoreIds) {
             $qb->andWhere($qb->expr()->notIn('t.id', ':ignoreIds'))
                 ->setParameter('ignoreIds', $ignoreIds);
         }

--- a/plugins/MauticSocialBundle/Helper/TwitterCommandHelper.php
+++ b/plugins/MauticSocialBundle/Helper/TwitterCommandHelper.php
@@ -129,7 +129,7 @@ final class TwitterCommandHelper
         }
         unset($expr);
 
-        if (!empty($usersByHandles)) {
+        if ([] !== $usersByHandles) {
             $leads = $this->leadRepository->getEntities(
                 [
                     'filter' => [

--- a/plugins/MauticSocialBundle/Integration/SocialIntegration.php
+++ b/plugins/MauticSocialBundle/Integration/SocialIntegration.php
@@ -60,7 +60,7 @@ abstract class SocialIntegration extends AbstractIntegration
         if (empty($fields)) {
             $s         = $this->getName();
             $available = $this->getAvailableLeadFields($settings);
-            if (empty($available)) {
+            if ([] === $available) {
                 return [];
             }
             // create social profile fields

--- a/plugins/MauticSocialBundle/Tests/Functional/V2API/MonitoringV2ApiTest.php
+++ b/plugins/MauticSocialBundle/Tests/Functional/V2API/MonitoringV2ApiTest.php
@@ -48,7 +48,7 @@ final class MonitoringV2ApiTest extends MauticMysqlTestCase
             [],
             [],
             $headers,
-            !empty($data) ? json_encode($data) : null
+            [] !== $data ? json_encode($data) : null
         );
 
         return [

--- a/plugins/MauticTagManagerBundle/Controller/TagController.php
+++ b/plugins/MauticTagManagerBundle/Controller/TagController.php
@@ -132,7 +132,7 @@ final class TagController extends FormController
         $session->set('mautic.tagmanager.page', $page);
 
         $tagIds    = array_map(fn (Tag $tag) => $tag->getId(), iterator_to_array($items->getIterator()));
-        $tagsCount = (!empty($tagIds)) ? $this->tagRepository->countByLeads($tagIds) : [];
+        $tagsCount = ([] !== $tagIds) ? $this->tagRepository->countByLeads($tagIds) : [];
 
         $parameters = [
             'items'       => $items,
@@ -796,7 +796,7 @@ final class TagController extends FormController
             }
 
             // Delete everything we are able to
-            if (!empty($deleteIds)) {
+            if ([] !== $deleteIds) {
                 try {
                     $entities = $this->leadTagModel->deleteEntities($deleteIds);
                 } catch (ForeignKeyConstraintViolationException) {

--- a/plugins/MauticTagManagerBundle/EventListener/SearchSubscriber.php
+++ b/plugins/MauticTagManagerBundle/EventListener/SearchSubscriber.php
@@ -35,7 +35,7 @@ final readonly class SearchSubscriber implements EventSubscriberInterface
             '@MauticTagManager/SubscribedEvents/Search/global.html.twig'
         );
 
-        if (!empty($results)) {
+        if ([] !== $results) {
             $event->addResults('mautic.tagmanager.tag.header.index', $results);
         }
     }


### PR DESCRIPTION
Replace `empty()` on array values with a direct `[] === $array` comparison. `empty()` also passes for `"0"`, `0`, `null` and `false`, so the explicit comparison states the actual intent.

```diff
-        if (empty($assets)) {
+        if ([] === $assets) {
```

```diff
-        if ($this->isKeyedById($results) && empty($entities)) {
+        if ($this->isKeyedById($results) && [] === $entities) {
```

Split out of #16955 to keep the diff reviewable.
