### PR TITLE
fix(campaign): prevent repeated summary batch persistence

### DIFF
--- a/app/bundles/CampaignBundle/Model/SummaryModel.php
+++ b/app/bundles/CampaignBundle/Model/SummaryModel.php
@@ -62,8 +62,8 @@ class SummaryModel extends AbstractCommonModel
             $this->logData[$key] = [
                 'campaignId' => $campaign->getId(),
                 'eventId'    => $event->getId(),
-                'dateFrom'   => $dateFrom,
-                'dateTo'     => $dateTo,
+                'dateFrom'   => clone $dateFrom,
+                'dateTo'     => clone $dateTo,
             ];
         }
 
@@ -153,6 +153,10 @@ class SummaryModel extends AbstractCommonModel
      */
     public function persistSummaries(): void
     {
+        if (!$this->logData) {
+            return;
+        }
+
         foreach ($this->logData as $log) {
             $dateFrom   = $log['dateFrom'];
             $dateTo     = $log['dateTo'];
@@ -160,6 +164,8 @@ class SummaryModel extends AbstractCommonModel
             $eventId    = $log['eventId'];
             $this->summaryRepository->summarize($dateFrom, $dateTo, $campaignId, $eventId);
         }
+
+        $this->logData = [];
     }
 
     private function outputProcessTime(\DateTime $startedAt, OutputInterface $output): void

--- a/app/bundles/CampaignBundle/Tests/Functional/Model/SummaryModelFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Model/SummaryModelFunctionalTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CampaignBundle\Tests\Functional\Model;
+
+use Mautic\CampaignBundle\Entity\Campaign;
+use Mautic\CampaignBundle\Entity\Event;
+use Mautic\CampaignBundle\Entity\Lead as CampaignLead;
+use Mautic\CampaignBundle\Entity\LeadEventLog;
+use Mautic\CampaignBundle\Model\SummaryModel;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\LeadBundle\Entity\Lead;
+
+final class SummaryModelFunctionalTest extends MauticMysqlTestCase
+{
+    private SummaryModel $summaryModel;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->summaryModel = static::getContainer()->get(SummaryModel::class);
+    }
+
+    public function testPersistSummariesGeneratesStableHourlyRowsPerEvent(): void
+    {
+        $campaign = $this->createCampaign('Summary campaign');
+        $lead     = $this->createLead('Summary lead');
+        $this->createCampaignLead($campaign, $lead);
+
+        $firstEvent  = $this->createEvent($campaign, 'First event');
+        $secondEvent = $this->createEvent($campaign, 'Second event');
+
+        $firstLog  = $this->createEventLog($campaign, $firstEvent, $lead, '2026-03-18 19:12:34');
+        $secondLog = $this->createEventLog($campaign, $secondEvent, $lead, '2026-03-19 09:45:10');
+
+        $this->em->flush();
+
+        $this->summaryModel->updateSummary([$firstLog, $secondLog]);
+        $this->summaryModel->persistSummaries();
+
+        $rows = $this->connection->createQueryBuilder()
+            ->select('event_id', 'date_triggered', 'triggered_count', 'log_counts_processed')
+            ->from(MAUTIC_TABLE_PREFIX.'campaign_summary')
+            ->where('campaign_id = :campaignId')
+            ->setParameter('campaignId', $campaign->getId())
+            ->orderBy('event_id', 'ASC')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        $this->assertCount(2, $rows);
+
+        $rowsByEvent = [];
+        foreach ($rows as $row) {
+            $rowsByEvent[(int) $row['event_id']] = $row;
+        }
+
+        $this->assertSame('2026-03-18 19:00:00', $rowsByEvent[$firstEvent->getId()]['date_triggered']);
+        $this->assertSame('1', $rowsByEvent[$firstEvent->getId()]['triggered_count']);
+        $this->assertSame('1', $rowsByEvent[$firstEvent->getId()]['log_counts_processed']);
+
+        $this->assertSame('2026-03-19 09:00:00', $rowsByEvent[$secondEvent->getId()]['date_triggered']);
+        $this->assertSame('1', $rowsByEvent[$secondEvent->getId()]['triggered_count']);
+        $this->assertSame('1', $rowsByEvent[$secondEvent->getId()]['log_counts_processed']);
+    }
+
+    public function testPersistSummariesClearsBufferedLogsAfterFlush(): void
+    {
+        $campaign = $this->createCampaign('Buffered summary campaign');
+        $lead     = $this->createLead('Buffered summary lead');
+        $this->createCampaignLead($campaign, $lead);
+
+        $event = $this->createEvent($campaign, 'Buffered event');
+        $log   = $this->createEventLog($campaign, $event, $lead, '2026-03-18 19:12:34');
+
+        $this->em->flush();
+
+        $this->summaryModel->updateSummary([$log]);
+        $this->summaryModel->persistSummaries();
+
+        $this->assertSame(1, $this->countSummaryRowsForCampaign($campaign));
+
+        $this->connection->delete(MAUTIC_TABLE_PREFIX.'campaign_summary', ['campaign_id' => $campaign->getId()]);
+
+        $this->summaryModel->persistSummaries();
+
+        $this->assertSame(0, $this->countSummaryRowsForCampaign($campaign));
+    }
+
+    private function countSummaryRowsForCampaign(Campaign $campaign): int
+    {
+        return (int) $this->connection->createQueryBuilder()
+            ->select('COUNT(*)')
+            ->from(MAUTIC_TABLE_PREFIX.'campaign_summary')
+            ->where('campaign_id = :campaignId')
+            ->setParameter('campaignId', $campaign->getId())
+            ->executeQuery()
+            ->fetchOne();
+    }
+
+    private function createCampaign(string $name): Campaign
+    {
+        $campaign = new Campaign();
+        $campaign->setName($name);
+        $campaign->setIsPublished(true);
+        $this->em->persist($campaign);
+
+        return $campaign;
+    }
+
+    private function createLead(string $firstname): Lead
+    {
+        $lead = new Lead();
+        $lead->setFirstname($firstname);
+        $this->em->persist($lead);
+
+        return $lead;
+    }
+
+    private function createCampaignLead(Campaign $campaign, Lead $lead): CampaignLead
+    {
+        $campaignLead = new CampaignLead();
+        $campaignLead->setCampaign($campaign);
+        $campaignLead->setLead($lead);
+        $campaignLead->setDateAdded(new \DateTime('2026-03-18 18:00:00'));
+        $this->em->persist($campaignLead);
+
+        return $campaignLead;
+    }
+
+    private function createEvent(Campaign $campaign, string $name): Event
+    {
+        $event = new Event();
+        $event->setCampaign($campaign);
+        $event->setName($name);
+        $event->setType(Event::TYPE_ACTION);
+        $event->setEventType('email.send');
+        $event->setTriggerMode('immediate');
+        $event->setTriggerInterval(1);
+        $this->em->persist($event);
+
+        return $event;
+    }
+
+    private function createEventLog(Campaign $campaign, Event $event, Lead $lead, string $dateTriggered): LeadEventLog
+    {
+        $eventLog = new LeadEventLog();
+        $eventLog->setCampaign($campaign);
+        $eventLog->setEvent($event);
+        $eventLog->setLead($lead);
+        $eventLog->setRotation(1);
+        $eventLog->setDateTriggered(new \DateTime($dateTriggered, new \DateTimeZone('UTC')));
+        $this->em->persist($eventLog);
+
+        return $eventLog;
+    }
+}


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️
| Related user documentation PR URL      | ❌
| Related developer documentation PR URL | ❌
| Issue(s) addressed                     | Fixes #15972

## Description

### What changed

Campaign summary batching now stores independent date window values for each queued summary row and clears the buffered summary data after it has been persisted.

### Why this is needed

`SummaryModel::updateSummary()` reused a mutable `DateTime` instance while building the summary batch. Later iterations could mutate date ranges already stored for earlier entries, causing summaries to be generated for the wrong hour.

`SummaryModel::persistSummaries()` also left the buffered entries in memory after writing them, so later calls could repeatedly rewrite the same `campaign_summary` rows.

### How it works

The summary model now clones both `dateFrom` and `dateTo` before storing them in the batch. `persistSummaries()` returns immediately when there is no buffered data and clears the batch after successful persistence.

### Impact

This is a focused bug fix with no database schema changes, no configuration changes, no BC breaks, and no plugin/API impact expected. It reduces unnecessary writes to `campaign_summary` and prevents corrupted summary date windows caused by shared mutable date objects.

---
### 📋 Steps to test this PR:

1. Open this PR on GitHub Codespaces or pull down for testing locally.

2. Open Mautic in the browser and log in as an administrator.

3. Go to **Campaigns**.

4. Create a new published campaign, or open an existing published test campaign.

5. Make sure the campaign has at least one campaign event that can be triggered by a contact, for example an action that adjusts contact points, sends an email, or updates a contact field.

6. Add at least one test contact to the campaign.

7. Run normal campaign processing:

   ```bash
   ddev exec php bin/console mautic:campaigns:rebuild -n
   ddev exec php bin/console mautic:campaigns:trigger -n
   ```

8. Open the campaign detail page.

9. Confirm the campaign statistics and event counts show the triggered contact activity.

10. Build the campaign summary statistics:

   ```bash
   ddev exec php bin/console mautic:campaigns:summarize --bypass-locking -n
   ```

11. Refresh the campaign detail page.

12. Confirm the campaign statistics remain correct after summary generation.

13. Run campaign processing again without adding new contacts and without changing the campaign:

   ```bash
   ddev exec php bin/console mautic:campaigns:rebuild -n
   ddev exec php bin/console mautic:campaigns:trigger -n
   ```

14. Run summary generation again:

   ```bash
   ddev exec php bin/console mautic:campaigns:summarize --bypass-locking -n
   ```

15. Refresh the campaign detail page.

16. Confirm the campaign statistics remain stable and do not increase again for the same contact activity.

17. Repeat summary generation one more time:

   ```bash
   ddev exec php bin/console mautic:campaigns:summarize --bypass-locking -n
   ```

18. Refresh the campaign detail page again.

19. Confirm the same counts are still stable.

20. Add a second test contact to the same campaign.

21. Run campaign processing again:

   ```bash
   ddev exec php bin/console mautic:campaigns:rebuild -n
   ddev exec php bin/console mautic:campaigns:trigger -n
   ```

22. Run summary generation again:

   ```bash
   ddev exec php bin/console mautic:campaigns:summarize --bypass-locking -n
   ```

23. Refresh the campaign detail page.

24. Confirm the campaign statistics increase only for the new contact activity.

25. Confirm there are no visible campaign summary/statistics errors, such as duplicated counts, missing event counts, or unexpectedly changing statistics after repeated processing and summary generation.