### PR TITLE
[symfony] Validator attributes: Lead entities (Company, Import, LeadField, LeadList)

### DIFF
--- a/app/bundles/LeadBundle/Entity/Company.php
+++ b/app/bundles/LeadBundle/Entity/Company.php
@@ -60,6 +60,7 @@ class Company extends FormEntity implements CustomFieldEntityInterface, Identifi
      * @var int|null
      */
     #[Groups(['company:read', 'company:write'])]
+    #[\Symfony\Component\Validator\Constraints\Range(min: 0, max: 2147483647)]
     private $score = 0;
 
     #[Groups(['company:read', 'company:write'])]
@@ -263,7 +264,6 @@ class Company extends FormEntity implements CustomFieldEntityInterface, Identifi
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
         $metadata->addConstraint(new UniqueCustomField(['object' => 'company']));
-        $metadata->addPropertyConstraint('score', new Assert\Range(min: 0, max: 2147483647));
     }
 
     public static function getDefaultIdentifierFields(): array

--- a/app/bundles/LeadBundle/Entity/Company.php
+++ b/app/bundles/LeadBundle/Entity/Company.php
@@ -60,7 +60,7 @@ class Company extends FormEntity implements CustomFieldEntityInterface, Identifi
      * @var int|null
      */
     #[Groups(['company:read', 'company:write'])]
-    #[\Symfony\Component\Validator\Constraints\Range(min: 0, max: 2147483647)]
+    #[Assert\Range(min: 0, max: 2147483647)]
     private $score = 0;
 
     #[Groups(['company:read', 'company:write'])]

--- a/app/bundles/LeadBundle/Entity/Import.php
+++ b/app/bundles/LeadBundle/Entity/Import.php
@@ -69,6 +69,7 @@ class Import extends FormEntity
      *
      * @var string
      */
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.lead.import.dir.notblank')]
     private $dir;
 
     /**
@@ -76,6 +77,7 @@ class Import extends FormEntity
      *
      * @var string
      */
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.lead.import.file.notblank')]
     private $file = 'import.csv';
 
     /**
@@ -161,17 +163,6 @@ class Import extends FormEntity
             ->addNullableField('dateEnded', Types::DATETIME_MUTABLE, 'date_ended')
             ->addField('object', Types::STRING)
             ->addNullableField('properties', Types::JSON);
-    }
-
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addPropertyConstraint('dir', new Assert\NotBlank(
-            message: 'mautic.lead.import.dir.notblank'
-        ));
-
-        $metadata->addPropertyConstraint('file', new Assert\NotBlank(
-            message: 'mautic.lead.import.file.notblank'
-        ));
     }
 
     /**

--- a/app/bundles/LeadBundle/Entity/Import.php
+++ b/app/bundles/LeadBundle/Entity/Import.php
@@ -10,7 +10,6 @@ use Mautic\CoreBundle\Entity\FormEntity;
 use Mautic\CoreBundle\Helper\Chart\PieChart;
 use Mautic\CoreBundle\Translation\Translator;
 use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 class Import extends FormEntity
 {
@@ -69,7 +68,7 @@ class Import extends FormEntity
      *
      * @var string
      */
-    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.lead.import.dir.notblank')]
+    #[Assert\NotBlank(message: 'mautic.lead.import.dir.notblank')]
     private $dir;
 
     /**
@@ -77,7 +76,7 @@ class Import extends FormEntity
      *
      * @var string
      */
-    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.lead.import.file.notblank')]
+    #[Assert\NotBlank(message: 'mautic.lead.import.file.notblank')]
     private $file = 'import.csv';
 
     /**

--- a/app/bundles/LeadBundle/Entity/LeadField.php
+++ b/app/bundles/LeadBundle/Entity/LeadField.php
@@ -44,6 +44,7 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
         'swagger_definition_name' => 'Write',
     ]
 )]
+#[\Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity(fields: ['alias'], message: 'mautic.lead.field.alias.unique')]
 class LeadField extends FormEntity implements CacheInvalidateInterface, UuidInterface
 {
     use UuidTrait;
@@ -74,6 +75,8 @@ class LeadField extends FormEntity implements CacheInvalidateInterface, UuidInte
      * @var string
      */
     #[Groups(['leadfield:read', 'leadfield:write'])]
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.lead.field.label.notblank')]
+    #[\Symfony\Component\Validator\Constraints\Length(max: 191, maxMessage: 'mautic.lead.field.label.maxlength')]
     private $label;
 
     /**
@@ -310,14 +313,6 @@ class LeadField extends FormEntity implements CacheInvalidateInterface, UuidInte
 
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
-        $metadata->addPropertyConstraint('label', new Assert\NotBlank(
-            message: 'mautic.lead.field.label.notblank'
-        ));
-
-        $metadata->addPropertyConstraint('label', new Assert\Length(max: 191, maxMessage: 'mautic.lead.field.label.maxlength'));
-
-        $metadata->addConstraint(new UniqueEntity(fields: ['alias'], message: 'mautic.lead.field.alias.unique'));
-
         $metadata->addConstraint(new Assert\Callback(
             function (LeadField $field, ExecutionContextInterface $context): void {
                 $violations = $context->getValidator()->validate($field, [new FieldAliasKeyword()]);

--- a/app/bundles/LeadBundle/Entity/LeadField.php
+++ b/app/bundles/LeadBundle/Entity/LeadField.php
@@ -44,7 +44,7 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
         'swagger_definition_name' => 'Write',
     ]
 )]
-#[\Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity(fields: ['alias'], message: 'mautic.lead.field.alias.unique')]
+#[UniqueEntity(fields: ['alias'], message: 'mautic.lead.field.alias.unique')]
 class LeadField extends FormEntity implements CacheInvalidateInterface, UuidInterface
 {
     use UuidTrait;
@@ -75,8 +75,8 @@ class LeadField extends FormEntity implements CacheInvalidateInterface, UuidInte
      * @var string
      */
     #[Groups(['leadfield:read', 'leadfield:write'])]
-    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.lead.field.label.notblank')]
-    #[\Symfony\Component\Validator\Constraints\Length(max: 191, maxMessage: 'mautic.lead.field.label.maxlength')]
+    #[Assert\NotBlank(message: 'mautic.lead.field.label.notblank')]
+    #[Assert\Length(max: 191, maxMessage: 'mautic.lead.field.label.maxlength')]
     private $label;
 
     /**

--- a/app/bundles/LeadBundle/Entity/LeadList.php
+++ b/app/bundles/LeadBundle/Entity/LeadList.php
@@ -46,7 +46,7 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
         'swagger_definition_name' => 'Write',
     ]
 )]
-#[\Mautic\LeadBundle\Form\Validator\Constraints\UniqueUserAlias(field: 'alias', message: 'mautic.lead.list.alias.unique')]
+#[UniqueUserAlias(field: 'alias', message: 'mautic.lead.list.alias.unique')]
 class LeadList extends FormEntity implements UuidInterface
 {
     use UuidTrait;
@@ -67,7 +67,7 @@ class LeadList extends FormEntity implements UuidInterface
      * @var string
      */
     #[Groups(['segment:read', 'segment:write', 'campaign:read', 'email:read', 'sms:read'])]
-    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.name.required')]
+    #[Assert\NotBlank(message: 'mautic.core.name.required')]
     private $name;
 
     /**

--- a/app/bundles/LeadBundle/Entity/LeadList.php
+++ b/app/bundles/LeadBundle/Entity/LeadList.php
@@ -46,6 +46,7 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
         'swagger_definition_name' => 'Write',
     ]
 )]
+#[\Mautic\LeadBundle\Form\Validator\Constraints\UniqueUserAlias(field: 'alias', message: 'mautic.lead.list.alias.unique')]
 class LeadList extends FormEntity implements UuidInterface
 {
     use UuidTrait;
@@ -66,6 +67,7 @@ class LeadList extends FormEntity implements UuidInterface
      * @var string
      */
     #[Groups(['segment:read', 'segment:write', 'campaign:read', 'email:read', 'sms:read'])]
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.name.required')]
     private $name;
 
     /**
@@ -182,15 +184,6 @@ class LeadList extends FormEntity implements UuidInterface
 
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
-        $metadata->addPropertyConstraint('name', new Assert\NotBlank(
-            message: 'mautic.core.name.required'
-        ));
-
-        $metadata->addConstraint(new UniqueUserAlias([
-            'field'   => 'alias',
-            'message' => 'mautic.lead.list.alias.unique',
-        ]));
-
         $metadata->addConstraint(new SegmentUsedInCampaigns());
         $metadata->addConstraint(new SegmentInUse());
     }

--- a/app/bundles/LeadBundle/Form/Validator/Constraints/UniqueUserAlias.php
+++ b/app/bundles/LeadBundle/Form/Validator/Constraints/UniqueUserAlias.php
@@ -2,14 +2,19 @@
 
 namespace Mautic\LeadBundle\Form\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
-#[\Attribute]
+#[\Attribute(\Attribute::TARGET_CLASS)]
 final class UniqueUserAlias extends Constraint
 {
-    public $message = 'This alias is already in use.';
-
-    public $field   = '';
+    #[HasNamedArguments]
+    public function __construct(
+        public string $field,
+        public string $message = 'This alias is already in use.',
+    ) {
+        parent::__construct();
+    }
 
     public function validatedBy(): string
     {
@@ -21,13 +26,13 @@ final class UniqueUserAlias extends Constraint
         return self::CLASS_CONSTRAINT;
     }
 
-    public function getRequiredOptions(): array
-    {
-        return ['field'];
-    }
+//    public function getRequiredOptions(): array
+//    {
+//        return ['field'];
+//    }
 
-    public function getDefaultOption(): string
-    {
-        return 'field';
-    }
+//    public function getDefaultOption(): string
+//    {
+//        return 'field';
+//    }
 }

--- a/app/bundles/LeadBundle/Form/Validator/Constraints/UniqueUserAlias.php
+++ b/app/bundles/LeadBundle/Form/Validator/Constraints/UniqueUserAlias.php
@@ -26,13 +26,13 @@ final class UniqueUserAlias extends Constraint
         return self::CLASS_CONSTRAINT;
     }
 
-//    public function getRequiredOptions(): array
-//    {
-//        return ['field'];
-//    }
+    //    public function getRequiredOptions(): array
+    //    {
+    //        return ['field'];
+    //    }
 
-//    public function getDefaultOption(): string
-//    {
-//        return 'field';
-//    }
+    //    public function getDefaultOption(): string
+    //    {
+    //        return 'field';
+    //    }
 }

--- a/app/config/config.php
+++ b/app/config/config.php
@@ -79,7 +79,7 @@ $container->loadFromExtension('framework', [
     'form'            => null,
     'csrf_protection' => true,
     'validation'      => [
-        'enable_attributes' => false,
+        'enable_attributes' => true,
     ],
     'default_locale' => '%mautic.locale%',
     'translator'     => [


### PR DESCRIPTION
Part of the split of #16958 into reviewable chunks.

Moves validation rules from `loadValidatorMetadata()` into native PHP attributes on the properties themselves. The rules and messages are unchanged, only their location is.

`app/config/config.php` enables `enable_attributes` for the validator, which is required for the attributes to be picked up. It is included in every part of the split so each PR works on its own; the change is identical everywhere, so it merges cleanly no matter the order.

```diff
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.name.required')]
     private ?string $name        = '';

-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addPropertyConstraint('name', new Assert\NotBlank(message: 'mautic.core.name.required'));
-    }
```
