### PR TITLE
[types] add Response return type to controller actions + PHPStan rule to keep it

### DIFF
--- a/app/bundles/ApiBundle/Controller/ClientController.php
+++ b/app/bundles/ApiBundle/Controller/ClientController.php
@@ -7,8 +7,6 @@ use Mautic\CoreBundle\Controller\AbstractStandardFormController;
 use Mautic\CoreBundle\Factory\PageHelperFactoryInterface;
 use Mautic\UserBundle\Entity\User;
 use OAuth2\OAuth2;
-use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
@@ -266,10 +264,8 @@ final class ClientController extends AbstractStandardFormController
      *
      * @param int  $objectId
      * @param bool $ignorePost
-     *
-     * @return JsonResponse|RedirectResponse|Response
      */
-    public function editAction(Request $request, $objectId, $ignorePost = false)
+    public function editAction(Request $request, $objectId, $ignorePost = false): Response
     {
         if (!$this->security->isGranted('api:clients:editother')) {
             $this->throwAccessDenied();
@@ -371,10 +367,8 @@ final class ClientController extends AbstractStandardFormController
      * Deletes the entity.
      *
      * @param int $objectId
-     *
-     * @return Response
      */
-    public function deleteAction(Request $request, $objectId)
+    public function deleteAction(Request $request, $objectId): Response
     {
         if (!$this->security->isGranted('api:clients:delete')) {
             $this->throwAccessDenied();

--- a/app/bundles/ApiBundle/Controller/CommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/CommonApiController.php
@@ -72,10 +72,8 @@ class CommonApiController extends FetchCommonApiController
 
     /**
      * Delete a batch of entities.
-     *
-     * @return array|Response
      */
-    public function deleteEntitiesAction(Request $request)
+    public function deleteEntitiesAction(Request $request): Response
     {
         $parameters = $request->query->all();
 
@@ -131,10 +129,8 @@ class CommonApiController extends FetchCommonApiController
      * Deletes an entity.
      *
      * @param int $id Entity ID
-     *
-     * @return Response
      */
-    public function deleteEntityAction($id)
+    public function deleteEntityAction($id): Response
     {
         $entity = $this->model->getEntity($id);
 
@@ -163,10 +159,8 @@ class CommonApiController extends FetchCommonApiController
 
     /**
      * Edit a batch of entities.
-     *
-     * @return array|Response
      */
-    public function editEntitiesAction(Request $request)
+    public function editEntitiesAction(Request $request): Response
     {
         $parameters = $request->request->all();
 
@@ -237,10 +231,8 @@ class CommonApiController extends FetchCommonApiController
      * Edits an existing entity or creates one on PUT if it doesn't exist.
      *
      * @param int $id Entity ID
-     *
-     * @return Response
      */
-    public function editEntityAction(Request $request, $id)
+    public function editEntityAction(Request $request, $id): Response
     {
         $entity     = $this->model->getEntity($id);
         $parameters = $request->request->all();
@@ -268,10 +260,8 @@ class CommonApiController extends FetchCommonApiController
 
     /**
      * Create a batch of new entities.
-     *
-     * @return array|Response
      */
-    public function newEntitiesAction(Request $request)
+    public function newEntitiesAction(Request $request): Response
     {
         $entity = $this->model->getEntity();
 
@@ -332,10 +322,8 @@ class CommonApiController extends FetchCommonApiController
 
     /**
      * Creates a new entity.
-     *
-     * @return Response
      */
-    public function newEntityAction(Request $request)
+    public function newEntityAction(Request $request): Response
     {
         $parameters = $request->request->all();
         $entity     = $this->getNewEntity($parameters);

--- a/app/bundles/ApiBundle/Controller/CommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/CommonApiController.php
@@ -72,8 +72,10 @@ class CommonApiController extends FetchCommonApiController
 
     /**
      * Delete a batch of entities.
+     *
+     * @return array|Response
      */
-    public function deleteEntitiesAction(Request $request): Response
+    public function deleteEntitiesAction(Request $request)
     {
         $parameters = $request->query->all();
 
@@ -129,8 +131,10 @@ class CommonApiController extends FetchCommonApiController
      * Deletes an entity.
      *
      * @param int $id Entity ID
+     *
+     * @return Response
      */
-    public function deleteEntityAction($id): Response
+    public function deleteEntityAction($id)
     {
         $entity = $this->model->getEntity($id);
 
@@ -159,8 +163,10 @@ class CommonApiController extends FetchCommonApiController
 
     /**
      * Edit a batch of entities.
+     *
+     * @return array|Response
      */
-    public function editEntitiesAction(Request $request): Response
+    public function editEntitiesAction(Request $request)
     {
         $parameters = $request->request->all();
 
@@ -231,8 +237,10 @@ class CommonApiController extends FetchCommonApiController
      * Edits an existing entity or creates one on PUT if it doesn't exist.
      *
      * @param int $id Entity ID
+     *
+     * @return Response
      */
-    public function editEntityAction(Request $request, $id): Response
+    public function editEntityAction(Request $request, $id)
     {
         $entity     = $this->model->getEntity($id);
         $parameters = $request->request->all();
@@ -260,8 +268,10 @@ class CommonApiController extends FetchCommonApiController
 
     /**
      * Create a batch of new entities.
+     *
+     * @return array|Response
      */
-    public function newEntitiesAction(Request $request): Response
+    public function newEntitiesAction(Request $request)
     {
         $entity = $this->model->getEntity();
 
@@ -322,8 +332,10 @@ class CommonApiController extends FetchCommonApiController
 
     /**
      * Creates a new entity.
+     *
+     * @return Response
      */
-    public function newEntityAction(Request $request): Response
+    public function newEntityAction(Request $request)
     {
         $parameters = $request->request->all();
         $entity     = $this->getNewEntity($parameters);

--- a/app/bundles/ApiBundle/Controller/FetchCommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/FetchCommonApiController.php
@@ -156,10 +156,8 @@ class FetchCommonApiController extends AbstractFOSRestController implements Maut
 
     /**
      * Obtains a list of entities as defined by the API URL.
-     *
-     * @return Response
      */
-    public function getEntitiesAction(Request $request, UserHelper $userHelper)
+    public function getEntitiesAction(Request $request, UserHelper $userHelper): Response
     {
         $repo          = $this->model->getRepository();
         $tableAlias    = $repo->getTableAlias();
@@ -305,10 +303,8 @@ class FetchCommonApiController extends AbstractFOSRestController implements Maut
      * Obtains a specific entity as defined by the API URL.
      *
      * @param int $id Entity ID
-     *
-     * @return Response
      */
-    public function getEntityAction(Request $request, $id)
+    public function getEntityAction(Request $request, $id): Response
     {
         $args = [];
         if ($select = InputHelper::cleanArray($request->get('select', []))) {

--- a/app/bundles/ApiBundle/Controller/FetchCommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/FetchCommonApiController.php
@@ -156,8 +156,10 @@ class FetchCommonApiController extends AbstractFOSRestController implements Maut
 
     /**
      * Obtains a list of entities as defined by the API URL.
+     *
+     * @return Response
      */
-    public function getEntitiesAction(Request $request, UserHelper $userHelper): Response
+    public function getEntitiesAction(Request $request, UserHelper $userHelper)
     {
         $repo          = $this->model->getRepository();
         $tableAlias    = $repo->getTableAlias();
@@ -303,8 +305,10 @@ class FetchCommonApiController extends AbstractFOSRestController implements Maut
      * Obtains a specific entity as defined by the API URL.
      *
      * @param int $id Entity ID
+     *
+     * @return Response
      */
-    public function getEntityAction(Request $request, $id): Response
+    public function getEntityAction(Request $request, $id)
     {
         $args = [];
         if ($select = InputHelper::cleanArray($request->get('select', []))) {

--- a/app/bundles/AssetBundle/Controller/AssetController.php
+++ b/app/bundles/AssetBundle/Controller/AssetController.php
@@ -399,10 +399,8 @@ final class AssetController extends FormController
      *
      * @param int  $objectId
      * @param bool $ignorePost
-     *
-     * @return JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse|Response
      */
-    public function editAction(Request $request, UploaderHelper $uploaderHelper, IntegrationHelper $integrationHelper, AssetModel $model, $objectId, $ignorePost = false)
+    public function editAction(Request $request, UploaderHelper $uploaderHelper, IntegrationHelper $integrationHelper, AssetModel $model, $objectId, $ignorePost = false): Response
     {
         $entity = $model->getEntity($objectId);
 
@@ -592,10 +590,8 @@ final class AssetController extends FormController
      * Deletes the entity.
      *
      * @param int $objectId
-     *
-     * @return Response
      */
-    public function deleteAction(Request $request, AssetModel $model, $objectId)
+    public function deleteAction(Request $request, AssetModel $model, $objectId): Response
     {
         $page      = $request->getSession()->get('mautic.asset.page', 1);
         $returnUrl = $this->generateUrl('mautic_asset_index', ['page' => $page]);
@@ -719,8 +715,6 @@ final class AssetController extends FormController
 
     /**
      * Renders the container for the remote file browser.
-     *
-     * @return JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse
      */
     public function remoteAction(Request $request, IntegrationHelper $integrationHelper): Response
     {

--- a/app/bundles/CampaignBundle/Controller/Api/EventLogApiController.php
+++ b/app/bundles/CampaignBundle/Controller/Api/EventLogApiController.php
@@ -88,10 +88,8 @@ final class EventLogApiController extends FetchCommonApiController
 
     /**
      * Get a list of events.
-     *
-     * @return Response
      */
-    public function getContactEventsAction(Request $request, UserHelper $userHelper, $contactId, $campaignId = null)
+    public function getContactEventsAction(Request $request, UserHelper $userHelper, $contactId, $campaignId = null): Response
     {
         // Ensure contact exists and user has access
         $contact = $this->checkLeadAccess($contactId, 'view');
@@ -138,10 +136,7 @@ final class EventLogApiController extends FetchCommonApiController
         return $this->getEntitiesAction($request, $userHelper);
     }
 
-    /**
-     * @return Response
-     */
-    public function editContactEventAction(Request $request, $eventId, $contactId)
+    public function editContactEventAction(Request $request, $eventId, $contactId): Response
     {
         $parameters = $request->request->all();
 

--- a/app/bundles/CampaignBundle/Controller/CampaignController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignController.php
@@ -286,8 +286,6 @@ class CampaignController extends AbstractStandardFormController
      * @param string|int $objectId
      * @param int        $page
      * @param int|null   $count
-     *
-     * @return JsonResponse|RedirectResponse|Response
      */
     public function contactsAction(
         Request $request,
@@ -297,7 +295,7 @@ class CampaignController extends AbstractStandardFormController
         $count = null,
         ?\DateTimeInterface $dateFrom = null,
         ?\DateTimeInterface $dateTo = null,
-    ) {
+    ): Response {
         $session = $request->getSession();
         $session->set('mautic.campaign.contact.page', $page);
 

--- a/app/bundles/CategoryBundle/Controller/CategoryController.php
+++ b/app/bundles/CategoryBundle/Controller/CategoryController.php
@@ -424,10 +424,8 @@ final class CategoryController extends AbstractFormController
 
     /**
      * Deletes the entity.
-     *
-     * @return Response
      */
-    public function deleteAction(Request $request, ?string $bundle, $objectId)
+    public function deleteAction(Request $request, ?string $bundle, $objectId): Response
     {
         $session    = $request->getSession();
         $page       = $session->get('mautic.category.page', 1);

--- a/app/bundles/ChannelBundle/Controller/MessageController.php
+++ b/app/bundles/ChannelBundle/Controller/MessageController.php
@@ -10,8 +10,6 @@ use Mautic\CoreBundle\Helper\Chart\LineChart;
 use Mautic\LeadBundle\Controller\EntityContactsTrait;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
-use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
@@ -34,18 +32,12 @@ final class MessageController extends AbstractStandardFormController
         $this->messageModel = $messageModel;
     }
 
-    /**
-     * @return JsonResponse|RedirectResponse
-     */
-    public function batchDeleteAction(Request $request)
+    public function batchDeleteAction(Request $request): Response
     {
         return $this->batchDeleteStandard($request);
     }
 
-    /**
-     * @return Response|JsonResponse|RedirectResponse
-     */
-    public function cloneAction(Request $request, $objectId)
+    public function cloneAction(Request $request, $objectId): Response
     {
         return $this->cloneStandard($request, $objectId);
     }
@@ -71,10 +63,7 @@ final class MessageController extends AbstractStandardFormController
         return $this->newStandard($request);
     }
 
-    /**
-     * @return array|JsonResponse|RedirectResponse|Response
-     */
-    public function viewAction(Request $request, $objectId)
+    public function viewAction(Request $request, $objectId): Response
     {
         return $this->viewStandard($request, $objectId, 'message', 'channel');
     }
@@ -179,10 +168,7 @@ final class MessageController extends AbstractStandardFormController
         return $args;
     }
 
-    /**
-     * @return JsonResponse|RedirectResponse
-     */
-    public function deleteAction(Request $request, $objectId)
+    public function deleteAction(Request $request, $objectId): Response
     {
         return $this->deleteStandard($request, $objectId);
     }
@@ -224,8 +210,6 @@ final class MessageController extends AbstractStandardFormController
 
     /**
      * @param int $page
-     *
-     * @return JsonResponse|RedirectResponse|Response
      */
     public function contactsAction(
         Request $request,
@@ -233,7 +217,7 @@ final class MessageController extends AbstractStandardFormController
         $objectId,
         $channel,
         $page = 1,
-    ) {
+    ): Response {
         $filter = [];
         if ('all' !== $channel) {
             $returnUrl = $this->generateUrl(

--- a/app/bundles/CoreBundle/Controller/AbstractFormController.php
+++ b/app/bundles/CoreBundle/Controller/AbstractFormController.php
@@ -7,8 +7,8 @@ use Mautic\CoreBundle\Model\FormModel;
 use Symfony\Component\Form\ClickableInterface;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 
 abstract class AbstractFormController extends CommonController
 {
@@ -16,8 +16,10 @@ abstract class AbstractFormController extends CommonController
 
     /**
      * @param string $objectModel
+     *
+     * @return RedirectResponse
      */
-    public function unlockAction(Request $request, $objectId, $objectModel): Response
+    public function unlockAction(Request $request, $objectId, $objectModel)
     {
         $model                = $this->getModel($objectModel);
         $entity               = $model->getEntity($objectId);
@@ -64,7 +66,7 @@ abstract class AbstractFormController extends CommonController
      * @param string $model
      * @param bool   $batch          Flag if a batch action is being performed
      *
-     * @return ($batch is true ? array : Response)
+     * @return ($batch is true ? array : \Symfony\Component\HttpFoundation\JsonResponse|RedirectResponse)
      */
     protected function isLocked($postActionVars, $entity, $model, $batch = false)
     {

--- a/app/bundles/CoreBundle/Controller/AbstractFormController.php
+++ b/app/bundles/CoreBundle/Controller/AbstractFormController.php
@@ -7,8 +7,8 @@ use Mautic\CoreBundle\Model\FormModel;
 use Symfony\Component\Form\ClickableInterface;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormInterface;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 abstract class AbstractFormController extends CommonController
 {
@@ -16,10 +16,8 @@ abstract class AbstractFormController extends CommonController
 
     /**
      * @param string $objectModel
-     *
-     * @return RedirectResponse
      */
-    public function unlockAction(Request $request, $objectId, $objectModel)
+    public function unlockAction(Request $request, $objectId, $objectModel): Response
     {
         $model                = $this->getModel($objectModel);
         $entity               = $model->getEntity($objectId);
@@ -66,7 +64,7 @@ abstract class AbstractFormController extends CommonController
      * @param string $model
      * @param bool   $batch          Flag if a batch action is being performed
      *
-     * @return ($batch is true ? array : \Symfony\Component\HttpFoundation\JsonResponse|RedirectResponse)
+     * @return ($batch is true ? array : Response)
      */
     protected function isLocked($postActionVars, $entity, $model, $batch = false)
     {

--- a/app/bundles/CoreBundle/Controller/AbstractStandardFormController.php
+++ b/app/bundles/CoreBundle/Controller/AbstractStandardFormController.php
@@ -619,7 +619,10 @@ abstract class AbstractStandardFormController extends AbstractFormController
         return $args;
     }
 
-    protected function getPostActionControllerAction($action): string
+    /**
+     * @return string
+     */
+    protected function getPostActionControllerAction($action)
     {
         return 'index';
     }

--- a/app/bundles/CoreBundle/Controller/AbstractStandardFormController.php
+++ b/app/bundles/CoreBundle/Controller/AbstractStandardFormController.php
@@ -619,10 +619,7 @@ abstract class AbstractStandardFormController extends AbstractFormController
         return $args;
     }
 
-    /**
-     * @return string
-     */
-    protected function getPostActionControllerAction($action)
+    protected function getPostActionControllerAction($action): string
     {
         return 'index';
     }

--- a/app/bundles/CoreBundle/Controller/Api/FileApiController.php
+++ b/app/bundles/CoreBundle/Controller/Api/FileApiController.php
@@ -56,11 +56,7 @@ final class FileApiController extends CommonApiController
     /**
      * Uploads a file.
      */
-<<<<<<< HEAD
-    public function createAction(Request $request, PathsHelper $pathsHelper, $dir)
-=======
-    public function createAction(Request $request, PathsHelper $pathsHelper, LoggerInterface $mauticLogger, $dir): Response
->>>>>>> d5b190b1f1 ([types] add Response return type to controller actions, add PHPStan rule to keep it)
+    public function createAction(Request $request, PathsHelper $pathsHelper, $dir): Response
     {
         try {
             $path = $this->getAbsolutePath($request, $pathsHelper, $dir, true);
@@ -97,11 +93,7 @@ final class FileApiController extends CommonApiController
     /**
      * List the files in /media directory.
      */
-<<<<<<< HEAD
-    public function listAction(Request $request, PathsHelper $pathsHelper, $dir)
-=======
-    public function listAction(Request $request, PathsHelper $pathsHelper, LoggerInterface $mauticLogger, $dir): Response
->>>>>>> d5b190b1f1 ([types] add Response return type to controller actions, add PHPStan rule to keep it)
+    public function listAction(Request $request, PathsHelper $pathsHelper, $dir): Response
     {
         try {
             $filePath = $this->getAbsolutePath($request, $pathsHelper, $dir);
@@ -130,11 +122,7 @@ final class FileApiController extends CommonApiController
     /**
      * Delete a file from /media directory.
      */
-<<<<<<< HEAD
-    public function deleteAction(Request $request, PathsHelper $pathsHelper, $dir, $file)
-=======
-    public function deleteAction(Request $request, PathsHelper $pathsHelper, LoggerInterface $mauticLogger, $dir, $file): Response
->>>>>>> d5b190b1f1 ([types] add Response return type to controller actions, add PHPStan rule to keep it)
+    public function deleteAction(Request $request, PathsHelper $pathsHelper, $dir, $file): Response
     {
         $response = ['success' => false];
 

--- a/app/bundles/CoreBundle/Controller/Api/FileApiController.php
+++ b/app/bundles/CoreBundle/Controller/Api/FileApiController.php
@@ -55,10 +55,12 @@ final class FileApiController extends CommonApiController
 
     /**
      * Uploads a file.
-     *
-     * @return Response
      */
+<<<<<<< HEAD
     public function createAction(Request $request, PathsHelper $pathsHelper, $dir)
+=======
+    public function createAction(Request $request, PathsHelper $pathsHelper, LoggerInterface $mauticLogger, $dir): Response
+>>>>>>> d5b190b1f1 ([types] add Response return type to controller actions, add PHPStan rule to keep it)
     {
         try {
             $path = $this->getAbsolutePath($request, $pathsHelper, $dir, true);
@@ -94,10 +96,12 @@ final class FileApiController extends CommonApiController
 
     /**
      * List the files in /media directory.
-     *
-     * @return Response
      */
+<<<<<<< HEAD
     public function listAction(Request $request, PathsHelper $pathsHelper, $dir)
+=======
+    public function listAction(Request $request, PathsHelper $pathsHelper, LoggerInterface $mauticLogger, $dir): Response
+>>>>>>> d5b190b1f1 ([types] add Response return type to controller actions, add PHPStan rule to keep it)
     {
         try {
             $filePath = $this->getAbsolutePath($request, $pathsHelper, $dir);
@@ -125,10 +129,12 @@ final class FileApiController extends CommonApiController
 
     /**
      * Delete a file from /media directory.
-     *
-     * @return Response
      */
+<<<<<<< HEAD
     public function deleteAction(Request $request, PathsHelper $pathsHelper, $dir, $file)
+=======
+    public function deleteAction(Request $request, PathsHelper $pathsHelper, LoggerInterface $mauticLogger, $dir, $file): Response
+>>>>>>> d5b190b1f1 ([types] add Response return type to controller actions, add PHPStan rule to keep it)
     {
         $response = ['success' => false];
 

--- a/app/bundles/CoreBundle/Controller/Api/ThemeApiController.php
+++ b/app/bundles/CoreBundle/Controller/Api/ThemeApiController.php
@@ -28,10 +28,8 @@ final class ThemeApiController extends CommonApiController
 
     /**
      * Accepts the zip file and installs the theme from it.
-     *
-     * @return Response
      */
-    public function newAction(Request $request, PathsHelper $pathsHelper)
+    public function newAction(Request $request, PathsHelper $pathsHelper): Response
     {
         if (!$this->security->isGranted('core:themes:create')) {
             return $this->accessDenied();
@@ -74,10 +72,8 @@ final class ThemeApiController extends CommonApiController
      * Get zip file of a theme.
      *
      * @param string $theme dir name
-     *
-     * @return Response
      */
-    public function getAction($theme)
+    public function getAction($theme): Response
     {
         if (!$this->security->isGranted('core:themes:view')) {
             return $this->accessDenied();
@@ -106,10 +102,8 @@ final class ThemeApiController extends CommonApiController
 
     /**
      * List the folders (themes) in the /themes directory.
-     *
-     * @return Response
      */
-    public function listAction()
+    public function listAction(): Response
     {
         if (!$this->security->isGranted('core:themes:view')) {
             return $this->accessDenied();
@@ -130,10 +124,8 @@ final class ThemeApiController extends CommonApiController
      * Delete a theme.
      *
      * @param string $theme
-     *
-     * @return Response
      */
-    public function deleteAction($theme)
+    public function deleteAction($theme): Response
     {
         if (!$this->security->isGranted('core:themes:delete')) {
             return $this->accessDenied();

--- a/app/bundles/CoreBundle/Controller/CommonController.php
+++ b/app/bundles/CoreBundle/Controller/CommonController.php
@@ -496,8 +496,10 @@ class CommonController extends AbstractController implements MauticController
      * @param int    $objectId
      * @param int    $objectSubId
      * @param string $objectModel
+     *
+     * @return Response
      */
-    public function executeAction(Request $request, $objectAction, $objectId = 0, $objectSubId = 0, $objectModel = ''): Response
+    public function executeAction(Request $request, $objectAction, $objectId = 0, $objectSubId = 0, $objectModel = '')
     {
         if (method_exists($this, $objectAction.'Action')) {
             return $this->forward(

--- a/app/bundles/CoreBundle/Controller/CommonController.php
+++ b/app/bundles/CoreBundle/Controller/CommonController.php
@@ -496,10 +496,8 @@ class CommonController extends AbstractController implements MauticController
      * @param int    $objectId
      * @param int    $objectSubId
      * @param string $objectModel
-     *
-     * @return Response
      */
-    public function executeAction(Request $request, $objectAction, $objectId = 0, $objectSubId = 0, $objectModel = '')
+    public function executeAction(Request $request, $objectAction, $objectId = 0, $objectSubId = 0, $objectModel = ''): Response
     {
         if (method_exists($this, $objectAction.'Action')) {
             return $this->forward(

--- a/app/bundles/DashboardBundle/Controller/Api/WidgetApiController.php
+++ b/app/bundles/DashboardBundle/Controller/Api/WidgetApiController.php
@@ -73,10 +73,8 @@ final class WidgetApiController extends CommonApiController
      * Obtains a list of available widget types.
      *
      * @param string $type of the widget
-     *
-     * @return Response
      */
-    public function getDataAction(Request $request, string $type)
+    public function getDataAction(Request $request, string $type): Response
     {
         $start      = microtime(true);
         $timezone   = InputHelper::clean($request->get('timezone'));

--- a/app/bundles/DynamicContentBundle/Controller/DynamicContentController.php
+++ b/app/bundles/DynamicContentBundle/Controller/DynamicContentController.php
@@ -446,10 +446,8 @@ final class DynamicContentController extends FormController
 
     /**
      * Deletes the entity.
-     *
-     * @return Response
      */
-    public function deleteAction(Request $request, $objectId)
+    public function deleteAction(Request $request, $objectId): Response
     {
         $page      = $request->getSession()->get('mautic.dynamicContent.page', 1);
         $returnUrl = $this->generateUrl('mautic_dynamicContent_index', ['page' => $page]);

--- a/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
+++ b/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
@@ -140,11 +140,9 @@ final class EmailApiController extends CommonApiController
      * @param int $id     Email ID
      * @param int $leadId Lead ID
      *
-     * @return Response
-     *
      * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      */
-    public function sendLeadAction(Request $request, $id, $leadId)
+    public function sendLeadAction(Request $request, $id, $leadId): Response
     {
         $entity = $this->model->getEntity($id);
 

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -929,10 +929,8 @@ final class EmailController extends FormController
 
     /**
      * Clone an entity.
-     *
-     * @return JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse|Response
      */
-    public function cloneAction(Request $request, EmailModel $model, ThemeHelper $themeHelper, $objectId)
+    public function cloneAction(Request $request, EmailModel $model, ThemeHelper $themeHelper, $objectId): Response
     {
         $emailEntity  = $model->getEntity($objectId);
         $entity       = null;
@@ -1186,10 +1184,8 @@ final class EmailController extends FormController
 
     /**
      * Deletes the entity.
-     *
-     * @return Response
      */
-    public function deleteAction(Request $request, $objectId)
+    public function deleteAction(Request $request, $objectId): Response
     {
         $page      = $request->getSession()->get('mautic.email.page', 1);
         $returnUrl = $this->generateUrl('mautic_email_index', ['page' => $page]);
@@ -1826,15 +1822,13 @@ final class EmailController extends FormController
 
     /**
      * @param int $page
-     *
-     * @return JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse|Response
      */
     public function contactsAction(
         Request $request,
         PageHelperFactoryInterface $pageHelperFactory,
         $objectId,
         $page = 1,
-    ) {
+    ): Response {
         $permissions = [
             'lead:leads:viewown',
             'lead:leads:viewother',

--- a/app/bundles/FormBundle/Controller/FormController.php
+++ b/app/bundles/FormBundle/Controller/FormController.php
@@ -480,10 +480,8 @@ class FormController extends CommonFormController
      * @param int|Form $objectId
      * @param bool     $ignorePost
      * @param bool     $forceTypeSelection
-     *
-     * @return \Symfony\Component\HttpFoundation\JsonResponse|Response
      */
-    public function editAction(Request $request, $objectId, $ignorePost = false, $forceTypeSelection = false)
+    public function editAction(Request $request, $objectId, $ignorePost = false, $forceTypeSelection = false): Response
     {
         $formData         = $request->request->all()['mauticform'] ?? [];
         $sessionId        = $formData['sessionId'] ?? null;
@@ -960,10 +958,8 @@ class FormController extends CommonFormController
      * Deletes the entity.
      *
      * @param int $objectId
-     *
-     * @return Response
      */
-    public function deleteAction(Request $request, $objectId)
+    public function deleteAction(Request $request, $objectId): Response
     {
         $page      = $request->getSession()->get('mautic.form.page', 1);
         $returnUrl = $this->generateUrl('mautic_form_index', ['page' => $page]);

--- a/app/bundles/FormBundle/Controller/PublicController.php
+++ b/app/bundles/FormBundle/Controller/PublicController.php
@@ -51,16 +51,13 @@ final class PublicController extends CommonFormController
 
     private array $tokens = [];
 
-    /**
-     * @return RedirectResponse|Response
-     */
     public function submitAction(
         Request $request,
         DateHelper $dateTemplateHelper,
         PageTokenHelper $pageTokenHelper,
         NotificationModel $notificationModel,
         UserRepository $userRepository,
-    ) {
+    ): Response {
         if ('POST' !== $request->getMethod()) {
             $this->throwAccessDenied();
         }

--- a/app/bundles/FormBundle/Controller/ResultController.php
+++ b/app/bundles/FormBundle/Controller/ResultController.php
@@ -386,10 +386,7 @@ final class ResultController extends CommonFormController
         );
     }
 
-    /**
-     * @return \Symfony\Component\HttpFoundation\JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse
-     */
-    public function batchDeleteAction(Request $request)
+    public function batchDeleteAction(Request $request): Response
     {
         return $this->batchDeleteStandard($request);
     }

--- a/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
@@ -404,10 +404,8 @@ final class LeadApiController extends CommonApiController
 
     /**
      * Adds a DNC to the contact.
-     *
-     * @return Response
      */
-    public function addDncAction(Request $request, $id, $channel)
+    public function addDncAction(Request $request, $id, $channel): Response
     {
         $entity = $this->model->getEntity((int) $id);
 
@@ -476,10 +474,8 @@ final class LeadApiController extends CommonApiController
      * @param int              $id
      * @param string           $method
      * @param array<mixed>|int $data
-     *
-     * @return Response
      */
-    protected function applyUtmTagsAction($id, $method, $data)
+    protected function applyUtmTagsAction($id, $method, $data): Response
     {
         $entity = $this->model->getEntity((int) $id);
 

--- a/app/bundles/LeadBundle/Controller/Api/ListApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/ListApiController.php
@@ -179,11 +179,9 @@ final class ListApiController extends CommonApiController
      *
      * @param int $id segement ID
      *
-     * @return Response
-     *
      * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      */
-    public function addLeadsAction(Request $request, $id)
+    public function addLeadsAction(Request $request, $id): Response
     {
         $contactIds = $request->request->all()['ids'] ?? null;
         if (null === $contactIds) {

--- a/app/bundles/LeadBundle/Controller/CompanyController.php
+++ b/app/bundles/LeadBundle/Controller/CompanyController.php
@@ -331,10 +331,8 @@ final class CompanyController extends FormController
      *
      * @param int  $objectId
      * @param bool $ignorePost
-     *
-     * @return JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse|Response
      */
-    public function editAction(Request $request, $objectId, $ignorePost = false)
+    public function editAction(Request $request, $objectId, $ignorePost = false): Response
     {
         $entity = $this->companyModel->getEntity($objectId);
 
@@ -695,10 +693,8 @@ final class CompanyController extends FormController
      * Deletes the entity.
      *
      * @param int $objectId
-     *
-     * @return Response
      */
-    public function deleteAction(Request $request, $objectId)
+    public function deleteAction(Request $request, $objectId): Response
     {
         $page      = $request->getSession()->get('mautic.company.page', 1);
         $returnUrl = $this->generateUrl('mautic_company_index', ['page' => $page]);

--- a/app/bundles/LeadBundle/Controller/FieldController.php
+++ b/app/bundles/LeadBundle/Controller/FieldController.php
@@ -398,10 +398,8 @@ final class FieldController extends FormController
 
     /**
      * Delete a field.
-     *
-     * @return Response
      */
-    public function deleteAction(Request $request, $objectId)
+    public function deleteAction(Request $request, $objectId): Response
     {
         if (!$this->security->isGranted('lead:fields:full')) {
             $this->throwAccessDenied();

--- a/app/bundles/LeadBundle/Controller/ImportController.php
+++ b/app/bundles/LeadBundle/Controller/ImportController.php
@@ -26,7 +26,6 @@ use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\File\Exception\FileException;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
@@ -68,8 +67,6 @@ final class ImportController extends FormController
 
     /**
      * @param int $page
-     *
-     * @return JsonResponse|RedirectResponse
      */
     public function indexAction(Request $request, $page = 1): Response
     {
@@ -119,18 +116,14 @@ final class ImportController extends FormController
 
     /**
      * @param int $objectId
-     *
-     * @return array|JsonResponse|RedirectResponse|Response
      */
-    public function viewAction(Request $request, $objectId)
+    public function viewAction(Request $request, $objectId): Response
     {
         return $this->viewStandard($request, $objectId, 'import', 'lead');
     }
 
     /**
      * Cancel and unpublish the import during manual import.
-     *
-     * @return JsonResponse|RedirectResponse
      */
     public function cancelAction(Request $request, NotificationModel $notificationModel, UserRepository $userRepository): Response
     {

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -1174,10 +1174,8 @@ final class LeadController extends FormController
 
     /**
      * Deletes the entity.
-     *
-     * @return Response
      */
-    public function deleteAction(Request $request, $objectId)
+    public function deleteAction(Request $request, $objectId): Response
     {
         $page      = $request->getSession()->get('mautic.lead.page', 1);
         $returnUrl = $this->generateUrl('mautic_contact_index', ['page' => $page]);

--- a/app/bundles/LeadBundle/Controller/ListController.php
+++ b/app/bundles/LeadBundle/Controller/ListController.php
@@ -20,8 +20,6 @@ use Mautic\LeadBundle\Model\ListModel;
 use Mautic\LeadBundle\Security\Permissions\LeadPermissions;
 use Mautic\LeadBundle\Segment\Stat\SegmentCampaignShare;
 use Mautic\LeadBundle\Segment\Stat\SegmentDependencies;
-use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
@@ -490,10 +488,8 @@ final class ListController extends FormController
 
     /**
      * Delete a list.
-     *
-     * @return Response
      */
-    public function deleteAction(Request $request, $objectId)
+    public function deleteAction(Request $request, $objectId): Response
     {
         $page      = $request->getSession()->get('mautic.segment.page', 1);
         $returnUrl = $this->generateUrl('mautic_segment_index', ['page' => $page]);
@@ -932,10 +928,8 @@ final class ListController extends FormController
     /**
      * @param int $objectId
      * @param int $page
-     *
-     * @return JsonResponse|RedirectResponse|Response
      */
-    public function contactsAction(Request $request, PageHelperFactoryInterface $pageHelperFactory, $objectId, $page = 1)
+    public function contactsAction(Request $request, PageHelperFactoryInterface $pageHelperFactory, $objectId, $page = 1): Response
     {
         $session = $request->getSession();
         $session->set('mautic.segment.contact.page', $page);

--- a/app/bundles/LeadBundle/Controller/NoteController.php
+++ b/app/bundles/LeadBundle/Controller/NoteController.php
@@ -365,10 +365,8 @@ final class NoteController extends FormController
      *
      * @param int $objectId
      * @param int $leadId
-     *
-     * @return Response
      */
-    public function executeNoteAction(Request $request, $objectAction, $objectId = 0, $leadId = 0)
+    public function executeNoteAction(Request $request, $objectAction, $objectId = 0, $leadId = 0): Response
     {
         if (method_exists($this, "{$objectAction}Action")) {
             return $this->{"{$objectAction}Action"}($request, $leadId, $objectId);

--- a/app/bundles/NotificationBundle/Controller/MobileNotificationController.php
+++ b/app/bundles/NotificationBundle/Controller/MobileNotificationController.php
@@ -11,7 +11,6 @@ use Mautic\LeadBundle\Controller\EntityContactsTrait;
 use Mautic\NotificationBundle\Entity\Notification;
 use Mautic\NotificationBundle\Model\NotificationModel;
 use Mautic\PluginBundle\Helper\IntegrationHelper;
-use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\Service\Attribute\Required;
@@ -577,10 +576,8 @@ final class MobileNotificationController extends FormController
 
     /**
      * Deletes the entity.
-     *
-     * @return Response
      */
-    public function deleteAction(Request $request, $objectId)
+    public function deleteAction(Request $request, $objectId): Response
     {
         $page      = $request->getSession()->get('mautic.mobile_notification.page', 1);
         $returnUrl = $this->generateUrl('mautic_mobile_notification_index', ['page' => $page]);
@@ -726,15 +723,13 @@ final class MobileNotificationController extends FormController
 
     /**
      * @param int $page
-     *
-     * @return JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse|Response
      */
     public function contactsAction(
         Request $request,
         PageHelperFactoryInterface $pageHelperFactory,
         $objectId,
         $page = 1,
-    ) {
+    ): Response {
         return $this->generateContactsGrid(
             $request,
             $pageHelperFactory,

--- a/app/bundles/NotificationBundle/Controller/NotificationController.php
+++ b/app/bundles/NotificationBundle/Controller/NotificationController.php
@@ -11,7 +11,6 @@ use Mautic\LeadBundle\Controller\EntityContactsTrait;
 use Mautic\NotificationBundle\Entity\Notification;
 use Mautic\NotificationBundle\Model\NotificationModel;
 use Symfony\Component\Form\FormFactoryInterface;
-use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\Service\Attribute\Required;
@@ -565,10 +564,8 @@ final class NotificationController extends AbstractFormController
 
     /**
      * Deletes the entity.
-     *
-     * @return Response
      */
-    public function deleteAction(Request $request, $objectId)
+    public function deleteAction(Request $request, $objectId): Response
     {
         $page      = $request->getSession()->get('mautic.notification.page', 1);
         $returnUrl = $this->generateUrl('mautic_notification_index', ['page' => $page]);
@@ -714,15 +711,13 @@ final class NotificationController extends AbstractFormController
 
     /**
      * @param int $page
-     *
-     * @return JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse|Response
      */
     public function contactsAction(
         Request $request,
         PageHelperFactoryInterface $pageHelperFactory,
         $objectId,
         $page = 1,
-    ) {
+    ): Response {
         return $this->generateContactsGrid(
             $request,
             $pageHelperFactory,

--- a/app/bundles/PageBundle/Controller/PageController.php
+++ b/app/bundles/PageBundle/Controller/PageController.php
@@ -20,7 +20,6 @@ use Mautic\PageBundle\Event\PageEditSubmitEvent;
 use Mautic\PageBundle\Exception\InvalidRenderedHtmlException;
 use Mautic\PageBundle\Helper\PageConfig;
 use Mautic\PageBundle\Model\PageModel;
-use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -480,8 +479,6 @@ final class PageController extends FormController
 
     /**
      * Generates edit form and processes post data.
-     *
-     * @return JsonResponse|Response
      */
     public function editAction(
         Request $request,
@@ -490,7 +487,7 @@ final class PageController extends FormController
         ThemeHelper $themeHelper,
         int $objectId,
         bool $ignorePost = false,
-    ) {
+    ): Response {
         $entity     = $model->getEntity($objectId);
         $session    = $request->getSession();
         $page       = $request->getSession()->get('mautic.page.page', 1);
@@ -714,10 +711,8 @@ final class PageController extends FormController
 
     /**
      * Deletes the entity.
-     *
-     * @return Response
      */
-    public function deleteAction(Request $request, PageModel $model, $objectId)
+    public function deleteAction(Request $request, PageModel $model, $objectId): Response
     {
         $page      = $request->getSession()->get('mautic.page.page', 1);
         $returnUrl = $this->generateUrl('mautic_page_index', ['page' => $page]);
@@ -918,10 +913,8 @@ final class PageController extends FormController
 
     /**
      * Make the variant the main.
-     *
-     * @return Response
      */
-    public function winnerAction(Request $request, PageModel $model, $objectId)
+    public function winnerAction(Request $request, PageModel $model, $objectId): Response
     {
         // todo - add confirmation to button click
         $page      = $request->getSession()->get('mautic.page.page', 1);

--- a/app/bundles/PluginBundle/Controller/AuthController.php
+++ b/app/bundles/PluginBundle/Controller/AuthController.php
@@ -15,8 +15,6 @@ final class AuthController extends FormController
 {
     /**
      * @param string $integration
-     *
-     * @return JsonResponse
      */
     public function authCallbackAction(Request $request, IntegrationHelper $integrationHelper, $integration): JsonResponse|RedirectResponse
     {

--- a/app/bundles/PointBundle/Controller/Api/PointApiController.php
+++ b/app/bundles/PointBundle/Controller/Api/PointApiController.php
@@ -80,10 +80,8 @@ final class PointApiController extends CommonApiController
      * @param int    $leadId
      * @param string $operator
      * @param int    $delta
-     *
-     * @return Response
      */
-    public function adjustPointsAction(Request $request, IpLookupHelper $ipLookupHelper, $leadId, $operator, $delta)
+    public function adjustPointsAction(Request $request, IpLookupHelper $ipLookupHelper, $leadId, $operator, $delta): Response
     {
         $lead = $this->checkLeadAccess($leadId, 'edit');
         if ($lead instanceof Response) {

--- a/app/bundles/PointBundle/Controller/GroupController.php
+++ b/app/bundles/PointBundle/Controller/GroupController.php
@@ -3,8 +3,6 @@
 namespace Mautic\PointBundle\Controller;
 
 use Mautic\CoreBundle\Controller\AbstractStandardFormController;
-use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -30,10 +28,8 @@ final class GroupController extends AbstractStandardFormController
 
     /**
      * Generates new form and processes post data.
-     *
-     * @return JsonResponse|Response
      */
-    public function newAction(Request $request)
+    public function newAction(Request $request): Response
     {
         return parent::newStandard($request);
     }
@@ -53,20 +49,16 @@ final class GroupController extends AbstractStandardFormController
      * Deletes the entity.
      *
      * @param int $objectId
-     *
-     * @return JsonResponse|RedirectResponse
      */
-    public function deleteAction(Request $request, $objectId)
+    public function deleteAction(Request $request, $objectId): Response
     {
         return parent::deleteStandard($request, $objectId);
     }
 
     /**
      * Deletes a group of entities.
-     *
-     * @return JsonResponse|RedirectResponse
      */
-    public function batchDeleteAction(Request $request)
+    public function batchDeleteAction(Request $request): Response
     {
         return parent::batchDeleteStandard($request);
     }

--- a/app/bundles/PointBundle/Controller/InsightController.php
+++ b/app/bundles/PointBundle/Controller/InsightController.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Mautic\PointBundle\Controller;
 
 use Mautic\CoreBundle\Controller\AbstractStandardFormController;
-use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -32,10 +30,8 @@ final class InsightController extends AbstractStandardFormController
 
     /**
      * Generates new form and processes post data.
-     *
-     * @return JsonResponse|Response
      */
-    public function newAction(Request $request)
+    public function newAction(Request $request): Response
     {
         return parent::newStandard($request);
     }
@@ -55,10 +51,8 @@ final class InsightController extends AbstractStandardFormController
      * Clones an existing Point Insight.
      *
      * @param int $objectId
-     *
-     * @return JsonResponse|Response
      */
-    public function cloneAction(Request $request, $objectId)
+    public function cloneAction(Request $request, $objectId): Response
     {
         return parent::cloneStandard($request, $objectId);
     }
@@ -67,20 +61,16 @@ final class InsightController extends AbstractStandardFormController
      * Deletes a Point Insight.
      *
      * @param int $objectId
-     *
-     * @return JsonResponse|RedirectResponse
      */
-    public function deleteAction(Request $request, $objectId)
+    public function deleteAction(Request $request, $objectId): Response
     {
         return parent::deleteStandard($request, $objectId);
     }
 
     /**
      * Deletes a group of entities.
-     *
-     * @return JsonResponse|RedirectResponse
      */
-    public function batchDeleteAction(Request $request)
+    public function batchDeleteAction(Request $request): Response
     {
         return parent::batchDeleteStandard($request);
     }

--- a/app/bundles/PointBundle/Controller/PointController.php
+++ b/app/bundles/PointBundle/Controller/PointController.php
@@ -7,7 +7,6 @@ use Mautic\CoreBundle\Factory\PageHelperFactoryInterface;
 use Mautic\PointBundle\Entity\Point;
 use Mautic\PointBundle\Model\PointModel;
 use Symfony\Component\Form\FormFactoryInterface;
-use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\Service\Attribute\Required;
@@ -203,10 +202,8 @@ final class PointController extends AbstractFormController
      *
      * @param int  $objectId
      * @param bool $ignorePost
-     *
-     * @return JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse|Response
      */
-    public function editAction(Request $request, FormFactoryInterface $formFactory, $objectId, $ignorePost = false)
+    public function editAction(Request $request, FormFactoryInterface $formFactory, $objectId, $ignorePost = false): Response
     {
         $entity = $this->pointModel->getEntity($objectId);
 
@@ -354,10 +351,8 @@ final class PointController extends AbstractFormController
      * Deletes the entity.
      *
      * @param int $objectId
-     *
-     * @return Response
      */
-    public function deleteAction(Request $request, $objectId)
+    public function deleteAction(Request $request, $objectId): Response
     {
         $page      = $request->getSession()->get('mautic.point.page', 1);
         $returnUrl = $this->generateUrl('mautic_point_index', ['page' => $page]);

--- a/app/bundles/PointBundle/Controller/TriggerController.php
+++ b/app/bundles/PointBundle/Controller/TriggerController.php
@@ -8,7 +8,6 @@ use Mautic\PointBundle\Entity\Trigger;
 use Mautic\PointBundle\Model\TriggerEventModel;
 use Mautic\PointBundle\Model\TriggerModel;
 use Symfony\Component\Form\FormError;
-use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\Service\Attribute\Required;
@@ -293,10 +292,8 @@ final class TriggerController extends FormController
      *
      * @param int  $objectId
      * @param bool $ignorePost
-     *
-     * @return JsonResponse|Response
      */
-    public function editAction(Request $request, $objectId, $ignorePost = false)
+    public function editAction(Request $request, $objectId, $ignorePost = false): Response
     {
         $entity     = $this->triggerModel->getEntity($objectId);
         $session    = $request->getSession();
@@ -493,10 +490,8 @@ final class TriggerController extends FormController
 
     /**
      * Deletes the entity.
-     *
-     * @return Response
      */
-    public function deleteAction(Request $request, $objectId)
+    public function deleteAction(Request $request, $objectId): Response
     {
         $page      = $request->getSession()->get('mautic.point.trigger.page', 1);
         $returnUrl = $this->generateUrl('mautic_pointtrigger_index', ['page' => $page]);

--- a/app/bundles/ReportBundle/Controller/ReportController.php
+++ b/app/bundles/ReportBundle/Controller/ReportController.php
@@ -284,8 +284,6 @@ final class ReportController extends FormController
      *
      * @param int  $objectId   Item ID
      * @param bool $ignorePost Flag to ignore POST data
-     *
-     * @return HttpFoundation\JsonResponse|HttpFoundation\RedirectResponse|Response
      */
     public function editAction(Request $request, int $objectId, $ignorePost = false): false|Response
     {
@@ -854,8 +852,6 @@ final class ReportController extends FormController
     /**
      * @param int    $reportId
      * @param string $format
-     *
-     * @return BinaryFileResponse
      *
      * @throws \Exception
      */

--- a/app/bundles/SmsBundle/Controller/SmsController.php
+++ b/app/bundles/SmsBundle/Controller/SmsController.php
@@ -575,10 +575,8 @@ final class SmsController extends FormController
 
     /**
      * Deletes the entity.
-     *
-     * @return Response
      */
-    public function deleteAction(Request $request, $objectId)
+    public function deleteAction(Request $request, $objectId): Response
     {
         $page      = $request->getSession()->get('mautic.sms.page', 1);
         $returnUrl = $this->generateUrl('mautic_sms_index', ['page' => $page]);
@@ -723,15 +721,13 @@ final class SmsController extends FormController
 
     /**
      * @param int $page
-     *
-     * @return JsonResponse|RedirectResponse|Response
      */
     public function contactsAction(
         Request $request,
         PageHelperFactoryInterface $pageHelperFactory,
         $objectId,
         $page = 1,
-    ) {
+    ): Response {
         return $this->generateContactsGrid(
             $request,
             $pageHelperFactory,

--- a/app/bundles/StageBundle/Controller/StageController.php
+++ b/app/bundles/StageBundle/Controller/StageController.php
@@ -11,7 +11,6 @@ use Mautic\StageBundle\Model\StageModel;
 use Mautic\StageBundle\Security\Permissions\StagePermissions;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
-use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\Service\Attribute\Required;
@@ -239,10 +238,8 @@ final class StageController extends AbstractFormController
      *
      * @param int  $objectId
      * @param bool $ignorePost
-     *
-     * @return JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse|Response
      */
-    public function editAction(Request $request, FormFactoryInterface $formFactory, $objectId, $ignorePost = false)
+    public function editAction(Request $request, FormFactoryInterface $formFactory, $objectId, $ignorePost = false): Response
     {
         $entity = $this->stageModel->getEntity($objectId);
 
@@ -486,10 +483,8 @@ final class StageController extends AbstractFormController
      * Deletes the entity.
      *
      * @param int $objectId
-     *
-     * @return Response
      */
-    public function deleteAction(Request $request, $objectId)
+    public function deleteAction(Request $request, $objectId): Response
     {
         $page      = $request->getSession()->get('mautic.stage.page', 1);
         $returnUrl = $this->generateUrl('mautic_stage_index', ['page' => $page]);

--- a/app/bundles/UserBundle/Controller/Api/UserApiController.php
+++ b/app/bundles/UserBundle/Controller/Api/UserApiController.php
@@ -72,7 +72,7 @@ final class UserApiController extends CommonApiController
     /**
      * Creates a new user.
      */
-    public function newEntityAction(Request $request)
+    public function newEntityAction(Request $request): Response
     {
         $entity = $this->model->getEntity();
 
@@ -95,11 +95,9 @@ final class UserApiController extends CommonApiController
      *
      * @param int $id User ID
      *
-     * @return Response
-     *
      * @throws NotFoundHttpException
      */
-    public function editEntityAction(Request $request, $id)
+    public function editEntityAction(Request $request, $id): Response
     {
         $entity     = $this->model->getEntity($id);
         $parameters = $request->request->all();

--- a/app/bundles/UserBundle/Controller/RoleController.php
+++ b/app/bundles/UserBundle/Controller/RoleController.php
@@ -343,10 +343,8 @@ final class RoleController extends FormController
      *
      * @param int  $objectId
      * @param bool $ignorePost
-     *
-     * @return \Symfony\Component\HttpFoundation\JsonResponse|Response
      */
-    public function editAction(Request $request, $objectId, $ignorePost = false)
+    public function editAction(Request $request, $objectId, $ignorePost = false): Response
     {
         if (!$this->security->isGranted(self::PERMISSION_EDIT)) {
             $this->throwAccessDenied();
@@ -498,10 +496,8 @@ final class RoleController extends FormController
      * Delete's a role.
      *
      * @param int $objectId
-     *
-     * @return Response
      */
-    public function deleteAction(Request $request, $objectId)
+    public function deleteAction(Request $request, $objectId): Response
     {
         if (!$this->security->isGranted(self::PERMISSION_DELETE)) {
             $this->throwAccessDenied();

--- a/app/bundles/UserBundle/Controller/UserController.php
+++ b/app/bundles/UserBundle/Controller/UserController.php
@@ -311,10 +311,12 @@ final class UserController extends FormController
      *
      * @param int  $objectId
      * @param bool $ignorePost
-     *
-     * @return JsonResponse|Response
      */
+<<<<<<< HEAD
     public function editAction(Request $request, LanguageHelper $languageHelper, SAMLHelper $samlHelper, $objectId, $ignorePost = false)
+=======
+    public function editAction(Request $request, LanguageHelper $languageHelper, UserPasswordHasherInterface $hasher, SAMLHelper $samlHelper, $objectId, $ignorePost = false): Response
+>>>>>>> f25657f603 ([types] add Response return type to controller actions, add PHPStan rule to keep it)
     {
         if (!$this->security->isGranted('user:users:edit')) {
             $this->throwAccessDenied();
@@ -460,10 +462,8 @@ final class UserController extends FormController
      * Deletes a user object.
      *
      * @param int $objectId
-     *
-     * @return Response
      */
-    public function deleteAction(Request $request, $objectId)
+    public function deleteAction(Request $request, $objectId): Response
     {
         if (!$this->security->isGranted('user:users:delete')) {
             $this->throwAccessDenied();

--- a/app/bundles/UserBundle/Controller/UserController.php
+++ b/app/bundles/UserBundle/Controller/UserController.php
@@ -312,11 +312,7 @@ final class UserController extends FormController
      * @param int  $objectId
      * @param bool $ignorePost
      */
-<<<<<<< HEAD
-    public function editAction(Request $request, LanguageHelper $languageHelper, SAMLHelper $samlHelper, $objectId, $ignorePost = false)
-=======
-    public function editAction(Request $request, LanguageHelper $languageHelper, UserPasswordHasherInterface $hasher, SAMLHelper $samlHelper, $objectId, $ignorePost = false): Response
->>>>>>> f25657f603 ([types] add Response return type to controller actions, add PHPStan rule to keep it)
+    public function editAction(Request $request, LanguageHelper $languageHelper, SAMLHelper $samlHelper, $objectId, $ignorePost = false): Response
     {
         if (!$this->security->isGranted('user:users:edit')) {
             $this->throwAccessDenied();

--- a/app/bundles/WebhookBundle/Controller/WebhookController.php
+++ b/app/bundles/WebhookBundle/Controller/WebhookController.php
@@ -48,8 +48,6 @@ final class WebhookController extends FormController
 
     /**
      * @param int $page
-     *
-     * @return \Symfony\Component\HttpFoundation\JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse
      */
     public function indexAction(Request $request, $page = 1): Response
     {
@@ -58,10 +56,8 @@ final class WebhookController extends FormController
 
     /**
      * Generates new form and processes post data.
-     *
-     * @return \Symfony\Component\HttpFoundation\JsonResponse
      */
-    public function newAction(Request $request)
+    public function newAction(Request $request): Response
     {
         return parent::newStandard($request);
     }
@@ -71,8 +67,6 @@ final class WebhookController extends FormController
      *
      * @param int  $objectId
      * @param bool $ignorePost
-     *
-     * @return \Symfony\Component\HttpFoundation\JsonResponse
      */
     public function editAction(Request $request, $objectId, $ignorePost = false): Response
     {
@@ -81,10 +75,8 @@ final class WebhookController extends FormController
 
     /**
      * Displays details on a Focus.
-     *
-     * @return array|\Symfony\Component\HttpFoundation\JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse
      */
-    public function viewAction(Request $request, $objectId)
+    public function viewAction(Request $request, $objectId): Response
     {
         return $this->viewStandard($request, $objectId, 'webhook', 'webhook', null, 'item');
     }
@@ -93,10 +85,8 @@ final class WebhookController extends FormController
      * Clone an entity.
      *
      * @param int $objectId
-     *
-     * @return \Symfony\Component\HttpFoundation\JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse
      */
-    public function cloneAction(Request $request, $objectId)
+    public function cloneAction(Request $request, $objectId): Response
     {
         return parent::cloneStandard($request, $objectId);
     }
@@ -105,20 +95,16 @@ final class WebhookController extends FormController
      * Deletes the entity.
      *
      * @param int $objectId
-     *
-     * @return \Symfony\Component\HttpFoundation\JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse
      */
-    public function deleteAction(Request $request, $objectId)
+    public function deleteAction(Request $request, $objectId): Response
     {
         return parent::deleteStandard($request, $objectId);
     }
 
     /**
      * Deletes a group of entities.
-     *
-     * @return \Symfony\Component\HttpFoundation\JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse
      */
-    public function batchDeleteAction(Request $request)
+    public function batchDeleteAction(Request $request): Response
     {
         return parent::batchDeleteStandard($request);
     }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1237,6 +1237,12 @@ parameters:
 			path: app/bundles/CoreBundle/Controller/AbstractFormController.php
 
 		-
+			message: '#^Method Mautic\\CoreBundle\\Controller\\AbstractFormController\:\:isLocked\(\) should return array\|Symfony\\Component\\HttpFoundation\\JsonResponse\|Symfony\\Component\\HttpFoundation\\RedirectResponse but returns Symfony\\Component\\HttpFoundation\\Response\.$#'
+			identifier: return.type
+			count: 1
+			path: app/bundles/CoreBundle/Controller/AbstractFormController.php
+
+		-
 			message: '#^Instead of assigning service property to a variable, use the property directly$#'
 			identifier: symplify.noJustPropertyAssign
 			count: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -169,12 +169,6 @@ parameters:
 			path: app/bundles/ApiBundle/Serializer/Exclusion/FieldInclusionStrategy.php
 
 		-
-			message: '#^Method Mautic\\AssetBundle\\Controller\\AssetController\:\:remoteAction\(\) should return Symfony\\Component\\HttpFoundation\\JsonResponse\|Symfony\\Component\\HttpFoundation\\RedirectResponse but returns Symfony\\Component\\HttpFoundation\\Response\.$#'
-			identifier: return.type
-			count: 1
-			path: app/bundles/AssetBundle/Controller/AssetController.php
-
-		-
 			message: '#^Call to an undefined method Symfony\\Component\\HttpFoundation\\File\\File\:\:getClientOriginalName\(\)\.$#'
 			identifier: method.notFound
 			count: 1
@@ -1239,12 +1233,6 @@ parameters:
 		-
 			message: '#^Method Mautic\\CoreBundle\\Controller\\AbstractFormController\:\:copyErrorsRecursively\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: app/bundles/CoreBundle/Controller/AbstractFormController.php
-
-		-
-			message: '#^Method Mautic\\CoreBundle\\Controller\\AbstractFormController\:\:isLocked\(\) should return array\|Symfony\\Component\\HttpFoundation\\JsonResponse\|Symfony\\Component\\HttpFoundation\\RedirectResponse but returns Symfony\\Component\\HttpFoundation\\Response\.$#'
-			identifier: return.type
 			count: 1
 			path: app/bundles/CoreBundle/Controller/AbstractFormController.php
 
@@ -5295,12 +5283,6 @@ parameters:
 		-
 			message: '#^Method Mautic\\LeadBundle\\Controller\\ImportController\:\:getLineCountLimit\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: app/bundles/LeadBundle/Controller/ImportController.php
-
-		-
-			message: '#^Method Mautic\\LeadBundle\\Controller\\ImportController\:\:indexAction\(\) should return Symfony\\Component\\HttpFoundation\\JsonResponse\|Symfony\\Component\\HttpFoundation\\RedirectResponse but returns Symfony\\Component\\HttpFoundation\\Response\.$#'
-			identifier: return.type
 			count: 1
 			path: app/bundles/LeadBundle/Controller/ImportController.php
 
@@ -9808,24 +9790,6 @@ parameters:
 			path: app/bundles/UserBundle/Security/SAML/User/UserCreator.php
 
 		-
-			message: '#^Method Mautic\\WebhookBundle\\Controller\\WebhookController\:\:editAction\(\) should return Symfony\\Component\\HttpFoundation\\JsonResponse but returns Symfony\\Component\\HttpFoundation\\Response\.$#'
-			identifier: return.type
-			count: 1
-			path: app/bundles/WebhookBundle/Controller/WebhookController.php
-
-		-
-			message: '#^Method Mautic\\WebhookBundle\\Controller\\WebhookController\:\:indexAction\(\) should return Symfony\\Component\\HttpFoundation\\JsonResponse\|Symfony\\Component\\HttpFoundation\\RedirectResponse but returns Symfony\\Component\\HttpFoundation\\Response\.$#'
-			identifier: return.type
-			count: 1
-			path: app/bundles/WebhookBundle/Controller/WebhookController.php
-
-		-
-			message: '#^Method Mautic\\WebhookBundle\\Controller\\WebhookController\:\:newAction\(\) should return Symfony\\Component\\HttpFoundation\\JsonResponse but returns array\|Symfony\\Component\\HttpFoundation\\Response\.$#'
-			identifier: return.type
-			count: 1
-			path: app/bundles/WebhookBundle/Controller/WebhookController.php
-
-		-
 			message: '#^Method Mautic\\WebhookBundle\\Entity\\EventRepository\:\:getEntitiesByEventType\(\) has parameter \$type with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -9938,30 +9902,6 @@ parameters:
 			identifier: missingType.return
 			count: 1
 			path: plugins/GrapesJsBuilderBundle/Model/GrapesJsBuilderModel.php
-
-		-
-			message: '#^Method MauticPlugin\\MauticClearbitBundle\\Controller\\ClearbitController\:\:batchLookupCompanyAction\(\) should return Symfony\\Component\\HttpFoundation\\JsonResponse but returns Symfony\\Component\\HttpFoundation\\Response\.$#'
-			identifier: return.type
-			count: 2
-			path: plugins/MauticClearbitBundle/Controller/ClearbitController.php
-
-		-
-			message: '#^Method MauticPlugin\\MauticClearbitBundle\\Controller\\ClearbitController\:\:batchLookupPersonAction\(\) should return Symfony\\Component\\HttpFoundation\\JsonResponse but returns Symfony\\Component\\HttpFoundation\\Response\.$#'
-			identifier: return.type
-			count: 2
-			path: plugins/MauticClearbitBundle/Controller/ClearbitController.php
-
-		-
-			message: '#^Method MauticPlugin\\MauticClearbitBundle\\Controller\\ClearbitController\:\:lookupCompanyAction\(\) should return Symfony\\Component\\HttpFoundation\\JsonResponse but returns Symfony\\Component\\HttpFoundation\\Response\.$#'
-			identifier: return.type
-			count: 2
-			path: plugins/MauticClearbitBundle/Controller/ClearbitController.php
-
-		-
-			message: '#^Method MauticPlugin\\MauticClearbitBundle\\Controller\\ClearbitController\:\:lookupPersonAction\(\) should return Symfony\\Component\\HttpFoundation\\JsonResponse but returns Symfony\\Component\\HttpFoundation\\Response\.$#'
-			identifier: return.type
-			count: 2
-			path: plugins/MauticClearbitBundle/Controller/ClearbitController.php
 
 		-
 			message: '#^Property Mautic\\LeadBundle\\Entity\\Lead\:\:\$imported \(bool\) in isset\(\) is not nullable\.$#'
@@ -12116,30 +12056,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: plugins/MauticFocusBundle/Security/Permissions/FocusPermissions.php
-
-		-
-			message: '#^Method MauticPlugin\\MauticFullContactBundle\\Controller\\FullContactController\:\:batchLookupCompanyAction\(\) should return Symfony\\Component\\HttpFoundation\\JsonResponse but returns Symfony\\Component\\HttpFoundation\\Response\.$#'
-			identifier: return.type
-			count: 2
-			path: plugins/MauticFullContactBundle/Controller/FullContactController.php
-
-		-
-			message: '#^Method MauticPlugin\\MauticFullContactBundle\\Controller\\FullContactController\:\:batchLookupPersonAction\(\) should return Symfony\\Component\\HttpFoundation\\JsonResponse but returns Symfony\\Component\\HttpFoundation\\Response\.$#'
-			identifier: return.type
-			count: 2
-			path: plugins/MauticFullContactBundle/Controller/FullContactController.php
-
-		-
-			message: '#^Method MauticPlugin\\MauticFullContactBundle\\Controller\\FullContactController\:\:lookupCompanyAction\(\) should return Symfony\\Component\\HttpFoundation\\JsonResponse but returns Symfony\\Component\\HttpFoundation\\Response\.$#'
-			identifier: return.type
-			count: 2
-			path: plugins/MauticFullContactBundle/Controller/FullContactController.php
-
-		-
-			message: '#^Method MauticPlugin\\MauticFullContactBundle\\Controller\\FullContactController\:\:lookupPersonAction\(\) should return Symfony\\Component\\HttpFoundation\\JsonResponse but returns Symfony\\Component\\HttpFoundation\\Response\.$#'
-			identifier: return.type
-			count: 2
-			path: plugins/MauticFullContactBundle/Controller/FullContactController.php
 
 		-
 			message: '#^Property Mautic\\LeadBundle\\Entity\\Lead\:\:\$imported \(bool\) in isset\(\) is not nullable\.$#'

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2212,36 +2212,6 @@ parameters:
 			path: app/bundles/CoreBundle/Helper/AssetGenerationHelper.php
 
 		-
-			message: '#^Property Mautic\\CoreBundle\\Helper\\BuilderTokenHelper\:\:\$bundleName has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/bundles/CoreBundle/Helper/BuilderTokenHelper.php
-
-		-
-			message: '#^Property Mautic\\CoreBundle\\Helper\\BuilderTokenHelper\:\:\$langVar has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/bundles/CoreBundle/Helper/BuilderTokenHelper.php
-
-		-
-			message: '#^Property Mautic\\CoreBundle\\Helper\\BuilderTokenHelper\:\:\$modelName has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/bundles/CoreBundle/Helper/BuilderTokenHelper.php
-
-		-
-			message: '#^Property Mautic\\CoreBundle\\Helper\\BuilderTokenHelper\:\:\$permissionSet has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/bundles/CoreBundle/Helper/BuilderTokenHelper.php
-
-		-
-			message: '#^Property Mautic\\CoreBundle\\Helper\\BuilderTokenHelper\:\:\$viewPermissionBase has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/bundles/CoreBundle/Helper/BuilderTokenHelper.php
-
-		-
 			message: '#^Method Mautic\\CoreBundle\\Helper\\BundleHelper\:\:getBundleConfig\(\) has parameter \$bundleName with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -3754,18 +3724,6 @@ parameters:
 			path: app/bundles/EmailBundle/Helper/MailHelper.php
 
 		-
-			message: '#^Method Mautic\\EmailBundle\\Helper\\PlainTextHelper\:\:convertPre\(\) has parameter \$text with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/bundles/EmailBundle/Helper/PlainTextHelper.php
-
-		-
-			message: '#^Method Mautic\\EmailBundle\\Helper\\PlainTextHelper\:\:converter\(\) has parameter \$text with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/bundles/EmailBundle/Helper/PlainTextHelper.php
-
-		-
 			message: '#^Method Mautic\\EmailBundle\\Helper\\PointEventHelper\:\:validateEmail\(\) has parameter \$eventDetails with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -5213,12 +5171,6 @@ parameters:
 			identifier: return.type
 			count: 1
 			path: app/bundles/IntegrationsBundle/Sync/DAO/Sync/Order/OrderDAO.php
-
-		-
-			message: '#^Method Mautic\\IntegrationsBundle\\Sync\\DAO\\Sync\\Report\\ReportDAO\:\:getInformationChangeRequest\(\) has parameter \$fieldName with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/bundles/IntegrationsBundle/Sync/DAO/Sync/Report/ReportDAO.php
 
 		-
 			message: '#^Method Mautic\\IntegrationsBundle\\Sync\\DAO\\Sync\\Report\\ReportDAO\:\:getInformationChangeRequest\(\) has parameter \$objectId with no type specified\.$#'
@@ -9025,12 +8977,6 @@ parameters:
 			path: app/bundles/ReportBundle/Controller/ReportController.php
 
 		-
-			message: '#^Method Mautic\\ReportBundle\\Controller\\ReportController\:\:downloadAction\(\) should return Symfony\\Component\\HttpFoundation\\BinaryFileResponse but returns Symfony\\Component\\HttpFoundation\\Response\.$#'
-			identifier: return.type
-			count: 2
-			path: app/bundles/ReportBundle/Controller/ReportController.php
-
-		-
 			message: '#^Instead of assigning service property to a variable, use the property directly$#'
 			identifier: symplify.noJustPropertyAssign
 			count: 1
@@ -9904,12 +9850,6 @@ parameters:
 			path: plugins/GrapesJsBuilderBundle/Model/GrapesJsBuilderModel.php
 
 		-
-			message: '#^Property Mautic\\LeadBundle\\Entity\\Lead\:\:\$imported \(bool\) in isset\(\) is not nullable\.$#'
-			identifier: isset.property
-			count: 1
-			path: plugins/MauticClearbitBundle/Controller/PublicController.php
-
-		-
 			message: '#^Parameter \#3 \$route of method Mautic\\CoreBundle\\Event\\CustomButtonEvent\:\:addButton\(\) expects string\|null, array\<int, array\<string, string\>\|string\> given\.$#'
 			identifier: argument.type
 			count: 1
@@ -10042,18 +9982,6 @@ parameters:
 			path: plugins/MauticCrmBundle/Api/DynamicsApi.php
 
 		-
-			message: '#^Method MauticPlugin\\MauticCrmBundle\\Api\\DynamicsApi\:\:request\(\) has parameter \$operation with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: plugins/MauticCrmBundle/Api/DynamicsApi.php
-
-		-
-			message: '#^Method MauticPlugin\\MauticCrmBundle\\Api\\DynamicsApi\:\:request\(\) has parameter \$settings with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: plugins/MauticCrmBundle/Api/DynamicsApi.php
-
-		-
 			message: '#^Method MauticPlugin\\MauticCrmBundle\\Api\\DynamicsApi\:\:updateLeads\(\) has parameter \$object with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -10134,12 +10062,6 @@ parameters:
 		-
 			message: '#^Method MauticPlugin\\MauticCrmBundle\\Api\\HubspotApi\:\:request\(\) has parameter \$parameters with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: plugins/MauticCrmBundle/Api/HubspotApi.php
-
-		-
-			message: '#^Property MauticPlugin\\MauticCrmBundle\\Api\\HubspotApi\:\:\$requestSettings has no type specified\.$#'
-			identifier: missingType.property
 			count: 1
 			path: plugins/MauticCrmBundle/Api/HubspotApi.php
 
@@ -10258,30 +10180,6 @@ parameters:
 			path: plugins/MauticCrmBundle/Api/SalesforceApi.php
 
 		-
-			message: '#^Property MauticPlugin\\MauticCrmBundle\\Api\\SalesforceApi\:\:\$apiRequestCounter has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: plugins/MauticCrmBundle/Api/SalesforceApi.php
-
-		-
-			message: '#^Property MauticPlugin\\MauticCrmBundle\\Api\\SalesforceApi\:\:\$maxLockRetries has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: plugins/MauticCrmBundle/Api/SalesforceApi.php
-
-		-
-			message: '#^Property MauticPlugin\\MauticCrmBundle\\Api\\SalesforceApi\:\:\$object has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: plugins/MauticCrmBundle/Api/SalesforceApi.php
-
-		-
-			message: '#^Property MauticPlugin\\MauticCrmBundle\\Api\\SalesforceApi\:\:\$requestCounter has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: plugins/MauticCrmBundle/Api/SalesforceApi.php
-
-		-
 			message: '#^Property MauticPlugin\\MauticCrmBundle\\Api\\SalesforceApi\:\:\$requestSettings has no type specified\.$#'
 			identifier: missingType.property
 			count: 1
@@ -10330,12 +10228,6 @@ parameters:
 			path: plugins/MauticCrmBundle/Api/SugarcrmApi.php
 
 		-
-			message: '#^Property MauticPlugin\\MauticCrmBundle\\Api\\SugarcrmApi\:\:\$object has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: plugins/MauticCrmBundle/Api/SugarcrmApi.php
-
-		-
 			message: '#^Method MauticPlugin\\MauticCrmBundle\\Api\\VtigerApi\:\:getLeadFields\(\) has parameter \$object with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -10344,36 +10236,6 @@ parameters:
 		-
 			message: '#^Method MauticPlugin\\MauticCrmBundle\\Api\\VtigerApi\:\:request\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: plugins/MauticCrmBundle/Api/VtigerApi.php
-
-		-
-			message: '#^Method MauticPlugin\\MauticCrmBundle\\Api\\VtigerApi\:\:request\(\) has parameter \$element with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: plugins/MauticCrmBundle/Api/VtigerApi.php
-
-		-
-			message: '#^Method MauticPlugin\\MauticCrmBundle\\Api\\VtigerApi\:\:request\(\) has parameter \$elementData with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: plugins/MauticCrmBundle/Api/VtigerApi.php
-
-		-
-			message: '#^Method MauticPlugin\\MauticCrmBundle\\Api\\VtigerApi\:\:request\(\) has parameter \$method with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: plugins/MauticCrmBundle/Api/VtigerApi.php
-
-		-
-			message: '#^Method MauticPlugin\\MauticCrmBundle\\Api\\VtigerApi\:\:request\(\) has parameter \$operation with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: plugins/MauticCrmBundle/Api/VtigerApi.php
-
-		-
-			message: '#^Property MauticPlugin\\MauticCrmBundle\\Api\\VtigerApi\:\:\$element has no type specified\.$#'
-			identifier: missingType.property
 			count: 1
 			path: plugins/MauticCrmBundle/Api/VtigerApi.php
 
@@ -11488,12 +11350,6 @@ parameters:
 			path: plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
 
 		-
-			message: '#^Method MauticPlugin\\MauticCrmBundle\\Integration\\SugarcrmIntegration\:\:buildCompositeBody\(\) has parameter \$object with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
-
-		-
 			message: '#^Method MauticPlugin\\MauticCrmBundle\\Integration\\SugarcrmIntegration\:\:buildCompositeBody\(\) has parameter \$objectId with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -11585,12 +11441,6 @@ parameters:
 
 		-
 			message: '#^Method MauticPlugin\\MauticCrmBundle\\Integration\\SugarcrmIntegration\:\:getObjectDataToUpdate\(\) has parameter \$leadSugarFields with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
-
-		-
-			message: '#^Method MauticPlugin\\MauticCrmBundle\\Integration\\SugarcrmIntegration\:\:getObjectDataToUpdate\(\) has parameter \$mauticData with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
 			path: plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
@@ -11836,30 +11686,6 @@ parameters:
 			path: plugins/MauticEmailMarketingBundle/Api/ConstantContactApi.php
 
 		-
-			message: '#^Method MauticPlugin\\MauticEmailMarketingBundle\\Api\\ConstantContactApi\:\:request\(\) has parameter \$endpoint with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: plugins/MauticEmailMarketingBundle/Api/ConstantContactApi.php
-
-		-
-			message: '#^Method MauticPlugin\\MauticEmailMarketingBundle\\Api\\ConstantContactApi\:\:request\(\) has parameter \$method with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: plugins/MauticEmailMarketingBundle/Api/ConstantContactApi.php
-
-		-
-			message: '#^Method MauticPlugin\\MauticEmailMarketingBundle\\Api\\ConstantContactApi\:\:request\(\) has parameter \$parameters with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: plugins/MauticEmailMarketingBundle/Api/ConstantContactApi.php
-
-		-
-			message: '#^Method MauticPlugin\\MauticEmailMarketingBundle\\Api\\ConstantContactApi\:\:request\(\) has parameter \$query with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: plugins/MauticEmailMarketingBundle/Api/ConstantContactApi.php
-
-		-
 			message: '#^Method MauticPlugin\\MauticEmailMarketingBundle\\Api\\ConstantContactApi\:\:subscribeLead\(\) has parameter \$email with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -11884,24 +11710,6 @@ parameters:
 			path: plugins/MauticEmailMarketingBundle/Api/IcontactApi.php
 
 		-
-			message: '#^Method MauticPlugin\\MauticEmailMarketingBundle\\Api\\IcontactApi\:\:request\(\) has parameter \$endpoint with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: plugins/MauticEmailMarketingBundle/Api/IcontactApi.php
-
-		-
-			message: '#^Method MauticPlugin\\MauticEmailMarketingBundle\\Api\\IcontactApi\:\:request\(\) has parameter \$method with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: plugins/MauticEmailMarketingBundle/Api/IcontactApi.php
-
-		-
-			message: '#^Method MauticPlugin\\MauticEmailMarketingBundle\\Api\\IcontactApi\:\:request\(\) has parameter \$parameters with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: plugins/MauticEmailMarketingBundle/Api/IcontactApi.php
-
-		-
 			message: '#^Method MauticPlugin\\MauticEmailMarketingBundle\\Api\\IcontactApi\:\:subscribeLead\(\) has parameter \$listId with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -11916,12 +11724,6 @@ parameters:
 		-
 			message: '#^Method MauticPlugin\\MauticEmailMarketingBundle\\Api\\MailchimpApi\:\:getLists\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: plugins/MauticEmailMarketingBundle/Api/MailchimpApi.php
-
-		-
-			message: '#^Method MauticPlugin\\MauticEmailMarketingBundle\\Api\\MailchimpApi\:\:request\(\) has parameter \$endpoint with no type specified\.$#'
-			identifier: missingType.parameter
 			count: 1
 			path: plugins/MauticEmailMarketingBundle/Api/MailchimpApi.php
 
@@ -12056,12 +11858,6 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: plugins/MauticFocusBundle/Security/Permissions/FocusPermissions.php
-
-		-
-			message: '#^Property Mautic\\LeadBundle\\Entity\\Lead\:\:\$imported \(bool\) in isset\(\) is not nullable\.$#'
-			identifier: isset.property
-			count: 2
-			path: plugins/MauticFullContactBundle/Controller/PublicController.php
 
 		-
 			message: '#^Parameter \#3 \$route of method Mautic\\CoreBundle\\Event\\CustomButtonEvent\:\:addButton\(\) expects string\|null, array\<int, array\<string, string\>\|string\> given\.$#'
@@ -12614,4 +12410,3 @@ parameters:
 			identifier: argument.type
 			count: 2
 			path: plugins/MauticSocialBundle/Security/Permissions/MauticSocialPermissions.php
-

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -268,6 +268,7 @@ rules:
 	- Utils\PHPStan\Rule\NoEntityManagerGetRepositoryRule
 	- Utils\PHPStan\Rule\PreferInterfaceInConstructorRule
 	- Utils\PHPStan\Rule\NoPropertyToPropertyAssignRule
+	- Utils\PHPStan\Rule\ControllerMethodMustReturnResponseRule
 
 	- Utils\PHPStan\Rule\NoServicesInBundleConfigRule
 	#- Utils\PHPStan\Rule\NoUnusedServiceAliasRule

--- a/plugins/MauticClearbitBundle/Controller/ClearbitController.php
+++ b/plugins/MauticClearbitBundle/Controller/ClearbitController.php
@@ -33,8 +33,6 @@ final class ClearbitController extends FormController
     /**
      * @param string $objectId
      *
-     * @return JsonResponse
-     *
      * @throws \InvalidArgumentException
      */
     public function lookupPersonAction(Request $request, LookupHelper $lookupHelper, $objectId = ''): JsonResponse|Response
@@ -125,8 +123,6 @@ final class ClearbitController extends FormController
     }
 
     /**
-     * @return JsonResponse
-     *
      * @throws \InvalidArgumentException
      */
     public function batchLookupPersonAction(Request $request, LookupHelper $lookupHelper): JsonResponse|Response
@@ -281,8 +277,6 @@ final class ClearbitController extends FormController
     /**
      * @param string $objectId
      *
-     * @return JsonResponse
-     *
      * @throws \InvalidArgumentException
      */
     public function lookupCompanyAction(Request $request, LookupHelper $lookupHelper, $objectId = ''): JsonResponse|Response
@@ -372,8 +366,6 @@ final class ClearbitController extends FormController
     }
 
     /**
-     * @return JsonResponse
-     *
      * @throws \InvalidArgumentException
      */
     public function batchLookupCompanyAction(Request $request, LookupHelper $lookupHelper): JsonResponse|Response

--- a/plugins/MauticFocusBundle/Controller/FocusController.php
+++ b/plugins/MauticFocusBundle/Controller/FocusController.php
@@ -8,8 +8,6 @@ use Mautic\CoreBundle\Form\Type\DateRangeType;
 use Mautic\PageBundle\Model\TrackableModel;
 use MauticPlugin\MauticFocusBundle\Entity\Focus;
 use MauticPlugin\MauticFocusBundle\Model\FocusModel;
-use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\Service\Attribute\Required;
@@ -53,10 +51,8 @@ final class FocusController extends AbstractStandardFormController
 
     /**
      * Generates new form and processes post data.
-     *
-     * @return JsonResponse|Response
      */
-    public function newAction(Request $request)
+    public function newAction(Request $request): Response
     {
         return parent::newStandard($request);
     }
@@ -74,10 +70,8 @@ final class FocusController extends AbstractStandardFormController
 
     /**
      * Displays details on a Focus.
-     *
-     * @return array|JsonResponse|RedirectResponse|Response
      */
-    public function viewAction(Request $request, $objectId)
+    public function viewAction(Request $request, $objectId): Response
     {
         return parent::viewStandard($request, $objectId, 'focus', 'focus');
     }
@@ -86,10 +80,8 @@ final class FocusController extends AbstractStandardFormController
      * Clone an entity.
      *
      * @param int $objectId
-     *
-     * @return JsonResponse|RedirectResponse|Response
      */
-    public function cloneAction(Request $request, $objectId)
+    public function cloneAction(Request $request, $objectId): Response
     {
         return parent::cloneStandard($request, $objectId);
     }
@@ -98,20 +90,16 @@ final class FocusController extends AbstractStandardFormController
      * Deletes the entity.
      *
      * @param int $objectId
-     *
-     * @return JsonResponse|RedirectResponse
      */
-    public function deleteAction(Request $request, $objectId)
+    public function deleteAction(Request $request, $objectId): Response
     {
         return parent::deleteStandard($request, $objectId);
     }
 
     /**
      * Deletes a group of entities.
-     *
-     * @return JsonResponse|RedirectResponse
      */
-    public function batchDeleteAction(Request $request)
+    public function batchDeleteAction(Request $request): Response
     {
         return parent::batchDeleteStandard($request);
     }

--- a/plugins/MauticFullContactBundle/Controller/FullContactController.php
+++ b/plugins/MauticFullContactBundle/Controller/FullContactController.php
@@ -33,8 +33,6 @@ final class FullContactController extends FormController
     /**
      * @param string $objectId
      *
-     * @return JsonResponse
-     *
      * @throws \InvalidArgumentException
      */
     public function lookupPersonAction(Request $request, LookupHelper $lookupHelper, $objectId = ''): JsonResponse|Response
@@ -125,8 +123,6 @@ final class FullContactController extends FormController
     }
 
     /**
-     * @return JsonResponse
-     *
      * @throws \InvalidArgumentException
      */
     public function batchLookupPersonAction(Request $request, LookupHelper $lookupHelper): JsonResponse|Response
@@ -281,8 +277,6 @@ final class FullContactController extends FormController
     /**
      * @param string $objectId
      *
-     * @return JsonResponse
-     *
      * @throws \InvalidArgumentException
      */
     public function lookupCompanyAction(Request $request, LookupHelper $lookupHelper, $objectId = ''): JsonResponse|Response
@@ -372,8 +366,6 @@ final class FullContactController extends FormController
     }
 
     /**
-     * @return JsonResponse
-     *
      * @throws \InvalidArgumentException
      */
     public function batchLookupCompanyAction(Request $request, LookupHelper $lookupHelper): JsonResponse|Response

--- a/plugins/MauticSocialBundle/Controller/MonitoringController.php
+++ b/plugins/MauticSocialBundle/Controller/MonitoringController.php
@@ -13,8 +13,6 @@ use MauticPlugin\MauticSocialBundle\Entity\Monitoring;
 use MauticPlugin\MauticSocialBundle\Entity\PostCountRepository;
 use MauticPlugin\MauticSocialBundle\Model\MonitoringModel;
 use Symfony\Component\Form\SubmitButton;
-use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\Service\Attribute\Required;
@@ -494,10 +492,8 @@ final class MonitoringController extends FormController
      * Deletes the entity.
      *
      * @param int $objectId
-     *
-     * @return Response
      */
-    public function deleteAction(Request $request, IpLookupHelper $ipLookupHelper, $objectId)
+    public function deleteAction(Request $request, IpLookupHelper $ipLookupHelper, $objectId): Response
     {
         if (!$this->security->isGranted('mauticSocial:monitoring:delete')) {
             $this->throwAccessDenied();
@@ -628,15 +624,13 @@ final class MonitoringController extends FormController
 
     /**
      * @param int $page
-     *
-     * @return JsonResponse|RedirectResponse|Response
      */
     public function contactsAction(
         Request $request,
         PageHelperFactoryInterface $pageHelperFactory,
         $objectId,
         $page = 1,
-    ) {
+    ): Response {
         return $this->generateContactsGrid(
             $request,
             $pageHelperFactory,

--- a/plugins/MauticSocialBundle/Controller/TweetController.php
+++ b/plugins/MauticSocialBundle/Controller/TweetController.php
@@ -91,10 +91,8 @@ final class TweetController extends FormController
 
     /**
      * Generates new form and processes post data.
-     *
-     * @return \Symfony\Component\HttpFoundation\JsonResponse|Response
      */
-    public function newAction(Request $request)
+    public function newAction(Request $request): Response
     {
         return parent::newStandard($request);
     }
@@ -124,10 +122,8 @@ final class TweetController extends FormController
 
     /**
      * @param int $objectId
-     *
-     * @return \Symfony\Component\HttpFoundation\JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse|Response
      */
-    public function cloneAction(Request $request, $objectId)
+    public function cloneAction(Request $request, $objectId): Response
     {
         return parent::cloneStandard($request, $objectId);
     }
@@ -136,20 +132,16 @@ final class TweetController extends FormController
      * Deletes the entity.
      *
      * @param int $objectId
-     *
-     * @return \Symfony\Component\HttpFoundation\JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse
      */
-    public function deleteAction(Request $request, $objectId)
+    public function deleteAction(Request $request, $objectId): Response
     {
         return parent::deleteStandard($request, $objectId);
     }
 
     /**
      * Deletes a group of entities.
-     *
-     * @return \Symfony\Component\HttpFoundation\JsonResponse|\Symfony\Component\HttpFoundation\RedirectResponse
      */
-    public function batchDeleteAction(Request $request)
+    public function batchDeleteAction(Request $request): Response
     {
         return parent::batchDeleteStandard($request);
     }

--- a/utils/phpstan/src/Rule/ControllerMethodMustReturnResponseRule.php
+++ b/utils/phpstan/src/Rule/ControllerMethodMustReturnResponseRule.php
@@ -25,6 +25,9 @@ use PHPStan\Rules\RuleErrorBuilder;
  * Only the public "*Action()" methods and "__invoke()" are actions. The public helpers a controller exposes next to
  * them - "getModelName()", "getViewArguments()" and the like - return their own data and are left alone.
  *
+ * The shared base controllers - "Abstract*" and "Common*" - are skipped. Their actions are widened by child
+ * controllers, so a narrow return type on the parent would lock the children out.
+ *
  * @implements Rule<ClassMethod>
  */
 final class ControllerMethodMustReturnResponseRule implements Rule
@@ -48,6 +51,11 @@ final class ControllerMethodMustReturnResponseRule implements Rule
      * @var string
      */
     private const INVOKE_METHOD = '__invoke';
+
+    /**
+     * @var string[]
+     */
+    private const SKIPPED_CLASS_PREFIXES = ['Abstract', 'Common'];
 
     public function __construct(
         private readonly ReflectionProvider $reflectionProvider,
@@ -104,7 +112,26 @@ final class ControllerMethodMustReturnResponseRule implements Rule
             return false;
         }
 
-        return str_ends_with($classReflection->getName(), self::CONTROLLER_SUFFIX);
+        $className = $classReflection->getName();
+        if (!str_ends_with($className, self::CONTROLLER_SUFFIX)) {
+            return false;
+        }
+
+        return !$this->isSharedBaseController($className);
+    }
+
+    private function isSharedBaseController(string $className): bool
+    {
+        $lastSeparatorPosition = strrpos($className, '\\');
+        $shortClassName        = false === $lastSeparatorPosition ? $className : substr($className, $lastSeparatorPosition + 1);
+
+        foreach (self::SKIPPED_CLASS_PREFIXES as $skippedClassPrefix) {
+            if (str_starts_with($shortClassName, $skippedClassPrefix)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function isAction(ClassMethod $classMethod): bool

--- a/utils/phpstan/src/Rule/ControllerMethodMustReturnResponseRule.php
+++ b/utils/phpstan/src/Rule/ControllerMethodMustReturnResponseRule.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Rule;
+
+use PhpParser\Node;
+use PhpParser\Node\ComplexType;
+use PhpParser\Node\Name;
+use PhpParser\Node\NullableType;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\UnionType;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * A controller action must declare a Response return type.
+ *
+ * An action answers an HTTP request, so it hands a Response back - either alone or as one part of a union. A missing
+ * or non-Response return type hides what the action really produces, and lets a docblock claim a narrower type than
+ * the code returns.
+ *
+ * Only the public "*Action()" methods and "__invoke()" are actions. The public helpers a controller exposes next to
+ * them - "getModelName()", "getViewArguments()" and the like - return their own data and are left alone.
+ *
+ * @implements Rule<ClassMethod>
+ */
+final class ControllerMethodMustReturnResponseRule implements Rule
+{
+    /**
+     * @var string
+     */
+    private const RESPONSE_CLASS = 'Symfony\\Component\\HttpFoundation\\Response';
+
+    /**
+     * @var string
+     */
+    private const CONTROLLER_SUFFIX = 'Controller';
+
+    /**
+     * @var string
+     */
+    private const ACTION_SUFFIX = 'action';
+
+    /**
+     * @var string
+     */
+    private const INVOKE_METHOD = '__invoke';
+
+    public function __construct(
+        private readonly ReflectionProvider $reflectionProvider,
+    ) {
+    }
+
+    public function getNodeType(): string
+    {
+        return ClassMethod::class;
+    }
+
+    /**
+     * @param ClassMethod $node
+     *
+     * @return list<\PHPStan\Rules\IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node->isPublic()) {
+            return [];
+        }
+
+        if (!$this->isAction($node)) {
+            return [];
+        }
+
+        if (!$this->isInController($scope)) {
+            return [];
+        }
+
+        if ($this->hasResponseReturnType($node->returnType, $scope)) {
+            return [];
+        }
+
+        $ruleError = RuleErrorBuilder::message(sprintf(
+            'Controller action "%s()" must return a Response, either alone or as part of a union.',
+            $node->name->toString()
+        ))
+            ->identifier('mautic.controllerMethodMustReturnResponse')
+            ->build();
+
+        return [$ruleError];
+    }
+
+    private function isInController(Scope $scope): bool
+    {
+        // inside a trait the scope class is the controller using it, so the trait method would be checked repeatedly
+        if ($scope->isInTrait()) {
+            return false;
+        }
+
+        $classReflection = $scope->getClassReflection();
+        if (!$classReflection instanceof \PHPStan\Reflection\ClassReflection) {
+            return false;
+        }
+
+        return str_ends_with($classReflection->getName(), self::CONTROLLER_SUFFIX);
+    }
+
+    private function isAction(ClassMethod $classMethod): bool
+    {
+        $methodName = $classMethod->name->toLowerString();
+
+        return str_ends_with($methodName, self::ACTION_SUFFIX) || self::INVOKE_METHOD === $methodName;
+    }
+
+    private function hasResponseReturnType(Node\Identifier|Name|ComplexType|null $type, Scope $scope): bool
+    {
+        if ($type instanceof Name) {
+            return $this->isResponseClass($scope->resolveName($type));
+        }
+
+        if ($type instanceof NullableType) {
+            return $this->hasResponseReturnType($type->type, $scope);
+        }
+
+        if ($type instanceof UnionType) {
+            foreach ($type->types as $unionedType) {
+                if ($this->hasResponseReturnType($unionedType, $scope)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private function isResponseClass(string $className): bool
+    {
+        if (!$this->reflectionProvider->hasClass($className)) {
+            return false;
+        }
+
+        return $this->reflectionProvider->getClass($className)->is(self::RESPONSE_CLASS);
+    }
+}

--- a/utils/phpstan/src/Rule/ControllerMethodMustReturnResponseRule.php
+++ b/utils/phpstan/src/Rule/ControllerMethodMustReturnResponseRule.php
@@ -25,8 +25,9 @@ use PHPStan\Rules\RuleErrorBuilder;
  * Only the public "*Action()" methods and "__invoke()" are actions. The public helpers a controller exposes next to
  * them - "getModelName()", "getViewArguments()" and the like - return their own data and are left alone.
  *
- * The shared base controllers - "Abstract*" and "Common*" - are skipped. Their actions are widened by child
- * controllers, so a narrow return type on the parent would lock the children out.
+ * The shared base controllers - those with "Abstract" or "Common" in their name, e.g. "AbstractFormController" or
+ * "FetchCommonApiController" - are skipped. Their actions are widened by child controllers, so a narrow return type
+ * on the parent would lock the children out.
  *
  * @implements Rule<ClassMethod>
  */
@@ -55,7 +56,7 @@ final class ControllerMethodMustReturnResponseRule implements Rule
     /**
      * @var string[]
      */
-    private const SKIPPED_CLASS_PREFIXES = ['Abstract', 'Common'];
+    private const SKIPPED_CLASS_NAME_PARTS = ['Abstract', 'Common'];
 
     public function __construct(
         private readonly ReflectionProvider $reflectionProvider,
@@ -125,8 +126,8 @@ final class ControllerMethodMustReturnResponseRule implements Rule
         $lastSeparatorPosition = strrpos($className, '\\');
         $shortClassName        = false === $lastSeparatorPosition ? $className : substr($className, $lastSeparatorPosition + 1);
 
-        foreach (self::SKIPPED_CLASS_PREFIXES as $skippedClassPrefix) {
-            if (str_starts_with($shortClassName, $skippedClassPrefix)) {
+        foreach (self::SKIPPED_CLASS_NAME_PARTS as $skippedClassNamePart) {
+            if (str_contains($shortClassName, $skippedClassNamePart)) {
                 return true;
             }
         }

--- a/utils/phpstan/tests/Rule/ControllerMethodMustReturnResponseRuleTest.php
+++ b/utils/phpstan/tests/Rule/ControllerMethodMustReturnResponseRuleTest.php
@@ -41,4 +41,10 @@ final class ControllerMethodMustReturnResponseRuleTest extends RuleTestCase
     {
         $this->analyse([__DIR__.'/Fixture/SomeAutowireService.php'], []);
     }
+
+    public function testSkipSharedBaseController(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/AbstractSomeController.php'], []);
+        $this->analyse([__DIR__.'/Fixture/CommonSomeController.php'], []);
+    }
 }

--- a/utils/phpstan/tests/Rule/ControllerMethodMustReturnResponseRuleTest.php
+++ b/utils/phpstan/tests/Rule/ControllerMethodMustReturnResponseRuleTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use Utils\PHPStan\Rule\ControllerMethodMustReturnResponseRule;
+
+/**
+ * @extends RuleTestCase<ControllerMethodMustReturnResponseRule>
+ */
+final class ControllerMethodMustReturnResponseRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new ControllerMethodMustReturnResponseRule($this->createReflectionProvider());
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/MissingResponseReturnTypeController.php'], [
+            [
+                'Controller action "indexAction()" must return a Response, either alone or as part of a union.',
+                9,
+            ],
+            [
+                'Controller action "nameAction()" must return a Response, either alone or as part of a union.',
+                14,
+            ],
+        ]);
+    }
+
+    public function testSkipResponseReturnTypeAndNonAction(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/ResponseReturnTypeController.php'], []);
+    }
+
+    public function testSkipNonControllerClass(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/SomeAutowireService.php'], []);
+    }
+}

--- a/utils/phpstan/tests/Rule/ControllerMethodMustReturnResponseRuleTest.php
+++ b/utils/phpstan/tests/Rule/ControllerMethodMustReturnResponseRuleTest.php
@@ -46,5 +46,6 @@ final class ControllerMethodMustReturnResponseRuleTest extends RuleTestCase
     {
         $this->analyse([__DIR__.'/Fixture/AbstractSomeController.php'], []);
         $this->analyse([__DIR__.'/Fixture/CommonSomeController.php'], []);
+        $this->analyse([__DIR__.'/Fixture/FetchCommonSomeController.php'], []);
     }
 }

--- a/utils/phpstan/tests/Rule/Fixture/AbstractSomeController.php
+++ b/utils/phpstan/tests/Rule/Fixture/AbstractSomeController.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+abstract class AbstractSomeController
+{
+    public function indexAction()
+    {
+        return [];
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/CommonSomeController.php
+++ b/utils/phpstan/tests/Rule/Fixture/CommonSomeController.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+class CommonSomeController
+{
+    public function indexAction()
+    {
+        return [];
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/FetchCommonSomeController.php
+++ b/utils/phpstan/tests/Rule/Fixture/FetchCommonSomeController.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+class FetchCommonSomeController
+{
+    public function indexAction()
+    {
+        return [];
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/MissingResponseReturnTypeController.php
+++ b/utils/phpstan/tests/Rule/Fixture/MissingResponseReturnTypeController.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+final class MissingResponseReturnTypeController
+{
+    public function indexAction()
+    {
+        return null;
+    }
+
+    public function nameAction(): string
+    {
+        return 'name';
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/ResponseReturnTypeController.php
+++ b/utils/phpstan/tests/Rule/Fixture/ResponseReturnTypeController.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ResponseReturnTypeController
+{
+    public function indexAction(): Response
+    {
+        return new Response('index');
+    }
+
+    public function saveAction(): JsonResponse|RedirectResponse
+    {
+        return new JsonResponse();
+    }
+
+    public function __invoke(): Response
+    {
+        return new Response('invoked');
+    }
+
+    public function getModelName(): string
+    {
+        return 'some.model';
+    }
+
+    private function buildSomethingAction(): string
+    {
+        return 'something';
+    }
+}


### PR DESCRIPTION
A controller action answers an HTTP request, so it hands a `Response` back. Many actions never said so: no native return type at all, or a `@return` docblock claiming something narrower than what the code really returns.

This adds the missing native types and a PHPStan rule so the next action cannot skip them :+1: 


```diff
/**
 * Generates new form and processes post data.
 *
- * @return \Symfony\Component\HttpFoundation\JsonResponse
 */
-public function newAction(Request $request)
+public function newAction(Request $request): Response
{
    return parent::newStandard($request);
}
```
