### PR TITLE
[symfony] Validator attributes: Stage, User, Role, Webhook entities

### DIFF
--- a/app/bundles/StageBundle/Entity/Stage.php
+++ b/app/bundles/StageBundle/Entity/Stage.php
@@ -42,6 +42,7 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
         'swagger_definition_name' => 'Write',
     ]
 )]
+#[\Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity(fields: ['weight'], message: 'mautic.stage.weight.unique')]
 class Stage extends FormEntity implements UuidInterface
 {
     use UuidTrait;
@@ -57,6 +58,7 @@ class Stage extends FormEntity implements UuidInterface
      * @var string
      */
     #[Groups(['stage:read', 'stage:write'])]
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.name.required')]
     private $name;
 
     /**
@@ -131,13 +133,6 @@ class Stage extends FormEntity implements UuidInterface
 
         static::addUuidField($builder);
         self::addProjectsField($builder, 'stage_projects_xref', 'stage_id');
-    }
-
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addPropertyConstraint('name', new Assert\NotBlank(message: 'mautic.core.name.required'));
-
-        $metadata->addConstraint(new UniqueEntity(fields: ['weight'], message: 'mautic.stage.weight.unique'));
     }
 
     /**

--- a/app/bundles/StageBundle/Entity/Stage.php
+++ b/app/bundles/StageBundle/Entity/Stage.php
@@ -21,7 +21,6 @@ use Mautic\ProjectBundle\Entity\ProjectTrait;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 #[ApiResource(
     operations: [
@@ -42,7 +41,7 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
         'swagger_definition_name' => 'Write',
     ]
 )]
-#[\Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity(fields: ['weight'], message: 'mautic.stage.weight.unique')]
+#[UniqueEntity(fields: ['weight'], message: 'mautic.stage.weight.unique')]
 class Stage extends FormEntity implements UuidInterface
 {
     use UuidTrait;
@@ -58,7 +57,7 @@ class Stage extends FormEntity implements UuidInterface
      * @var string
      */
     #[Groups(['stage:read', 'stage:write'])]
-    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.name.required')]
+    #[Assert\NotBlank(message: 'mautic.core.name.required')]
     private $name;
 
     /**

--- a/app/bundles/UserBundle/Entity/Role.php
+++ b/app/bundles/UserBundle/Entity/Role.php
@@ -56,6 +56,7 @@ class Role extends FormEntity implements CacheInvalidateInterface, UuidInterface
      * @var string
      */
     #[Groups(['role:read', 'role:write'])]
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.name.required')]
     private $name;
 
     /**
@@ -124,13 +125,6 @@ class Role extends FormEntity implements CacheInvalidateInterface, UuidInterface
             ->build();
 
         static::addUuidField($builder);
-    }
-
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addPropertyConstraint('name', new Assert\NotBlank(
-            message: 'mautic.core.name.required'
-        ));
     }
 
     /**

--- a/app/bundles/UserBundle/Entity/Role.php
+++ b/app/bundles/UserBundle/Entity/Role.php
@@ -19,7 +19,6 @@ use Mautic\CoreBundle\Entity\UuidInterface;
 use Mautic\CoreBundle\Entity\UuidTrait;
 use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 #[ApiResource(
     operations: [
@@ -56,7 +55,7 @@ class Role extends FormEntity implements CacheInvalidateInterface, UuidInterface
      * @var string
      */
     #[Groups(['role:read', 'role:write'])]
-    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.name.required')]
+    #[Assert\NotBlank(message: 'mautic.core.name.required')]
     private $name;
 
     /**

--- a/app/bundles/UserBundle/Entity/User.php
+++ b/app/bundles/UserBundle/Entity/User.php
@@ -44,8 +44,8 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
         'swagger_definition_name' => 'Write',
     ]
 )]
-#[\Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity(fields: ['username'], message: 'mautic.user.user.username.unique', repositoryMethod: 'checkUniqueUsernameEmail')]
-#[\Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity(fields: ['email'], message: 'mautic.user.user.email.unique', repositoryMethod: 'checkUniqueUsernameEmail', groups: ['User', 'SecondPass'])]
+#[UniqueEntity(fields: ['username'], message: 'mautic.user.user.username.unique', repositoryMethod: 'checkUniqueUsernameEmail')]
+#[UniqueEntity(fields: ['email'], message: 'mautic.user.user.email.unique', repositoryMethod: 'checkUniqueUsernameEmail', groups: ['User', 'SecondPass'])]
 class User extends FormEntity implements UserInterface, EquatableInterface, PasswordAuthenticatedUserInterface, CacheInvalidateInterface
 {
     public const CACHE_NAMESPACE = 'User';
@@ -57,7 +57,7 @@ class User extends FormEntity implements UserInterface, EquatableInterface, Pass
     protected $id;
 
     #[Groups(['user:read', 'user:write'])]
-    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.user.user.username.notblank')]
+    #[Assert\NotBlank(message: 'mautic.user.user.username.notblank')]
     protected ?string $username = null;
 
     /**
@@ -71,8 +71,8 @@ class User extends FormEntity implements UserInterface, EquatableInterface, Pass
      * @var ?string
      */
     #[Groups(['user:write'])]
-    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.user.user.password.notblank', groups: ['CheckPasswordNotBlank'])]
-    #[\Symfony\Component\Validator\Constraints\Length(min: 6, minMessage: 'mautic.user.user.password.minlength', groups: ['CheckPassword'])]
+    #[Assert\NotBlank(message: 'mautic.user.user.password.notblank', groups: ['CheckPasswordNotBlank'])]
+    #[Assert\Length(min: 6, minMessage: 'mautic.user.user.password.minlength', groups: ['CheckPassword'])]
     private $plainPassword;
 
     /**
@@ -86,36 +86,36 @@ class User extends FormEntity implements UserInterface, EquatableInterface, Pass
      * @var string
      */
     #[Groups(['user:read', 'user:write'])]
-    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.user.user.firstname.notblank')]
+    #[Assert\NotBlank(message: 'mautic.user.user.firstname.notblank')]
     private $firstName;
 
     /**
      * @var string
      */
     #[Groups(['user:read', 'user:write'])]
-    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.user.user.lastname.notblank')]
+    #[Assert\NotBlank(message: 'mautic.user.user.lastname.notblank')]
     private $lastName;
 
     /**
      * @var string
      */
     #[Groups(['user:read', 'user:write'])]
-    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.user.user.email.valid')]
-    #[\Symfony\Component\Validator\Constraints\Email(message: 'mautic.user.user.email.valid', groups: ['SecondPass'])]
+    #[Assert\NotBlank(message: 'mautic.user.user.email.valid')]
+    #[Assert\Email(message: 'mautic.user.user.email.valid', groups: ['SecondPass'])]
     private $email;
 
     /**
      * @var string|null
      */
     #[Groups(['user:read', 'user:write'])]
-    #[\Symfony\Component\Validator\Constraints\Length(max: 191, maxMessage: 'mautic.user.user.position.toolong')]
+    #[Assert\Length(max: 191, maxMessage: 'mautic.user.user.position.toolong')]
     private $position;
 
     /**
      * @var Role
      */
     #[Groups(['user:read', 'user:write'])]
-    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.user.user.role.notblank')]
+    #[Assert\NotBlank(message: 'mautic.user.user.role.notblank')]
     private $role;
 
     /**

--- a/app/bundles/UserBundle/Entity/User.php
+++ b/app/bundles/UserBundle/Entity/User.php
@@ -44,6 +44,8 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
         'swagger_definition_name' => 'Write',
     ]
 )]
+#[\Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity(fields: ['username'], message: 'mautic.user.user.username.unique', repositoryMethod: 'checkUniqueUsernameEmail')]
+#[\Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity(fields: ['email'], message: 'mautic.user.user.email.unique', repositoryMethod: 'checkUniqueUsernameEmail', groups: ['User', 'SecondPass'])]
 class User extends FormEntity implements UserInterface, EquatableInterface, PasswordAuthenticatedUserInterface, CacheInvalidateInterface
 {
     public const CACHE_NAMESPACE = 'User';
@@ -55,6 +57,7 @@ class User extends FormEntity implements UserInterface, EquatableInterface, Pass
     protected $id;
 
     #[Groups(['user:read', 'user:write'])]
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.user.user.username.notblank')]
     protected ?string $username = null;
 
     /**
@@ -68,6 +71,8 @@ class User extends FormEntity implements UserInterface, EquatableInterface, Pass
      * @var ?string
      */
     #[Groups(['user:write'])]
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.user.user.password.notblank', groups: ['CheckPasswordNotBlank'])]
+    #[\Symfony\Component\Validator\Constraints\Length(min: 6, minMessage: 'mautic.user.user.password.minlength', groups: ['CheckPassword'])]
     private $plainPassword;
 
     /**
@@ -81,30 +86,36 @@ class User extends FormEntity implements UserInterface, EquatableInterface, Pass
      * @var string
      */
     #[Groups(['user:read', 'user:write'])]
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.user.user.firstname.notblank')]
     private $firstName;
 
     /**
      * @var string
      */
     #[Groups(['user:read', 'user:write'])]
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.user.user.lastname.notblank')]
     private $lastName;
 
     /**
      * @var string
      */
     #[Groups(['user:read', 'user:write'])]
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.user.user.email.valid')]
+    #[\Symfony\Component\Validator\Constraints\Email(message: 'mautic.user.user.email.valid', groups: ['SecondPass'])]
     private $email;
 
     /**
      * @var string|null
      */
     #[Groups(['user:read', 'user:write'])]
+    #[\Symfony\Component\Validator\Constraints\Length(max: 191, maxMessage: 'mautic.user.user.position.toolong')]
     private $position;
 
     /**
      * @var Role
      */
     #[Groups(['user:read', 'user:write'])]
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.user.user.role.notblank')]
     private $role;
 
     /**
@@ -229,38 +240,6 @@ class User extends FormEntity implements UserInterface, EquatableInterface, Pass
 
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
-        $metadata->addPropertyConstraint('username', new Assert\NotBlank(
-            message: 'mautic.user.user.username.notblank'
-        ));
-
-        $metadata->addConstraint(new UniqueEntity(fields: ['username'], message: 'mautic.user.user.username.unique', repositoryMethod: 'checkUniqueUsernameEmail'));
-
-        $metadata->addPropertyConstraint('firstName', new Assert\NotBlank(
-            message: 'mautic.user.user.firstname.notblank'
-        ));
-
-        $metadata->addPropertyConstraint('lastName', new Assert\NotBlank(
-            message: 'mautic.user.user.lastname.notblank'
-        ));
-
-        $metadata->addPropertyConstraint('email', new Assert\NotBlank(
-            message: 'mautic.user.user.email.valid'
-        ));
-
-        $metadata->addPropertyConstraint('email', new Assert\Email(message: 'mautic.user.user.email.valid', groups: ['SecondPass']));
-
-        $metadata->addConstraint(new UniqueEntity(fields: ['email'], message: 'mautic.user.user.email.unique', repositoryMethod: 'checkUniqueUsernameEmail', groups: ['User', 'SecondPass']));
-
-        $metadata->addPropertyConstraint('position', new Assert\Length(max: 191, maxMessage: 'mautic.user.user.position.toolong'));
-
-        $metadata->addPropertyConstraint('role', new Assert\NotBlank(
-            message: 'mautic.user.user.role.notblank'
-        ));
-
-        $metadata->addPropertyConstraint('plainPassword', new Assert\NotBlank(message: 'mautic.user.user.password.notblank', groups: ['CheckPasswordNotBlank']));
-
-        $metadata->addPropertyConstraint('plainPassword', new Assert\Length(min: 6, minMessage: 'mautic.user.user.password.minlength', groups: ['CheckPassword']));
-
         $metadata->addPropertyConstraint('plainPassword', new NotWeak(
             [
                 'message'    => 'mautic.user.user.password.weak',

--- a/app/bundles/WebhookBundle/Entity/Webhook.php
+++ b/app/bundles/WebhookBundle/Entity/Webhook.php
@@ -59,6 +59,7 @@ class Webhook extends FormEntity implements SkipModifiedInterface
      * @var ?string
      */
     #[Groups(['webhook:read', 'webhook:write'])]
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.name.required')]
     private $name;
 
     /**
@@ -71,6 +72,8 @@ class Webhook extends FormEntity implements SkipModifiedInterface
      * @var ?string
      */
     #[Groups(['webhook:read', 'webhook:write'])]
+    #[\Symfony\Component\Validator\Constraints\Url(message: 'mautic.core.valid_url_required')]
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.valid_url_required')]
     private $webhookUrl;
 
     /**
@@ -190,27 +193,6 @@ class Webhook extends FormEntity implements SkipModifiedInterface
 
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
-        $metadata->addPropertyConstraint(
-            'name',
-            new NotBlank(
-                message: 'mautic.core.name.required'
-            )
-        );
-
-        $metadata->addPropertyConstraint(
-            'webhookUrl',
-            new Assert\Url(
-                message: 'mautic.core.valid_url_required'
-            )
-        );
-
-        $metadata->addPropertyConstraint(
-            'webhookUrl',
-            new NotBlank(
-                message: 'mautic.core.valid_url_required'
-            )
-        );
-
         $metadata->addPropertyConstraint(
             'eventsOrderbyDir',
             new Assert\Choice(

--- a/app/bundles/WebhookBundle/Entity/Webhook.php
+++ b/app/bundles/WebhookBundle/Entity/Webhook.php
@@ -59,7 +59,7 @@ class Webhook extends FormEntity implements SkipModifiedInterface
      * @var ?string
      */
     #[Groups(['webhook:read', 'webhook:write'])]
-    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.name.required')]
+    #[NotBlank(message: 'mautic.core.name.required')]
     private $name;
 
     /**
@@ -72,8 +72,8 @@ class Webhook extends FormEntity implements SkipModifiedInterface
      * @var ?string
      */
     #[Groups(['webhook:read', 'webhook:write'])]
-    #[\Symfony\Component\Validator\Constraints\Url(message: 'mautic.core.valid_url_required')]
-    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.valid_url_required')]
+    #[Assert\Url(message: 'mautic.core.valid_url_required')]
+    #[NotBlank(message: 'mautic.core.valid_url_required')]
     private $webhookUrl;
 
     /**

--- a/app/config/config.php
+++ b/app/config/config.php
@@ -79,7 +79,7 @@ $container->loadFromExtension('framework', [
     'form'            => null,
     'csrf_protection' => true,
     'validation'      => [
-        'enable_attributes' => false,
+        'enable_attributes' => true,
     ],
     'default_locale' => '%mautic.locale%',
     'translator'     => [


### PR DESCRIPTION
Part of the split of #16958 into reviewable chunks.

Moves validation rules from `loadValidatorMetadata()` into native PHP attributes on the properties themselves. The rules and messages are unchanged, only their location is.

`app/config/config.php` enables `enable_attributes` for the validator, which is required for the attributes to be picked up. It is included in every part of the split so each PR works on its own; the change is identical everywhere, so it merges cleanly no matter the order.

```diff
+    #[\Symfony\Component\Validator\Constraints\NotBlank(message: 'mautic.core.name.required')]
     private ?string $name        = '';

-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addPropertyConstraint('name', new Assert\NotBlank(message: 'mautic.core.name.required'));
-    }
```
