### PR TITLE
[phpstan] Add rule requiring #[\Attribute] on Symfony Constraint classes, convert all constraints

### DIFF
--- a/app/bundles/ApiBundle/Form/Validator/Constraints/OAuthCallback.php
+++ b/app/bundles/ApiBundle/Form/Validator/Constraints/OAuthCallback.php
@@ -2,11 +2,27 @@
 
 namespace Mautic\ApiBundle\Form\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 final class OAuthCallback extends Constraint
 {
-    public $message = 'The callback URL is invalid.';
+    public string $message;
+
+    /**
+     * @param string[]|null $groups
+     */
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'The callback URL is invalid.',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(null, $groups, $payload);
+
+        $this->message = $message;
+    }
 
     public function validatedBy(): string
     {

--- a/app/bundles/AssetBundle/Validator/Constraints/Upload.php
+++ b/app/bundles/AssetBundle/Validator/Constraints/Upload.php
@@ -6,6 +6,7 @@ namespace Mautic\AssetBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class Upload extends Constraint
 {
     public function getTargets(): string

--- a/app/bundles/CampaignBundle/Form/Validator/Constraints/InfiniteLoop.php
+++ b/app/bundles/CampaignBundle/Form/Validator/Constraints/InfiniteLoop.php
@@ -6,6 +6,7 @@ namespace Mautic\CampaignBundle\Form\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 final class InfiniteLoop extends Constraint
 {
 }

--- a/app/bundles/CampaignBundle/Validator/Constraints/NoOrphanEvents.php
+++ b/app/bundles/CampaignBundle/Validator/Constraints/NoOrphanEvents.php
@@ -6,6 +6,7 @@ namespace Mautic\CampaignBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class NoOrphanEvents extends Constraint
 {
     public function getTargets(): string

--- a/app/bundles/CoreBundle/Form/Validator/Constraints/CircularDependency.php
+++ b/app/bundles/CoreBundle/Form/Validator/Constraints/CircularDependency.php
@@ -2,11 +2,27 @@
 
 namespace Mautic\CoreBundle\Form\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 final class CircularDependency extends Constraint
 {
-    public $message;
+    public ?string $message;
+
+    /**
+     * @param string[]|null $groups
+     */
+    #[HasNamedArguments]
+    public function __construct(
+        ?string $message = null,
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(null, $groups, $payload);
+
+        $this->message = $message;
+    }
 
     public function validatedBy(): string
     {

--- a/app/bundles/CoreBundle/Form/Validator/Constraints/FileEncoding.php
+++ b/app/bundles/CoreBundle/Form/Validator/Constraints/FileEncoding.php
@@ -2,13 +2,35 @@
 
 namespace Mautic\CoreBundle\Form\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 final class FileEncoding extends Constraint
 {
-    public $encodingFormatMessage = 'mautic.core.invalid_file_encoding';
+    public string $encodingFormatMessage;
 
-    public $encodingFormat        = '[UTF-8]';
+    /**
+     * @var string|string[]
+     */
+    public string|array $encodingFormat;
+
+    /**
+     * @param string|string[] $encodingFormat
+     * @param string[]|null   $groups
+     */
+    #[HasNamedArguments]
+    public function __construct(
+        string $encodingFormatMessage = 'mautic.core.invalid_file_encoding',
+        string|array $encodingFormat = '[UTF-8]',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(null, $groups, $payload);
+
+        $this->encodingFormatMessage = $encodingFormatMessage;
+        $this->encodingFormat        = $encodingFormat;
+    }
 
     public function validatedBy(): string
     {

--- a/app/bundles/CoreBundle/Tests/Unit/Form/Validator/Constraints/CircularDependencyValidatorTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Form/Validator/Constraints/CircularDependencyValidatorTest.php
@@ -52,7 +52,7 @@ final class CircularDependencyValidatorTest extends \PHPUnit\Framework\TestCase
         $this->mockListModel->expects($this->never())
             ->method('getEntity');
 
-        $this->validator->validate([], new CircularDependency([]));
+        $this->validator->validate([], new CircularDependency());
     }
 
     /**
@@ -155,7 +155,7 @@ final class CircularDependencyValidatorTest extends \PHPUnit\Framework\TestCase
     public function testValidateOnInvalid(?string $message, int $currentSegmentId, array $filters): void
     {
         $this->configureValidator($message, $currentSegmentId)
-            ->validate($filters, new CircularDependency(['message' => 'mautic.core.segment.circular_dependency_exists']));
+            ->validate($filters, new CircularDependency(message: 'mautic.core.segment.circular_dependency_exists'));
     }
 
     /**
@@ -163,7 +163,7 @@ final class CircularDependencyValidatorTest extends \PHPUnit\Framework\TestCase
      */
     public static function validateDataProvider(): \Iterator
     {
-        $constraint = new CircularDependency(['message' => 'mautic.core.segment.circular_dependency_exists']);
+        $constraint = new CircularDependency(message: 'mautic.core.segment.circular_dependency_exists');
         // Segment 1 is dependent on Segment 2 which is dependent on segment 1 - circular
         yield [
             $constraint->message,

--- a/app/bundles/CoreBundle/Validator/EntityEvent.php
+++ b/app/bundles/CoreBundle/Validator/EntityEvent.php
@@ -6,6 +6,7 @@ namespace Mautic\CoreBundle\Validator;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class EntityEvent extends Constraint
 {
     public function getTargets(): string

--- a/app/bundles/CoreBundle/Validator/SafeRemoteUrl.php
+++ b/app/bundles/CoreBundle/Validator/SafeRemoteUrl.php
@@ -4,9 +4,25 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\Validator;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 final class SafeRemoteUrl extends Constraint
 {
-    public string $message = 'mautic.core.remote_url_not_allowed';
+    public string $message;
+
+    /**
+     * @param string[]|null $groups
+     */
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'mautic.core.remote_url_not_allowed',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(null, $groups, $payload);
+
+        $this->message = $message;
+    }
 }

--- a/app/bundles/DynamicContentBundle/Validator/Constraints/NoNesting.php
+++ b/app/bundles/DynamicContentBundle/Validator/Constraints/NoNesting.php
@@ -4,12 +4,28 @@ declare(strict_types=1);
 
 namespace Mautic\DynamicContentBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 /**
  * This constraint checks if the content does not include another DWC token.
  */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 final class NoNesting extends Constraint
 {
-    public string $message = 'mautic.dynamicContent.no_nesting';
+    public string $message;
+
+    /**
+     * @param string[]|null $groups
+     */
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'mautic.dynamicContent.no_nesting',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(null, $groups, $payload);
+
+        $this->message = $message;
+    }
 }

--- a/app/bundles/DynamicContentBundle/Validator/Constraints/SlotNameType.php
+++ b/app/bundles/DynamicContentBundle/Validator/Constraints/SlotNameType.php
@@ -4,14 +4,30 @@ declare(strict_types=1);
 
 namespace Mautic\DynamicContentBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 /**
  * This constraint makes sure all entities with same slot name have the same type.
  */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class SlotNameType extends Constraint
 {
-    public string $message = 'mautic.dynamicContent.slot_name_type';
+    public string $message;
+
+    /**
+     * @param string[]|null $groups
+     */
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'mautic.dynamicContent.slot_name_type',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(null, $groups, $payload);
+
+        $this->message = $message;
+    }
 
     public function getTargets(): string
     {

--- a/app/bundles/EmailBundle/Entity/Email.php
+++ b/app/bundles/EmailBundle/Entity/Email.php
@@ -498,7 +498,7 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
 
         $metadata->addPropertyConstraint(
             'fromAddress',
-            new EmailOrEmailTokenList(['allowMultiple' => false]),
+            new EmailOrEmailTokenList(allowMultiple: false),
         );
 
         $metadata->addPropertyConstraint(

--- a/app/bundles/EmailBundle/Form/Type/ConfigType.php
+++ b/app/bundles/EmailBundle/Form/Type/ConfigType.php
@@ -266,7 +266,7 @@ final class ConfigType extends AbstractType
                     new NotBlank(
                         message: 'mautic.core.email.required'
                     ),
-                    new EmailOrEmailTokenList(['allowMultiple' => false]),
+                    new EmailOrEmailTokenList(allowMultiple: false),
                 ],
             ]
         );

--- a/app/bundles/EmailBundle/Tests/Validator/EmailOrEmailTokenListValidatorTest.php
+++ b/app/bundles/EmailBundle/Tests/Validator/EmailOrEmailTokenListValidatorTest.php
@@ -70,7 +70,7 @@ final class EmailOrEmailTokenListValidatorTest extends TestCase
         );
 
         $validator->initialize($context);
-        $validator->validate('john@doe.com, jane@doe.com', new EmailOrEmailTokenList(['allowMultiple' => false]));
+        $validator->validate('john@doe.com, jane@doe.com', new EmailOrEmailTokenList(allowMultiple: false));
 
         $this->assertSame(1, $context->violationCount);
     }

--- a/app/bundles/EmailBundle/Validator/Dsn.php
+++ b/app/bundles/EmailBundle/Validator/Dsn.php
@@ -6,6 +6,7 @@ namespace Mautic\EmailBundle\Validator;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 final class Dsn extends Constraint
 {
 }

--- a/app/bundles/EmailBundle/Validator/EmailLists.php
+++ b/app/bundles/EmailBundle/Validator/EmailLists.php
@@ -6,6 +6,7 @@ namespace Mautic\EmailBundle\Validator;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class EmailLists extends Constraint
 {
     public function getTargets(): string

--- a/app/bundles/EmailBundle/Validator/EmailOrEmailTokenList.php
+++ b/app/bundles/EmailBundle/Validator/EmailOrEmailTokenList.php
@@ -4,9 +4,25 @@ declare(strict_types=1);
 
 namespace Mautic\EmailBundle\Validator;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 final class EmailOrEmailTokenList extends Constraint
 {
-    public bool $allowMultiple = true;
+    public bool $allowMultiple;
+
+    /**
+     * @param string[]|null $groups
+     */
+    #[HasNamedArguments]
+    public function __construct(
+        bool $allowMultiple = true,
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(null, $groups, $payload);
+
+        $this->allowMultiple = $allowMultiple;
+    }
 }

--- a/app/bundles/EmailBundle/Validator/MultipleEmailsValid.php
+++ b/app/bundles/EmailBundle/Validator/MultipleEmailsValid.php
@@ -4,6 +4,7 @@ namespace Mautic\EmailBundle\Validator;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 final class MultipleEmailsValid extends Constraint
 {
     public function getTargets(): string

--- a/app/bundles/EmailBundle/Validator/ScheduleDateRange.php
+++ b/app/bundles/EmailBundle/Validator/ScheduleDateRange.php
@@ -4,11 +4,27 @@ declare(strict_types=1);
 
 namespace Mautic\EmailBundle\Validator;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class ScheduleDateRange extends Constraint
 {
-    public string $message = 'mautic.form.date_time_range.invalid_range';
+    public string $message;
+
+    /**
+     * @param string[]|null $groups
+     */
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'mautic.form.date_time_range.invalid_range',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(null, $groups, $payload);
+
+        $this->message = $message;
+    }
 
     public function getTargets(): string
     {

--- a/app/bundles/EmailBundle/Validator/TextOnlyDynamicContent.php
+++ b/app/bundles/EmailBundle/Validator/TextOnlyDynamicContent.php
@@ -4,9 +4,25 @@ declare(strict_types=1);
 
 namespace Mautic\EmailBundle\Validator;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 final class TextOnlyDynamicContent extends Constraint
 {
-    public string $message = 'mautic.email.subject.dynamic_content.text_only';
+    public string $message;
+
+    /**
+     * @param string[]|null $groups
+     */
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'mautic.email.subject.dynamic_content.text_only',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(null, $groups, $payload);
+
+        $this->message = $message;
+    }
 }

--- a/app/bundles/EmailBundle/Validator/ValidEmailLinks.php
+++ b/app/bundles/EmailBundle/Validator/ValidEmailLinks.php
@@ -4,11 +4,27 @@ declare(strict_types=1);
 
 namespace Mautic\EmailBundle\Validator;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class ValidEmailLinks extends Constraint
 {
-    public string $message = 'mautic.email.links.invalid';
+    public string $message;
+
+    /**
+     * @param string[]|null $groups
+     */
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'mautic.email.links.invalid',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(null, $groups, $payload);
+
+        $this->message = $message;
+    }
 
     public function getTargets(): string
     {

--- a/app/bundles/FormBundle/Form/Type/FormFieldSliderType.php
+++ b/app/bundles/FormBundle/Form/Type/FormFieldSliderType.php
@@ -32,9 +32,7 @@ final class FormFieldSliderType extends AbstractType
             'attr'        => ['class' => 'form-control'],
             'data'        => $options['data']['max'] ?? 100,
             'constraints' => [
-                new SliderMaxGreaterThanMin([
-                    'message' => 'mautic.form.field.form.slider_max_gt_min_error',
-                ]),
+                new SliderMaxGreaterThanMin(message: 'mautic.form.field.form.slider_max_gt_min_error'),
             ],
         ]);
 
@@ -46,9 +44,7 @@ final class FormFieldSliderType extends AbstractType
             'data'        => $options['data']['step'] ?? 1,
             'constraints' => [
                 new Range(min: 1, minMessage: 'mautic.form.field.form.slider_step_min_error'),
-                new SliderStepLessThanMax([
-                    'message' => 'mautic.form.field.form.slider_step_lt_max_error',
-                ]),
+                new SliderStepLessThanMax(message: 'mautic.form.field.form.slider_step_lt_max_error'),
             ],
         ]);
     }

--- a/app/bundles/FormBundle/Validator/Constraint/FileExtensionConstraint.php
+++ b/app/bundles/FormBundle/Validator/Constraint/FileExtensionConstraint.php
@@ -2,9 +2,25 @@
 
 namespace Mautic\FormBundle\Validator\Constraint;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 final class FileExtensionConstraint extends Constraint
 {
-    public $message = 'File extension contains an illegal extension: "{{ forbidden }}".';
+    public string $message;
+
+    /**
+     * @param string[]|null $groups
+     */
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'File extension contains an illegal extension: "{{ forbidden }}".',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(null, $groups, $payload);
+
+        $this->message = $message;
+    }
 }

--- a/app/bundles/FormBundle/Validator/Constraint/IsPostActionRedirectUrl.php
+++ b/app/bundles/FormBundle/Validator/Constraint/IsPostActionRedirectUrl.php
@@ -4,9 +4,25 @@ declare(strict_types=1);
 
 namespace Mautic\FormBundle\Validator\Constraint;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 final class IsPostActionRedirectUrl extends Constraint
 {
-    public string $message = 'mautic.form.form.postactionproperty_redirect.url';
+    public string $message;
+
+    /**
+     * @param string[]|null $groups
+     */
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'mautic.form.form.postactionproperty_redirect.url',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(null, $groups, $payload);
+
+        $this->message = $message;
+    }
 }

--- a/app/bundles/FormBundle/Validator/Constraint/PhoneNumberConstraint.php
+++ b/app/bundles/FormBundle/Validator/Constraint/PhoneNumberConstraint.php
@@ -2,19 +2,33 @@
 
 namespace Mautic\FormBundle\Validator\Constraint;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 /**
  * Phone number constraint.
  */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 final class PhoneNumberConstraint extends Constraint
 {
-    public $message;
+    public ?string $message;
 
-    public function getMessage()
+    /**
+     * @param string[]|null $groups
+     */
+    #[HasNamedArguments]
+    public function __construct(
+        ?string $message = null,
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(null, $groups, $payload);
+
+        $this->message = $message;
+    }
+
+    public function getMessage(): ?string
     {
-        if (null !== $this->message) {
-            return $this->message;
-        }
+        return $this->message;
     }
 }

--- a/app/bundles/FormBundle/Validator/Constraint/SliderMaxGreaterThanMin.php
+++ b/app/bundles/FormBundle/Validator/Constraint/SliderMaxGreaterThanMin.php
@@ -4,9 +4,25 @@ declare(strict_types=1);
 
 namespace Mautic\FormBundle\Validator\Constraint;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 final class SliderMaxGreaterThanMin extends Constraint
 {
-    public string $message = 'mautic.form.field.form.slider_max_gt_min_error';
+    public string $message;
+
+    /**
+     * @param string[]|null $groups
+     */
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'mautic.form.field.form.slider_max_gt_min_error',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(null, $groups, $payload);
+
+        $this->message = $message;
+    }
 }

--- a/app/bundles/FormBundle/Validator/Constraint/SliderStepLessThanMax.php
+++ b/app/bundles/FormBundle/Validator/Constraint/SliderStepLessThanMax.php
@@ -4,9 +4,25 @@ declare(strict_types=1);
 
 namespace Mautic\FormBundle\Validator\Constraint;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 final class SliderStepLessThanMax extends Constraint
 {
-    public string $message = 'mautic.form.field.form.slider_step_lt_max_error';
+    public string $message;
+
+    /**
+     * @param string[]|null $groups
+     */
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'mautic.form.field.form.slider_step_lt_max_error',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(null, $groups, $payload);
+
+        $this->message = $message;
+    }
 }

--- a/app/bundles/InstallBundle/Configurator/Form/UserStepType.php
+++ b/app/bundles/InstallBundle/Configurator/Form/UserStepType.php
@@ -119,9 +119,7 @@ final class UserStepType extends AbstractType
                         message: 'mautic.core.value.required'
                     ),
                     new Assert\Length(min: 6, minMessage: 'mautic.install.password.minlength'),
-                    new NotWeak([
-                        'message' => 'mautic.user.user.password.weak',
-                    ]),
+                    new NotWeak(message: 'mautic.user.user.password.weak'),
                 ],
             ]
         );

--- a/app/bundles/LeadBundle/Entity/Company.php
+++ b/app/bundles/LeadBundle/Entity/Company.php
@@ -262,7 +262,7 @@ class Company extends FormEntity implements CustomFieldEntityInterface, Identifi
 
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
-        $metadata->addConstraint(new UniqueCustomField(['object' => 'company']));
+        $metadata->addConstraint(new UniqueCustomField(object: 'company'));
         $metadata->addPropertyConstraint('score', new Assert\Range(min: 0, max: 2147483647));
     }
 

--- a/app/bundles/LeadBundle/Entity/Lead.php
+++ b/app/bundles/LeadBundle/Entity/Lead.php
@@ -528,7 +528,7 @@ class Lead extends FormEntity implements CustomFieldEntityInterface, IdentifierF
 
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
-        $metadata->addConstraint(new UniqueCustomField(['object' => 'lead']));
+        $metadata->addConstraint(new UniqueCustomField(object: 'lead'));
     }
 
     public static function getDefaultIdentifierFields(): array

--- a/app/bundles/LeadBundle/Form/Type/LeadImportType.php
+++ b/app/bundles/LeadBundle/Form/Type/LeadImportType.php
@@ -30,10 +30,8 @@ final class LeadImportType extends AbstractType
                 'constraints' => [
                     new File(mimeTypes: ['text/*', 'application/octet-stream', 'application/csv'], mimeTypesMessage: 'mautic.core.invalid_file_type'),
                     new EncodingValidation(
-                        [
-                            'encodingFormat'        => ['UTF-8'],
-                            'encodingFormatMessage' => 'mautic.core.invalid_file_encoding',
-                        ]
+                        encodingFormatMessage: 'mautic.core.invalid_file_encoding',
+                        encodingFormat: ['UTF-8'],
                     ),
                     new NotBlank(
                         message: 'mautic.import.file.required'

--- a/app/bundles/LeadBundle/Form/Type/ListType.php
+++ b/app/bundles/LeadBundle/Form/Type/ListType.php
@@ -143,12 +143,8 @@ final class ListType extends AbstractType
                     'allow_delete'   => true,
                     'label'          => false,
                     'constraints'    => [
-                        new CircularDependency([
-                            'message' => 'mautic.core.segment.circular_dependency_exists',
-                        ]),
-                        new SegmentDate([
-                            'message' => 'mautic.lead.segment.date_invalid',
-                        ]),
+                        new CircularDependency(message: 'mautic.core.segment.circular_dependency_exists'),
+                        new SegmentDate(message: 'mautic.lead.segment.date_invalid'),
                     ],
                 ]
             )->addModelTransformer($filterModalTransformer)

--- a/app/bundles/LeadBundle/Form/Validator/Constraints/DbRegex.php
+++ b/app/bundles/LeadBundle/Form/Validator/Constraints/DbRegex.php
@@ -6,6 +6,7 @@ namespace Mautic\LeadBundle\Form\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 final class DbRegex extends Constraint
 {
 }

--- a/app/bundles/LeadBundle/Form/Validator/Constraints/FieldAliasKeyword.php
+++ b/app/bundles/LeadBundle/Form/Validator/Constraints/FieldAliasKeyword.php
@@ -2,11 +2,27 @@
 
 namespace Mautic\LeadBundle\Form\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 final class FieldAliasKeyword extends Constraint
 {
-    public $message = 'mautic.lead.field.keyword.invalid';
+    public string $message;
+
+    /**
+     * @param string[]|null $groups
+     */
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'mautic.lead.field.keyword.invalid',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(null, $groups, $payload);
+
+        $this->message = $message;
+    }
 
     public function validatedBy(): string
     {

--- a/app/bundles/LeadBundle/Form/Validator/Constraints/SegmentInUse.php
+++ b/app/bundles/LeadBundle/Form/Validator/Constraints/SegmentInUse.php
@@ -4,11 +4,27 @@ declare(strict_types=1);
 
 namespace Mautic\LeadBundle\Form\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class SegmentInUse extends Constraint
 {
-    public $message = 'mautic.lead_list.is_in_use.unpublish';
+    public string $message;
+
+    /**
+     * @param string[]|null $groups
+     */
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'mautic.lead_list.is_in_use.unpublish',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(null, $groups, $payload);
+
+        $this->message = $message;
+    }
 
     public function validatedBy(): string
     {

--- a/app/bundles/LeadBundle/Form/Validator/Constraints/UniqueCustomField.php
+++ b/app/bundles/LeadBundle/Form/Validator/Constraints/UniqueCustomField.php
@@ -4,13 +4,31 @@ declare(strict_types=1);
 
 namespace Mautic\LeadBundle\Form\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class UniqueCustomField extends Constraint
 {
-    public string $message = 'mautic.lead.field.unique.is_used';
+    public string $message;
 
     public string $object;
+
+    /**
+     * @param string[]|null $groups
+     */
+    #[HasNamedArguments]
+    public function __construct(
+        string $object,
+        string $message = 'mautic.lead.field.unique.is_used',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(null, $groups, $payload);
+
+        $this->object  = $object;
+        $this->message = $message;
+    }
 
     public function getTargets(): string
     {

--- a/app/bundles/LeadBundle/Validator/Constraints/SafeUrl.php
+++ b/app/bundles/LeadBundle/Validator/Constraints/SafeUrl.php
@@ -4,9 +4,25 @@ declare(strict_types=1);
 
 namespace Mautic\LeadBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 final class SafeUrl extends Constraint
 {
-    public string $dataProtocolMessage = 'mautic.lead.dataProtocolMessage';
+    public string $dataProtocolMessage;
+
+    /**
+     * @param string[]|null $groups
+     */
+    #[HasNamedArguments]
+    public function __construct(
+        string $dataProtocolMessage = 'mautic.lead.dataProtocolMessage',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(null, $groups, $payload);
+
+        $this->dataProtocolMessage = $dataProtocolMessage;
+    }
 }

--- a/app/bundles/LeadBundle/Validator/Constraints/SegmentDate.php
+++ b/app/bundles/LeadBundle/Validator/Constraints/SegmentDate.php
@@ -4,11 +4,27 @@ declare(strict_types=1);
 
 namespace Mautic\LeadBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 final class SegmentDate extends Constraint
 {
     public string $message;
+
+    /**
+     * @param string[]|null $groups
+     */
+    #[HasNamedArguments]
+    public function __construct(
+        string $message,
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(null, $groups, $payload);
+
+        $this->message = $message;
+    }
 
     public function validatedBy(): string
     {

--- a/app/bundles/LeadBundle/Validator/Constraints/SegmentUsedInCampaigns.php
+++ b/app/bundles/LeadBundle/Validator/Constraints/SegmentUsedInCampaigns.php
@@ -6,6 +6,7 @@ namespace Mautic\LeadBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class SegmentUsedInCampaigns extends Constraint
 {
     public function getTargets(): string

--- a/app/bundles/LeadBundle/Validator/LeadFieldMinimumLength.php
+++ b/app/bundles/LeadBundle/Validator/LeadFieldMinimumLength.php
@@ -4,11 +4,27 @@ declare(strict_types=1);
 
 namespace Mautic\LeadBundle\Validator;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class LeadFieldMinimumLength extends Constraint
 {
-    public string $message = 'mautic.lead.field.char_length_limit.too_short';
+    public string $message;
+
+    /**
+     * @param string[]|null $groups
+     */
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'mautic.lead.field.char_length_limit.too_short',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(null, $groups, $payload);
+
+        $this->message = $message;
+    }
 
     public function getTargets(): string
     {

--- a/app/bundles/MessengerBundle/Validator/Dsn.php
+++ b/app/bundles/MessengerBundle/Validator/Dsn.php
@@ -6,6 +6,7 @@ namespace Mautic\MessengerBundle\Validator;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 final class Dsn extends Constraint
 {
 }

--- a/app/bundles/PageBundle/Validator/PageHit.php
+++ b/app/bundles/PageBundle/Validator/PageHit.php
@@ -6,6 +6,7 @@ namespace Mautic\PageBundle\Validator;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class PageHit extends Constraint
 {
     public function getTargets(): string

--- a/app/bundles/PluginBundle/Form/Constraint/CanPublish.php
+++ b/app/bundles/PluginBundle/Form/Constraint/CanPublish.php
@@ -4,16 +4,29 @@ declare(strict_types=1);
 
 namespace Mautic\PluginBundle\Form\Constraint;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 final class CanPublish extends Constraint
 {
-    public string $message =  'mautic.lead_list.not_allowed_plugin_publish';
+    public string $message;
 
     public string $integrationName;
 
-    public function getDefaultOption(): string
-    {
-        return 'integrationName';
+    /**
+     * @param string[]|null $groups
+     */
+    #[HasNamedArguments]
+    public function __construct(
+        string $integrationName,
+        string $message = 'mautic.lead_list.not_allowed_plugin_publish',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(null, $groups, $payload);
+
+        $this->integrationName = $integrationName;
+        $this->message         = $message;
     }
 }

--- a/app/bundles/PluginBundle/Form/Type/DetailsType.php
+++ b/app/bundles/PluginBundle/Form/Type/DetailsType.php
@@ -25,7 +25,7 @@ final class DetailsType extends AbstractType
     {
         $builder->add('isPublished', YesNoButtonGroupType::class, [
             'constraints' => [
-                new CanPublish($options['integration'] ?? ''),
+                new CanPublish(integrationName: $options['integration'] ?? ''),
             ],
         ]);
 

--- a/app/bundles/PluginBundle/Tests/Form/Constraint/CanPublishValidatorTest.php
+++ b/app/bundles/PluginBundle/Tests/Form/Constraint/CanPublishValidatorTest.php
@@ -55,7 +55,7 @@ final class CanPublishValidatorTest extends TestCase
 
         $this->canPublishValidator->initialize($this->createStub(ExecutionContext::class));
 
-        $this->canPublishValidator->validate(1, new CanPublish('testIntegration'));
+        $this->canPublishValidator->validate(1, new CanPublish(integrationName: 'testIntegration'));
     }
 
     public function testEventNotDispatchedIfUnpublished(): void
@@ -75,7 +75,7 @@ final class CanPublishValidatorTest extends TestCase
 
         $this->canPublishValidator->initialize($this->createStub(ExecutionContext::class));
 
-        $this->canPublishValidator->validate(0, new CanPublish('testIntegration'));
+        $this->canPublishValidator->validate(0, new CanPublish(integrationName: 'testIntegration'));
     }
 
     public function testExceptionIsThrown(): void

--- a/app/bundles/ProjectBundle/Validator/Constraints/UniqueName.php
+++ b/app/bundles/ProjectBundle/Validator/Constraints/UniqueName.php
@@ -4,11 +4,27 @@ declare(strict_types=1);
 
 namespace Mautic\ProjectBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class UniqueName extends Constraint
 {
-    public string $message = 'project.name.already.exists';
+    public string $message;
+
+    /**
+     * @param string[]|null $groups
+     */
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'project.name.already.exists',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(null, $groups, $payload);
+
+        $this->message = $message;
+    }
 
     public function getTargets(): string
     {

--- a/app/bundles/ReportBundle/Scheduler/Validator/ScheduleIsValid.php
+++ b/app/bundles/ReportBundle/Scheduler/Validator/ScheduleIsValid.php
@@ -4,6 +4,7 @@ namespace Mautic\ReportBundle\Scheduler\Validator;
 
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class ScheduleIsValid extends Constraint
 {
     public function getTargets(): string

--- a/app/bundles/SmsBundle/Form/Validator/Constraints/MediaMaxAllowedSize.php
+++ b/app/bundles/SmsBundle/Form/Validator/Constraints/MediaMaxAllowedSize.php
@@ -4,11 +4,27 @@ declare(strict_types=1);
 
 namespace Mautic\SmsBundle\Form\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class MediaMaxAllowedSize extends Constraint
 {
-    public string $message = 'mautic.sms.form.max.size.media.error';
+    public string $message;
+
+    /**
+     * @param string[]|null $groups
+     */
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'mautic.sms.form.max.size.media.error',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(null, $groups, $payload);
+
+        $this->message = $message;
+    }
 
     public function getTargets(): string
     {

--- a/app/bundles/UserBundle/Entity/User.php
+++ b/app/bundles/UserBundle/Entity/User.php
@@ -261,12 +261,7 @@ class User extends FormEntity implements UserInterface, EquatableInterface, Pass
 
         $metadata->addPropertyConstraint('plainPassword', new Assert\Length(min: 6, minMessage: 'mautic.user.user.password.minlength', groups: ['CheckPassword']));
 
-        $metadata->addPropertyConstraint('plainPassword', new NotWeak(
-            [
-                'message'    => 'mautic.user.user.password.weak',
-                'groups'     => ['CheckPassword'],
-            ]
-        ));
+        $metadata->addPropertyConstraint('plainPassword', new NotWeak(message: 'mautic.user.user.password.weak', groups: ['CheckPassword']));
 
         $metadata->setGroupSequence(['User', 'SecondPass', 'CheckPassword']);
     }

--- a/app/bundles/UserBundle/Form/Type/PasswordResetConfirmType.php
+++ b/app/bundles/UserBundle/Form/Type/PasswordResetConfirmType.php
@@ -59,9 +59,7 @@ final class PasswordResetConfirmType extends AbstractType
                     'constraints'    => [
                         new Assert\NotBlank(message: 'mautic.user.user.passwordreset.notblank'),
                         new Assert\Length(min: 6, minMessage: 'mautic.user.user.password.minlength'),
-                        new NotWeak([
-                            'message' => 'mautic.user.user.password.weak',
-                        ]),
+                        new NotWeak(message: 'mautic.user.user.password.weak'),
                     ],
                 ],
                 'second_name'    => 'confirm',

--- a/app/bundles/UserBundle/Form/Validator/Constraints/NotWeak.php
+++ b/app/bundles/UserBundle/Form/Validator/Constraints/NotWeak.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Mautic\UserBundle\Form\Validator\Constraints;
 
 use Mautic\UserBundle\Model\PasswordStrengthEstimatorModel;
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 final class NotWeak extends Constraint
 {
     public const TOO_WEAK = 'f61e730a-284e-11eb-adc1-0242ac120002';
@@ -15,7 +17,23 @@ final class NotWeak extends Constraint
         self::TOO_WEAK => 'PASSWORD_TOO_WEAK_ERROR',
     ];
 
-    public string $message = 'This password is too weak. Consider using a stronger password.';
+    public string $message;
 
-    public int $score = PasswordStrengthEstimatorModel::MINIMUM_PASSWORD_STRENGTH_ALLOWED;
+    public int $score;
+
+    /**
+     * @param string[]|null $groups
+     */
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'This password is too weak. Consider using a stronger password.',
+        int $score = PasswordStrengthEstimatorModel::MINIMUM_PASSWORD_STRENGTH_ALLOWED,
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(null, $groups, $payload);
+
+        $this->message = $message;
+        $this->score   = $score;
+    }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -260,6 +260,7 @@ rules:
 	- Utils\PHPStan\Rule\NoGetModelWithStringInControllerRule
 	- Utils\PHPStan\Rule\NoRequiredMethodWithConstructorInControllerRule
 	- Utils\PHPStan\Rule\CommandMustHaveAsCommandAttributeRule
+	- Utils\PHPStan\Rule\ConstraintMustHaveAttributeRule
 	- Utils\PHPStan\Rule\NoNullableServiceInConstructorRule
 	- Utils\PHPStan\Rule\NoGetRepositoryWithEntityInRepositoryRule
 	- Utils\PHPStan\Rule\NoContainerGetRule

--- a/utils/phpstan/src/Rule/ConstraintMustHaveAttributeRule.php
+++ b/utils/phpstan/src/Rule/ConstraintMustHaveAttributeRule.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Rule;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Every class that extends Symfony Constraint must declare the #[\Attribute] attribute,
+ * so it can be used as a PHP attribute on entity properties.
+ *
+ * @implements Rule<Class_>
+ */
+final class ConstraintMustHaveAttributeRule implements Rule
+{
+    public function __construct(
+        private readonly ReflectionProvider $reflectionProvider,
+    ) {
+    }
+
+    public function getNodeType(): string
+    {
+        return Class_::class;
+    }
+
+    /**
+     * @param Class_ $node
+     *
+     * @return list<\PHPStan\Rules\IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        // an anonymous class carries no name to report, and cannot be used as an attribute
+        if (!$node->name instanceof Node\Identifier) {
+            return [];
+        }
+
+        // abstract base constraints are never used directly
+        if ($node->isAbstract()) {
+            return [];
+        }
+
+        $className = (string) $node->namespacedName;
+        if (!$this->reflectionProvider->hasClass($className)) {
+            return [];
+        }
+
+        if (!$this->reflectionProvider->getClass($className)->is(Constraint::class)) {
+            return [];
+        }
+
+        foreach ($node->attrGroups as $attrGroup) {
+            foreach ($attrGroup->attrs as $attr) {
+                if (\Attribute::class === $attr->name->toString()) {
+                    return [];
+                }
+            }
+        }
+
+        $ruleError = RuleErrorBuilder::message(sprintf(
+            'Class "%s" extends Constraint but is missing the #[\Attribute] attribute. Add it, so the constraint can be used as an attribute on properties, as Symfony convention.',
+            $className
+        ))
+            ->identifier('mautic.constraintAttribute')
+            ->build();
+
+        return [$ruleError];
+    }
+}

--- a/utils/phpstan/tests/Rule/ConstraintMustHaveAttributeRuleTest.php
+++ b/utils/phpstan/tests/Rule/ConstraintMustHaveAttributeRuleTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use Utils\PHPStan\Rule\ConstraintMustHaveAttributeRule;
+
+/**
+ * @extends RuleTestCase<ConstraintMustHaveAttributeRule>
+ */
+final class ConstraintMustHaveAttributeRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new ConstraintMustHaveAttributeRule($this->createReflectionProvider());
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/ConstraintMissingAttribute.php'], [
+            [
+                'Class "Utils\PHPStan\Tests\Rule\Fixture\ConstraintMissingAttribute" extends Constraint but is missing the #[\Attribute] attribute. Add it, so the constraint can be used as an attribute on properties, as Symfony convention.',
+                9,
+            ],
+        ]);
+    }
+
+    public function testSkipConstraintWithAttribute(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/ConstraintWithAttribute.php'], []);
+    }
+
+    public function testSkipAbstractBaseConstraint(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/AbstractBaseConstraint.php'], []);
+    }
+
+    public function testSkipConstraintValidator(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/ConstraintValidatorWithoutAttribute.php'], []);
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/AbstractBaseConstraint.php
+++ b/utils/phpstan/tests/Rule/Fixture/AbstractBaseConstraint.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+use Symfony\Component\Validator\Constraint;
+
+abstract class AbstractBaseConstraint extends Constraint
+{
+}

--- a/utils/phpstan/tests/Rule/Fixture/ConstraintMissingAttribute.php
+++ b/utils/phpstan/tests/Rule/Fixture/ConstraintMissingAttribute.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+use Symfony\Component\Validator\Constraint;
+
+final class ConstraintMissingAttribute extends Constraint
+{
+}

--- a/utils/phpstan/tests/Rule/Fixture/ConstraintValidatorWithoutAttribute.php
+++ b/utils/phpstan/tests/Rule/Fixture/ConstraintValidatorWithoutAttribute.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+final class ConstraintValidatorWithoutAttribute extends ConstraintValidator
+{
+    public function validate($value, Constraint $constraint): void
+    {
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/ConstraintWithAttribute.php
+++ b/utils/phpstan/tests/Rule/Fixture/ConstraintWithAttribute.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+use Symfony\Component\Validator\Constraint;
+
+#[\Attribute]
+final class ConstraintWithAttribute extends Constraint
+{
+}


### PR DESCRIPTION
Adds a PHPStan rule that reports every class extending `Symfony\Component\Validator\Constraint` that is missing the `#[\Attribute]` marker, and converts all 37 Mautic constraints so the rule passes.

Without the marker a constraint cannot be used as a PHP attribute on a property, so validation has to stay in `loadValidatorMetadata()`.

Abstract constraints, anonymous classes and `ConstraintValidator` classes are skipped by the rule.

## The rule

```php
final class SafeRemoteUrl extends Constraint // reported
```

## How each constraint changed

Symfony 7.3 deprecated the options-array syntax in favour of named arguments: [New in Symfony 7.3: Validator Improvements](https://symfony.com/blog/new-in-symfony-7-3-validator-improvements#deprecated-option-arrays). So the constraints get the `#[\Attribute]` marker plus a constructor with named arguments:

```diff
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;

+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 final class SafeRemoteUrl extends Constraint
 {
-    public string $message = 'mautic.core.remote_url_not_allowed';
+    public string $message;
+
+    /**
+     * @param string[]|null $groups
+     */
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'mautic.core.remote_url_not_allowed',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(null, $groups, $payload);
+
+        $this->message = $message;
+    }
 }
```

Class constraints (those with `getTargets(): self::CLASS_CONSTRAINT`) get `\Attribute::TARGET_CLASS` instead. Constraints without any configurable option only get the marker, no constructor.

## Usages moved to named arguments

```diff
-        $metadata->addConstraint(new UniqueCustomField(['object' => 'company']));
+        $metadata->addConstraint(new UniqueCustomField(object: 'company'));
```

```diff
-                    new NotWeak([
-                        'message' => 'mautic.user.user.password.weak',
-                    ]),
+                    new NotWeak(message: 'mautic.user.user.password.weak'),
```

## What this unlocks

Constraints can now be written as attributes on the property, instead of being registered in `loadValidatorMetadata()`:

```diff
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addPropertyConstraint('remotePath', new SafeRemoteUrl());
-    }
+    #[SafeRemoteUrl]
+    private ?string $remotePath = null;
```

That migration for the entities is done in #16958 and its split PRs.
