### PR TITLE
[validator] Make 4 constraints usable as attributes with named arguments

### DIFF
--- a/app/bundles/CoreBundle/Validator/SafeRemoteUrl.php
+++ b/app/bundles/CoreBundle/Validator/SafeRemoteUrl.php
@@ -4,9 +4,25 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\Validator;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 final class SafeRemoteUrl extends Constraint
 {
-    public string $message = 'mautic.core.remote_url_not_allowed';
+    public string $message;
+
+    /**
+     * @param string[]|null $groups
+     */
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'mautic.core.remote_url_not_allowed',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(null, $groups, $payload);
+
+        $this->message = $message;
+    }
 }

--- a/app/bundles/DynamicContentBundle/Validator/Constraints/NoNesting.php
+++ b/app/bundles/DynamicContentBundle/Validator/Constraints/NoNesting.php
@@ -4,12 +4,28 @@ declare(strict_types=1);
 
 namespace Mautic\DynamicContentBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
 /**
  * This constraint checks if the content does not include another DWC token.
  */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 final class NoNesting extends Constraint
 {
-    public string $message = 'mautic.dynamicContent.no_nesting';
+    public string $message;
+
+    /**
+     * @param string[]|null $groups
+     */
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'mautic.dynamicContent.no_nesting',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(null, $groups, $payload);
+
+        $this->message = $message;
+    }
 }

--- a/app/bundles/LeadBundle/Validator/Constraints/SafeUrl.php
+++ b/app/bundles/LeadBundle/Validator/Constraints/SafeUrl.php
@@ -4,9 +4,25 @@ declare(strict_types=1);
 
 namespace Mautic\LeadBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 final class SafeUrl extends Constraint
 {
-    public string $dataProtocolMessage = 'mautic.lead.dataProtocolMessage';
+    public string $dataProtocolMessage;
+
+    /**
+     * @param string[]|null $groups
+     */
+    #[HasNamedArguments]
+    public function __construct(
+        string $dataProtocolMessage = 'mautic.lead.dataProtocolMessage',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(null, $groups, $payload);
+
+        $this->dataProtocolMessage = $dataProtocolMessage;
+    }
 }

--- a/app/bundles/ProjectBundle/Validator/Constraints/UniqueName.php
+++ b/app/bundles/ProjectBundle/Validator/Constraints/UniqueName.php
@@ -4,11 +4,27 @@ declare(strict_types=1);
 
 namespace Mautic\ProjectBundle\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class UniqueName extends Constraint
 {
-    public string $message = 'project.name.already.exists';
+    public string $message;
+
+    /**
+     * @param string[]|null $groups
+     */
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'project.name.already.exists',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(null, $groups, $payload);
+
+        $this->message = $message;
+    }
 
     public function getTargets(): string
     {


### PR DESCRIPTION
First batch of constraints made usable as PHP attributes, following the Symfony convention (see `Symfony\Component\Validator\Constraints\NotBlank`):

- `Mautic\CoreBundle\Validator\SafeRemoteUrl`
- `Mautic\DynamicContentBundle\Validator\Constraints\NoNesting`
- `Mautic\LeadBundle\Validator\Constraints\SafeUrl`
- `Mautic\ProjectBundle\Validator\Constraints\UniqueName`

Each gets the `#[\Attribute]` marker and a constructor with named arguments, instead of public properties configured through the options array. Symfony 7.3 deprecated the options-array syntax in favour of named arguments: [New in Symfony 7.3: Validator Improvements](https://symfony.com/blog/new-in-symfony-7-3-validator-improvements#deprecated-option-arrays).

## How to migrate a constraint

```diff
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;

+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 final class SafeRemoteUrl extends Constraint
 {
-    public string $message = 'mautic.core.remote_url_not_allowed';
+    public string $message;
+
+    /**
+     * @param string[]|null $groups
+     */
+    #[HasNamedArguments]
+    public function __construct(
+        string $message = 'mautic.core.remote_url_not_allowed',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(null, $groups, $payload);
+
+        $this->message = $message;
+    }
 }
```

Then the constraint can be used as an attribute on the property, instead of being registered in `loadValidatorMetadata()`:

```diff
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addPropertyConstraint('remotePath', new SafeRemoteUrl());
-    }
+    #[SafeRemoteUrl]
+    private ?string $remotePath = null;
```

`UniqueName` is a class constraint, so it gets `TARGET_CLASS` instead of `TARGET_PROPERTY`.

All four are constructed without arguments everywhere in the codebase, so nothing else changes.

Follow-up to #16966, which adds the PHPStan rule reporting the constraints still missing the marker (33 left after this PR).
