### PR TITLE
[symfony] Validator attributes instead of loadValidatorMetadata() - step 1

### DIFF
--- a/app/bundles/ApiBundle/Entity/oAuth2/Client.php
+++ b/app/bundles/ApiBundle/Entity/oAuth2/Client.php
@@ -22,6 +22,7 @@ class Client extends BaseClient
     /**
      * @var string
      */
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.name.required')]
     protected $name;
 
     /**
@@ -41,6 +42,7 @@ class Client extends BaseClient
     /**
      * @var array<string>
      */
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.api.client.redirecturis.notblank')]
     protected array $redirectUris = [];
 
     /**
@@ -98,17 +100,6 @@ class Client extends BaseClient
             ->addJoinColumn('role_id', 'id', true, false)
             ->cascadePersist()
             ->build();
-    }
-
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addPropertyConstraint('name', new Assert\NotBlank(
-            message: 'mautic.core.name.required'
-        ));
-
-        $metadata->addPropertyConstraint('redirectUris', new Assert\NotBlank(
-            message: 'mautic.api.client.redirecturis.notblank'
-        ));
     }
 
     /**

--- a/app/bundles/ApiBundle/Entity/oAuth2/Client.php
+++ b/app/bundles/ApiBundle/Entity/oAuth2/Client.php
@@ -10,7 +10,6 @@ use Mautic\UserBundle\Entity\Role;
 use Mautic\UserBundle\Entity\User;
 use OAuth2\OAuth2;
 use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 class Client extends BaseClient
 {
@@ -22,7 +21,7 @@ class Client extends BaseClient
     /**
      * @var string
      */
-    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.name.required')]
+    #[Assert\NotBlank(message: 'mautic.core.name.required')]
     protected $name;
 
     /**
@@ -42,7 +41,7 @@ class Client extends BaseClient
     /**
      * @var array<string>
      */
-    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.api.client.redirecturis.notblank')]
+    #[Assert\NotBlank(message: 'mautic.api.client.redirecturis.notblank')]
     protected array $redirectUris = [];
 
     /**

--- a/app/bundles/AssetBundle/Entity/Asset.php
+++ b/app/bundles/AssetBundle/Entity/Asset.php
@@ -90,7 +90,7 @@ class Asset extends FormEntity implements UuidInterface
      * @var string|null
      */
     #[Groups(['asset:read', 'asset:write', 'download:read', 'email:read'])]
-    #[\Symfony\Component\Validator\Constraints\Sequentially([
+    #[Sequentially([
         new Assert\Url(message: 'mautic.asset.validation.error.url'),
         new SafeRemoteUrl(),
     ])]

--- a/app/bundles/AssetBundle/Entity/Asset.php
+++ b/app/bundles/AssetBundle/Entity/Asset.php
@@ -90,6 +90,10 @@ class Asset extends FormEntity implements UuidInterface
      * @var string|null
      */
     #[Groups(['asset:read', 'asset:write', 'download:read', 'email:read'])]
+    #[\Symfony\Component\Validator\Constraints\Sequentially([
+        new Assert\Url(message: 'mautic.asset.validation.error.url'),
+        new SafeRemoteUrl(),
+    ])]
     private $remotePath;
 
     /**
@@ -292,10 +296,6 @@ class Asset extends FormEntity implements UuidInterface
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
         $metadata->addConstraint(new Upload());
-        $metadata->addPropertyConstraint('remotePath', new Sequentially([
-            new Assert\Url(message: 'mautic.asset.validation.error.url'),
-            new SafeRemoteUrl(),
-        ]));
     }
 
     /**

--- a/app/bundles/CampaignBundle/Entity/Campaign.php
+++ b/app/bundles/CampaignBundle/Entity/Campaign.php
@@ -74,7 +74,7 @@ class Campaign extends FormEntity implements OptimisticLockInterface, UuidInterf
      * @var string|null
      */
     #[Groups(['campaign:read', 'campaign:write'])]
-    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.name.required')]
+    #[Assert\NotBlank(message: 'mautic.core.name.required')]
     private $name;
 
     /**

--- a/app/bundles/CampaignBundle/Entity/Campaign.php
+++ b/app/bundles/CampaignBundle/Entity/Campaign.php
@@ -74,6 +74,7 @@ class Campaign extends FormEntity implements OptimisticLockInterface, UuidInterf
      * @var string|null
      */
     #[Groups(['campaign:read', 'campaign:write'])]
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.name.required')]
     private $name;
 
     /**
@@ -218,13 +219,6 @@ class Campaign extends FormEntity implements OptimisticLockInterface, UuidInterf
 
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
-        $metadata->addPropertyConstraint(
-            'name',
-            new Assert\NotBlank(
-                message: 'mautic.core.name.required'
-            )
-        );
-
         $metadata->addConstraint(new NoOrphanEvents());
     }
 

--- a/app/bundles/CategoryBundle/Entity/Category.php
+++ b/app/bundles/CategoryBundle/Entity/Category.php
@@ -17,7 +17,6 @@ use Mautic\CoreBundle\Entity\UuidInterface;
 use Mautic\CoreBundle\Entity\UuidTrait;
 use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Validator\Constraints\NotBlank;
-use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 #[ApiResource(
     operations: [
@@ -51,7 +50,7 @@ class Category extends FormEntity implements UuidInterface
      * @var string
      */
     #[Groups(['category:read', 'category:write', 'stage:read', 'asset:read', 'download:read', 'event:read', 'leadcategory:read', 'notification:read', 'dynamicContent:read', 'webhook:read', 'sms:read', 'page:read', 'campaign:read', 'email:read', 'point:read', 'trigger:read', 'message:read', 'focus:read', 'form:read', 'beeFreeRow:read', 'segment:read'])]
-    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.title.required')]
+    #[NotBlank(message: 'mautic.core.title.required')]
     private $title;
 
     /**
@@ -76,7 +75,7 @@ class Category extends FormEntity implements UuidInterface
      * @var string
      */
     #[Groups(['category:read', 'category:write', 'stage:read', 'asset:read', 'download:read', 'event:read', 'leadcategory:read', 'notification:read', 'dynamicContent:read', 'webhook:read', 'sms:read', 'page:read', 'campaign:read', 'email:read', 'point:read', 'trigger:read', 'message:read', 'focus:read', 'form:read', 'beeFreeRow:read', 'segment:read'])]
-    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.value.required')]
+    #[NotBlank(message: 'mautic.core.value.required')]
     private $bundle;
 
     public static function loadMetadata(ORM\ClassMetadata $metadata): void

--- a/app/bundles/CategoryBundle/Entity/Category.php
+++ b/app/bundles/CategoryBundle/Entity/Category.php
@@ -51,6 +51,7 @@ class Category extends FormEntity implements UuidInterface
      * @var string
      */
     #[Groups(['category:read', 'category:write', 'stage:read', 'asset:read', 'download:read', 'event:read', 'leadcategory:read', 'notification:read', 'dynamicContent:read', 'webhook:read', 'sms:read', 'page:read', 'campaign:read', 'email:read', 'point:read', 'trigger:read', 'message:read', 'focus:read', 'form:read', 'beeFreeRow:read', 'segment:read'])]
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.title.required')]
     private $title;
 
     /**
@@ -75,6 +76,7 @@ class Category extends FormEntity implements UuidInterface
      * @var string
      */
     #[Groups(['category:read', 'category:write', 'stage:read', 'asset:read', 'download:read', 'event:read', 'leadcategory:read', 'notification:read', 'dynamicContent:read', 'webhook:read', 'sms:read', 'page:read', 'campaign:read', 'email:read', 'point:read', 'trigger:read', 'message:read', 'focus:read', 'form:read', 'beeFreeRow:read', 'segment:read'])]
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.value.required')]
     private $bundle;
 
     public static function loadMetadata(ORM\ClassMetadata $metadata): void
@@ -99,23 +101,6 @@ class Category extends FormEntity implements UuidInterface
             ->build();
 
         static::addUuidField($builder);
-    }
-
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addPropertyConstraint(
-            'title',
-            new NotBlank(
-                message: 'mautic.core.title.required'
-            )
-        );
-
-        $metadata->addPropertyConstraint(
-            'bundle',
-            new NotBlank(
-                message: 'mautic.core.value.required'
-            )
-        );
     }
 
     /**

--- a/app/config/config.php
+++ b/app/config/config.php
@@ -79,7 +79,7 @@ $container->loadFromExtension('framework', [
     'form'            => null,
     'csrf_protection' => true,
     'validation'      => [
-        'enable_attributes' => false,
+        'enable_attributes' => true,
     ],
     'default_locale' => '%mautic.locale%',
     'translator'     => [


### PR DESCRIPTION
Moves validation rules from `loadValidatorMetadata()` into native PHP attributes on the properties themselves. The rules and messages are unchanged, only their location is.

`app/config/config.php` enables `enable_attributes` for the validator, which is required for the attributes to be picked up.

```diff
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.name.required')]
     private ?string $name        = '';

-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addPropertyConstraint('name', new Assert\NotBlank(message: 'mautic.core.name.required'));
-    }
```

Covered entities: Api, Asset, Campaign, Category, Channel, Dashboard, DynamicContent, Report, Email, Form, Page, Lead (Company, Import, LeadField, LeadList), Point, Stage, User, Role and Webhook.

This PR merges the previously split #16960, #16961, #16962, #16964 and #16965, which are now closed.
