### PR TITLE
[symfony] Validator attributes: Email, Form, Page entities

### DIFF
--- a/app/bundles/EmailBundle/Entity/Email.php
+++ b/app/bundles/EmailBundle/Entity/Email.php
@@ -96,6 +96,8 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
      * @var string
      */
     #[Groups(['email:read', 'email:write', 'download:read'])]
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.name.required')]
+    #[\Symfony\Component\Validator\Constraints\Length(max: self::MAX_NAME_SUBJECT_LENGTH, maxMessage: 'mautic.email.name.length')]
     private $name;
 
     /**
@@ -108,6 +110,8 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
      * @var string|null
      */
     #[Groups(['email:read', 'email:write', 'download:read'])]
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.subject.required')]
+    #[\Symfony\Component\Validator\Constraints\Length(max: self::MAX_NAME_SUBJECT_LENGTH, maxMessage: 'mautic.email.subject.length')]
     private $subject;
 
     /**
@@ -120,6 +124,7 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
     private bool $sendToDnc = false;
 
     #[Groups(['email:read', 'email:write', 'download:read'])]
+    #[\Symfony\Component\Validator\Constraints\Length(max: 130, maxMessage: 'mautic.email.preheader_text.length')]
     private ?string $preheaderText = null;
 
     /**
@@ -138,12 +143,14 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
      * @var string|null
      */
     #[Groups(['email:read', 'email:write', 'download:read'])]
+    #[\Symfony\Component\Validator\Constraints\Email(message: 'mautic.core.email.required')]
     private $replyToAddress;
 
     /**
      * @var string|null
      */
     #[Groups(['email:read', 'email:write', 'download:read'])]
+    #[\Symfony\Component\Validator\Constraints\Email(message: 'mautic.core.email.required')]
     private $bccAddress;
 
     /**
@@ -468,51 +475,8 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
         $metadata->addPropertyConstraint(
-            'name',
-            new NotBlank(
-                message: 'mautic.core.name.required'
-            )
-        );
-
-        $metadata->addPropertyConstraint(
-            'name',
-            new Length(max: self::MAX_NAME_SUBJECT_LENGTH, maxMessage: 'mautic.email.name.length')
-        );
-
-        $metadata->addPropertyConstraint(
-            'subject',
-            new NotBlank(
-                message: 'mautic.core.subject.required'
-            )
-        );
-
-        $metadata->addPropertyConstraint(
-            'subject',
-            new Length(max: self::MAX_NAME_SUBJECT_LENGTH, maxMessage: 'mautic.email.subject.length')
-        );
-
-        $metadata->addPropertyConstraint(
-            'preheaderText',
-            new Length(max: 130, maxMessage: 'mautic.email.preheader_text.length')
-        );
-
-        $metadata->addPropertyConstraint(
             'fromAddress',
             new EmailOrEmailTokenList(['allowMultiple' => false]),
-        );
-
-        $metadata->addPropertyConstraint(
-            'replyToAddress',
-            new \Symfony\Component\Validator\Constraints\Email(
-                message: 'mautic.core.email.required'
-            )
-        );
-
-        $metadata->addPropertyConstraint(
-            'bccAddress',
-            new \Symfony\Component\Validator\Constraints\Email(
-                message: 'mautic.core.email.required'
-            )
         );
 
         $metadata->addPropertyConstraint('subject', new TextOnlyDynamicContent());

--- a/app/bundles/EmailBundle/Entity/Email.php
+++ b/app/bundles/EmailBundle/Entity/Email.php
@@ -96,8 +96,8 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
      * @var string
      */
     #[Groups(['email:read', 'email:write', 'download:read'])]
-    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.name.required')]
-    #[\Symfony\Component\Validator\Constraints\Length(max: self::MAX_NAME_SUBJECT_LENGTH, maxMessage: 'mautic.email.name.length')]
+    #[NotBlank(message: 'mautic.core.name.required')]
+    #[Length(max: self::MAX_NAME_SUBJECT_LENGTH, maxMessage: 'mautic.email.name.length')]
     private $name;
 
     /**
@@ -110,8 +110,8 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
      * @var string|null
      */
     #[Groups(['email:read', 'email:write', 'download:read'])]
-    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.subject.required')]
-    #[\Symfony\Component\Validator\Constraints\Length(max: self::MAX_NAME_SUBJECT_LENGTH, maxMessage: 'mautic.email.subject.length')]
+    #[NotBlank(message: 'mautic.core.subject.required')]
+    #[Length(max: self::MAX_NAME_SUBJECT_LENGTH, maxMessage: 'mautic.email.subject.length')]
     private $subject;
 
     /**
@@ -124,7 +124,7 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
     private bool $sendToDnc = false;
 
     #[Groups(['email:read', 'email:write', 'download:read'])]
-    #[\Symfony\Component\Validator\Constraints\Length(max: 130, maxMessage: 'mautic.email.preheader_text.length')]
+    #[Length(max: 130, maxMessage: 'mautic.email.preheader_text.length')]
     private ?string $preheaderText = null;
 
     /**

--- a/app/bundles/FormBundle/Entity/Action.php
+++ b/app/bundles/FormBundle/Entity/Action.php
@@ -64,6 +64,7 @@ class Action implements UuidInterface
      * @var string
      */
     #[Groups(['action:read', 'action:write', 'form:read'])]
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.name.required', groups: ['action'])]
     private $type;
 
     /**
@@ -141,11 +142,6 @@ class Action implements UuidInterface
                 ]
             )
             ->build();
-    }
-
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addPropertyConstraint('type', new Assert\NotBlank(message: 'mautic.core.name.required', groups: ['action']));
     }
 
     private function isChanged(string $prop, mixed $val): void

--- a/app/bundles/FormBundle/Entity/Action.php
+++ b/app/bundles/FormBundle/Entity/Action.php
@@ -16,7 +16,6 @@ use Mautic\CoreBundle\Entity\UuidInterface;
 use Mautic\CoreBundle\Entity\UuidTrait;
 use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 #[ApiResource(
     operations: [
@@ -64,7 +63,7 @@ class Action implements UuidInterface
      * @var string
      */
     #[Groups(['action:read', 'action:write', 'form:read'])]
-    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.name.required', groups: ['action'])]
+    #[Assert\NotBlank(message: 'mautic.core.name.required', groups: ['action'])]
     private $type;
 
     /**

--- a/app/bundles/FormBundle/Entity/Form.php
+++ b/app/bundles/FormBundle/Entity/Form.php
@@ -68,6 +68,7 @@ class Form extends FormEntity implements UuidInterface
      * @var string
      */
     #[Groups(['form:read', 'form:write', 'download:read', 'campaign:read', 'email:read'])]
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.name.required', groups: ['form'])]
     private $name;
 
     /**
@@ -110,6 +111,9 @@ class Form extends FormEntity implements UuidInterface
      * @var string|null
      */
     #[Groups(['form:read', 'form:write', 'download:read', 'campaign:read', 'email:read'])]
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.form.form.postactionproperty_message.notblank', groups: ['messageRequired'])]
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.form.form.postactionproperty_redirect.notblank', groups: ['urlRequired'])]
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.form.form.postactionproperty_hideform.notblank', groups: ['hideformRequired'])]
     private $postActionProperty;
 
     /**
@@ -181,6 +185,7 @@ class Form extends FormEntity implements UuidInterface
      * @var int|null
      */
     #[Groups(['form:read', 'form:write', 'download:read', 'campaign:read', 'email:read'])]
+    #[\Symfony\Component\Validator\Constraints\GreaterThan(value: 0, message: 'mautic.form.form.progressive_profiling_limit.error', groups: ['progressiveProfilingLimit'])]
     private $progressiveProfilingLimit;
 
     #[Groups(['form:read', 'form:write', 'download:read', 'campaign:read', 'email:read'])]
@@ -311,17 +316,7 @@ class Form extends FormEntity implements UuidInterface
 
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
-        $metadata->addPropertyConstraint('name', new Assert\NotBlank(message: 'mautic.core.name.required', groups: ['form']));
-
-        $metadata->addPropertyConstraint('postActionProperty', new Assert\NotBlank(message: 'mautic.form.form.postactionproperty_message.notblank', groups: ['messageRequired']));
-
-        $metadata->addPropertyConstraint('postActionProperty', new Assert\NotBlank(message: 'mautic.form.form.postactionproperty_redirect.notblank', groups: ['urlRequired']));
-
         $metadata->addPropertyConstraint('postActionProperty', new IsPostActionRedirectUrl(groups: ['urlRequired']));
-
-        $metadata->addPropertyConstraint('postActionProperty', new Assert\NotBlank(message: 'mautic.form.form.postactionproperty_hideform.notblank', groups: ['hideformRequired']));
-
-        $metadata->addPropertyConstraint('progressiveProfilingLimit', new Assert\GreaterThan(value: 0, message: 'mautic.form.form.progressive_profiling_limit.error', groups: ['progressiveProfilingLimit']));
     }
 
     public static function determineValidationGroups(\Symfony\Component\Form\Form $form): array

--- a/app/bundles/FormBundle/Entity/Form.php
+++ b/app/bundles/FormBundle/Entity/Form.php
@@ -68,7 +68,7 @@ class Form extends FormEntity implements UuidInterface
      * @var string
      */
     #[Groups(['form:read', 'form:write', 'download:read', 'campaign:read', 'email:read'])]
-    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.name.required', groups: ['form'])]
+    #[Assert\NotBlank(message: 'mautic.core.name.required', groups: ['form'])]
     private $name;
 
     /**
@@ -111,9 +111,9 @@ class Form extends FormEntity implements UuidInterface
      * @var string|null
      */
     #[Groups(['form:read', 'form:write', 'download:read', 'campaign:read', 'email:read'])]
-    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.form.form.postactionproperty_message.notblank', groups: ['messageRequired'])]
-    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.form.form.postactionproperty_redirect.notblank', groups: ['urlRequired'])]
-    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.form.form.postactionproperty_hideform.notblank', groups: ['hideformRequired'])]
+    #[Assert\NotBlank(message: 'mautic.form.form.postactionproperty_message.notblank', groups: ['messageRequired'])]
+    #[Assert\NotBlank(message: 'mautic.form.form.postactionproperty_redirect.notblank', groups: ['urlRequired'])]
+    #[Assert\NotBlank(message: 'mautic.form.form.postactionproperty_hideform.notblank', groups: ['hideformRequired'])]
     private $postActionProperty;
 
     /**
@@ -185,7 +185,7 @@ class Form extends FormEntity implements UuidInterface
      * @var int|null
      */
     #[Groups(['form:read', 'form:write', 'download:read', 'campaign:read', 'email:read'])]
-    #[\Symfony\Component\Validator\Constraints\GreaterThan(value: 0, message: 'mautic.form.form.progressive_profiling_limit.error', groups: ['progressiveProfilingLimit'])]
+    #[Assert\GreaterThan(value: 0, message: 'mautic.form.form.progressive_profiling_limit.error', groups: ['progressiveProfilingLimit'])]
     private $progressiveProfilingLimit;
 
     #[Groups(['form:read', 'form:write', 'download:read', 'campaign:read', 'email:read'])]

--- a/app/bundles/PageBundle/Entity/Page.php
+++ b/app/bundles/PageBundle/Entity/Page.php
@@ -78,6 +78,7 @@ class Page extends FormEntity implements TranslationEntityInterface, VariantEnti
      * @var string
      */
     #[Groups(['page:read', 'page:write', 'download:read', 'email:read'])]
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.title.required')]
     private $title;
 
     /**
@@ -320,8 +321,6 @@ class Page extends FormEntity implements TranslationEntityInterface, VariantEnti
 
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
-        $metadata->addPropertyConstraint('title', new NotBlank(message: 'mautic.core.title.required'));
-
         $metadata->addConstraint(new Callback(
             function (Page $page, ExecutionContextInterface $context): void {
                 $type = $page->getRedirectType();

--- a/app/bundles/PageBundle/Entity/Page.php
+++ b/app/bundles/PageBundle/Entity/Page.php
@@ -78,7 +78,7 @@ class Page extends FormEntity implements TranslationEntityInterface, VariantEnti
      * @var string
      */
     #[Groups(['page:read', 'page:write', 'download:read', 'email:read'])]
-    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.title.required')]
+    #[NotBlank(message: 'mautic.core.title.required')]
     private $title;
 
     /**

--- a/app/config/config.php
+++ b/app/config/config.php
@@ -79,7 +79,7 @@ $container->loadFromExtension('framework', [
     'form'            => null,
     'csrf_protection' => true,
     'validation'      => [
-        'enable_attributes' => false,
+        'enable_attributes' => true,
     ],
     'default_locale' => '%mautic.locale%',
     'translator'     => [


### PR DESCRIPTION
Part of the split of #16958 into reviewable chunks.

Moves validation rules from `loadValidatorMetadata()` into native PHP attributes on the properties themselves. The rules and messages are unchanged, only their location is.

`app/config/config.php` enables `enable_attributes` for the validator, which is required for the attributes to be picked up. It is included in every part of the split so each PR works on its own; the change is identical everywhere, so it merges cleanly no matter the order.

```diff
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.name.required')]
     private ?string $name        = '';

-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addPropertyConstraint('name', new Assert\NotBlank(message: 'mautic.core.name.required'));
-    }
```
