### PR TITLE
[symfony] Validator attributes: Point entities

### DIFF
--- a/app/bundles/PointBundle/Entity/Group.php
+++ b/app/bundles/PointBundle/Entity/Group.php
@@ -21,6 +21,7 @@ class Group extends FormEntity implements UuidInterface
 
     private ?int $id             = null;
 
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.name.required')]
     private ?string $name        = '';
 
     private ?string $description = '';
@@ -38,11 +39,6 @@ class Group extends FormEntity implements UuidInterface
         static::addUuidField($builder);
 
         $builder->addIdColumns();
-    }
-
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addPropertyConstraint('name', new Assert\NotBlank(message: 'mautic.core.name.required'));
     }
 
     public static function loadApiMetadata(ApiMetadataDriver $metadata): void

--- a/app/bundles/PointBundle/Entity/Group.php
+++ b/app/bundles/PointBundle/Entity/Group.php
@@ -9,7 +9,6 @@ use Mautic\CoreBundle\Entity\FormEntity;
 use Mautic\CoreBundle\Entity\UuidInterface;
 use Mautic\CoreBundle\Entity\UuidTrait;
 use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 class Group extends FormEntity implements UuidInterface
 {
@@ -21,7 +20,7 @@ class Group extends FormEntity implements UuidInterface
 
     private ?int $id             = null;
 
-    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.name.required')]
+    #[Assert\NotBlank(message: 'mautic.core.name.required')]
     private ?string $name        = '';
 
     private ?string $description = '';

--- a/app/bundles/PointBundle/Entity/Point.php
+++ b/app/bundles/PointBundle/Entity/Point.php
@@ -59,6 +59,7 @@ class Point extends FormEntity implements UuidInterface
      * @var string
      */
     #[Groups(['point:read', 'point:write'])]
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.name.required')]
     private $name;
 
     /**
@@ -71,6 +72,7 @@ class Point extends FormEntity implements UuidInterface
      * @var string
      */
     #[Groups(['point:read', 'point:write'])]
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.point.type.notblank')]
     private $type;
 
     /**
@@ -95,6 +97,8 @@ class Point extends FormEntity implements UuidInterface
      * @var int
      */
     #[Groups(['point:read', 'point:write'])]
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.point.delta.notblank')]
+    #[\Symfony\Component\Validator\Constraints\Range(min: IntHelper::MIN_INTEGER_VALUE, max: IntHelper::MAX_INTEGER_VALUE)]
     private $delta = 0;
 
     /**
@@ -168,17 +172,6 @@ class Point extends FormEntity implements UuidInterface
 
         static::addUuidField($builder);
         self::addProjectsField($builder, 'point_projects_xref', 'point_id');
-    }
-
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addPropertyConstraint('name', new Assert\NotBlank(message: 'mautic.core.name.required'));
-
-        $metadata->addPropertyConstraint('type', new Assert\NotBlank(message: 'mautic.point.type.notblank'));
-
-        $metadata->addPropertyConstraint('delta', new Assert\NotBlank(message: 'mautic.point.delta.notblank'));
-
-        $metadata->addPropertyConstraint('delta', new Assert\Range(min: IntHelper::MIN_INTEGER_VALUE, max: IntHelper::MAX_INTEGER_VALUE));
     }
 
     /**

--- a/app/bundles/PointBundle/Entity/Point.php
+++ b/app/bundles/PointBundle/Entity/Point.php
@@ -21,7 +21,6 @@ use Mautic\CoreBundle\Helper\IntHelper;
 use Mautic\ProjectBundle\Entity\ProjectTrait;
 use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 #[ApiResource(
     operations: [
@@ -59,7 +58,7 @@ class Point extends FormEntity implements UuidInterface
      * @var string
      */
     #[Groups(['point:read', 'point:write'])]
-    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.name.required')]
+    #[Assert\NotBlank(message: 'mautic.core.name.required')]
     private $name;
 
     /**
@@ -72,7 +71,7 @@ class Point extends FormEntity implements UuidInterface
      * @var string
      */
     #[Groups(['point:read', 'point:write'])]
-    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.point.type.notblank')]
+    #[Assert\NotBlank(message: 'mautic.point.type.notblank')]
     private $type;
 
     /**
@@ -97,8 +96,8 @@ class Point extends FormEntity implements UuidInterface
      * @var int
      */
     #[Groups(['point:read', 'point:write'])]
-    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.point.delta.notblank')]
-    #[\Symfony\Component\Validator\Constraints\Range(min: IntHelper::MIN_INTEGER_VALUE, max: IntHelper::MAX_INTEGER_VALUE)]
+    #[Assert\NotBlank(message: 'mautic.point.delta.notblank')]
+    #[Assert\Range(min: IntHelper::MIN_INTEGER_VALUE, max: IntHelper::MAX_INTEGER_VALUE)]
     private $delta = 0;
 
     /**

--- a/app/bundles/PointBundle/Entity/PointInsight.php
+++ b/app/bundles/PointBundle/Entity/PointInsight.php
@@ -19,6 +19,7 @@ class PointInsight extends FormEntity
 
     private ?int $id = null;
 
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.name.required')]
     private string $name = '';
 
     /**
@@ -29,11 +30,13 @@ class PointInsight extends FormEntity
     /**
      * @var string
      */
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.point.insight.type.required')]
     private $insightType = self::INSIGHT_TYPE_COMPARE_POINT_GROUPS;
 
     /**
      * @var string
      */
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.point.insight.action.required')]
     private $insightAction = self::INSIGHT_ACTION_SET_CUSTOM_FIELD;
 
     /**
@@ -85,15 +88,6 @@ class PointInsight extends FormEntity
             ->build();
 
         $builder->addCategory();
-    }
-
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addPropertyConstraint('name', new Assert\NotBlank(message: 'mautic.core.name.required'));
-
-        $metadata->addPropertyConstraint('insightType', new Assert\NotBlank(message: 'mautic.point.insight.type.required'));
-
-        $metadata->addPropertyConstraint('insightAction', new Assert\NotBlank(message: 'mautic.point.insight.action.required'));
     }
 
     /**

--- a/app/bundles/PointBundle/Entity/PointInsight.php
+++ b/app/bundles/PointBundle/Entity/PointInsight.php
@@ -9,7 +9,6 @@ use Mautic\CategoryBundle\Entity\Category;
 use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
 use Mautic\CoreBundle\Entity\FormEntity;
 use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 class PointInsight extends FormEntity
 {
@@ -19,7 +18,7 @@ class PointInsight extends FormEntity
 
     private ?int $id = null;
 
-    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.name.required')]
+    #[Assert\NotBlank(message: 'mautic.core.name.required')]
     private string $name = '';
 
     /**
@@ -30,13 +29,13 @@ class PointInsight extends FormEntity
     /**
      * @var string
      */
-    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.point.insight.type.required')]
+    #[Assert\NotBlank(message: 'mautic.point.insight.type.required')]
     private $insightType = self::INSIGHT_TYPE_COMPARE_POINT_GROUPS;
 
     /**
      * @var string
      */
-    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.point.insight.action.required')]
+    #[Assert\NotBlank(message: 'mautic.point.insight.action.required')]
     private $insightAction = self::INSIGHT_ACTION_SET_CUSTOM_FIELD;
 
     /**

--- a/app/bundles/PointBundle/Entity/Trigger.php
+++ b/app/bundles/PointBundle/Entity/Trigger.php
@@ -20,7 +20,6 @@ use Mautic\CoreBundle\Entity\UuidTrait;
 use Mautic\ProjectBundle\Entity\ProjectTrait;
 use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 #[ApiResource(
     operations: [
@@ -58,7 +57,7 @@ class Trigger extends FormEntity implements UuidInterface
      * @var string
      */
     #[Groups(['trigger:read', 'trigger:write'])]
-    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.name.required')]
+    #[Assert\NotBlank(message: 'mautic.core.name.required')]
     private $name;
 
     /**

--- a/app/bundles/PointBundle/Entity/Trigger.php
+++ b/app/bundles/PointBundle/Entity/Trigger.php
@@ -58,6 +58,7 @@ class Trigger extends FormEntity implements UuidInterface
      * @var string
      */
     #[Groups(['trigger:read', 'trigger:write'])]
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.name.required')]
     private $name;
 
     /**
@@ -161,11 +162,6 @@ class Trigger extends FormEntity implements UuidInterface
 
         static::addUuidField($builder);
         self::addProjectsField($builder, 'point_trigger_projects_xref', 'point_trigger_id');
-    }
-
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addPropertyConstraint('name', new Assert\NotBlank(message: 'mautic.core.name.required'));
     }
 
     /**

--- a/app/config/config.php
+++ b/app/config/config.php
@@ -79,7 +79,7 @@ $container->loadFromExtension('framework', [
     'form'            => null,
     'csrf_protection' => true,
     'validation'      => [
-        'enable_attributes' => false,
+        'enable_attributes' => true,
     ],
     'default_locale' => '%mautic.locale%',
     'translator'     => [


### PR DESCRIPTION
Part of the split of #16958 into reviewable chunks.

Moves validation rules from `loadValidatorMetadata()` into native PHP attributes on the properties themselves. The rules and messages are unchanged, only their location is.

`app/config/config.php` enables `enable_attributes` for the validator, which is required for the attributes to be picked up. It is included in every part of the split so each PR works on its own; the change is identical everywhere, so it merges cleanly no matter the order.

```diff
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.name.required')]
     private ?string $name        = '';

-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addPropertyConstraint('name', new Assert\NotBlank(message: 'mautic.core.name.required'));
-    }
```
