### PR TITLE
[phpstan] re-use existing injected services instead of passing them as method parameters

### DIFF
--- a/app/AppTestKernel.php
+++ b/app/AppTestKernel.php
@@ -46,6 +46,7 @@ class AppTestKernel extends AppKernel
 
         $this->isTestContainerSet = true;
 
+        /** @var Mautic\CoreBundle\Test\Container\TestContainer $testContainer */
         $testContainer = $this->container->get('test.service_container');
         $testContainer->setPublicContainer($this->container);
 

--- a/app/bundles/CampaignBundle/Tests/Entity/CampaignRepositoryTest.php
+++ b/app/bundles/CampaignBundle/Tests/Entity/CampaignRepositoryTest.php
@@ -31,7 +31,6 @@ final class CampaignRepositoryTest extends TestCase
             'mautic.campaign.campaign.searchcommand.ispending' => 'is:pending',
             default                                            => $id,
         });
-
         $this->repository->autowireCommonRepository($translator);
     }
 

--- a/app/bundles/CoreBundle/Model/AbstractCommonModel.php
+++ b/app/bundles/CoreBundle/Model/AbstractCommonModel.php
@@ -94,11 +94,11 @@ abstract class AbstractCommonModel implements MauticModelInterface
     public function getEntities(array $args = [])
     {
         // set the translator
-        $repo = $this->getRepository();
+        $repository = $this->getRepository();
 
-        $repo->setCurrentUser($this->userHelper->getUser());
+        $repository->setCurrentUser($this->userHelper->getUser());
 
-        return $repo->getEntities($args);
+        return $repository->getEntities($args);
     }
 
     /**

--- a/app/bundles/CoreBundle/Model/AbstractCommonModel.php
+++ b/app/bundles/CoreBundle/Model/AbstractCommonModel.php
@@ -94,11 +94,12 @@ abstract class AbstractCommonModel implements MauticModelInterface
     public function getEntities(array $args = [])
     {
         // set the translator
-        $repository = $this->getRepository();
+        $repo = $this->getRepository();
 
-        $repository->setCurrentUser($this->userHelper->getUser());
+        $repo->setTranslator($this->translator);
+        $repo->setCurrentUser($this->userHelper->getUser());
 
-        return $repository->getEntities($args);
+        return $repo->getEntities($args);
     }
 
     /**

--- a/app/bundles/CoreBundle/Model/AbstractCommonModel.php
+++ b/app/bundles/CoreBundle/Model/AbstractCommonModel.php
@@ -96,7 +96,6 @@ abstract class AbstractCommonModel implements MauticModelInterface
         // set the translator
         $repo = $this->getRepository();
 
-        $repo->setTranslator($this->translator);
         $repo->setCurrentUser($this->userHelper->getUser());
 
         return $repo->getEntities($args);

--- a/app/bundles/InstallBundle/Helper/SchemaHelper.php
+++ b/app/bundles/InstallBundle/Helper/SchemaHelper.php
@@ -19,8 +19,6 @@ final class SchemaHelper
 {
     private Connection $db;
 
-    private ?EntityManagerInterface $em = null;
-
     /**
      * @var AbstractPlatform
      */
@@ -36,8 +34,10 @@ final class SchemaHelper
     /**
      * @throws \Doctrine\DBAL\Exception
      */
-    public function __construct(array $dbParams)
-    {
+    public function __construct(
+        array $dbParams,
+        private readonly EntityManagerInterface $entityManager,
+    ) {
         // suppress display of errors as we know its going to happen while testing the connection
         ini_set('display_errors', '0');
 
@@ -57,11 +57,6 @@ final class SchemaHelper
         $this->db = DriverManager::getConnection($dbParams);
 
         $this->dbParams = $dbParams;
-    }
-
-    public function setEntityManager(EntityManagerInterface $em): void
-    {
-        $this->em = $em;
     }
 
     /**
@@ -132,14 +127,14 @@ final class SchemaHelper
         $this->platform = $this->db->getDatabasePlatform();
         $backupPrefix   = (!empty($this->dbParams['backup_prefix'])) ? $this->dbParams['backup_prefix'] : 'bak_';
 
-        $metadatas = $this->em->getMetadataFactory()->getAllMetadata();
+        $metadatas = $this->entityManager->getMetadataFactory()->getAllMetadata();
         if (empty($metadatas)) {
             $this->db->close();
 
             return false;
         }
 
-        $schemaTool    = new SchemaTool($this->em);
+        $schemaTool    = new SchemaTool($this->entityManager);
         $installSchema = $schemaTool->getSchemaFromMetadata($metadatas);
         $mauticTables  = [];
 
@@ -148,7 +143,7 @@ final class SchemaHelper
             $mauticTables[$tableName] = $this->generateBackupName($this->dbParams['table_prefix'], $backupPrefix, $tableName);
         }
 
-        $isSqlite = $this->em->getConnection()->getDatabasePlatform() instanceof SqlitePlatform;
+        $isSqlite = $this->entityManager->getConnection()->getDatabasePlatform() instanceof SqlitePlatform;
         $sql      = $isSqlite ? [] : ['SET foreign_key_checks = 0;'];
         if ($this->dbParams['backup_tables']) {
             $sql = array_merge($sql, $this->backupExistingSchema($tables, $mauticTables, $backupPrefix));

--- a/app/bundles/InstallBundle/Install/InstallService.php
+++ b/app/bundles/InstallBundle/Install/InstallService.php
@@ -250,7 +250,7 @@ class InstallService
         }
 
         // Check if connection works and/or create database if applicable
-        $schemaHelper = new SchemaHelper($dbParams);
+        $schemaHelper = new SchemaHelper($dbParams, $this->entityManager);
 
         try {
             $schemaHelper->testConnection();
@@ -296,8 +296,7 @@ class InstallService
      */
     public function createSchemaStep(array $dbParams): array
     {
-        $schemaHelper = new SchemaHelper($dbParams);
-        $schemaHelper->setEntityManager($this->entityManager);
+        $schemaHelper = new SchemaHelper($dbParams, $this->entityManager);
 
         $messages = [];
         try {

--- a/app/bundles/InstallBundle/Tests/Install/InstallSchemaTest.php
+++ b/app/bundles/InstallBundle/Tests/Install/InstallSchemaTest.php
@@ -9,6 +9,7 @@ use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Table;
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Test\EnvLoader;
 use Mautic\InstallBundle\Helper\SchemaHelper;
 use PHPUnit\Framework\TestCase;
@@ -80,7 +81,7 @@ final class InstallSchemaTest extends TestCase
 
     public function testBackupIndexesWithConfigOptions(): void
     {
-        $schemaHelper = new SchemaHelper($this->dbParams);
+        $schemaHelper = new SchemaHelper($this->dbParams, $this->createStub(EntityManagerInterface::class));
 
         // Make the backupExistingSchema method public so we can test that functionality without mocking all the SchemaHelper's functionality.
         $controllerReflection = new \ReflectionClass(SchemaHelper::class);

--- a/app/bundles/IntegrationsBundle/Controller/ConfigController.php
+++ b/app/bundles/IntegrationsBundle/Controller/ConfigController.php
@@ -26,8 +26,6 @@ use Mautic\IntegrationsBundle\Integration\Interfaces\ConfigFormNotesInterface;
 use Mautic\IntegrationsBundle\Integration\Interfaces\ConfigFormSyncInterface;
 use Mautic\IntegrationsBundle\IntegrationEvents;
 use Mautic\PluginBundle\Entity\Integration;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -40,17 +38,12 @@ final class ConfigController extends AbstractFormController
      */
     private $integrationObject;
 
-    /**
-     * @var Integration
-     */
-    private $integrationConfiguration;
+    private ?Integration $integrationConfiguration = null;
 
     public function editAction(
         Request $request,
         ConfigIntegrationsHelper $integrationsHelper,
-        EventDispatcherInterface $dispatcher,
         FieldValidationHelper $fieldValidator,
-        FormFactoryInterface $formFactory,
         FormExtension $formExtension,
         string $integration,
     ): Response {
@@ -67,13 +60,13 @@ final class ConfigController extends AbstractFormController
         }
 
         $event = new FormLoadEvent($this->integrationConfiguration);
-        $dispatcher->dispatch($event, IntegrationEvents::INTEGRATION_CONFIG_FORM_LOAD);
+        $this->dispatcher->dispatch($event, IntegrationEvents::INTEGRATION_CONFIG_FORM_LOAD);
 
         // Create the form
-        $form = $this->getForm($formFactory);
+        $form = $this->getForm();
 
         if (Request::METHOD_POST === $request->getMethod()) {
-            return $this->submitForm($request, $integrationsHelper, $fieldValidator, $dispatcher, $formFactory, $formExtension, $form);
+            return $this->submitForm($request, $integrationsHelper, $fieldValidator, $formExtension, $form);
         }
 
         // Clear the session of previously stored fields in case it got stuck
@@ -90,8 +83,6 @@ final class ConfigController extends AbstractFormController
         Request $request,
         ConfigIntegrationsHelper $integrationsHelper,
         FieldValidationHelper $fieldValidator,
-        EventDispatcherInterface $eventDispatcher,
-        FormFactoryInterface $formFactory,
         FormExtension $formExtension,
         FormInterface $form,
     ): JsonResponse|Response {
@@ -131,7 +122,8 @@ final class ConfigController extends AbstractFormController
 
         // Dispatch event prior to saving the Integration. Bundles/plugins may need to modify some field values before save
         $configEvent = new ConfigSaveEvent($this->integrationConfiguration);
-        $eventDispatcher->dispatch($configEvent, IntegrationEvents::INTEGRATION_CONFIG_BEFORE_SAVE);
+
+        $this->dispatcher->dispatch($configEvent, IntegrationEvents::INTEGRATION_CONFIG_BEFORE_SAVE);
 
         // Show the form if there are errors and the plugin is published or the authorized button was clicked
         $integrationDetailsPost = $request->request->all()['integration_details'] ?? [];
@@ -144,13 +136,13 @@ final class ConfigController extends AbstractFormController
         $integrationsHelper->saveIntegrationConfiguration($this->integrationConfiguration);
 
         // Dispatch after save event
-        $eventDispatcher->dispatch($configEvent, IntegrationEvents::INTEGRATION_CONFIG_AFTER_SAVE);
+        $this->dispatcher->dispatch($configEvent, IntegrationEvents::INTEGRATION_CONFIG_AFTER_SAVE);
 
         // Show the form if the apply button was clicked
         if ($this->isFormApplied($form)) {
             // Regenerate the form
             $this->resetFieldsInSession($request);
-            $form = $this->getForm($formFactory);
+            $form = $this->getForm();
 
             return $this->showForm($request, $form, $formExtension);
         }
@@ -162,9 +154,9 @@ final class ConfigController extends AbstractFormController
     /**
      * @return FormInterface<mixed>
      */
-    private function getForm(FormFactoryInterface $formFactory): FormInterface
+    private function getForm(): FormInterface
     {
-        return $formFactory->create(
+        return $this->createForm(
             $this->integrationObject->getConfigFormName() ?: IntegrationConfigType::class,
             $this->integrationConfiguration,
             [

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -2171,7 +2171,7 @@ final class LeadController extends FormController
      *
      * @throws \Exception
      */
-    public function batchExportAction(Request $request, ExportHelper $exportHelper, EventDispatcherInterface $dispatcher): Response
+    public function batchExportAction(Request $request, ExportHelper $exportHelper): Response
     {
         // set some permissions
         $permissions = $this->security->isGranted(
@@ -2253,7 +2253,7 @@ final class LeadController extends FormController
         }
 
         if ('csv' === $fileType && $this->coreParametersHelper->get('contact_export_in_background', false)) {
-            return $this->contactExportCSVScheduler($dispatcher, $permissions);
+            return $this->contactExportCSVScheduler($permissions);
         }
 
         $iterator = new IteratorExportDataModel(
@@ -2266,7 +2266,7 @@ final class LeadController extends FormController
         $details['total'] = $iterator->getTotal();
         $details['args']  = $iterator->getArgs();
 
-        $dispatcher->dispatch(
+        $this->dispatcher->dispatch(
             new ContactExportEvent($details, 'ContactExports'),
             LeadEvents::POST_CONTACT_EXPORT
         );
@@ -2338,12 +2338,12 @@ final class LeadController extends FormController
     /**
      * @param array<mixed> $permissions
      */
-    private function contactExportCSVScheduler(EventDispatcherInterface $dispatcher, array $permissions): JsonResponse
+    private function contactExportCSVScheduler(array $permissions): JsonResponse
     {
         $data                   = $this->contactExportSchedulerModel->prepareData($permissions);
         $contactExportScheduler = $this->contactExportSchedulerModel->saveEntity($data);
 
-        $dispatcher->dispatch(
+        $this->dispatcher->dispatch(
             new ContactExportSchedulerEvent($contactExportScheduler),
             LeadEvents::POST_CONTACT_EXPORT_SCHEDULED
         );

--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -10,6 +10,7 @@ use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\ProjectBundle\Entity\ProjectRepositoryTrait;
 use Mautic\UserBundle\Entity\User;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\Service\Attribute\Required;
 
 /**
  * @extends CommonRepository<LeadList>
@@ -358,8 +359,10 @@ class LeadListRepository extends CommonRepository
         return $objectFilters;
     }
 
-    public function setDispatcher(EventDispatcherInterface $dispatcher): void
-    {
+    #[Required]
+    public function autowireLeadListRepository(
+        EventDispatcherInterface $dispatcher,
+    ): void {
         $this->dispatcher = $dispatcher;
     }
 

--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -60,10 +60,7 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
         $this->doNotContactRepository = $doNotContactRepository;
     }
 
-    /**
-     * @var EventDispatcherInterface
-     */
-    protected $dispatcher;
+    protected EventDispatcherInterface $dispatcher;
 
     private array $availableSocialFields = [];
 
@@ -97,8 +94,10 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
         $this->triggerModel = $triggerModel;
     }
 
-    public function setDispatcher(EventDispatcherInterface $dispatcher): void
-    {
+    #[Required]
+    public function setDispatcher(
+        EventDispatcherInterface $dispatcher,
+    ): void {
         $this->dispatcher = $dispatcher;
     }
 
@@ -993,15 +992,13 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
                 break;
         }
 
-        if ($this->dispatcher) {
-            $event = new LeadBuildSearchEvent($filter->string, $filter->command, $unique, $filter->not, $q);
-            $this->dispatcher->dispatch($event, LeadEvents::LEAD_BUILD_SEARCH_COMMANDS);
-            if ($event->isSearchDone()) {
-                $returnParameter = $event->getReturnParameters();
-                $filter->strict  = $event->getStrict();
-                $expr            = $event->getSubQuery();
-                $parameters      = array_merge($parameters, $event->getParameters());
-            }
+        $event = new LeadBuildSearchEvent($filter->string, $filter->command, $unique, $filter->not, $q);
+        $this->dispatcher->dispatch($event, LeadEvents::LEAD_BUILD_SEARCH_COMMANDS);
+        if ($event->isSearchDone()) {
+            $returnParameter = $event->getReturnParameters();
+            $filter->strict  = $event->getStrict();
+            $expr            = $event->getSubQuery();
+            $parameters      = array_merge($parameters, $event->getParameters());
         }
 
         if ($returnParameter) {

--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -92,8 +92,6 @@ class ListModel extends FormModel implements GlobalSearchInterface
 
     public function getRepository(): LeadListRepository
     {
-        $this->leadListRepository->setDispatcher($this->dispatcher);
-
         return $this->leadListRepository;
     }
 

--- a/app/bundles/PageBundle/Controller/PageController.php
+++ b/app/bundles/PageBundle/Controller/PageController.php
@@ -8,12 +8,10 @@ use Mautic\CoreBundle\Event\DetermineWinnerEvent;
 use Mautic\CoreBundle\Factory\PageHelperFactoryInterface;
 use Mautic\CoreBundle\Form\Type\ContentPreviewSettingsType;
 use Mautic\CoreBundle\Form\Type\DateRangeType;
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\CoreBundle\Helper\ThemeHelper;
 use Mautic\CoreBundle\Model\AuditLogModel;
 use Mautic\CoreBundle\Translation\Translator;
-use Mautic\CoreBundle\Twig\Helper\AssetsHelper;
 use Mautic\FormBundle\Model\SubmissionModel;
 use Mautic\PageBundle\Entity\Page;
 use Mautic\PageBundle\Event\PageEditSubmitEvent;
@@ -23,7 +21,6 @@ use Mautic\PageBundle\Model\PageModel;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Service\Attribute\Required;
 
 final class PageController extends FormController
@@ -369,7 +366,7 @@ final class PageController extends FormController
      *
      * @param Page|null $entity
      */
-    public function newAction(Request $request, PageConfig $pageConfig, AssetsHelper $assetsHelper, Translator $translator, RouterInterface $routerHelper, CoreParametersHelper $coreParametersHelper, ThemeHelper $themeHelper, PageModel $model, $entity = null): Response
+    public function newAction(Request $request, PageConfig $pageConfig, Translator $translator, ThemeHelper $themeHelper, PageModel $model, $entity = null): Response
     {
         if (!$entity instanceof Page) {
             $entity = $model->getEntity();
@@ -679,7 +676,7 @@ final class PageController extends FormController
      *
      * @param int $objectId
      */
-    public function cloneAction(Request $request, PageConfig $pageConfig, AssetsHelper $assetsHelper, Translator $translator, RouterInterface $routerHelper, CoreParametersHelper $coreParametersHelper, ThemeHelper $themeHelper, PageModel $model, $objectId): Response
+    public function cloneAction(Request $request, PageConfig $pageConfig, Translator $translator, ThemeHelper $themeHelper, PageModel $model, $objectId): Response
     {
         $entity = $model->getEntity($objectId);
 
@@ -706,7 +703,7 @@ final class PageController extends FormController
             $session->set($contentName, $entity->getCustomHtml());
         }
 
-        return $this->newAction($request, $pageConfig, $assetsHelper, $translator, $routerHelper, $coreParametersHelper, $themeHelper, $model, $entity);
+        return $this->newAction($request, $pageConfig, $translator, $themeHelper, $model, $entity);
     }
 
     /**
@@ -879,7 +876,7 @@ final class PageController extends FormController
     /**
      * @param int $objectId
      */
-    public function abtestAction(Request $request, PageConfig $pageConfig, AssetsHelper $assetsHelper, Translator $translator, RouterInterface $routerHelper, CoreParametersHelper $coreParametersHelper, ThemeHelper $themeHelper, PageModel $model, $objectId): Response
+    public function abtestAction(Request $request, PageConfig $pageConfig, Translator $translator, ThemeHelper $themeHelper, PageModel $model, $objectId): Response
     {
         $entity = $model->getEntity($objectId);
 
@@ -908,7 +905,7 @@ final class PageController extends FormController
         $clone->setIsPublished(false);
         $clone->setVariantParent($entity);
 
-        return $this->newAction($request, $pageConfig, $assetsHelper, $translator, $routerHelper, $coreParametersHelper, $themeHelper, $model, $clone);
+        return $this->newAction($request, $pageConfig, $translator, $themeHelper, $model, $clone);
     }
 
     /**

--- a/app/bundles/ProjectBundle/Controller/ProjectController.php
+++ b/app/bundles/ProjectBundle/Controller/ProjectController.php
@@ -135,7 +135,7 @@ final class ProjectController extends AbstractFormController
         ]);
     }
 
-    public function newAction(Request $request, ProjectModel $projectModel, FormFactoryInterface $formFactory, CorePermissions $corePermissions): Response
+    public function newAction(Request $request, ProjectModel $projectModel, CorePermissions $corePermissions): Response
     {
         if (!$corePermissions->isGranted(ProjectPermissions::CAN_CREATE)) {
             $this->throwAccessDenied();
@@ -146,7 +146,7 @@ final class ProjectController extends AbstractFormController
         $returnUrl = $this->generateUrl(self::ROUTE_INDEX, ['page' => $page]);
         $action    = $this->generateUrl(self::ROUTE_ACTION, ['objectAction' => 'new']);
 
-        $form = $this->buildForm($project, $action, $formFactory);
+        $form = $this->buildForm($project, $action);
 
         if ('POST' === $request->getMethod()) {
             $valid     = $this->isFormValid($form);
@@ -176,7 +176,7 @@ final class ProjectController extends AbstractFormController
             }
 
             if ($valid) {
-                return $this->editAction($project->getId(), $request, $projectModel, $formFactory, $corePermissions, true);
+                return $this->editAction($project->getId(), $request, $projectModel, $corePermissions, true);
             }
         }
 
@@ -194,7 +194,7 @@ final class ProjectController extends AbstractFormController
         ]);
     }
 
-    public function editAction(string|int $objectId, Request $request, ProjectModel $projectModel, FormFactoryInterface $formFactory, CorePermissions $corePermissions, bool $ignorePost = false): Response
+    public function editAction(string|int $objectId, Request $request, ProjectModel $projectModel, CorePermissions $corePermissions, bool $ignorePost = false): Response
     {
         if (!$corePermissions->isGranted(ProjectPermissions::CAN_EDIT)) {
             $this->throwAccessDenied();
@@ -211,7 +211,7 @@ final class ProjectController extends AbstractFormController
             }
 
             $action = $this->generateUrl(self::ROUTE_ACTION, ['objectAction' => 'edit', 'objectId' => $objectId]);
-            $form   = $this->buildForm($project, $action, $formFactory);
+            $form   = $this->buildForm($project, $action);
 
             if (!$ignorePost && 'POST' === $request->getMethod()) {
                 if ($this->isFormCancelled($form)) {
@@ -242,7 +242,7 @@ final class ProjectController extends AbstractFormController
                         // Re-create the form once more with the fresh project and action.
                         // The alias was empty on redirect after cloning.
                         $editAction = $this->generateUrl(self::ROUTE_ACTION, ['objectAction' => 'edit', 'objectId' => $project->getId()]);
-                        $form       = $this->buildForm($project, $editAction, $formFactory);
+                        $form       = $this->buildForm($project, $editAction);
 
                         $postActionVars['viewParameters'] = [
                             'objectAction' => 'edit',
@@ -735,8 +735,8 @@ final class ProjectController extends AbstractFormController
     /**
      * @return FormInterface<FormInterface>&FormInterface
      */
-    private function buildForm(Project $project, string $action, FormFactoryInterface $formFactory): FormInterface
+    private function buildForm(Project $project, string $action): FormInterface
     {
-        return $formFactory->create(ProjectEntityType::class, $project, ['action' => $action]);
+        return $this->createForm(ProjectEntityType::class, $project, ['action' => $action]);
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -266,6 +266,7 @@ rules:
 	- Utils\PHPStan\Rule\ControllerMethodMustReturnResponseRule
 
 	- Utils\PHPStan\Rule\NoServicesInBundleConfigRule
+	- Utils\PHPStan\Rule\NoServiceInMethodParameterRule
 	#- Utils\PHPStan\Rule\NoUnusedServiceAliasRule
 	- Utils\PHPStan\Rule\NoParentConstructorForwardingRule
 	- Utils\PHPStan\Rule\NoServiceJugglingRule


### PR DESCRIPTION
Re-use services already injected into the class instead of passing them around as method parameters or setters.

Split out of the original PR: the PHPStan rule that reports these moved to #16984, the logger fixes to #16985. This PR is only the remaining fixes.

Repositories got their services through manual setter calls from the model layer:

```diff
     public function getRepository(): LeadListRepository
     {
-        $this->leadListRepository->setDispatcher($this->dispatcher);
-        $this->leadListRepository->setTranslator($this->translator);
-
         return $this->leadListRepository;
     }
```

The setters become `#[Required]` autowire methods, so Symfony injects them once and every caller stops carrying the service:

```diff
-    public function setDispatcher(EventDispatcherInterface $dispatcher): void
-    {
+    #[Required]
+    public function autowireLeadListRepository(
+        EventDispatcherInterface $dispatcher,
+    ): void {
         $this->dispatcher = $dispatcher;
     }
```

Same treatment for `CommonRepository::setTranslator()`, and for services handed into methods in `SchemaHelper`, `InstallService`, `AbstractFormFieldHelper`, `LeadController`, `PageController`, `CampaignController` and `GrapesJsBuilderModel`.
