### PR TITLE
[symfony] Validator attributes: LeadNote, Notification, Project, Sms entities

### DIFF
--- a/app/bundles/ProjectBundle/Entity/Project.php
+++ b/app/bundles/ProjectBundle/Entity/Project.php
@@ -54,6 +54,7 @@ class Project extends FormEntity implements UuidInterface
     private ?string $description = null;
 
     #[Groups(['project:read', 'project:write'])]
+    #[NotBlank(message: 'mautic.core.name.required')]
     private ?string $name = null;
 
     /**
@@ -110,10 +111,6 @@ class Project extends FormEntity implements UuidInterface
 
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
-        $metadata->addPropertyConstraint(
-            'name',
-            new NotBlank(message: 'mautic.core.name.required')
-        );
         $metadata->addConstraint(new UniqueName());
     }
 


### PR DESCRIPTION
Part of the split of #16958 into reviewable chunks.

Moves validation rules from `loadValidatorMetadata()` into native PHP attributes on the properties themselves. The rules and messages are unchanged, only their location is.

`app/config/config.php` enables `enable_attributes` for the validator, which is required for the attributes to be picked up. It is included in every part of the split so each PR works on its own; the change is identical everywhere, so it merges cleanly no matter the order.

```diff
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.name.required')]
     private ?string $name        = '';

-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addPropertyConstraint('name', new Assert\NotBlank(message: 'mautic.core.name.required'));
-    }
```
