### PR TITLE
[symfony] Validator attributes: Channel, Dashboard, DynamicContent, Report entities

### DIFF
--- a/app/bundles/ChannelBundle/Entity/Message.php
+++ b/app/bundles/ChannelBundle/Entity/Message.php
@@ -20,7 +20,6 @@ use Mautic\CoreBundle\Entity\UuidTrait;
 use Mautic\ProjectBundle\Entity\ProjectTrait;
 use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Validator\Constraints\NotBlank;
-use Symfony\Component\Validator\Mapping\ClassMetadata as ValidationClassMetadata;
 
 #[ApiResource(
     operations: [
@@ -56,7 +55,7 @@ class Message extends FormEntity implements UuidInterface
      * @var string
      */
     #[Groups(['message:read', 'message:write', 'channel:read'])]
-    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.name.required')]
+    #[NotBlank(message: 'mautic.core.name.required')]
     private $name;
 
     /**

--- a/app/bundles/ChannelBundle/Entity/Message.php
+++ b/app/bundles/ChannelBundle/Entity/Message.php
@@ -56,6 +56,7 @@ class Message extends FormEntity implements UuidInterface
      * @var string
      */
     #[Groups(['message:read', 'message:write', 'channel:read'])]
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.name.required')]
     private $name;
 
     /**
@@ -117,11 +118,6 @@ class Message extends FormEntity implements UuidInterface
 
         static::addUuidField($builder);
         self::addProjectsField($builder, 'message_projects_xref', 'message_id');
-    }
-
-    public static function loadValidatorMetadata(ValidationClassMetadata $metadata): void
-    {
-        $metadata->addPropertyConstraint('name', new NotBlank(message: 'mautic.core.name.required'));
     }
 
     public static function loadApiMetadata(ApiMetadataDriver $metadata): void

--- a/app/bundles/DashboardBundle/Entity/Widget.php
+++ b/app/bundles/DashboardBundle/Entity/Widget.php
@@ -40,6 +40,7 @@ class Widget extends FormEntity
     /**
      * @var string
      */
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.type.required')]
     private $type;
 
     /**
@@ -96,11 +97,6 @@ class Widget extends FormEntity
         $builder->addNullableField('cacheTimeout', Types::INTEGER, 'cache_timeout');
         $builder->addNullableField('ordering', Types::INTEGER);
         $builder->addNullableField('params', Types::ARRAY);
-    }
-
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addPropertyConstraint('type', new NotBlank(message: 'mautic.core.type.required'));
     }
 
     /**

--- a/app/bundles/DashboardBundle/Entity/Widget.php
+++ b/app/bundles/DashboardBundle/Entity/Widget.php
@@ -8,7 +8,6 @@ use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
 use Mautic\CoreBundle\Entity\FormEntity;
 use Mautic\CoreBundle\Helper\InputHelper;
 use Symfony\Component\Validator\Constraints\NotBlank;
-use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 class Widget extends FormEntity
 {
@@ -40,7 +39,7 @@ class Widget extends FormEntity
     /**
      * @var string
      */
-    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.type.required')]
+    #[NotBlank(message: 'mautic.core.type.required')]
     private $type;
 
     /**

--- a/app/bundles/DynamicContentBundle/Entity/DynamicContent.php
+++ b/app/bundles/DynamicContentBundle/Entity/DynamicContent.php
@@ -76,9 +76,11 @@ class DynamicContent extends FormEntity implements VariantEntityInterface, Trans
     private $id;
 
     #[Groups(['dynamicContent:read', 'dynamicContent:write'])]
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.name.required')]
     private ?string $name = null;
 
     #[Groups(['dynamicContent:read', 'dynamicContent:write'])]
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.type.required')]
     private string $type = TypeList::HTML;
 
     #[Groups(['dynamicContent:read', 'dynamicContent:write'])]
@@ -231,10 +233,7 @@ class DynamicContent extends FormEntity implements VariantEntityInterface, Trans
      */
     public static function loadValidatorMetaData(ClassMetadata $metadata): void
     {
-        $metadata->addPropertyConstraint('name', new NotBlank(message: 'mautic.core.name.required'));
         $metadata->addPropertyConstraint('content', new NoNesting());
-
-        $metadata->addPropertyConstraint('type', new NotBlank(message: 'mautic.core.type.required'));
         $metadata->addPropertyConstraint('type', new Choice(choices: (new TypeList())->getChoices()));
 
         $metadata->addConstraint(new SlotNameType());

--- a/app/bundles/DynamicContentBundle/Entity/DynamicContent.php
+++ b/app/bundles/DynamicContentBundle/Entity/DynamicContent.php
@@ -76,11 +76,11 @@ class DynamicContent extends FormEntity implements VariantEntityInterface, Trans
     private $id;
 
     #[Groups(['dynamicContent:read', 'dynamicContent:write'])]
-    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.name.required')]
+    #[NotBlank(message: 'mautic.core.name.required')]
     private ?string $name = null;
 
     #[Groups(['dynamicContent:read', 'dynamicContent:write'])]
-    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.type.required')]
+    #[NotBlank(message: 'mautic.core.type.required')]
     private string $type = TypeList::HTML;
 
     #[Groups(['dynamicContent:read', 'dynamicContent:write'])]

--- a/app/bundles/ReportBundle/Entity/Report.php
+++ b/app/bundles/ReportBundle/Entity/Report.php
@@ -57,6 +57,7 @@ class Report extends FormEntity implements SchedulerInterface, UuidInterface
      * @var string
      */
     #[Groups(['report:read', 'report:write'])]
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.name.required')]
     private $name;
 
     /**
@@ -219,8 +220,6 @@ class Report extends FormEntity implements SchedulerInterface, UuidInterface
 
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
-        $metadata->addPropertyConstraint('name', new NotBlank(message: 'mautic.core.name.required'));
-
         $metadata->addPropertyConstraint('toAddress', new EmailAssert\MultipleEmailsValid());
 
         $metadata->addConstraint(new ReportAssert\ScheduleIsValid());

--- a/app/bundles/ReportBundle/Entity/Report.php
+++ b/app/bundles/ReportBundle/Entity/Report.php
@@ -57,7 +57,7 @@ class Report extends FormEntity implements SchedulerInterface, UuidInterface
      * @var string
      */
     #[Groups(['report:read', 'report:write'])]
-    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.name.required')]
+    #[NotBlank(message: 'mautic.core.name.required')]
     private $name;
 
     /**

--- a/app/config/config.php
+++ b/app/config/config.php
@@ -79,7 +79,7 @@ $container->loadFromExtension('framework', [
     'form'            => null,
     'csrf_protection' => true,
     'validation'      => [
-        'enable_attributes' => false,
+        'enable_attributes' => true,
     ],
     'default_locale' => '%mautic.locale%',
     'translator'     => [


### PR DESCRIPTION
Part of the split of #16958 into reviewable chunks.

Moves validation rules from `loadValidatorMetadata()` into native PHP attributes on the properties themselves. The rules and messages are unchanged, only their location is.

`app/config/config.php` enables `enable_attributes` for the validator, which is required for the attributes to be picked up. It is included in every part of the split so each PR works on its own; the change is identical everywhere, so it merges cleanly no matter the order.

```diff
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.name.required')]
     private ?string $name        = '';

-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addPropertyConstraint('name', new Assert\NotBlank(message: 'mautic.core.name.required'));
-    }
```
