### PR TITLE
[di] Inject form factory in FormModel instead of passing it to createForm()

### DIFF
--- a/app/bundles/ApiBundle/Controller/ClientController.php
+++ b/app/bundles/ApiBundle/Controller/ClientController.php
@@ -185,7 +185,7 @@ final class ClientController extends AbstractStandardFormController
 
         // get the user form factory
         $action = $this->generateUrl('mautic_client_action', ['objectAction' => 'new']);
-        $form   = $this->clientModel->createForm($client, $this->formFactory, $action);
+        $form   = $this->clientModel->createForm($client, $action);
 
         // remove the client id and secret fields as they'll be auto generated
         $form->remove('randomId');
@@ -306,7 +306,7 @@ final class ClientController extends AbstractStandardFormController
         }
 
         $action = $this->generateUrl('mautic_client_action', ['objectAction' => 'edit', 'objectId' => $objectId]);
-        $form   = $this->clientModel->createForm($client, $this->formFactory, $action);
+        $form   = $this->clientModel->createForm($client, $action);
 
         // remove api_mode field
         $form->remove('api_mode');

--- a/app/bundles/ApiBundle/Controller/CommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/CommonApiController.php
@@ -354,6 +354,7 @@ class CommonApiController extends FetchCommonApiController
     {
         return $this->model->createForm(
             $entity,
+            $this->formFactory,
             null,
             array_merge(
                 [

--- a/app/bundles/ApiBundle/Controller/CommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/CommonApiController.php
@@ -354,7 +354,6 @@ class CommonApiController extends FetchCommonApiController
     {
         return $this->model->createForm(
             $entity,
-            $this->formFactory,
             null,
             array_merge(
                 [

--- a/app/bundles/ApiBundle/Model/ClientModel.php
+++ b/app/bundles/ApiBundle/Model/ClientModel.php
@@ -74,10 +74,8 @@ final class ClientModel extends FormModel implements GlobalSearchInterface
     /**
      * @throws MethodNotAllowedHttpException
      */
-    public function createForm($entity, mixed ...$args): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
-        [$action, $options] = $this->resolveCreateFormArgs($args);
-
         if (!$entity instanceof Client) {
             throw new MethodNotAllowedHttpException(['Client']);
         }

--- a/app/bundles/ApiBundle/Model/ClientModel.php
+++ b/app/bundles/ApiBundle/Model/ClientModel.php
@@ -74,8 +74,10 @@ final class ClientModel extends FormModel implements GlobalSearchInterface
     /**
      * @throws MethodNotAllowedHttpException
      */
-    public function createForm($entity, $action = null, $options = []): FormInterface
+    public function createForm($entity, mixed ...$args): FormInterface
     {
+        [$action, $options] = $this->resolveCreateFormArgs($args);
+
         if (!$entity instanceof Client) {
             throw new MethodNotAllowedHttpException(['Client']);
         }

--- a/app/bundles/ApiBundle/Model/ClientModel.php
+++ b/app/bundles/ApiBundle/Model/ClientModel.php
@@ -10,7 +10,6 @@ use Mautic\ApiBundle\Form\Type\ClientType;
 use Mautic\CoreBundle\Model\FormModel;
 use Mautic\CoreBundle\Model\GlobalSearchInterface;
 use Mautic\UserBundle\Entity\User;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
@@ -75,7 +74,7 @@ final class ClientModel extends FormModel implements GlobalSearchInterface
     /**
      * @throws MethodNotAllowedHttpException
      */
-    public function createForm($entity, FormFactoryInterface $formFactory, $action = null, $options = []): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
         if (!$entity instanceof Client) {
             throw new MethodNotAllowedHttpException(['Client']);
@@ -83,7 +82,7 @@ final class ClientModel extends FormModel implements GlobalSearchInterface
 
         $params = (!empty($action)) ? ['action' => $action] : [];
 
-        return $formFactory->create(ClientType::class, $entity, $params);
+        return $this->formFactory->create(ClientType::class, $entity, $params);
     }
 
     public function getEntity($id = null): ?Client

--- a/app/bundles/ApiBundle/Tests/ApiPlatform/EventListener/MauticDenyAccessListenerTest.php
+++ b/app/bundles/ApiBundle/Tests/ApiPlatform/EventListener/MauticDenyAccessListenerTest.php
@@ -175,8 +175,9 @@ final class MauticDenyAccessListenerTest extends TestCase
         };
 
         $requestObject = new class($customObjectMock) {
-            public function __construct(private readonly object $customObject)
-            {
+            public function __construct(
+                private readonly object $customObject,
+            ) {
             }
 
             public function getCustomObject(): object
@@ -224,8 +225,9 @@ final class MauticDenyAccessListenerTest extends TestCase
         };
 
         $requestObject = new class($customFieldMock) {
-            public function __construct(private readonly object $customField)
-            {
+            public function __construct(
+                private readonly object $customField,
+            ) {
             }
 
             public function getCustomField(): object

--- a/app/bundles/AssetBundle/Controller/AssetController.php
+++ b/app/bundles/AssetBundle/Controller/AssetController.php
@@ -311,7 +311,7 @@ final class AssetController extends FormController
         $uploadEndpoint = $uploaderHelper->endpoint('asset');
 
         // create the form
-        $form = $model->createForm($entity, $this->formFactory, $action);
+        $form = $model->createForm($entity, $action);
 
         // /Check for a submitted form and process it
         if ('POST' === $method) {
@@ -471,7 +471,7 @@ final class AssetController extends FormController
 
         // Create the form
         $action = $this->generateUrl('mautic_asset_action', ['objectAction' => 'edit', 'objectId' => $objectId]);
-        $form   = $model->createForm($entity, $this->formFactory, $action);
+        $form   = $model->createForm($entity, $action);
 
         // /Check for a submitted form and process it
         if (!$ignorePost && 'POST' === $method) {

--- a/app/bundles/AssetBundle/Model/AssetModel.php
+++ b/app/bundles/AssetBundle/Model/AssetModel.php
@@ -35,7 +35,6 @@ use Mautic\LeadBundle\Tracker\Service\DeviceCreatorService\DeviceCreatorServiceI
 use Mautic\LeadBundle\Tracker\Service\DeviceTrackingService\DeviceTrackingServiceInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -308,7 +307,7 @@ class AssetModel extends FormModel implements GlobalSearchInterface
         return 'getTitle';
     }
 
-    public function createForm($entity, FormFactoryInterface $formFactory, $action = null, $options = []): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
         if (!$entity instanceof Asset) {
             throw new MethodNotAllowedHttpException(['Asset']);
@@ -318,7 +317,7 @@ class AssetModel extends FormModel implements GlobalSearchInterface
             $options['action'] = $action;
         }
 
-        return $formFactory->create(AssetType::class, $entity, $options);
+        return $this->formFactory->create(AssetType::class, $entity, $options);
     }
 
     /**

--- a/app/bundles/AssetBundle/Model/AssetModel.php
+++ b/app/bundles/AssetBundle/Model/AssetModel.php
@@ -307,8 +307,10 @@ class AssetModel extends FormModel implements GlobalSearchInterface
         return 'getTitle';
     }
 
-    public function createForm($entity, $action = null, $options = []): FormInterface
+    public function createForm($entity, mixed ...$args): FormInterface
     {
+        [$action, $options] = $this->resolveCreateFormArgs($args);
+
         if (!$entity instanceof Asset) {
             throw new MethodNotAllowedHttpException(['Asset']);
         }

--- a/app/bundles/AssetBundle/Model/AssetModel.php
+++ b/app/bundles/AssetBundle/Model/AssetModel.php
@@ -307,10 +307,8 @@ class AssetModel extends FormModel implements GlobalSearchInterface
         return 'getTitle';
     }
 
-    public function createForm($entity, mixed ...$args): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
-        [$action, $options] = $this->resolveCreateFormArgs($args);
-
         if (!$entity instanceof Asset) {
             throw new MethodNotAllowedHttpException(['Asset']);
         }

--- a/app/bundles/CampaignBundle/Controller/CampaignController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignController.php
@@ -452,7 +452,7 @@ class CampaignController extends AbstractStandardFormController
 
         $options = $this->getEntityFormOptions();
         $action  = $this->generateUrl('mautic_campaign_action', ['objectAction' => 'new']);
-        $form    = $this->campaignModel->createForm($campaign, $this->formFactory, $action, $options);
+        $form    = $this->campaignModel->createForm($campaign, $action, $options);
 
         // /Check for a submitted form and process it
         $isPost = 'POST' === $request->getMethod();

--- a/app/bundles/CampaignBundle/Model/CampaignModel.php
+++ b/app/bundles/CampaignBundle/Model/CampaignModel.php
@@ -41,7 +41,6 @@ use Mautic\LeadBundle\Tracker\ContactTracker;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -108,7 +107,7 @@ class CampaignModel extends CommonFormModel implements GlobalSearchInterface
      * @param string|null $action
      * @param array       $options
      */
-    public function createForm($entity, FormFactoryInterface $formFactory, $action = null, $options = []): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
         if (!$entity instanceof Campaign) {
             throw new MethodNotAllowedHttpException(['Campaign']);
@@ -118,7 +117,7 @@ class CampaignModel extends CommonFormModel implements GlobalSearchInterface
             $options['action'] = $action;
         }
 
-        return $formFactory->create(CampaignType::class, $entity, $options);
+        return $this->formFactory->create(CampaignType::class, $entity, $options);
     }
 
     /**

--- a/app/bundles/CampaignBundle/Model/CampaignModel.php
+++ b/app/bundles/CampaignBundle/Model/CampaignModel.php
@@ -103,12 +103,12 @@ class CampaignModel extends CommonFormModel implements GlobalSearchInterface
     }
 
     /**
-     * @param object      $entity
-     * @param string|null $action
-     * @param array       $options
+     * @param object $entity
      */
-    public function createForm($entity, $action = null, $options = []): FormInterface
+    public function createForm($entity, mixed ...$args): FormInterface
     {
+        [$action, $options] = $this->resolveCreateFormArgs($args);
+
         if (!$entity instanceof Campaign) {
             throw new MethodNotAllowedHttpException(['Campaign']);
         }

--- a/app/bundles/CampaignBundle/Model/CampaignModel.php
+++ b/app/bundles/CampaignBundle/Model/CampaignModel.php
@@ -103,12 +103,12 @@ class CampaignModel extends CommonFormModel implements GlobalSearchInterface
     }
 
     /**
-     * @param object $entity
+     * @param object      $entity
+     * @param string|null $action
+     * @param array       $options
      */
-    public function createForm($entity, mixed ...$args): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
-        [$action, $options] = $this->resolveCreateFormArgs($args);
-
         if (!$entity instanceof Campaign) {
             throw new MethodNotAllowedHttpException(['Campaign']);
         }

--- a/app/bundles/CategoryBundle/Controller/CategoryController.php
+++ b/app/bundles/CategoryBundle/Controller/CategoryController.php
@@ -8,7 +8,6 @@ use Mautic\CategoryBundle\Model\CategoryModel;
 use Mautic\CoreBundle\Controller\AbstractFormController;
 use Mautic\CoreBundle\Exception\DeleteEntityDependencyException;
 use Mautic\CoreBundle\Service\FlashBag;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -16,16 +15,12 @@ use Symfony\Contracts\Service\Attribute\Required;
 
 final class CategoryController extends AbstractFormController
 {
-    private FormFactoryInterface $formFactory;
-
     private CategoryModel $categoryModel;
 
     #[Required]
     public function autowireCategoryController(
-        FormFactoryInterface $formFactory,
         CategoryModel $categoryModel,
     ): void {
-        $this->formFactory   = $formFactory;
         $this->categoryModel = $categoryModel;
     }
 
@@ -211,7 +206,7 @@ final class CategoryController extends AbstractFormController
             'objectAction' => 'new',
             'bundle'       => $bundle,
         ]);
-        $form = $this->categoryModel->createForm($entity, $this->formFactory, $action, ['bundle' => $bundle, 'show_bundle_select' => 'category' === $bundle]);
+        $form = $this->categoryModel->createForm($entity, $action, ['bundle' => $bundle, 'show_bundle_select' => 'category' === $bundle]);
         $form['inForm']->setData($inForm);
         // /Check for a submitted form and process it
         if (Request::METHOD_POST === $method) {
@@ -324,7 +319,7 @@ final class CategoryController extends AbstractFormController
                 'bundle'       => $bundle,
             ]
         );
-        $form = $this->categoryModel->createForm($entity, $this->formFactory, $action, ['bundle' => $bundle]);
+        $form = $this->categoryModel->createForm($entity, $action, ['bundle' => $bundle]);
         $form['inForm']->setData($inForm);
 
         // /Check for a submitted form and process it
@@ -354,7 +349,7 @@ final class CategoryController extends AbstractFormController
                                 'bundle'       => $bundle,
                             ]
                         );
-                        $form = $this->categoryModel->createForm($entity, $this->formFactory, $action, ['bundle' => $bundle]);
+                        $form = $this->categoryModel->createForm($entity, $action, ['bundle' => $bundle]);
                     }
                 }
             } else {

--- a/app/bundles/CategoryBundle/Model/CategoryModel.php
+++ b/app/bundles/CategoryBundle/Model/CategoryModel.php
@@ -10,7 +10,6 @@ use Mautic\CategoryBundle\Event\CategoryTypeEntityEvent;
 use Mautic\CategoryBundle\Form\Type\CategoryType;
 use Mautic\CoreBundle\Model\AjaxLookupModelInterface;
 use Mautic\CoreBundle\Model\FormModel;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
@@ -95,7 +94,7 @@ class CategoryModel extends FormModel implements AjaxLookupModelInterface
      * @param string|null $action
      * @param array       $options
      */
-    public function createForm($entity, FormFactoryInterface $formFactory, $action = null, $options = []): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
         if (!$entity instanceof Category) {
             throw new MethodNotAllowedHttpException(['Category']);
@@ -104,7 +103,7 @@ class CategoryModel extends FormModel implements AjaxLookupModelInterface
             $options['action'] = $action;
         }
 
-        return $formFactory->create(CategoryType::class, $entity, $options);
+        return $this->formFactory->create(CategoryType::class, $entity, $options);
     }
 
     /**

--- a/app/bundles/CategoryBundle/Model/CategoryModel.php
+++ b/app/bundles/CategoryBundle/Model/CategoryModel.php
@@ -90,10 +90,12 @@ class CategoryModel extends FormModel implements AjaxLookupModelInterface
         parent::saveEntity($entity, $unlock);
     }
 
-    public function createForm($entity, mixed ...$args): FormInterface
+    /**
+     * @param string|null $action
+     * @param array       $options
+     */
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
-        [$action, $options] = $this->resolveCreateFormArgs($args);
-
         if (!$entity instanceof Category) {
             throw new MethodNotAllowedHttpException(['Category']);
         }

--- a/app/bundles/CategoryBundle/Model/CategoryModel.php
+++ b/app/bundles/CategoryBundle/Model/CategoryModel.php
@@ -90,12 +90,10 @@ class CategoryModel extends FormModel implements AjaxLookupModelInterface
         parent::saveEntity($entity, $unlock);
     }
 
-    /**
-     * @param string|null $action
-     * @param array       $options
-     */
-    public function createForm($entity, $action = null, $options = []): FormInterface
+    public function createForm($entity, mixed ...$args): FormInterface
     {
+        [$action, $options] = $this->resolveCreateFormArgs($args);
+
         if (!$entity instanceof Category) {
             throw new MethodNotAllowedHttpException(['Category']);
         }

--- a/app/bundles/ChannelBundle/Model/MessageModel.php
+++ b/app/bundles/ChannelBundle/Model/MessageModel.php
@@ -85,13 +85,14 @@ class MessageModel extends FormModel implements AjaxLookupModelInterface, Global
     }
 
     /**
-     * @param object  $entity
-     * @param mixed[] $options
+     * @param object $entity
      *
      * @return FormInterface<mixed>
      */
-    public function createForm($entity, $action = null, $options = []): FormInterface
+    public function createForm($entity, mixed ...$args): FormInterface
     {
+        [$action, $options] = $this->resolveCreateFormArgs($args);
+
         if (!empty($action)) {
             $options['action'] = $action;
         }

--- a/app/bundles/ChannelBundle/Model/MessageModel.php
+++ b/app/bundles/ChannelBundle/Model/MessageModel.php
@@ -12,7 +12,6 @@ use Mautic\ChannelBundle\Helper\ChannelListHelper;
 use Mautic\CoreBundle\Model\AjaxLookupModelInterface;
 use Mautic\CoreBundle\Model\FormModel;
 use Mautic\CoreBundle\Model\GlobalSearchInterface;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Contracts\EventDispatcher\Event;
@@ -91,13 +90,13 @@ class MessageModel extends FormModel implements AjaxLookupModelInterface, Global
      *
      * @return FormInterface<mixed>
      */
-    public function createForm($entity, FormFactoryInterface $formFactory, $action = null, $options = []): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
         if (!empty($action)) {
             $options['action'] = $action;
         }
 
-        return $formFactory->create(MessageType::class, $entity, $options);
+        return $this->formFactory->create(MessageType::class, $entity, $options);
     }
 
     /**

--- a/app/bundles/ChannelBundle/Model/MessageModel.php
+++ b/app/bundles/ChannelBundle/Model/MessageModel.php
@@ -85,14 +85,13 @@ class MessageModel extends FormModel implements AjaxLookupModelInterface, Global
     }
 
     /**
-     * @param object $entity
+     * @param object  $entity
+     * @param mixed[] $options
      *
      * @return FormInterface<mixed>
      */
-    public function createForm($entity, mixed ...$args): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
-        [$action, $options] = $this->resolveCreateFormArgs($args);
-
         if (!empty($action)) {
             $options['action'] = $action;
         }

--- a/app/bundles/CoreBundle/Controller/AbstractStandardFormController.php
+++ b/app/bundles/CoreBundle/Controller/AbstractStandardFormController.php
@@ -392,7 +392,7 @@ abstract class AbstractStandardFormController extends AbstractFormController
 
         $options = $this->getEntityFormOptions();
         $action  = $this->generateUrl($this->getActionRoute(), ['objectAction' => 'edit', 'objectId' => $objectId]);
-        $form    = $model->createForm($entity, $this->formFactory, $action, $options);
+        $form    = $model->createForm($entity, $action, $options);
 
         $isPost = !$ignorePost && 'POST' === $request->getMethod();
         $this->beforeFormProcessed($entity, $form, 'edit', $isPost, $objectId, $isClone);
@@ -463,7 +463,7 @@ abstract class AbstractStandardFormController extends AbstractFormController
             if ($valid) {
                 // Rebuild the form with new action so that apply doesn't keep creating a clone
                 $action = $this->generateUrl($this->getActionRoute(), ['objectAction' => 'edit', 'objectId' => $entity->getId()]);
-                $form   = $model->createForm($entity, $this->formFactory, $action);
+                $form   = $model->createForm($entity, $action);
                 $this->beforeFormProcessed($entity, $form, 'edit', false, $isClone);
                 $this->setOptimisticLockVersion($entity, $form);
             }
@@ -937,7 +937,7 @@ abstract class AbstractStandardFormController extends AbstractFormController
 
         $options = $this->getEntityFormOptions();
         $action  = $this->generateUrl($this->getActionRoute(), ['objectAction' => 'new']);
-        $form    = $model->createForm($entity, $this->formFactory, $action, $options);
+        $form    = $model->createForm($entity, $action, $options);
 
         // /Check for a submitted form and process it
         $isPost = 'POST' === $request->getMethod();

--- a/app/bundles/CoreBundle/Controller/AjaxController.php
+++ b/app/bundles/CoreBundle/Controller/AjaxController.php
@@ -16,7 +16,6 @@ use Mautic\CoreBundle\Model\FormModel;
 use Mautic\CoreBundle\Model\NotificationModel;
 use Mautic\CoreBundle\Service\FlashBag;
 use Mautic\CoreBundle\Service\SearchCommandListInterface;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -392,7 +391,7 @@ class AjaxController extends CommonController
     /**
      * Fetch IP Lookup form.
      */
-    public function getIpLookupFormAction(Request $request, FormFactoryInterface $formFactory, IpLookupFactory $ipServiceFactory): JsonResponse
+    public function getIpLookupFormAction(Request $request, IpLookupFactory $ipServiceFactory): JsonResponse
     {
         $dataArray = ['html' => '', 'attribution' => ''];
 
@@ -408,7 +407,7 @@ class AjaxController extends CommonController
                         $themes   = $ipService->getConfigFormThemes();
                         $themes[] = '@MauticCore/FormTheme/Config/config_layout.html.twig';
 
-                        $form = $formFactory->createBuilder()
+                        $form = $this->createFormBuilder()
                             ->add(
                                 'ip_lookup_config',
                                 $formType,

--- a/app/bundles/CoreBundle/Model/FormModel.php
+++ b/app/bundles/CoreBundle/Model/FormModel.php
@@ -376,10 +376,29 @@ class FormModel extends AbstractCommonModel
      * @return FormInterface<mixed>
      *
      * @throws NotFoundHttpException
+     *
+     * @deprecated since 7.0, the $formFactory argument is ignored and will be removed in 8.0; child models use the injected form factory
      */
-    public function createForm($entity, $action = null, $options = []): FormInterface
+    public function createForm($entity, FormFactoryInterface $formFactory, $action = null, $options = []): FormInterface
     {
         throw new NotFoundHttpException('Object does not support edits.');
+    }
+
+    /**
+     * Normalizes the createForm() arguments, so child models can be called with or without
+     * the deprecated $formFactory argument.
+     *
+     * @param mixed[] $args
+     *
+     * @return array{0: string|null, 1: mixed[]}
+     */
+    protected function resolveCreateFormArgs(array $args): array
+    {
+        if (($args[0] ?? null) instanceof FormFactoryInterface) {
+            array_shift($args);
+        }
+
+        return [$args[0] ?? null, $args[1] ?? []];
     }
 
     /**

--- a/app/bundles/CoreBundle/Model/FormModel.php
+++ b/app/bundles/CoreBundle/Model/FormModel.php
@@ -376,29 +376,10 @@ class FormModel extends AbstractCommonModel
      * @return FormInterface<mixed>
      *
      * @throws NotFoundHttpException
-     *
-     * @deprecated since 7.0, the $formFactory argument is ignored and will be removed in 8.0; child models use the injected form factory
      */
-    public function createForm($entity, FormFactoryInterface $formFactory, $action = null, $options = []): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
         throw new NotFoundHttpException('Object does not support edits.');
-    }
-
-    /**
-     * Normalizes the createForm() arguments, so child models can be called with or without
-     * the deprecated $formFactory argument.
-     *
-     * @param mixed[] $args
-     *
-     * @return array{0: string|null, 1: mixed[]}
-     */
-    protected function resolveCreateFormArgs(array $args): array
-    {
-        if (($args[0] ?? null) instanceof FormFactoryInterface) {
-            array_shift($args);
-        }
-
-        return [$args[0] ?? null, $args[1] ?? []];
     }
 
     /**

--- a/app/bundles/CoreBundle/Model/FormModel.php
+++ b/app/bundles/CoreBundle/Model/FormModel.php
@@ -21,6 +21,14 @@ use Symfony\Contracts\EventDispatcher\Event;
  */
 class FormModel extends AbstractCommonModel
 {
+    protected FormFactoryInterface $formFactory;
+
+    public function autowireFormModel(
+        FormFactoryInterface $formFactory,
+    ): void {
+        $this->formFactory = $formFactory;
+    }
+
     /**
      * Lock an entity to prevent multiple people from editing.
      *
@@ -367,7 +375,7 @@ class FormModel extends AbstractCommonModel
      *
      * @throws NotFoundHttpException
      */
-    public function createForm($entity, FormFactoryInterface $formFactory, $action = null, $options = []): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
         throw new NotFoundHttpException('Object does not support edits.');
     }

--- a/app/bundles/CoreBundle/Model/FormModel.php
+++ b/app/bundles/CoreBundle/Model/FormModel.php
@@ -13,6 +13,7 @@ use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Contracts\EventDispatcher\Event;
+use Symfony\Contracts\Service\Attribute\Required;
 
 /**
  * @template T of object
@@ -23,6 +24,7 @@ class FormModel extends AbstractCommonModel
 {
     protected FormFactoryInterface $formFactory;
 
+    #[Required]
     public function autowireFormModel(
         FormFactoryInterface $formFactory,
     ): void {

--- a/app/bundles/DashboardBundle/Controller/DashboardController.php
+++ b/app/bundles/DashboardBundle/Controller/DashboardController.php
@@ -15,7 +15,6 @@ use Mautic\DashboardBundle\Form\Type\UploadType;
 use Mautic\DashboardBundle\Model\DashboardModel;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Form\FormError;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -40,7 +39,7 @@ final class DashboardController extends AbstractFormController
     /**
      * Generates the default view.
      */
-    public function indexAction(Request $request, WidgetService $widget, FormFactoryInterface $formFactory, PathsHelper $pathsHelper, RouterInterface $urlGenerator): Response
+    public function indexAction(Request $request, WidgetService $widget, PathsHelper $pathsHelper, RouterInterface $urlGenerator): Response
     {
         $widgets = $this->dashboardModel->getWidgets();
 
@@ -76,7 +75,7 @@ final class DashboardController extends AbstractFormController
         // Set the final date range to the form
         $dateRangeFilter['date_from'] = $filter['dateFrom']->format(WidgetService::FORMAT_HUMAN);
         $dateRangeFilter['date_to']   = $filter['dateTo']->format(WidgetService::FORMAT_HUMAN);
-        $dateRangeForm                = $formFactory->create(DateRangeType::class, $dateRangeFilter, ['action' => $action]);
+        $dateRangeForm                = $this->createForm(DateRangeType::class, $dateRangeFilter, ['action' => $action]);
 
         $this->dashboardModel->populateWidgetsContent($widgets, $filter);
         $releaseMetadata = ThisRelease::getMetadata();
@@ -132,14 +131,14 @@ final class DashboardController extends AbstractFormController
     /**
      * Generate new dashboard widget and processes post data.
      */
-    public function newAction(Request $request, FormFactoryInterface $formFactory): JsonResponse|Response
+    public function newAction(Request $request): JsonResponse|Response
     {
         // retrieve the entity
         $widget = new Widget();
         $action = $this->generateUrl('mautic_dashboard_action', ['objectAction' => 'new']);
 
         // get the user form factory
-        $form       = $this->dashboardModel->createForm($widget, $formFactory, $action);
+        $form       = $this->dashboardModel->createForm($widget, $action);
         $closeModal = false;
         $valid      = false;
 
@@ -193,13 +192,13 @@ final class DashboardController extends AbstractFormController
     /**
      * edit widget and processes post data.
      */
-    public function editAction(Request $request, FormFactoryInterface $formFactory, $objectId): JsonResponse|Response
+    public function editAction(Request $request, $objectId): JsonResponse|Response
     {
         $widget = $this->dashboardModel->getEntity($objectId);
         $action = $this->generateUrl('mautic_dashboard_action', ['objectAction' => 'edit', 'objectId' => $objectId]);
 
         // get the user form factory
-        $form       = $this->dashboardModel->createForm($widget, $formFactory, $action);
+        $form       = $this->dashboardModel->createForm($widget, $action);
         $closeModal = false;
         $valid      = false;
         // /Check for a submitted form and process it
@@ -421,7 +420,7 @@ final class DashboardController extends AbstractFormController
         return $this->redirect($urlGenerator->generate('mautic_dashboard_index'));
     }
 
-    public function importAction(Request $request, FormFactoryInterface $formFactory, PathsHelper $pathsHelper): Response
+    public function importAction(Request $request, PathsHelper $pathsHelper): Response
     {
         $preview = $request->get('preview');
 
@@ -431,7 +430,7 @@ final class DashboardController extends AbstractFormController
         ];
 
         $action = $this->generateUrl('mautic_dashboard_action', ['objectAction' => 'import']);
-        $form   = $formFactory->create(UploadType::class, [], ['action' => $action]);
+        $form   = $this->createForm(UploadType::class, [], ['action' => $action]);
 
         if ($request->isMethod(Request::METHOD_POST)) {
             if (!$this->isFormCancelled($form)) {

--- a/app/bundles/DashboardBundle/Model/DashboardModel.php
+++ b/app/bundles/DashboardBundle/Model/DashboardModel.php
@@ -265,16 +265,16 @@ class DashboardModel extends FormModel
     }
 
     /**
-     * @param Widget $entity
+     * @param Widget      $entity
+     * @param string|null $action
+     * @param array       $options
      *
      * @return FormInterface<mixed>
      *
      * @throws MethodNotAllowedHttpException
      */
-    public function createForm($entity, mixed ...$args): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
-        [$action, $options] = $this->resolveCreateFormArgs($args);
-
         if (!$entity instanceof Widget) {
             throw new MethodNotAllowedHttpException(['Widget'], 'Entity must be of class Widget()');
         }

--- a/app/bundles/DashboardBundle/Model/DashboardModel.php
+++ b/app/bundles/DashboardBundle/Model/DashboardModel.php
@@ -265,16 +265,16 @@ class DashboardModel extends FormModel
     }
 
     /**
-     * @param Widget      $entity
-     * @param string|null $action
-     * @param array       $options
+     * @param Widget $entity
      *
      * @return FormInterface<mixed>
      *
      * @throws MethodNotAllowedHttpException
      */
-    public function createForm($entity, $action = null, $options = []): FormInterface
+    public function createForm($entity, mixed ...$args): FormInterface
     {
+        [$action, $options] = $this->resolveCreateFormArgs($args);
+
         if (!$entity instanceof Widget) {
             throw new MethodNotAllowedHttpException(['Widget'], 'Entity must be of class Widget()');
         }

--- a/app/bundles/DashboardBundle/Model/DashboardModel.php
+++ b/app/bundles/DashboardBundle/Model/DashboardModel.php
@@ -22,7 +22,6 @@ use Mautic\DashboardBundle\Form\Type\WidgetType;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Filesystem\Exception\IOException;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
@@ -274,7 +273,7 @@ class DashboardModel extends FormModel
      *
      * @throws MethodNotAllowedHttpException
      */
-    public function createForm($entity, FormFactoryInterface $formFactory, $action = null, $options = []): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
         if (!$entity instanceof Widget) {
             throw new MethodNotAllowedHttpException(['Widget'], 'Entity must be of class Widget()');
@@ -284,7 +283,7 @@ class DashboardModel extends FormModel
             $options['action'] = $action;
         }
 
-        return $formFactory->create(WidgetType::class, $entity, $options);
+        return $this->formFactory->create(WidgetType::class, $entity, $options);
     }
 
     /**

--- a/app/bundles/DynamicContentBundle/Controller/DynamicContentController.php
+++ b/app/bundles/DynamicContentBundle/Controller/DynamicContentController.php
@@ -140,7 +140,7 @@ final class DynamicContentController extends FormController
         $updateSelect = 'POST' === $method
             ? ($dwc['updateSelect'] ?? false)
             : $request->get('updateSelect', false);
-        $form         = $this->dynamicContentModel->createForm($entity, $this->formFactory, $action, ['update_select' => $updateSelect]);
+        $form         = $this->dynamicContentModel->createForm($entity, $action, ['update_select' => $updateSelect]);
 
         if (Request::METHOD_POST === $method) {
             $valid = false;
@@ -280,7 +280,7 @@ final class DynamicContentController extends FormController
             ? ($dwc['updateSelect'] ?? false)
             : $request->get('updateSelect', false);
 
-        $form = $this->dynamicContentModel->createForm($entity, $this->formFactory, $action, ['update_select' => $updateSelect]);
+        $form = $this->dynamicContentModel->createForm($entity, $action, ['update_select' => $updateSelect]);
 
         // /Check for a submitted form and process it
         if (!$ignorePost && 'POST' === $method) {

--- a/app/bundles/DynamicContentBundle/Model/DynamicContentModel.php
+++ b/app/bundles/DynamicContentBundle/Model/DynamicContentModel.php
@@ -115,13 +115,12 @@ class DynamicContentModel extends FormModel implements AjaxLookupModelInterface,
     }
 
     /**
-     * @param string|null $action
-     * @param array       $options
-     *
      * @throws \InvalidArgumentException
      */
-    public function createForm($entity, $action = null, $options = []): FormInterface
+    public function createForm($entity, mixed ...$args): FormInterface
     {
+        [$action, $options] = $this->resolveCreateFormArgs($args);
+
         if (!$entity instanceof DynamicContent) {
             throw new \InvalidArgumentException('Entity must be of class DynamicContent');
         }

--- a/app/bundles/DynamicContentBundle/Model/DynamicContentModel.php
+++ b/app/bundles/DynamicContentBundle/Model/DynamicContentModel.php
@@ -18,7 +18,6 @@ use Mautic\DynamicContentBundle\Entity\StatRepository;
 use Mautic\DynamicContentBundle\Event\DynamicContentEvent;
 use Mautic\DynamicContentBundle\Form\Type\DynamicContentType;
 use Mautic\LeadBundle\Entity\Lead;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Contracts\EventDispatcher\Event;
@@ -121,7 +120,7 @@ class DynamicContentModel extends FormModel implements AjaxLookupModelInterface,
      *
      * @throws \InvalidArgumentException
      */
-    public function createForm($entity, FormFactoryInterface $formFactory, $action = null, $options = []): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
         if (!$entity instanceof DynamicContent) {
             throw new \InvalidArgumentException('Entity must be of class DynamicContent');
@@ -131,7 +130,7 @@ class DynamicContentModel extends FormModel implements AjaxLookupModelInterface,
             $options['action'] = $action;
         }
 
-        return $formFactory->create(DynamicContentType::class, $entity, $options);
+        return $this->formFactory->create(DynamicContentType::class, $entity, $options);
     }
 
     public function setSlotContentForLead(DynamicContent $dwc, Lead $lead, $slot): void

--- a/app/bundles/DynamicContentBundle/Model/DynamicContentModel.php
+++ b/app/bundles/DynamicContentBundle/Model/DynamicContentModel.php
@@ -115,12 +115,13 @@ class DynamicContentModel extends FormModel implements AjaxLookupModelInterface,
     }
 
     /**
+     * @param string|null $action
+     * @param array       $options
+     *
      * @throws \InvalidArgumentException
      */
-    public function createForm($entity, mixed ...$args): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
-        [$action, $options] = $this->resolveCreateFormArgs($args);
-
         if (!$entity instanceof DynamicContent) {
             throw new \InvalidArgumentException('Entity must be of class DynamicContent');
         }

--- a/app/bundles/EmailBundle/Controller/AjaxController.php
+++ b/app/bundles/EmailBundle/Controller/AjaxController.php
@@ -16,7 +16,6 @@ use Mautic\EmailBundle\Model\EmailModel;
 use Mautic\EmailBundle\MonitoredEmail\Mailbox;
 use Mautic\EmailBundle\Stats\EmailDependencies;
 use Mautic\PageBundle\Form\Type\AbTestPropertiesType;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -40,12 +39,12 @@ final class AjaxController extends CommonAjaxController
         $this->emailModel = $emailModel;
     }
 
-    public function getAbTestFormAction(Request $request, FormFactoryInterface $formFactory, EmailModel $emailModel, Environment $twig): JsonResponse
+    public function getAbTestFormAction(Request $request, EmailModel $emailModel, Environment $twig): JsonResponse
     {
         return $this->sendJsonResponse($this->getAbTestForm(
             $request,
             $emailModel,
-            fn ($formType, $formOptions): FormInterface => $formFactory->create(AbTestPropertiesType::class, [], ['formType' => $formType, 'formTypeOptions' => $formOptions]),
+            fn ($formType, $formOptions): FormInterface => $this->createForm(AbTestPropertiesType::class, [], ['formType' => $formType, 'formTypeOptions' => $formOptions]),
             fn (FormInterface $form): string => $this->renderView('@MauticEmail/AbTest/form.html.twig', ['form' => $this->setFormTheme($form, $twig, ['@MauticEmail/AbTest/form.html.twig', '@MauticEmail/FormTheme/Email/layout.html.twig'])]),
             'email_abtest_settings',
             'emailform'

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -536,7 +536,7 @@ final class EmailController extends FormController
         }
 
         // create the form
-        $form = $model->createForm($entity, $this->formFactory, $action, ['update_select' => $updateSelect]);
+        $form = $model->createForm($entity, $action, ['update_select' => $updateSelect]);
 
         // /Check for a submitted form and process it
         if ('POST' === $method) {
@@ -739,7 +739,7 @@ final class EmailController extends FormController
             // Force type to template
             $entity->setEmailType('template');
         }
-        $form = $model->createForm($entity, $this->formFactory, $action, ['update_select' => $updateSelect]);
+        $form = $model->createForm($entity, $action, ['update_select' => $updateSelect]);
         $this->setOptimisticLockVersion($entity, $form);
 
         // /Check for a submitted form and process it
@@ -843,7 +843,7 @@ final class EmailController extends FormController
             }
             if ($valid) {
                 // Rebuild the form in the case apply is clicked so that DEC content is properly populated if all were removed
-                $form = $model->createForm($entity, $this->formFactory, $action, ['update_select' => $updateSelect]);
+                $form = $model->createForm($entity, $action, ['update_select' => $updateSelect]);
                 $this->setOptimisticLockVersion($entity, $form);
             }
         } else {
@@ -987,7 +987,7 @@ final class EmailController extends FormController
 
         // Create the form
         $action = $this->generateUrl('mautic_email_action', ['objectAction' => 'clone', 'objectId' => $objectId]);
-        $form   = $model->createForm($entity, $this->formFactory, $action);
+        $form   = $model->createForm($entity, $action);
 
         // /Check for a submitted form and process it
         if ('POST' === $method) {

--- a/app/bundles/EmailBundle/Controller/EmailGraphStatsController.php
+++ b/app/bundles/EmailBundle/Controller/EmailGraphStatsController.php
@@ -6,7 +6,6 @@ use Mautic\CoreBundle\Form\Type\DateRangeType;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\EmailBundle\Model\EmailModel;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
@@ -26,7 +25,6 @@ final class EmailGraphStatsController extends AbstractController
     public function viewAction(
         Request $request,
         EmailModel $model,
-        FormFactoryInterface $formFactory,
         CorePermissions $security,
         $objectId,
         $isVariant,
@@ -39,7 +37,7 @@ final class EmailGraphStatsController extends AbstractController
         // Init the date range filter form
         $dateRangeValues = ['date_from' => $dateFrom, 'date_to' => $dateTo];
         $action          = $this->generateUrl('mautic_email_action', ['objectAction' => 'view', 'objectId' => $objectId]);
-        $dateRangeForm   = $formFactory->create(DateRangeType::class, $dateRangeValues, ['action' => $action]);
+        $dateRangeForm   = $this->createForm(DateRangeType::class, $dateRangeValues, ['action' => $action]);
 
         if (null === $email || !$security->hasEntityAccess(
             'email:emails:viewown',

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -73,7 +73,6 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
@@ -323,7 +322,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
      *
      * @return FormInterface<Email>
      */
-    public function createForm($entity, FormFactoryInterface $formFactory, $action = null, $options = []): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
         if (!$entity instanceof Email) {
             throw new MethodNotAllowedHttpException(['Email']);
@@ -332,7 +331,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
             $options['action'] = $action;
         }
 
-        return $formFactory->create(EmailType::class, $entity, $options);
+        return $this->formFactory->create(EmailType::class, $entity, $options);
     }
 
     /**

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -317,13 +317,12 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
     }
 
     /**
-     * @param string|null $action
-     * @param array       $options
-     *
      * @return FormInterface<Email>
      */
-    public function createForm($entity, $action = null, $options = []): FormInterface
+    public function createForm($entity, mixed ...$args): FormInterface
     {
+        [$action, $options] = $this->resolveCreateFormArgs($args);
+
         if (!$entity instanceof Email) {
             throw new MethodNotAllowedHttpException(['Email']);
         }

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -317,12 +317,13 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
     }
 
     /**
+     * @param string|null $action
+     * @param array       $options
+     *
      * @return FormInterface<Email>
      */
-    public function createForm($entity, mixed ...$args): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
-        [$action, $options] = $this->resolveCreateFormArgs($args);
-
         if (!$entity instanceof Email) {
             throw new MethodNotAllowedHttpException(['Email']);
         }

--- a/app/bundles/FormBundle/Controller/Api/FormApiController.php
+++ b/app/bundles/FormBundle/Controller/Api/FormApiController.php
@@ -299,7 +299,6 @@ final class FormApiController extends CommonApiController
 
         return $this->actionModel->createForm(
             $entity,
-            $this->formFactory,
             null,
             [
                 'csrf_protection'    => false,
@@ -318,7 +317,6 @@ final class FormApiController extends CommonApiController
     {
         return $this->fieldModel->createForm(
             $entity,
-            $this->formFactory,
             null,
             [
                 'csrf_protection'    => false,

--- a/app/bundles/FormBundle/Controller/FieldController.php
+++ b/app/bundles/FormBundle/Controller/FieldController.php
@@ -421,7 +421,6 @@ final class FieldController extends CommonFormController
         $customParams     = $customComponents['fields'][$formField['type']] ?? false;
         $form = $this->formFieldModel->createForm(
             $formField,
-            $this->formFactory,
             (!empty($formField['id'])) ?
                 $this->generateUrl('mautic_formfield_action', ['objectAction' => 'edit', 'objectId' => $formField['id']])
                 : $this->generateUrl('mautic_formfield_action', ['objectAction' => 'new']),

--- a/app/bundles/FormBundle/Controller/FormController.php
+++ b/app/bundles/FormBundle/Controller/FormController.php
@@ -304,7 +304,7 @@ class FormController extends CommonFormController
         $deletedActions  = $session->get('mautic.form.'.$sessionId.'.actions.deleted', []);
 
         $action = $this->generateUrl('mautic_form_action', ['objectAction' => 'new']);
-        $form   = $this->formModel->createForm($entity, $this->formFactory, $action);
+        $form   = $this->formModel->createForm($entity, $action);
 
         // /Check for a submitted form and process it
         if ('POST' === $request->getMethod()) {
@@ -551,7 +551,7 @@ class FormController extends CommonFormController
         }
 
         $action = $this->generateUrl('mautic_form_action', ['objectAction' => 'edit', 'objectId' => $objectId]);
-        $form   = $this->formModel->createForm($entity, $this->formFactory, $action);
+        $form   = $this->formModel->createForm($entity, $action);
 
         // /Check for a submitted form and process it
         if (!$ignorePost && 'POST' === $request->getMethod()) {
@@ -681,7 +681,7 @@ class FormController extends CommonFormController
 
                 // Rebuild the form with new action so that apply doesn't keep creating a clone
                 $action = $this->generateUrl('mautic_form_action', ['objectAction' => 'edit', 'objectId' => $entity->getId()]);
-                $form   = $this->formModel->createForm($entity, $this->formFactory, $action);
+                $form   = $this->formModel->createForm($entity, $action);
             }
         } else {
             // lock the entity

--- a/app/bundles/FormBundle/Model/ActionModel.php
+++ b/app/bundles/FormBundle/Model/ActionModel.php
@@ -44,11 +44,10 @@ class ActionModel extends CommonFormModel
 
     /**
      * @param object $entity
+     * @param array  $options
      */
-    public function createForm($entity, mixed ...$args): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
-        [$action, $options] = $this->resolveCreateFormArgs($args);
-
         if (!$entity instanceof Action) {
             throw new \InvalidArgumentException('Entity must be of class Action');
         }

--- a/app/bundles/FormBundle/Model/ActionModel.php
+++ b/app/bundles/FormBundle/Model/ActionModel.php
@@ -6,7 +6,6 @@ use Mautic\CoreBundle\Model\FormModel as CommonFormModel;
 use Mautic\FormBundle\Entity\Action;
 use Mautic\FormBundle\Entity\ActionRepository;
 use Mautic\FormBundle\Form\Type\ActionType;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Contracts\Service\Attribute\Required;
 
@@ -47,7 +46,7 @@ class ActionModel extends CommonFormModel
      * @param object $entity
      * @param array  $options
      */
-    public function createForm($entity, FormFactoryInterface $formFactory, $action = null, $options = []): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
         if (!$entity instanceof Action) {
             throw new \InvalidArgumentException('Entity must be of class Action');
@@ -61,7 +60,7 @@ class ActionModel extends CommonFormModel
             $options['formId'] = $entity->getForm()->getId();
         }
 
-        return $formFactory->create(ActionType::class, $entity->convertToArray(), $options);
+        return $this->formFactory->create(ActionType::class, $entity->convertToArray(), $options);
     }
 
     /**

--- a/app/bundles/FormBundle/Model/ActionModel.php
+++ b/app/bundles/FormBundle/Model/ActionModel.php
@@ -44,10 +44,11 @@ class ActionModel extends CommonFormModel
 
     /**
      * @param object $entity
-     * @param array  $options
      */
-    public function createForm($entity, $action = null, $options = []): FormInterface
+    public function createForm($entity, mixed ...$args): FormInterface
     {
+        [$action, $options] = $this->resolveCreateFormArgs($args);
+
         if (!$entity instanceof Action) {
             throw new \InvalidArgumentException('Entity must be of class Action');
         }

--- a/app/bundles/FormBundle/Model/FieldModel.php
+++ b/app/bundles/FormBundle/Model/FieldModel.php
@@ -50,13 +50,13 @@ class FieldModel extends CommonFormModel
 
     /**
      * @param object|array<mixed> $entity
-     * @param string|null         $action
-     * @param array               $options
      *
      * @return FormInterface<mixed>
      */
-    public function createForm($entity, $action = null, $options = []): FormInterface
+    public function createForm($entity, mixed ...$args): FormInterface
     {
+        [$action, $options] = $this->resolveCreateFormArgs($args);
+
         if ($action) {
             $options['action'] = $action;
         }

--- a/app/bundles/FormBundle/Model/FieldModel.php
+++ b/app/bundles/FormBundle/Model/FieldModel.php
@@ -50,13 +50,13 @@ class FieldModel extends CommonFormModel
 
     /**
      * @param object|array<mixed> $entity
+     * @param string|null         $action
+     * @param array               $options
      *
      * @return FormInterface<mixed>
      */
-    public function createForm($entity, mixed ...$args): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
-        [$action, $options] = $this->resolveCreateFormArgs($args);
-
         if ($action) {
             $options['action'] = $action;
         }

--- a/app/bundles/FormBundle/Model/FieldModel.php
+++ b/app/bundles/FormBundle/Model/FieldModel.php
@@ -10,7 +10,6 @@ use Mautic\FormBundle\Event\FormFieldEvent;
 use Mautic\FormBundle\Form\Type\FieldType;
 use Mautic\FormBundle\FormEvents;
 use Mautic\LeadBundle\Model\FieldModel as LeadFieldModel;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -56,13 +55,13 @@ class FieldModel extends CommonFormModel
      *
      * @return FormInterface<mixed>
      */
-    public function createForm($entity, FormFactoryInterface $formFactory, $action = null, $options = []): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
         if ($action) {
             $options['action'] = $action;
         }
 
-        return $formFactory->create(FieldType::class, $entity, $options);
+        return $this->formFactory->create(FieldType::class, $entity, $options);
     }
 
     public function getRepository(): FieldRepository

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -90,10 +90,8 @@ class FormModel extends CommonFormModel implements GlobalSearchInterface
         return 'getName';
     }
 
-    public function createForm($entity, mixed ...$args): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
-        [$action, $options] = $this->resolveCreateFormArgs($args);
-
         if (!$entity instanceof Form) {
             throw new MethodNotAllowedHttpException(['Form']);
         }

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -90,8 +90,10 @@ class FormModel extends CommonFormModel implements GlobalSearchInterface
         return 'getName';
     }
 
-    public function createForm($entity, $action = null, $options = []): FormInterface
+    public function createForm($entity, mixed ...$args): FormInterface
     {
+        [$action, $options] = $this->resolveCreateFormArgs($args);
+
         if (!$entity instanceof Form) {
             throw new MethodNotAllowedHttpException(['Form']);
         }

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -36,7 +36,6 @@ use Mautic\LeadBundle\Model\FieldModel as LeadFieldModel;
 use Mautic\LeadBundle\Tracker\ContactTracker;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
@@ -91,7 +90,7 @@ class FormModel extends CommonFormModel implements GlobalSearchInterface
         return 'getName';
     }
 
-    public function createForm($entity, FormFactoryInterface $formFactory, $action = null, $options = []): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
         if (!$entity instanceof Form) {
             throw new MethodNotAllowedHttpException(['Form']);
@@ -101,7 +100,7 @@ class FormModel extends CommonFormModel implements GlobalSearchInterface
             $options['action'] = $action;
         }
 
-        return $formFactory->create(FormType::class, $entity, $options);
+        return $this->formFactory->create(FormType::class, $entity, $options);
     }
 
     /**

--- a/app/bundles/IntegrationsBundle/Controller/FieldPaginationController.php
+++ b/app/bundles/IntegrationsBundle/Controller/FieldPaginationController.php
@@ -11,7 +11,6 @@ use Mautic\IntegrationsBundle\Helper\ConfigIntegrationsHelper;
 use Mautic\IntegrationsBundle\Helper\FieldFilterHelper;
 use Mautic\IntegrationsBundle\Helper\FieldMergerHelper;
 use Mautic\IntegrationsBundle\Integration\Interfaces\ConfigFormSyncInterface;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -20,7 +19,6 @@ final class FieldPaginationController extends CommonController
 {
     public function paginateAction(
         Request $request,
-        FormFactoryInterface $formFactory,
         ConfigIntegrationsHelper $integrationsHelper,
         string $integration,
         string $object,
@@ -52,7 +50,7 @@ final class FieldPaginationController extends CommonController
         }
 
         // Create the form
-        $form = $formFactory->create(
+        $form = $this->createForm(
             IntegrationSyncSettingsObjectFieldMappingType::class,
             $currentFields,
             [

--- a/app/bundles/LeadBundle/Controller/AjaxController.php
+++ b/app/bundles/LeadBundle/Controller/AjaxController.php
@@ -55,11 +55,9 @@ final class AjaxController extends CommonAjaxController
 
     private DoNotContactRepository $doNotContactRepository;
 
-<<<<<<< HEAD
-    private FormFieldHelper $formFieldHelper;
-=======
     private FormFactoryInterface $formFactory;
->>>>>>> fe0615a14b (use injected form factory in FormModel::createForm() instead of passing it as parameter)
+
+    private FormFieldHelper $formFieldHelper;
 
     #[Required]
     public function autowireLeadAjaxController(
@@ -68,22 +66,16 @@ final class AjaxController extends CommonAjaxController
         LeadFieldRepository $leadFieldRepository,
         LeadModel $leadModel,
         DoNotContactRepository $doNotContactRepository,
-<<<<<<< HEAD
-        FormFieldHelper $formFieldHelper,
-=======
         FormFactoryInterface $formFactory,
->>>>>>> fe0615a14b (use injected form factory in FormModel::createForm() instead of passing it as parameter)
+        FormFieldHelper $formFieldHelper,
     ): void {
         $this->leadModel = $leadModel;
         $this->doNotContactRepository = $doNotContactRepository;
         $this->leadRepository = $leadRepository;
         $this->emailRepository = $emailRepository;
         $this->leadFieldRepository = $leadFieldRepository;
-<<<<<<< HEAD
-        $this->formFieldHelper = $formFieldHelper;
-=======
         $this->formFactory = $formFactory;
->>>>>>> fe0615a14b (use injected form factory in FormModel::createForm() instead of passing it as parameter)
+        $this->formFieldHelper = $formFieldHelper;
     }
 
     public function userListAction(Request $request): JsonResponse

--- a/app/bundles/LeadBundle/Controller/AjaxController.php
+++ b/app/bundles/LeadBundle/Controller/AjaxController.php
@@ -55,7 +55,11 @@ final class AjaxController extends CommonAjaxController
 
     private DoNotContactRepository $doNotContactRepository;
 
+<<<<<<< HEAD
     private FormFieldHelper $formFieldHelper;
+=======
+    private FormFactoryInterface $formFactory;
+>>>>>>> fe0615a14b (use injected form factory in FormModel::createForm() instead of passing it as parameter)
 
     #[Required]
     public function autowireLeadAjaxController(
@@ -64,14 +68,22 @@ final class AjaxController extends CommonAjaxController
         LeadFieldRepository $leadFieldRepository,
         LeadModel $leadModel,
         DoNotContactRepository $doNotContactRepository,
+<<<<<<< HEAD
         FormFieldHelper $formFieldHelper,
+=======
+        FormFactoryInterface $formFactory,
+>>>>>>> fe0615a14b (use injected form factory in FormModel::createForm() instead of passing it as parameter)
     ): void {
         $this->leadModel = $leadModel;
         $this->doNotContactRepository = $doNotContactRepository;
         $this->leadRepository = $leadRepository;
         $this->emailRepository = $emailRepository;
         $this->leadFieldRepository = $leadFieldRepository;
+<<<<<<< HEAD
         $this->formFieldHelper = $formFieldHelper;
+=======
+        $this->formFactory = $formFactory;
+>>>>>>> fe0615a14b (use injected form factory in FormModel::createForm() instead of passing it as parameter)
     }
 
     public function userListAction(Request $request): JsonResponse
@@ -155,7 +167,6 @@ final class AjaxController extends CommonAjaxController
 
     public function loadSegmentFilterFormAction(
         Request $request,
-        FormFactoryInterface $formFactory,
         FormAdjustmentsProviderInterface $formAdjustmentsProvider,
         ListModel $listModel,
     ): JsonResponse {
@@ -165,7 +176,7 @@ final class AjaxController extends CommonAjaxController
         $search      = InputHelper::clean($request->request->get('search'));
         $filterNum   = (int) $request->request->get('filterNum');
 
-        $form = $formFactory->createNamed('RENAME', FilterPropertiesType::class);
+        $form = $this->formFactory->createNamed('RENAME', FilterPropertiesType::class);
 
         if ($fieldAlias && $operator) {
             $formAdjustmentsProvider->adjustForm(

--- a/app/bundles/LeadBundle/Controller/CompanyController.php
+++ b/app/bundles/LeadBundle/Controller/CompanyController.php
@@ -217,7 +217,7 @@ final class CompanyController extends FormController
                 : $request->get('updateSelect', false)
         );
         $fields = $this->fieldModel->getPublishedFieldArrays('company');
-        $form   = $this->companyModel->createForm($entity, $this->formFactory, $action, ['fields' => $fields, 'update_select' => $updateSelect]);
+        $form   = $this->companyModel->createForm($entity, $action, ['fields' => $fields, 'update_select' => $updateSelect]);
 
         $viewParameters = ['page' => $page];
         $returnUrl      = $this->generateUrl('mautic_company_index', $viewParameters);
@@ -390,7 +390,6 @@ final class CompanyController extends FormController
         $fields = $this->fieldModel->getPublishedFieldArrays('company');
         $form   = $this->companyModel->createForm(
             $entity,
-            $this->formFactory,
             $action,
             ['fields' => $fields, 'update_select' => $updateSelect]
         );
@@ -473,7 +472,7 @@ final class CompanyController extends FormController
             if ($valid) {
                 // Refetch and recreate the form in order to populate data manipulated in the entity itself
                 $company = $this->companyModel->getEntity($objectId);
-                $form    = $this->companyModel->createForm($company, $this->formFactory, $action, ['fields' => $fields, 'update_select' => $updateSelect]);
+                $form    = $this->companyModel->createForm($company, $action, ['fields' => $fields, 'update_select' => $updateSelect]);
             }
         } else {
             // lock the entity

--- a/app/bundles/LeadBundle/Controller/FieldController.php
+++ b/app/bundles/LeadBundle/Controller/FieldController.php
@@ -137,7 +137,7 @@ final class FieldController extends FormController
         $returnUrl = $this->generateUrl('mautic_contactfield_index');
         $action    = $this->generateUrl('mautic_contactfield_action', ['objectAction' => 'new']);
         // get the user form factory
-        $form = $this->fieldModel->createForm($field, $this->formFactory, $action);
+        $form = $this->fieldModel->createForm($field, $action);
 
         // /Check for a submitted form and process it
         if ('POST' === $request->getMethod()) {
@@ -214,7 +214,7 @@ final class FieldController extends FormController
             }
             // some bug in Symfony prevents repopulating list options on errors
             $field   = $form->getData();
-            $newForm = $this->fieldModel->createForm($field, $this->formFactory, $action);
+            $newForm = $this->fieldModel->createForm($field, $action);
             $this->copyErrorsRecursively($form, $newForm);
             $form = $newForm;
         }
@@ -278,7 +278,7 @@ final class FieldController extends FormController
         }
 
         $action = $this->generateUrl('mautic_contactfield_action', ['objectAction' => 'edit', 'objectId' => $objectId]);
-        $form   = $this->fieldModel->createForm($field, $this->formFactory, $action);
+        $form   = $this->fieldModel->createForm($field, $action);
 
         // /Check for a submitted form and process it
         if (!$ignorePost && 'POST' === $request->getMethod()) {
@@ -338,11 +338,11 @@ final class FieldController extends FormController
             if ($valid) {
                 // Rebuild the form with new action so that apply doesn't keep creating a clone
                 $action = $this->generateUrl('mautic_contactfield_action', ['objectAction' => 'edit', 'objectId' => $field->getId()]);
-                $form   = $this->fieldModel->createForm($field, $this->formFactory, $action);
+                $form   = $this->fieldModel->createForm($field, $action);
             } else {
                 // some bug in Symfony prevents repopulating list options on errors
                 $field   = $form->getData();
-                $newForm = $this->fieldModel->createForm($field, $this->formFactory, $action);
+                $newForm = $this->fieldModel->createForm($field, $action);
                 $this->copyErrorsRecursively($form, $newForm);
                 $form = $newForm;
             }
@@ -380,7 +380,7 @@ final class FieldController extends FormController
         $fieldAliasHelper->makeAliasUnique($clone);
 
         $action    = $this->generateUrl('mautic_contactfield_action', ['objectAction' => 'new']);
-        $form      = $fieldModel->createForm($clone, $this->formFactory, $action);
+        $form      = $fieldModel->createForm($clone, $action);
 
         return $this->delegateView([
             'viewParameters' => [

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -370,7 +370,7 @@ final class LeadController extends FormController
             ]
         );
 
-        $quickForm = $this->leadModel->createForm($this->leadModel->getEntity(), $this->formFactory, $action, ['fields' => $fields, 'isShortForm' => true]);
+        $quickForm = $this->leadModel->createForm($this->leadModel->getEntity(), $action, ['fields' => $fields, 'isShortForm' => true]);
 
         // set the default owner to the currently logged in user
         $currentUser = $tokenStorage->getToken()->getUser();
@@ -561,7 +561,7 @@ final class LeadController extends FormController
         $page           = $request->getSession()->get('mautic.lead.page', 1);
         $action         = $this->generateUrl('mautic_contact_action', ['objectAction' => 'new']);
         $fields = $this->leadFieldModel->getPublishedFieldArrays('lead');
-        $form   = $this->leadModel->createForm($lead, $this->formFactory, $action, ['fields' => $fields]);
+        $form   = $this->leadModel->createForm($lead, $action, ['fields' => $fields]);
 
         // /Check for a submitted form and process it
         if (Request::METHOD_POST === $request->getMethod()) {
@@ -765,7 +765,7 @@ final class LeadController extends FormController
 
         $action         = $this->generateUrl('mautic_contact_action', ['objectAction' => 'edit', 'objectId' => $objectId]);
         $fields = $this->leadFieldModel->getPublishedFieldArrays('lead');
-        $form   = $this->leadModel->createForm($lead, $this->formFactory, $action, ['fields' => $fields]);
+        $form   = $this->leadModel->createForm($lead, $action, ['fields' => $fields]);
 
         // /Check for a submitted form and process it
         if (!$ignorePost && 'POST' === $request->getMethod()) {
@@ -864,7 +864,7 @@ final class LeadController extends FormController
             if ($valid) {
                 // Refetch and recreate the form in order to populate data manipulated in the entity itself
                 $lead = $this->leadModel->getEntity($objectId);
-                $form = $this->leadModel->createForm($lead, $this->formFactory, $action, ['fields' => $fields]);
+                $form = $this->leadModel->createForm($lead, $action, ['fields' => $fields]);
             }
         } else {
             // lock the entity

--- a/app/bundles/LeadBundle/Controller/ListController.php
+++ b/app/bundles/LeadBundle/Controller/ListController.php
@@ -325,7 +325,7 @@ final class ListController extends FormController
         $returnUrl = $this->generateUrl('mautic_segment_index', ['page' => $page]);
 
         // get the user form factory
-        $form = $segmentModel->createForm($segment, $this->formFactory, $action);
+        $form = $segmentModel->createForm($segment, $action);
 
         // Check for a submitted form and process it
         if (!$ignorePost && Request::METHOD_POST === $request->getMethod()) {
@@ -388,7 +388,7 @@ final class ListController extends FormController
             return $this->isLocked($postActionVars, $segment, 'lead.list');
         }
 
-        $form = $segmentModel->createForm($segment, $this->formFactory, $action);
+        $form = $segmentModel->createForm($segment, $action);
 
         // /Check for a submitted form and process it
         if (!$ignorePost && 'POST' === $request->getMethod()) {
@@ -415,7 +415,7 @@ final class ListController extends FormController
                             'objectId'     => $segment->getId(),
                         ]);
 
-                        $form = $segmentModel->createForm($segment, $this->formFactory, $postActionVars['returnUrl']);
+                        $form = $segmentModel->createForm($segment, $postActionVars['returnUrl']);
 
                         $postActionVars['viewParameters'] = [
                             'objectAction' => 'edit',

--- a/app/bundles/LeadBundle/Controller/NoteController.php
+++ b/app/bundles/LeadBundle/Controller/NoteController.php
@@ -186,7 +186,7 @@ final class NoteController extends FormController
             ]
         );
         // get the user form factory
-        $form       = $this->noteModel->createForm($note, $this->formFactory, $action);
+        $form       = $this->noteModel->createForm($note, $action);
         $closeModal = false;
         $valid      = false;
         // /Check for a submitted form and process it
@@ -273,7 +273,7 @@ final class NoteController extends FormController
                 'leadId'       => $leadId,
             ]
         );
-        $form = $this->noteModel->createForm($note, $this->formFactory, $action);
+        $form = $this->noteModel->createForm($note, $action);
 
         // /Check for a submitted form and process it
         if (Request::METHOD_POST === $request->getMethod()) {

--- a/app/bundles/LeadBundle/Model/CompanyModel.php
+++ b/app/bundles/LeadBundle/Model/CompanyModel.php
@@ -145,10 +145,8 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
     /**
      * @throws MethodNotAllowedHttpException
      */
-    public function createForm($entity, mixed ...$args): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
-        [$action, $options] = $this->resolveCreateFormArgs($args);
-
         if (!$entity instanceof Company) {
             throw new MethodNotAllowedHttpException(['Company']);
         }

--- a/app/bundles/LeadBundle/Model/CompanyModel.php
+++ b/app/bundles/LeadBundle/Model/CompanyModel.php
@@ -34,7 +34,6 @@ use Mautic\UserBundle\Entity\User;
 use Mautic\UserBundle\Entity\UserRepository;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -146,7 +145,7 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
     /**
      * @throws MethodNotAllowedHttpException
      */
-    public function createForm($entity, FormFactoryInterface $formFactory, $action = null, $options = []): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
         if (!$entity instanceof Company) {
             throw new MethodNotAllowedHttpException(['Company']);
@@ -155,7 +154,7 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
             $options['action'] = $action;
         }
 
-        return $formFactory->create(CompanyType::class, $entity, $options);
+        return $this->formFactory->create(CompanyType::class, $entity, $options);
     }
 
     public function getEntity($id = null): ?Company

--- a/app/bundles/LeadBundle/Model/CompanyModel.php
+++ b/app/bundles/LeadBundle/Model/CompanyModel.php
@@ -145,8 +145,10 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
     /**
      * @throws MethodNotAllowedHttpException
      */
-    public function createForm($entity, $action = null, $options = []): FormInterface
+    public function createForm($entity, mixed ...$args): FormInterface
     {
+        [$action, $options] = $this->resolveCreateFormArgs($args);
+
         if (!$entity instanceof Company) {
             throw new MethodNotAllowedHttpException(['Company']);
         }

--- a/app/bundles/LeadBundle/Model/DeviceModel.php
+++ b/app/bundles/LeadBundle/Model/DeviceModel.php
@@ -49,11 +49,10 @@ final class DeviceModel extends FormModel
         return parent::getEntity($id);
     }
 
-    /**
-     * @param array $options
-     */
-    public function createForm($entity, $action = null, $options = []): FormInterface
+    public function createForm($entity, mixed ...$args): FormInterface
     {
+        [$action, $options] = $this->resolveCreateFormArgs($args);
+
         if (!$entity instanceof LeadDevice) {
             throw new MethodNotAllowedHttpException(['LeadDevice']);
         }

--- a/app/bundles/LeadBundle/Model/DeviceModel.php
+++ b/app/bundles/LeadBundle/Model/DeviceModel.php
@@ -8,7 +8,6 @@ use Mautic\LeadBundle\Entity\LeadDeviceRepository;
 use Mautic\LeadBundle\Event\LeadDeviceEvent;
 use Mautic\LeadBundle\Form\Type\DeviceType;
 use Mautic\LeadBundle\LeadEvents;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Contracts\EventDispatcher\Event;
@@ -53,7 +52,7 @@ final class DeviceModel extends FormModel
     /**
      * @param array $options
      */
-    public function createForm($entity, FormFactoryInterface $formFactory, $action = null, $options = []): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
         if (!$entity instanceof LeadDevice) {
             throw new MethodNotAllowedHttpException(['LeadDevice']);
@@ -63,7 +62,7 @@ final class DeviceModel extends FormModel
             $options['action'] = $action;
         }
 
-        return $formFactory->create(DeviceType::class, $entity, $options);
+        return $this->formFactory->create(DeviceType::class, $entity, $options);
     }
 
     /**

--- a/app/bundles/LeadBundle/Model/DeviceModel.php
+++ b/app/bundles/LeadBundle/Model/DeviceModel.php
@@ -49,10 +49,11 @@ final class DeviceModel extends FormModel
         return parent::getEntity($id);
     }
 
-    public function createForm($entity, mixed ...$args): FormInterface
+    /**
+     * @param array $options
+     */
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
-        [$action, $options] = $this->resolveCreateFormArgs($args);
-
         if (!$entity instanceof LeadDevice) {
             throw new MethodNotAllowedHttpException(['LeadDevice']);
         }

--- a/app/bundles/LeadBundle/Model/FieldModel.php
+++ b/app/bundles/LeadBundle/Model/FieldModel.php
@@ -35,7 +35,6 @@ use Mautic\LeadBundle\Helper\FormFieldHelper;
 use Mautic\LeadBundle\LeadEvents;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -799,7 +798,7 @@ class FieldModel extends FormModel
      *
      * @throws MethodNotAllowedHttpException
      */
-    public function createForm($entity, FormFactoryInterface $formFactory, $action = null, $options = []): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
         if (!$entity instanceof LeadField) {
             throw new MethodNotAllowedHttpException(['LeadField']);
@@ -809,7 +808,7 @@ class FieldModel extends FormModel
             $options['action'] = $action;
         }
 
-        return $formFactory->create(FieldType::class, $entity, $options);
+        return $this->formFactory->create(FieldType::class, $entity, $options);
     }
 
     /**

--- a/app/bundles/LeadBundle/Model/FieldModel.php
+++ b/app/bundles/LeadBundle/Model/FieldModel.php
@@ -794,12 +794,12 @@ class FieldModel extends FormModel
     }
 
     /**
-     * @param array $options
-     *
      * @throws MethodNotAllowedHttpException
      */
-    public function createForm($entity, $action = null, $options = []): FormInterface
+    public function createForm($entity, mixed ...$args): FormInterface
     {
+        [$action, $options] = $this->resolveCreateFormArgs($args);
+
         if (!$entity instanceof LeadField) {
             throw new MethodNotAllowedHttpException(['LeadField']);
         }

--- a/app/bundles/LeadBundle/Model/FieldModel.php
+++ b/app/bundles/LeadBundle/Model/FieldModel.php
@@ -794,12 +794,12 @@ class FieldModel extends FormModel
     }
 
     /**
+     * @param array $options
+     *
      * @throws MethodNotAllowedHttpException
      */
-    public function createForm($entity, mixed ...$args): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
-        [$action, $options] = $this->resolveCreateFormArgs($args);
-
         if (!$entity instanceof LeadField) {
             throw new MethodNotAllowedHttpException(['LeadField']);
         }

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -285,7 +285,7 @@ class LeadModel extends FormModel
      *
      * @throws MethodNotAllowedHttpException
      */
-    public function createForm($entity, FormFactoryInterface $formFactory, $action = null, $options = []): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
         if (!$entity instanceof Lead) {
             throw new MethodNotAllowedHttpException(['Lead'], 'Entity must be of class Lead()');
@@ -294,7 +294,7 @@ class LeadModel extends FormModel
             $options['action'] = $action;
         }
 
-        return $formFactory->create(LeadType::class, $entity, $options);
+        return $this->formFactory->create(LeadType::class, $entity, $options);
     }
 
     /**
@@ -622,7 +622,6 @@ class LeadModel extends FormModel
             // Cleanup the field values
             $form = $this->createForm(
                 new Lead(), // use empty lead to prevent binding errors
-                $this->formFactory,
                 null,
                 ['fields' => $this->flattenedFields, 'csrf_protection' => false, 'allow_extra_fields' => true]
             );

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -277,16 +277,16 @@ class LeadModel extends FormModel
     }
 
     /**
-     * @param Lead        $entity
-     * @param string|null $action
-     * @param array       $options
+     * @param Lead $entity
      *
      * @return FormInterface<Lead>
      *
      * @throws MethodNotAllowedHttpException
      */
-    public function createForm($entity, $action = null, $options = []): FormInterface
+    public function createForm($entity, mixed ...$args): FormInterface
     {
+        [$action, $options] = $this->resolveCreateFormArgs($args);
+
         if (!$entity instanceof Lead) {
             throw new MethodNotAllowedHttpException(['Lead'], 'Entity must be of class Lead()');
         }

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -277,16 +277,16 @@ class LeadModel extends FormModel
     }
 
     /**
-     * @param Lead $entity
+     * @param Lead        $entity
+     * @param string|null $action
+     * @param array       $options
      *
      * @return FormInterface<Lead>
      *
      * @throws MethodNotAllowedHttpException
      */
-    public function createForm($entity, mixed ...$args): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
-        [$action, $options] = $this->resolveCreateFormArgs($args);
-
         if (!$entity instanceof Lead) {
             throw new MethodNotAllowedHttpException(['Lead'], 'Entity must be of class Lead()');
         }

--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -214,12 +214,13 @@ class ListModel extends FormModel implements GlobalSearchInterface
     }
 
     /**
+     * @param string|null $action
+     * @param array       $options
+     *
      * @return FormInterface<LeadList>
      */
-    public function createForm($entity, mixed ...$args): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
-        [$action, $options] = $this->resolveCreateFormArgs($args);
-
         if (!$entity instanceof LeadList) {
             throw new MethodNotAllowedHttpException(['LeadList'], 'Entity must be of class LeadList()');
         }

--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -45,7 +45,6 @@ use Mautic\LeadBundle\Segment\Stat\SegmentChartQueryFactory;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
@@ -220,7 +219,7 @@ class ListModel extends FormModel implements GlobalSearchInterface
      *
      * @return FormInterface<LeadList>
      */
-    public function createForm($entity, FormFactoryInterface $formFactory, $action = null, $options = []): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
         if (!$entity instanceof LeadList) {
             throw new MethodNotAllowedHttpException(['LeadList'], 'Entity must be of class LeadList()');
@@ -230,7 +229,7 @@ class ListModel extends FormModel implements GlobalSearchInterface
             $options['action'] = $action;
         }
 
-        return $formFactory->create(ListType::class, $entity, $options);
+        return $this->formFactory->create(ListType::class, $entity, $options);
     }
 
     /**

--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -214,13 +214,12 @@ class ListModel extends FormModel implements GlobalSearchInterface
     }
 
     /**
-     * @param string|null $action
-     * @param array       $options
-     *
      * @return FormInterface<LeadList>
      */
-    public function createForm($entity, $action = null, $options = []): FormInterface
+    public function createForm($entity, mixed ...$args): FormInterface
     {
+        [$action, $options] = $this->resolveCreateFormArgs($args);
+
         if (!$entity instanceof LeadList) {
             throw new MethodNotAllowedHttpException(['LeadList'], 'Entity must be of class LeadList()');
         }

--- a/app/bundles/LeadBundle/Model/NoteModel.php
+++ b/app/bundles/LeadBundle/Model/NoteModel.php
@@ -9,7 +9,6 @@ use Mautic\LeadBundle\Entity\LeadNoteRepository;
 use Mautic\LeadBundle\Event\LeadNoteEvent;
 use Mautic\LeadBundle\Form\Type\NoteType;
 use Mautic\LeadBundle\LeadEvents;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
@@ -60,7 +59,7 @@ final class NoteModel extends FormModel
      * @param string|null $action
      * @param array       $options
      */
-    public function createForm($entity, FormFactoryInterface $formFactory, $action = null, $options = []): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
         if (!$entity instanceof LeadNote) {
             throw new MethodNotAllowedHttpException(['LeadNote']);
@@ -70,7 +69,7 @@ final class NoteModel extends FormModel
             $options['action'] = $action;
         }
 
-        return $formFactory->create(NoteType::class, $entity, $options);
+        return $this->formFactory->create(NoteType::class, $entity, $options);
     }
 
     /**

--- a/app/bundles/LeadBundle/Model/NoteModel.php
+++ b/app/bundles/LeadBundle/Model/NoteModel.php
@@ -55,10 +55,12 @@ final class NoteModel extends FormModel
         return parent::getEntity($id);
     }
 
-    public function createForm($entity, mixed ...$args): FormInterface
+    /**
+     * @param string|null $action
+     * @param array       $options
+     */
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
-        [$action, $options] = $this->resolveCreateFormArgs($args);
-
         if (!$entity instanceof LeadNote) {
             throw new MethodNotAllowedHttpException(['LeadNote']);
         }

--- a/app/bundles/LeadBundle/Model/NoteModel.php
+++ b/app/bundles/LeadBundle/Model/NoteModel.php
@@ -55,12 +55,10 @@ final class NoteModel extends FormModel
         return parent::getEntity($id);
     }
 
-    /**
-     * @param string|null $action
-     * @param array       $options
-     */
-    public function createForm($entity, $action = null, $options = []): FormInterface
+    public function createForm($entity, mixed ...$args): FormInterface
     {
+        [$action, $options] = $this->resolveCreateFormArgs($args);
+
         if (!$entity instanceof LeadNote) {
             throw new MethodNotAllowedHttpException(['LeadNote']);
         }

--- a/app/bundles/LeadBundle/Model/TagModel.php
+++ b/app/bundles/LeadBundle/Model/TagModel.php
@@ -92,11 +92,12 @@ class TagModel extends FormModel
     }
 
     /**
-     * @param Tag   $entity
-     * @param array $options
+     * @param Tag $entity
      */
-    public function createForm($entity, $action = null, $options = []): FormInterface
+    public function createForm($entity, mixed ...$args): FormInterface
     {
+        [$action, $options] = $this->resolveCreateFormArgs($args);
+
         if (!$entity instanceof Tag) {
             throw new MethodNotAllowedHttpException(['Tag']);
         }

--- a/app/bundles/LeadBundle/Model/TagModel.php
+++ b/app/bundles/LeadBundle/Model/TagModel.php
@@ -92,12 +92,11 @@ class TagModel extends FormModel
     }
 
     /**
-     * @param Tag $entity
+     * @param Tag   $entity
+     * @param array $options
      */
-    public function createForm($entity, mixed ...$args): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
-        [$action, $options] = $this->resolveCreateFormArgs($args);
-
         if (!$entity instanceof Tag) {
             throw new MethodNotAllowedHttpException(['Tag']);
         }

--- a/app/bundles/LeadBundle/Model/TagModel.php
+++ b/app/bundles/LeadBundle/Model/TagModel.php
@@ -19,7 +19,6 @@ use Mautic\PointBundle\Entity\TriggerEvent;
 use Mautic\PointBundle\Entity\TriggerEventRepository;
 use Mautic\ReportBundle\Entity\Report;
 use Mautic\ReportBundle\Entity\ReportRepository;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Contracts\EventDispatcher\Event;
@@ -96,7 +95,7 @@ class TagModel extends FormModel
      * @param Tag   $entity
      * @param array $options
      */
-    public function createForm($entity, FormFactoryInterface $formFactory, $action = null, $options = []): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
         if (!$entity instanceof Tag) {
             throw new MethodNotAllowedHttpException(['Tag']);
@@ -106,7 +105,7 @@ class TagModel extends FormModel
             $options['action'] = $action;
         }
 
-        return $formFactory->create(TagEntityType::class, $entity, $options);
+        return $this->formFactory->create(TagEntityType::class, $entity, $options);
     }
 
     /**

--- a/app/bundles/NotificationBundle/Controller/MobileNotificationController.php
+++ b/app/bundles/NotificationBundle/Controller/MobileNotificationController.php
@@ -286,7 +286,7 @@ final class MobileNotificationController extends FormController
         }
 
         // create the form
-        $form = $this->notificationModel->createForm($entity, $this->formFactory, $action, ['update_select' => $updateSelect]);
+        $form = $this->notificationModel->createForm($entity, $action, ['update_select' => $updateSelect]);
 
         // /Check for a submitted form and process it
         if ('POST' === $method) {
@@ -447,7 +447,7 @@ final class MobileNotificationController extends FormController
             ? ($notification['updateSelect'] ?? false)
             : $request->get('updateSelect', false);
 
-        $form = $this->notificationModel->createForm($entity, $this->formFactory, $action, ['update_select' => $updateSelect]);
+        $form = $this->notificationModel->createForm($entity, $action, ['update_select' => $updateSelect]);
 
         // /Check for a submitted form and process it
         if (!$ignorePost && 'POST' === $method) {

--- a/app/bundles/NotificationBundle/Controller/NotificationController.php
+++ b/app/bundles/NotificationBundle/Controller/NotificationController.php
@@ -10,11 +10,6 @@ use Mautic\CoreBundle\Model\AuditLogModel;
 use Mautic\LeadBundle\Controller\EntityContactsTrait;
 use Mautic\NotificationBundle\Entity\Notification;
 use Mautic\NotificationBundle\Model\NotificationModel;
-<<<<<<< HEAD
-use Symfony\Component\Form\FormFactoryInterface;
-=======
-use Symfony\Component\HttpFoundation\JsonResponse;
->>>>>>> 5a984947ee (use injected form factory in FormModel::createForm() instead of passing it as parameter)
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\Service\Attribute\Required;

--- a/app/bundles/NotificationBundle/Controller/NotificationController.php
+++ b/app/bundles/NotificationBundle/Controller/NotificationController.php
@@ -10,7 +10,11 @@ use Mautic\CoreBundle\Model\AuditLogModel;
 use Mautic\LeadBundle\Controller\EntityContactsTrait;
 use Mautic\NotificationBundle\Entity\Notification;
 use Mautic\NotificationBundle\Model\NotificationModel;
+<<<<<<< HEAD
 use Symfony\Component\Form\FormFactoryInterface;
+=======
+use Symfony\Component\HttpFoundation\JsonResponse;
+>>>>>>> 5a984947ee (use injected form factory in FormModel::createForm() instead of passing it as parameter)
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\Service\Attribute\Required;
@@ -153,7 +157,7 @@ final class NotificationController extends AbstractFormController
     /**
      * Loads a specific form into the detailed panel.
      */
-    public function viewAction(Request $request, FormFactoryInterface $formFactory, $objectId): Response
+    public function viewAction(Request $request, $objectId): Response
     {
         $security = $this->security;
 
@@ -198,7 +202,7 @@ final class NotificationController extends AbstractFormController
         // Init the date range filter form
         $dateRangeValues = $request->query->all()['daterange'] ?? $request->request->all()['daterange'] ?? [];
         $action          = $this->generateUrl('mautic_notification_action', ['objectAction' => 'view', 'objectId' => $objectId]);
-        $dateRangeForm   = $formFactory->create(DateRangeType::class, $dateRangeValues, ['action' => $action]);
+        $dateRangeForm   = $this->createForm(DateRangeType::class, $dateRangeValues, ['action' => $action]);
         $entityViews     = $this->notificationModel->getHitsLineChartData(
             null,
             new \DateTime($dateRangeForm->get('date_from')->getData()),
@@ -252,7 +256,7 @@ final class NotificationController extends AbstractFormController
      *
      * @param Notification $entity
      */
-    public function newAction(Request $request, FormFactoryInterface $formFactory, $entity = null): Response
+    public function newAction(Request $request, $entity = null): Response
     {
         if (!$entity instanceof Notification) {
             /** @var Notification $entity */
@@ -279,7 +283,7 @@ final class NotificationController extends AbstractFormController
         }
 
         // create the form
-        $form = $this->notificationModel->createForm($entity, $formFactory, $action, ['update_select' => $updateSelect]);
+        $form = $this->notificationModel->createForm($entity, $action, ['update_select' => $updateSelect]);
 
         // /Check for a submitted form and process it
         if ('POST' === $method) {
@@ -313,7 +317,7 @@ final class NotificationController extends AbstractFormController
                         $template  = 'Mautic\NotificationBundle\Controller\NotificationController::viewAction';
                     } else {
                         // return edit view so that all the session stuff is loaded
-                        return $this->editAction($request, $formFactory, $entity->getId(), true);
+                        return $this->editAction($request, $entity->getId(), true);
                     }
                 }
             } else {
@@ -381,7 +385,7 @@ final class NotificationController extends AbstractFormController
      * @param bool $ignorePost
      * @param bool $forceTypeSelection
      */
-    public function editAction(Request $request, FormFactoryInterface $formFactory, $objectId, $ignorePost = false, $forceTypeSelection = false): Response
+    public function editAction(Request $request, $objectId, $ignorePost = false, $forceTypeSelection = false): Response
     {
         $method  = $request->getMethod();
         $entity  = $this->notificationModel->getEntity($objectId);
@@ -437,7 +441,7 @@ final class NotificationController extends AbstractFormController
             ? ($notification['updateSelect'] ?? false)
             : $request->get('updateSelect', false);
 
-        $form = $this->notificationModel->createForm($entity, $formFactory, $action, ['update_select' => $updateSelect]);
+        $form = $this->notificationModel->createForm($entity, $action, ['update_select' => $updateSelect]);
 
         // /Check for a submitted form and process it
         if (!$ignorePost && 'POST' === $method) {
@@ -541,7 +545,7 @@ final class NotificationController extends AbstractFormController
     /**
      * Clone an entity.
      */
-    public function cloneAction(Request $request, FormFactoryInterface $formFactory, $objectId): Response
+    public function cloneAction(Request $request, $objectId): Response
     {
         $entity = $this->notificationModel->getEntity($objectId);
 
@@ -559,7 +563,7 @@ final class NotificationController extends AbstractFormController
             $entity      = clone $entity;
         }
 
-        return $this->newAction($request, $formFactory, $entity);
+        return $this->newAction($request, $entity);
     }
 
     /**

--- a/app/bundles/NotificationBundle/Model/NotificationModel.php
+++ b/app/bundles/NotificationBundle/Model/NotificationModel.php
@@ -95,14 +95,14 @@ final class NotificationModel extends FormModel implements AjaxLookupModelInterf
 
     /**
      * @param Notification|null $entity
-     * @param string|null       $action
-     * @param array             $options
      *
      * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      * @throws MethodNotAllowedHttpException
      */
-    public function createForm($entity, $action = null, $options = []): FormInterface
+    public function createForm($entity, mixed ...$args): FormInterface
     {
+        [$action, $options] = $this->resolveCreateFormArgs($args);
+
         if (!$entity instanceof Notification) {
             throw new MethodNotAllowedHttpException(['Notification']);
         }

--- a/app/bundles/NotificationBundle/Model/NotificationModel.php
+++ b/app/bundles/NotificationBundle/Model/NotificationModel.php
@@ -19,7 +19,6 @@ use Mautic\NotificationBundle\Form\Type\MobileNotificationType;
 use Mautic\NotificationBundle\Form\Type\NotificationType;
 use Mautic\NotificationBundle\NotificationEvents;
 use Mautic\PageBundle\Model\TrackableModel;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Contracts\EventDispatcher\Event;
@@ -102,7 +101,7 @@ final class NotificationModel extends FormModel implements AjaxLookupModelInterf
      * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      * @throws MethodNotAllowedHttpException
      */
-    public function createForm($entity, FormFactoryInterface $formFactory, $action = null, $options = []): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
         if (!$entity instanceof Notification) {
             throw new MethodNotAllowedHttpException(['Notification']);
@@ -113,7 +112,7 @@ final class NotificationModel extends FormModel implements AjaxLookupModelInterf
 
         $type = str_contains($action, 'mobile_') ? MobileNotificationType::class : NotificationType::class;
 
-        return $formFactory->create($type, $entity, $options);
+        return $this->formFactory->create($type, $entity, $options);
     }
 
     /**

--- a/app/bundles/NotificationBundle/Model/NotificationModel.php
+++ b/app/bundles/NotificationBundle/Model/NotificationModel.php
@@ -95,14 +95,14 @@ final class NotificationModel extends FormModel implements AjaxLookupModelInterf
 
     /**
      * @param Notification|null $entity
+     * @param string|null       $action
+     * @param array             $options
      *
      * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      * @throws MethodNotAllowedHttpException
      */
-    public function createForm($entity, mixed ...$args): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
-        [$action, $options] = $this->resolveCreateFormArgs($args);
-
         if (!$entity instanceof Notification) {
             throw new MethodNotAllowedHttpException(['Notification']);
         }

--- a/app/bundles/PageBundle/Controller/AjaxController.php
+++ b/app/bundles/PageBundle/Controller/AjaxController.php
@@ -7,7 +7,6 @@ use Mautic\CoreBundle\Controller\VariantAjaxControllerTrait;
 use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\PageBundle\Form\Type\AbTestPropertiesType;
 use Mautic\PageBundle\Model\PageModel;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -27,12 +26,12 @@ final class AjaxController extends CommonAjaxController
         $this->pageModel = $pageModel;
     }
 
-    public function getAbTestFormAction(Request $request, FormFactoryInterface $formFactory, PageModel $pageModel, Environment $twig): JsonResponse
+    public function getAbTestFormAction(Request $request, PageModel $pageModel, Environment $twig): JsonResponse
     {
         return $this->sendJsonResponse($this->getAbTestForm(
             $request,
             $pageModel,
-            fn ($formType, $formOptions): FormInterface => $formFactory->create(AbTestPropertiesType::class, [], ['formType' => $formType, 'formTypeOptions' => $formOptions]),
+            fn ($formType, $formOptions): FormInterface => $this->createForm(AbTestPropertiesType::class, [], ['formType' => $formType, 'formTypeOptions' => $formOptions]),
             fn (FormInterface $form): string => $this->renderView('@MauticPage/AbTest/form.html.twig', ['form' => $this->setFormTheme($form, $twig, ['@MauticPage/AbTest/form.html.twig', 'MauticPageBundle:FormTheme\Page'])]),
             'page_abtest_settings',
             'page'

--- a/app/bundles/PageBundle/Controller/PageController.php
+++ b/app/bundles/PageBundle/Controller/PageController.php
@@ -386,7 +386,7 @@ final class PageController extends FormController
         $action = $this->generateUrl('mautic_page_action', ['objectAction' => 'new']);
 
         // create the form
-        $form = $model->createForm($entity, $this->formFactory, $action);
+        $form = $model->createForm($entity, $action);
 
         // /Check for a submitted form and process it
         if ('POST' === $method) {
@@ -533,7 +533,7 @@ final class PageController extends FormController
 
         // Create the form
         $action = $this->generateUrl('mautic_page_action', ['objectAction' => 'edit', 'objectId' => $objectId]);
-        $form   = $model->createForm($entity, $this->formFactory, $action);
+        $form   = $model->createForm($entity, $action);
         $this->setOptimisticLockVersion($entity, $form);
         $existingPage = clone $entity;
         $this->restoreNullifiedFieldsDuringClone($existingPage, $entity);
@@ -597,7 +597,7 @@ final class PageController extends FormController
             }
             if ($valid) {
                 // Rebuild the form in the case apply is clicked so that DEC content is properly populated if all were removed
-                $form = $model->createForm($entity, $this->formFactory, $action);
+                $form = $model->createForm($entity, $action);
                 $this->setOptimisticLockVersion($entity, $form);
             }
         } else {

--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -55,7 +55,6 @@ use Mautic\PageBundle\Form\Type\PageType;
 use Mautic\PageBundle\PageEvents;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
@@ -221,7 +220,7 @@ class PageModel extends FormModel implements GlobalSearchInterface
         parent::deleteEntity($entity);
     }
 
-    public function createForm($entity, FormFactoryInterface $formFactory, $action = null, $options = []): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
         if (!$entity instanceof Page) {
             throw new MethodNotAllowedHttpException(['Page']);
@@ -237,7 +236,7 @@ class PageModel extends FormModel implements GlobalSearchInterface
             $options['action'] = $action;
         }
 
-        return $formFactory->create($formClass, $entity, $options);
+        return $this->formFactory->create($formClass, $entity, $options);
     }
 
     public function getEntity($id = null): ?Page

--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -220,10 +220,8 @@ class PageModel extends FormModel implements GlobalSearchInterface
         parent::deleteEntity($entity);
     }
 
-    public function createForm($entity, mixed ...$args): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
-        [$action, $options] = $this->resolveCreateFormArgs($args);
-
         if (!$entity instanceof Page) {
             throw new MethodNotAllowedHttpException(['Page']);
         }

--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -220,8 +220,10 @@ class PageModel extends FormModel implements GlobalSearchInterface
         parent::deleteEntity($entity);
     }
 
-    public function createForm($entity, $action = null, $options = []): FormInterface
+    public function createForm($entity, mixed ...$args): FormInterface
     {
+        [$action, $options] = $this->resolveCreateFormArgs($args);
+
         if (!$entity instanceof Page) {
             throw new MethodNotAllowedHttpException(['Page']);
         }

--- a/app/bundles/PointBundle/Controller/AjaxController.php
+++ b/app/bundles/PointBundle/Controller/AjaxController.php
@@ -6,7 +6,6 @@ use Mautic\CoreBundle\Controller\AjaxController as CommonAjaxController;
 use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\PointBundle\Form\Type\PointActionType;
 use Mautic\PointBundle\Model\PointModel;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Contracts\Service\Attribute\Required;
@@ -40,7 +39,7 @@ final class AjaxController extends CommonAjaxController
         return $this->sendJsonResponse($dataArray);
     }
 
-    public function getActionFormAction(Request $request, FormFactoryInterface $formFactory): JsonResponse
+    public function getActionFormAction(Request $request): JsonResponse
     {
         $type      = InputHelper::clean($request->request->get('actionType'));
         $dataArray = [
@@ -60,7 +59,7 @@ final class AjaxController extends CommonAjaxController
 
                 $formType        = (!empty($actions['actions'][$type]['formType'])) ? $actions['actions'][$type]['formType'] : null;
                 $formTypeOptions = (!empty($actions['actions'][$type]['formTypeOptions'])) ? $actions['actions'][$type]['formTypeOptions'] : [];
-                $form            = $formFactory->create(PointActionType::class, [], ['formType' => $formType, 'formTypeOptions' => $formTypeOptions]);
+                $form            = $this->createForm(PointActionType::class, [], ['formType' => $formType, 'formTypeOptions' => $formTypeOptions]);
                 $html            = $this->renderView('@MauticPoint/Point/actionform.html.twig', [
                     'form'       => $form->createView(),
                     'formThemes' => $themes,

--- a/app/bundles/PointBundle/Controller/Api/TriggerApiController.php
+++ b/app/bundles/PointBundle/Controller/Api/TriggerApiController.php
@@ -130,7 +130,6 @@ final class TriggerApiController extends CommonApiController
     {
         return $this->triggerEventModel->createForm(
             $entity,
-            $this->formFactory,
             null,
             [
                 'csrf_protection'    => false,

--- a/app/bundles/PointBundle/Controller/PointController.php
+++ b/app/bundles/PointBundle/Controller/PointController.php
@@ -6,11 +6,6 @@ use Mautic\CoreBundle\Controller\AbstractFormController;
 use Mautic\CoreBundle\Factory\PageHelperFactoryInterface;
 use Mautic\PointBundle\Entity\Point;
 use Mautic\PointBundle\Model\PointModel;
-<<<<<<< HEAD
-use Symfony\Component\Form\FormFactoryInterface;
-=======
-use Symfony\Component\HttpFoundation\JsonResponse;
->>>>>>> 5a984947ee (use injected form factory in FormModel::createForm() instead of passing it as parameter)
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\Service\Attribute\Required;
@@ -207,11 +202,7 @@ final class PointController extends AbstractFormController
      * @param int  $objectId
      * @param bool $ignorePost
      */
-<<<<<<< HEAD
-    public function editAction(Request $request, FormFactoryInterface $formFactory, $objectId, $ignorePost = false): Response
-=======
-    public function editAction(Request $request, $objectId, $ignorePost = false)
->>>>>>> 5a984947ee (use injected form factory in FormModel::createForm() instead of passing it as parameter)
+    public function editAction(Request $request, $objectId, $ignorePost = false): Response
     {
         $entity = $this->pointModel->getEntity($objectId);
 

--- a/app/bundles/PointBundle/Controller/PointController.php
+++ b/app/bundles/PointBundle/Controller/PointController.php
@@ -6,7 +6,11 @@ use Mautic\CoreBundle\Controller\AbstractFormController;
 use Mautic\CoreBundle\Factory\PageHelperFactoryInterface;
 use Mautic\PointBundle\Entity\Point;
 use Mautic\PointBundle\Model\PointModel;
+<<<<<<< HEAD
 use Symfony\Component\Form\FormFactoryInterface;
+=======
+use Symfony\Component\HttpFoundation\JsonResponse;
+>>>>>>> 5a984947ee (use injected form factory in FormModel::createForm() instead of passing it as parameter)
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\Service\Attribute\Required;
@@ -103,7 +107,7 @@ final class PointController extends AbstractFormController
      *
      * @param Point $entity
      */
-    public function newAction(Request $request, FormFactoryInterface $formFactory, $entity = null): Response
+    public function newAction(Request $request, $entity = null): Response
     {
         if (!$entity instanceof Point) {
             /** @var Point $entity */
@@ -121,7 +125,7 @@ final class PointController extends AbstractFormController
         $actionType = 'POST' === $method ? ($point['type'] ?? '') : '';
         $action     = $this->generateUrl('mautic_point_action', ['objectAction' => 'new']);
         $actions    = $this->pointModel->getPointActions();
-        $form       = $this->pointModel->createForm($entity, $formFactory, $action, [
+        $form       = $this->pointModel->createForm($entity, $action, [
             'pointActions' => $actions,
             'actionType'   => $actionType,
         ]);
@@ -150,7 +154,7 @@ final class PointController extends AbstractFormController
                         $template  = 'Mautic\PointBundle\Controller\PointController::indexAction';
                     } else {
                         // return edit view so that all the session stuff is loaded
-                        return $this->editAction($request, $formFactory, $entity->getId(), true);
+                        return $this->editAction($request, $entity->getId(), true);
                     }
                 }
             } else {
@@ -203,7 +207,11 @@ final class PointController extends AbstractFormController
      * @param int  $objectId
      * @param bool $ignorePost
      */
+<<<<<<< HEAD
     public function editAction(Request $request, FormFactoryInterface $formFactory, $objectId, $ignorePost = false): Response
+=======
+    public function editAction(Request $request, $objectId, $ignorePost = false)
+>>>>>>> 5a984947ee (use injected form factory in FormModel::createForm() instead of passing it as parameter)
     {
         $entity = $this->pointModel->getEntity($objectId);
 
@@ -252,7 +260,7 @@ final class PointController extends AbstractFormController
 
         $action  = $this->generateUrl('mautic_point_action', ['objectAction' => 'edit', 'objectId' => $objectId]);
         $actions = $this->pointModel->getPointActions();
-        $form    = $this->pointModel->createForm($entity, $formFactory, $action, [
+        $form    = $this->pointModel->createForm($entity, $action, [
             'pointActions' => $actions,
             'actionType'   => $actionType,
         ]);
@@ -331,7 +339,7 @@ final class PointController extends AbstractFormController
     /**
      * @param int $objectId
      */
-    public function cloneAction(Request $request, FormFactoryInterface $formFactory, $objectId): Response
+    public function cloneAction(Request $request, $objectId): Response
     {
         $entity = $this->pointModel->getEntity($objectId);
 
@@ -344,7 +352,7 @@ final class PointController extends AbstractFormController
             $entity->setIsPublished(false);
         }
 
-        return $this->newAction($request, $formFactory, $entity);
+        return $this->newAction($request, $entity);
     }
 
     /**

--- a/app/bundles/PointBundle/Controller/TriggerController.php
+++ b/app/bundles/PointBundle/Controller/TriggerController.php
@@ -195,7 +195,7 @@ final class TriggerController extends FormController
         $deletedEvents = $session->get('mautic.point.'.$sessionId.'.triggerevents.deleted', []);
 
         $action = $this->generateUrl('mautic_pointtrigger_action', ['objectAction' => 'new']);
-        $form   = $this->triggerModel->createForm($entity, $this->formFactory, $action);
+        $form   = $this->triggerModel->createForm($entity, $action);
         $form->get('sessionId')->setData($sessionId);
 
         // Check for a submitted form and process it
@@ -337,7 +337,7 @@ final class TriggerController extends FormController
         }
 
         $action = $this->generateUrl('mautic_pointtrigger_action', ['objectAction' => 'edit', 'objectId' => $objectId]);
-        $form   = $this->triggerModel->createForm($entity, $this->formFactory, $action);
+        $form   = $this->triggerModel->createForm($entity, $action);
         $form->get('sessionId')->setData($objectId);
 
         // /Check for a submitted form and process it

--- a/app/bundles/PointBundle/Model/InsightModel.php
+++ b/app/bundles/PointBundle/Model/InsightModel.php
@@ -45,12 +45,12 @@ final class InsightModel extends CommonFormModel
     }
 
     /**
+     * @param array<string, mixed> $options
+     *
      * @throws MethodNotAllowedHttpException
      */
-    public function createForm($entity, mixed ...$args): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
-        [$action, $options] = $this->resolveCreateFormArgs($args);
-
         if (!$entity instanceof PointInsight) {
             throw new MethodNotAllowedHttpException(['PointInsight']);
         }

--- a/app/bundles/PointBundle/Model/InsightModel.php
+++ b/app/bundles/PointBundle/Model/InsightModel.php
@@ -12,7 +12,6 @@ use Mautic\PointBundle\Entity\GroupContactScore;
 use Mautic\PointBundle\Entity\PointInsight;
 use Mautic\PointBundle\Entity\PointInsightRepository;
 use Mautic\PointBundle\Form\Type\PointInsightType;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Contracts\Service\Attribute\Required;
@@ -50,7 +49,7 @@ final class InsightModel extends CommonFormModel
      *
      * @throws MethodNotAllowedHttpException
      */
-    public function createForm($entity, FormFactoryInterface $formFactory, $action = null, $options = []): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
         if (!$entity instanceof PointInsight) {
             throw new MethodNotAllowedHttpException(['PointInsight']);
@@ -60,7 +59,7 @@ final class InsightModel extends CommonFormModel
             $options['action'] = $action;
         }
 
-        return $formFactory->create(PointInsightType::class, $entity, $options);
+        return $this->formFactory->create(PointInsightType::class, $entity, $options);
     }
 
     public function getEntity($id = null): ?PointInsight

--- a/app/bundles/PointBundle/Model/InsightModel.php
+++ b/app/bundles/PointBundle/Model/InsightModel.php
@@ -45,12 +45,12 @@ final class InsightModel extends CommonFormModel
     }
 
     /**
-     * @param array<string, mixed> $options
-     *
      * @throws MethodNotAllowedHttpException
      */
-    public function createForm($entity, $action = null, $options = []): FormInterface
+    public function createForm($entity, mixed ...$args): FormInterface
     {
+        [$action, $options] = $this->resolveCreateFormArgs($args);
+
         if (!$entity instanceof PointInsight) {
             throw new MethodNotAllowedHttpException(['PointInsight']);
         }

--- a/app/bundles/PointBundle/Model/PointGroupModel.php
+++ b/app/bundles/PointBundle/Model/PointGroupModel.php
@@ -43,14 +43,14 @@ class PointGroupModel extends CommonFormModel implements GlobalSearchInterface
     }
 
     /**
-     * @param object $entity
+     * @param object               $entity
+     * @param string|null          $action
+     * @param array<string,string> $options
      *
      * @throws MethodNotAllowedHttpException
      */
-    public function createForm($entity, mixed ...$args): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
-        [$action, $options] = $this->resolveCreateFormArgs($args);
-
         if (!$entity instanceof Group) {
             throw new MethodNotAllowedHttpException(['Group']);
         }

--- a/app/bundles/PointBundle/Model/PointGroupModel.php
+++ b/app/bundles/PointBundle/Model/PointGroupModel.php
@@ -43,14 +43,14 @@ class PointGroupModel extends CommonFormModel implements GlobalSearchInterface
     }
 
     /**
-     * @param object               $entity
-     * @param string|null          $action
-     * @param array<string,string> $options
+     * @param object $entity
      *
      * @throws MethodNotAllowedHttpException
      */
-    public function createForm($entity, $action = null, $options = []): FormInterface
+    public function createForm($entity, mixed ...$args): FormInterface
     {
+        [$action, $options] = $this->resolveCreateFormArgs($args);
+
         if (!$entity instanceof Group) {
             throw new MethodNotAllowedHttpException(['Group']);
         }

--- a/app/bundles/PointBundle/Model/PointGroupModel.php
+++ b/app/bundles/PointBundle/Model/PointGroupModel.php
@@ -13,7 +13,6 @@ use Mautic\PointBundle\Entity\GroupRepository;
 use Mautic\PointBundle\Event as Events;
 use Mautic\PointBundle\Form\Type\GroupType;
 use Mautic\PointBundle\PointGroupEvents;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Contracts\EventDispatcher\Event;
@@ -50,7 +49,7 @@ class PointGroupModel extends CommonFormModel implements GlobalSearchInterface
      *
      * @throws MethodNotAllowedHttpException
      */
-    public function createForm($entity, FormFactoryInterface $formFactory, $action = null, $options = []): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
         if (!$entity instanceof Group) {
             throw new MethodNotAllowedHttpException(['Group']);
@@ -60,7 +59,7 @@ class PointGroupModel extends CommonFormModel implements GlobalSearchInterface
             $options['action'] = $action;
         }
 
-        return $formFactory->create(GroupType::class, $entity, $options);
+        return $this->formFactory->create(GroupType::class, $entity, $options);
     }
 
     /**

--- a/app/bundles/PointBundle/Model/PointModel.php
+++ b/app/bundles/PointBundle/Model/PointModel.php
@@ -74,8 +74,10 @@ class PointModel extends CommonFormModel implements GlobalSearchInterface, Reset
     /**
      * @throws MethodNotAllowedHttpException
      */
-    public function createForm($entity, $action = null, $options = []): FormInterface
+    public function createForm($entity, mixed ...$args): FormInterface
     {
+        [$action, $options] = $this->resolveCreateFormArgs($args);
+
         if (!$entity instanceof Point) {
             throw new MethodNotAllowedHttpException(['Point']);
         }

--- a/app/bundles/PointBundle/Model/PointModel.php
+++ b/app/bundles/PointBundle/Model/PointModel.php
@@ -25,7 +25,6 @@ use Mautic\PointBundle\Form\Type\PointType;
 use Mautic\PointBundle\PointEvents;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
@@ -75,7 +74,7 @@ class PointModel extends CommonFormModel implements GlobalSearchInterface, Reset
     /**
      * @throws MethodNotAllowedHttpException
      */
-    public function createForm($entity, FormFactoryInterface $formFactory, $action = null, $options = []): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
         if (!$entity instanceof Point) {
             throw new MethodNotAllowedHttpException(['Point']);
@@ -89,7 +88,7 @@ class PointModel extends CommonFormModel implements GlobalSearchInterface, Reset
             $options['pointActions'] = $this->getPointActions();
         }
 
-        return $formFactory->create(PointType::class, $entity, $options);
+        return $this->formFactory->create(PointType::class, $entity, $options);
     }
 
     public function getEntity($id = null): ?Point

--- a/app/bundles/PointBundle/Model/PointModel.php
+++ b/app/bundles/PointBundle/Model/PointModel.php
@@ -74,10 +74,8 @@ class PointModel extends CommonFormModel implements GlobalSearchInterface, Reset
     /**
      * @throws MethodNotAllowedHttpException
      */
-    public function createForm($entity, mixed ...$args): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
-        [$action, $options] = $this->resolveCreateFormArgs($args);
-
         if (!$entity instanceof Point) {
             throw new MethodNotAllowedHttpException(['Point']);
         }

--- a/app/bundles/PointBundle/Model/TriggerEventModel.php
+++ b/app/bundles/PointBundle/Model/TriggerEventModel.php
@@ -46,8 +46,10 @@ class TriggerEventModel extends CommonFormModel
     /**
      * @throws MethodNotAllowedHttpException
      */
-    public function createForm($entity, $action = null, $options = []): FormInterface
+    public function createForm($entity, mixed ...$args): FormInterface
     {
+        [$action, $options] = $this->resolveCreateFormArgs($args);
+
         if (!$entity instanceof TriggerEvent) {
             throw new MethodNotAllowedHttpException(['Trigger']);
         }

--- a/app/bundles/PointBundle/Model/TriggerEventModel.php
+++ b/app/bundles/PointBundle/Model/TriggerEventModel.php
@@ -46,10 +46,8 @@ class TriggerEventModel extends CommonFormModel
     /**
      * @throws MethodNotAllowedHttpException
      */
-    public function createForm($entity, mixed ...$args): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
-        [$action, $options] = $this->resolveCreateFormArgs($args);
-
         if (!$entity instanceof TriggerEvent) {
             throw new MethodNotAllowedHttpException(['Trigger']);
         }

--- a/app/bundles/PointBundle/Model/TriggerEventModel.php
+++ b/app/bundles/PointBundle/Model/TriggerEventModel.php
@@ -6,7 +6,6 @@ use Mautic\CoreBundle\Model\FormModel as CommonFormModel;
 use Mautic\PointBundle\Entity\TriggerEvent;
 use Mautic\PointBundle\Entity\TriggerEventRepository;
 use Mautic\PointBundle\Form\Type\TriggerEventType;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Contracts\Service\Attribute\Required;
@@ -47,7 +46,7 @@ class TriggerEventModel extends CommonFormModel
     /**
      * @throws MethodNotAllowedHttpException
      */
-    public function createForm($entity, FormFactoryInterface $formFactory, $action = null, $options = []): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
         if (!$entity instanceof TriggerEvent) {
             throw new MethodNotAllowedHttpException(['Trigger']);
@@ -57,7 +56,7 @@ class TriggerEventModel extends CommonFormModel
             $options['action'] = $action;
         }
 
-        return $formFactory->create(TriggerEventType::class, $entity, $options);
+        return $this->formFactory->create(TriggerEventType::class, $entity, $options);
     }
 
     /**

--- a/app/bundles/PointBundle/Model/TriggerModel.php
+++ b/app/bundles/PointBundle/Model/TriggerModel.php
@@ -85,8 +85,10 @@ class TriggerModel extends CommonFormModel implements GlobalSearchInterface
     /**
      * @throws MethodNotAllowedHttpException
      */
-    public function createForm($entity, $action = null, $options = []): FormInterface
+    public function createForm($entity, mixed ...$args): FormInterface
     {
+        [$action, $options] = $this->resolveCreateFormArgs($args);
+
         if (!$entity instanceof Trigger) {
             throw new MethodNotAllowedHttpException(['Trigger']);
         }

--- a/app/bundles/PointBundle/Model/TriggerModel.php
+++ b/app/bundles/PointBundle/Model/TriggerModel.php
@@ -27,7 +27,6 @@ use Mautic\PointBundle\Form\Type\TriggerType;
 use Mautic\PointBundle\PointEvents;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -86,7 +85,7 @@ class TriggerModel extends CommonFormModel implements GlobalSearchInterface
     /**
      * @throws MethodNotAllowedHttpException
      */
-    public function createForm($entity, FormFactoryInterface $formFactory, $action = null, $options = []): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
         if (!$entity instanceof Trigger) {
             throw new MethodNotAllowedHttpException(['Trigger']);
@@ -96,7 +95,7 @@ class TriggerModel extends CommonFormModel implements GlobalSearchInterface
             $options['action'] = $action;
         }
 
-        return $formFactory->create(TriggerType::class, $entity, $options);
+        return $this->formFactory->create(TriggerType::class, $entity, $options);
     }
 
     /**

--- a/app/bundles/PointBundle/Model/TriggerModel.php
+++ b/app/bundles/PointBundle/Model/TriggerModel.php
@@ -85,10 +85,8 @@ class TriggerModel extends CommonFormModel implements GlobalSearchInterface
     /**
      * @throws MethodNotAllowedHttpException
      */
-    public function createForm($entity, mixed ...$args): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
-        [$action, $options] = $this->resolveCreateFormArgs($args);
-
         if (!$entity instanceof Trigger) {
             throw new MethodNotAllowedHttpException(['Trigger']);
         }

--- a/app/bundles/ReportBundle/Controller/ReportController.php
+++ b/app/bundles/ReportBundle/Controller/ReportController.php
@@ -318,7 +318,7 @@ final class ReportController extends FormController
 
         // Create the form
         $action = $this->generateUrl('mautic_report_action', ['objectAction' => 'edit', 'objectId' => $objectId]);
-        $form   = $this->reportModel->createForm($entity, $this->formFactory, $action);
+        $form   = $this->reportModel->createForm($entity, $action);
 
         // /Check for a submitted form and process it
         if (!$ignorePost && 'POST' === $request->getMethod()) {
@@ -398,7 +398,7 @@ final class ReportController extends FormController
             }
             if ($valid) {
                 // Rebuild the form for updated columns
-                $form = $this->reportModel->createForm($entity, $this->formFactory, $action);
+                $form = $this->reportModel->createForm($entity, $action);
             }
         } else {
             // lock the entity
@@ -441,7 +441,7 @@ final class ReportController extends FormController
         $page    = $session->get('mautic.report.page', 1);
 
         $action = $this->generateUrl('mautic_report_action', ['objectAction' => 'new']);
-        $form   = $this->reportModel->createForm($entity, $this->formFactory, $action);
+        $form   = $this->reportModel->createForm($entity, $action);
 
         // /Check for a submitted form and process it
         if (Request::METHOD_POST === $request->getMethod()) {

--- a/app/bundles/ReportBundle/Model/ReportModel.php
+++ b/app/bundles/ReportBundle/Model/ReportModel.php
@@ -106,10 +106,8 @@ class ReportModel extends FormModel implements GlobalSearchInterface
     /**
      * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      */
-    public function createForm($entity, mixed ...$args): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
-        [$action, $options] = $this->resolveCreateFormArgs($args);
-
         if (!$entity instanceof Report) {
             throw new MethodNotAllowedHttpException(['Report']);
         }

--- a/app/bundles/ReportBundle/Model/ReportModel.php
+++ b/app/bundles/ReportBundle/Model/ReportModel.php
@@ -106,8 +106,10 @@ class ReportModel extends FormModel implements GlobalSearchInterface
     /**
      * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      */
-    public function createForm($entity, $action = null, $options = []): FormInterface
+    public function createForm($entity, mixed ...$args): FormInterface
     {
+        [$action, $options] = $this->resolveCreateFormArgs($args);
+
         if (!$entity instanceof Report) {
             throw new MethodNotAllowedHttpException(['Report']);
         }

--- a/app/bundles/ReportBundle/Model/ReportModel.php
+++ b/app/bundles/ReportBundle/Model/ReportModel.php
@@ -106,7 +106,7 @@ class ReportModel extends FormModel implements GlobalSearchInterface
     /**
      * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      */
-    public function createForm($entity, FormFactoryInterface $formFactory, $action = null, $options = []): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
         if (!$entity instanceof Report) {
             throw new MethodNotAllowedHttpException(['Report']);
@@ -125,7 +125,7 @@ class ReportModel extends FormModel implements GlobalSearchInterface
 
         // Fire the REPORT_ON_BUILD event off to get the table/column data
 
-        $reportGenerator = new ReportGenerator($this->dispatcher, $this->em->getConnection(), $entity, $this->channelListHelper, $formFactory);
+        $reportGenerator = new ReportGenerator($this->dispatcher, $this->em->getConnection(), $entity, $this->channelListHelper, $this->formFactory);
 
         return $reportGenerator->getForm($entity, $options);
     }

--- a/app/bundles/SmsBundle/Controller/SmsController.php
+++ b/app/bundles/SmsBundle/Controller/SmsController.php
@@ -284,7 +284,7 @@ final class SmsController extends FormController
         }
 
         // create the form
-        $form = $this->smsModel->createForm($entity, $this->formFactory, $action, ['update_select' => $updateSelect]);
+        $form = $this->smsModel->createForm($entity, $action, ['update_select' => $updateSelect]);
 
         // /Check for a submitted form and process it
         if ('POST' === $method) {
@@ -445,7 +445,7 @@ final class SmsController extends FormController
             ? ($sms['updateSelect'] ?? false)
             : $request->get('updateSelect', false);
 
-        $form = $this->smsModel->createForm($entity, $this->formFactory, $action, ['update_select' => $updateSelect]);
+        $form = $this->smsModel->createForm($entity, $action, ['update_select' => $updateSelect]);
 
         // /Check for a submitted form and process it
         if (!$ignorePost && 'POST' === $method) {

--- a/app/bundles/SmsBundle/Model/SmsModel.php
+++ b/app/bundles/SmsBundle/Model/SmsModel.php
@@ -132,12 +132,12 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface, GlobalSear
     }
 
     /**
-     * @param mixed[] $options
-     *
      * @throws MethodNotAllowedHttpException
      */
-    public function createForm($entity, $action = null, $options = []): FormInterface
+    public function createForm($entity, mixed ...$args): FormInterface
     {
+        [$action, $options] = $this->resolveCreateFormArgs($args);
+
         if (!$entity instanceof Sms) {
             throw new MethodNotAllowedHttpException(['Sms']);
         }

--- a/app/bundles/SmsBundle/Model/SmsModel.php
+++ b/app/bundles/SmsBundle/Model/SmsModel.php
@@ -36,7 +36,6 @@ use Mautic\SmsBundle\Sms\TransportChain;
 use Mautic\SmsBundle\SmsEvents;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -137,7 +136,7 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface, GlobalSear
      *
      * @throws MethodNotAllowedHttpException
      */
-    public function createForm($entity, FormFactoryInterface $formFactory, $action = null, $options = []): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
         if (!$entity instanceof Sms) {
             throw new MethodNotAllowedHttpException(['Sms']);
@@ -146,7 +145,7 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface, GlobalSear
             $options['action'] = $action;
         }
 
-        return $formFactory->create(SmsType::class, $entity, $options);
+        return $this->formFactory->create(SmsType::class, $entity, $options);
     }
 
     /**

--- a/app/bundles/SmsBundle/Model/SmsModel.php
+++ b/app/bundles/SmsBundle/Model/SmsModel.php
@@ -132,12 +132,12 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface, GlobalSear
     }
 
     /**
+     * @param mixed[] $options
+     *
      * @throws MethodNotAllowedHttpException
      */
-    public function createForm($entity, mixed ...$args): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
-        [$action, $options] = $this->resolveCreateFormArgs($args);
-
         if (!$entity instanceof Sms) {
             throw new MethodNotAllowedHttpException(['Sms']);
         }

--- a/app/bundles/StageBundle/Controller/AjaxController.php
+++ b/app/bundles/StageBundle/Controller/AjaxController.php
@@ -6,7 +6,6 @@ use Mautic\CoreBundle\Controller\AjaxController as CommonAjaxController;
 use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\StageBundle\Form\Type\StageActionType;
 use Mautic\StageBundle\Model\StageModel;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Contracts\Service\Attribute\Required;
@@ -23,7 +22,7 @@ final class AjaxController extends CommonAjaxController
         $this->stageModel = $stageModel;
     }
 
-    public function getActionFormAction(Request $request, FormFactoryInterface $formFactory, Environment $twig): JsonResponse
+    public function getActionFormAction(Request $request, Environment $twig): JsonResponse
     {
         $dataArray = [
             'success' => 0,
@@ -42,7 +41,7 @@ final class AjaxController extends CommonAjaxController
                 $formType        = (!empty($actions['actions'][$type]['formType'])) ? $actions['actions'][$type]['formType'] : 'genericstage_settings';
                 $formTypeOptions = (!empty($actions['actions'][$type]['formTypeOptions'])) ? $actions['actions'][$type]['formTypeOptions'] : [];
 
-                $form = $formFactory->create(StageActionType::class, [], ['formType' => $formType, 'formTypeOptions' => $formTypeOptions]);
+                $form = $this->createForm(StageActionType::class, [], ['formType' => $formType, 'formTypeOptions' => $formTypeOptions]);
                 $html = $this->renderView('@MauticStage/Stage/actionform.html.twig', [
                     'form' => $this->setFormTheme($form, $twig, $themes),
                 ]);

--- a/app/bundles/StageBundle/Controller/StageController.php
+++ b/app/bundles/StageBundle/Controller/StageController.php
@@ -237,11 +237,7 @@ final class StageController extends AbstractFormController
      * @param int  $objectId
      * @param bool $ignorePost
      */
-<<<<<<< HEAD
-    public function editAction(Request $request, FormFactoryInterface $formFactory, $objectId, $ignorePost = false): Response
-=======
-    public function editAction(Request $request, $objectId, $ignorePost = false)
->>>>>>> 5a984947ee (use injected form factory in FormModel::createForm() instead of passing it as parameter)
+    public function editAction(Request $request, $objectId, $ignorePost = false): Response
     {
         $entity = $this->stageModel->getEntity($objectId);
 

--- a/app/bundles/StageBundle/Controller/StageController.php
+++ b/app/bundles/StageBundle/Controller/StageController.php
@@ -9,7 +9,6 @@ use Mautic\StageBundle\Entity\StageRepository;
 use Mautic\StageBundle\Form\Type\StageMergeType;
 use Mautic\StageBundle\Model\StageModel;
 use Mautic\StageBundle\Security\Permissions\StagePermissions;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -120,7 +119,7 @@ final class StageController extends AbstractFormController
      *
      * @param Stage $entity
      */
-    public function newAction(Request $request, FormFactoryInterface $formFactory, $entity = null): Response
+    public function newAction(Request $request, $entity = null): Response
     {
         if (!$entity instanceof Stage) {
             /** @var Stage $entity */
@@ -140,7 +139,6 @@ final class StageController extends AbstractFormController
         $actions    = $this->stageModel->getStageActions();
         $form       = $this->stageModel->createForm(
             $entity,
-            $formFactory,
             $action,
             [
                 'stageActions' => $actions,
@@ -178,7 +176,7 @@ final class StageController extends AbstractFormController
                         $template  = 'Mautic\StageBundle\Controller\StageController::indexAction';
                     } else {
                         // return edit view so that all the session stuff is loaded
-                        return $this->editAction($request, $formFactory, $entity->getId(), true);
+                        return $this->editAction($request, $entity->getId(), true);
                     }
                 }
             } else {
@@ -239,7 +237,11 @@ final class StageController extends AbstractFormController
      * @param int  $objectId
      * @param bool $ignorePost
      */
+<<<<<<< HEAD
     public function editAction(Request $request, FormFactoryInterface $formFactory, $objectId, $ignorePost = false): Response
+=======
+    public function editAction(Request $request, $objectId, $ignorePost = false)
+>>>>>>> 5a984947ee (use injected form factory in FormModel::createForm() instead of passing it as parameter)
     {
         $entity = $this->stageModel->getEntity($objectId);
 
@@ -291,7 +293,6 @@ final class StageController extends AbstractFormController
         $actions = $this->stageModel->getStageActions();
         $form    = $this->stageModel->createForm(
             $entity,
-            $formFactory,
             $action,
             [
                 'stageActions' => $actions,
@@ -389,7 +390,7 @@ final class StageController extends AbstractFormController
      *
      * @param int $objectId
      */
-    public function cloneAction(Request $request, FormFactoryInterface $formFactory, $objectId): Response
+    public function cloneAction(Request $request, $objectId): Response
     {
         $entity = $this->stageModel->getEntity($objectId);
 
@@ -402,10 +403,10 @@ final class StageController extends AbstractFormController
             $entity->setIsPublished(false);
         }
 
-        return $this->newAction($request, $formFactory, $entity);
+        return $this->newAction($request, $entity);
     }
 
-    public function mergeAction(Request $request, FormFactoryInterface $formFactory, StageModel $model, int $objectId): Response
+    public function mergeAction(Request $request, StageModel $model, int $objectId): Response
     {
         $secondaryStage = $model->getEntity($objectId);
         $page           = $request->getSession()->get('mautic.stage.page', 1);
@@ -441,7 +442,7 @@ final class StageController extends AbstractFormController
 
         $action = $this->generateUrl('mautic_stage_action', ['objectAction' => 'merge', 'objectId' => $secondaryStage->getId()]);
 
-        $form = $formFactory->create(
+        $form = $this->createForm(
             StageMergeType::class,
             [],
             [

--- a/app/bundles/StageBundle/Model/StageModel.php
+++ b/app/bundles/StageBundle/Model/StageModel.php
@@ -60,8 +60,10 @@ class StageModel extends CommonFormModel implements GlobalSearchInterface
     /**
      * @throws MethodNotAllowedHttpException
      */
-    public function createForm($entity, $action = null, $options = []): FormInterface
+    public function createForm($entity, mixed ...$args): FormInterface
     {
+        [$action, $options] = $this->resolveCreateFormArgs($args);
+
         if (!$entity instanceof Stage) {
             throw new MethodNotAllowedHttpException(['Stage']);
         }

--- a/app/bundles/StageBundle/Model/StageModel.php
+++ b/app/bundles/StageBundle/Model/StageModel.php
@@ -60,10 +60,8 @@ class StageModel extends CommonFormModel implements GlobalSearchInterface
     /**
      * @throws MethodNotAllowedHttpException
      */
-    public function createForm($entity, mixed ...$args): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
-        [$action, $options] = $this->resolveCreateFormArgs($args);
-
         if (!$entity instanceof Stage) {
             throw new MethodNotAllowedHttpException(['Stage']);
         }

--- a/app/bundles/StageBundle/Model/StageModel.php
+++ b/app/bundles/StageBundle/Model/StageModel.php
@@ -16,7 +16,6 @@ use Mautic\StageBundle\Event\StageBuilderEvent;
 use Mautic\StageBundle\Event\StageEvent;
 use Mautic\StageBundle\Form\Type\StageType;
 use Mautic\StageBundle\StageEvents;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Contracts\EventDispatcher\Event;
@@ -61,7 +60,7 @@ class StageModel extends CommonFormModel implements GlobalSearchInterface
     /**
      * @throws MethodNotAllowedHttpException
      */
-    public function createForm($entity, FormFactoryInterface $formFactory, $action = null, $options = []): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
         if (!$entity instanceof Stage) {
             throw new MethodNotAllowedHttpException(['Stage']);
@@ -70,7 +69,7 @@ class StageModel extends CommonFormModel implements GlobalSearchInterface
             $options['action'] = $action;
         }
 
-        return $formFactory->create(StageType::class, $entity, $options);
+        return $this->formFactory->create(StageType::class, $entity, $options);
     }
 
     public function getEntity($id = null): ?Stage

--- a/app/bundles/UserBundle/Controller/ProfileController.php
+++ b/app/bundles/UserBundle/Controller/ProfileController.php
@@ -49,7 +49,7 @@ final class ProfileController extends FormController
         ];
 
         $action = $this->generateUrl('mautic_user_account');
-        $form   = $this->userModel->createForm($me, $this->formFactory, $action, ['in_profile' => true]);
+        $form   = $this->userModel->createForm($me, $action, ['in_profile' => true]);
 
         $overrides = [];
 

--- a/app/bundles/UserBundle/Controller/RoleController.php
+++ b/app/bundles/UserBundle/Controller/RoleController.php
@@ -148,7 +148,7 @@ final class RoleController extends FormController
 
         // get the user form factory
         $permissionsConfig = $this->getPermissionsConfig($entity);
-        $form              = $this->roleModel->createForm($entity, $this->formFactory, $action, ['permissionsConfig' => $permissionsConfig['config']]);
+        $form              = $this->roleModel->createForm($entity, $action, ['permissionsConfig' => $permissionsConfig['config']]);
 
         // /Check for a submitted form and process it
         if ('POST' === $request->getMethod()) {
@@ -269,7 +269,7 @@ final class RoleController extends FormController
         $entity            = $model->cloneEntity($source);
         $permissionsConfig = $this->getPermissionsConfig($source);
         $action            = $this->generateUrl('mautic_role_action', ['objectAction' => 'clone', 'objectId' => $objectId]);
-        $form              = $model->createForm($entity, $this->formFactory, $action, ['permissionsConfig' => $permissionsConfig['config']]);
+        $form              = $model->createForm($entity, $action, ['permissionsConfig' => $permissionsConfig['config']]);
         if (!$request->isMethod('POST')) {
             return $this->renderRoleCloneForm($form, $permissionsConfig, $action);
         }
@@ -388,7 +388,7 @@ final class RoleController extends FormController
 
         $permissionsConfig = $this->getPermissionsConfig($entity);
         $action            = $this->generateUrl('mautic_role_action', ['objectAction' => 'edit', 'objectId' => $objectId]);
-        $form              = $this->roleModel->createForm($entity, $this->formFactory, $action, ['permissionsConfig' => $permissionsConfig['config']]);
+        $form              = $this->roleModel->createForm($entity, $action, ['permissionsConfig' => $permissionsConfig['config']]);
 
         // /Check for a submitted form and process it
         if (!$ignorePost && 'POST' === $request->getMethod()) {
@@ -423,7 +423,7 @@ final class RoleController extends FormController
             }
             // the form has to be rebuilt because the permissions were updated
             $permissionsConfig = $this->getPermissionsConfig($entity);
-            $form              = $this->roleModel->createForm($entity, $this->formFactory, $action, ['permissionsConfig' => $permissionsConfig['config']]);
+            $form              = $this->roleModel->createForm($entity, $action, ['permissionsConfig' => $permissionsConfig['config']]);
         } else {
             // lock the entity
             $this->roleModel->lockEntity($entity);

--- a/app/bundles/UserBundle/Controller/UserController.php
+++ b/app/bundles/UserBundle/Controller/UserController.php
@@ -212,7 +212,7 @@ final class UserController extends FormController
 
         // get the user form factory
         $action   = $this->generateUrl('mautic_user_action', ['objectAction' => 'new']);
-        $form     = $this->userModel->createForm($user, $this->formFactory, $action);
+        $form     = $this->userModel->createForm($user, $action);
         $response = null;
 
         // Check for a submitted form and process it
@@ -359,7 +359,7 @@ final class UserController extends FormController
         }
 
         $action = $this->generateUrl('mautic_user_action', ['objectAction' => 'edit', 'objectId' => $objectId]);
-        $form   = $this->userModel->createForm($user, $this->formFactory, $action);
+        $form   = $this->userModel->createForm($user, $action);
 
         $isSamlUser    = $samlHelper->isSamlSession();
         if ($isSamlUser) {

--- a/app/bundles/UserBundle/Model/RoleModel.php
+++ b/app/bundles/UserBundle/Model/RoleModel.php
@@ -11,7 +11,6 @@ use Mautic\UserBundle\Entity\UserRepository;
 use Mautic\UserBundle\Event\RoleEvent;
 use Mautic\UserBundle\Form\Type\RoleType;
 use Mautic\UserBundle\UserEvents;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Component\HttpKernel\Exception\PreconditionRequiredHttpException;
@@ -109,7 +108,7 @@ final class RoleModel extends FormModel implements GlobalSearchInterface
         parent::deleteEntity($entity);
     }
 
-    public function createForm($entity, FormFactoryInterface $formFactory, $action = null, $options = []): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
         if (!$entity instanceof Role) {
             throw new MethodNotAllowedHttpException(['Role']);
@@ -119,7 +118,7 @@ final class RoleModel extends FormModel implements GlobalSearchInterface
             $options['action'] = $action;
         }
 
-        return $formFactory->create(RoleType::class, $entity, $options);
+        return $this->formFactory->create(RoleType::class, $entity, $options);
     }
 
     public function getEntity($id = null): ?Role

--- a/app/bundles/UserBundle/Model/RoleModel.php
+++ b/app/bundles/UserBundle/Model/RoleModel.php
@@ -108,10 +108,8 @@ final class RoleModel extends FormModel implements GlobalSearchInterface
         parent::deleteEntity($entity);
     }
 
-    public function createForm($entity, mixed ...$args): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
-        [$action, $options] = $this->resolveCreateFormArgs($args);
-
         if (!$entity instanceof Role) {
             throw new MethodNotAllowedHttpException(['Role']);
         }

--- a/app/bundles/UserBundle/Model/RoleModel.php
+++ b/app/bundles/UserBundle/Model/RoleModel.php
@@ -108,8 +108,10 @@ final class RoleModel extends FormModel implements GlobalSearchInterface
         parent::deleteEntity($entity);
     }
 
-    public function createForm($entity, $action = null, $options = []): FormInterface
+    public function createForm($entity, mixed ...$args): FormInterface
     {
+        [$action, $options] = $this->resolveCreateFormArgs($args);
+
         if (!$entity instanceof Role) {
             throw new MethodNotAllowedHttpException(['Role']);
         }

--- a/app/bundles/UserBundle/Model/UserModel.php
+++ b/app/bundles/UserBundle/Model/UserModel.php
@@ -122,8 +122,10 @@ class UserModel extends FormModel implements GlobalSearchInterface
         return $entity->getPassword();
     }
 
-    public function createForm($entity, $action = null, $options = []): FormInterface
+    public function createForm($entity, mixed ...$args): FormInterface
     {
+        [$action, $options] = $this->resolveCreateFormArgs($args);
+
         if (!$entity instanceof User) {
             throw new MethodNotAllowedHttpException(['User'], $this->translator->trans('mautic.user.entity.must.be.user', [], 'validators'));
         }

--- a/app/bundles/UserBundle/Model/UserModel.php
+++ b/app/bundles/UserBundle/Model/UserModel.php
@@ -122,10 +122,8 @@ class UserModel extends FormModel implements GlobalSearchInterface
         return $entity->getPassword();
     }
 
-    public function createForm($entity, mixed ...$args): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
-        [$action, $options] = $this->resolveCreateFormArgs($args);
-
         if (!$entity instanceof User) {
             throw new MethodNotAllowedHttpException(['User'], $this->translator->trans('mautic.user.entity.must.be.user', [], 'validators'));
         }

--- a/app/bundles/UserBundle/Model/UserModel.php
+++ b/app/bundles/UserBundle/Model/UserModel.php
@@ -26,7 +26,6 @@ use Mautic\UserBundle\Model\UserToken\UserTokenServiceInterface;
 use Mautic\UserBundle\UserEvents;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
@@ -123,7 +122,7 @@ class UserModel extends FormModel implements GlobalSearchInterface
         return $entity->getPassword();
     }
 
-    public function createForm($entity, FormFactoryInterface $formFactory, $action = null, $options = []): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
         if (!$entity instanceof User) {
             throw new MethodNotAllowedHttpException(['User'], $this->translator->trans('mautic.user.entity.must.be.user', [], 'validators'));
@@ -132,7 +131,7 @@ class UserModel extends FormModel implements GlobalSearchInterface
             $options['action'] = $action;
         }
 
-        return $formFactory->create(UserType::class, $entity, $options);
+        return $this->formFactory->create(UserType::class, $entity, $options);
     }
 
     public function getEntity($id = null): ?User

--- a/app/bundles/WebhookBundle/Model/WebhookModel.php
+++ b/app/bundles/WebhookBundle/Model/WebhookModel.php
@@ -159,14 +159,13 @@ class WebhookModel extends FormModel
     }
 
     /**
-     * @param Webhook $entity
+     * @param Webhook      $entity
+     * @param array<mixed> $options
      *
      * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      */
-    public function createForm($entity, mixed ...$args): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
-        [$action, $options] = $this->resolveCreateFormArgs($args);
-
         if (!$entity instanceof Webhook) {
             throw new MethodNotAllowedHttpException(['Webhook']);
         }

--- a/app/bundles/WebhookBundle/Model/WebhookModel.php
+++ b/app/bundles/WebhookBundle/Model/WebhookModel.php
@@ -30,7 +30,6 @@ use Mautic\WebhookBundle\Service\WebhookService;
 use Mautic\WebhookBundle\WebhookEvents;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -165,7 +164,7 @@ class WebhookModel extends FormModel
      *
      * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      */
-    public function createForm($entity, FormFactoryInterface $formFactory, $action = null, $options = []): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
         if (!$entity instanceof Webhook) {
             throw new MethodNotAllowedHttpException(['Webhook']);
@@ -177,7 +176,7 @@ class WebhookModel extends FormModel
 
         $options['events'] = $this->getEvents();
 
-        return $formFactory->create(WebhookType::class, $entity, $options);
+        return $this->formFactory->create(WebhookType::class, $entity, $options);
     }
 
     public function getEntity($id = null): ?Webhook

--- a/app/bundles/WebhookBundle/Model/WebhookModel.php
+++ b/app/bundles/WebhookBundle/Model/WebhookModel.php
@@ -159,13 +159,14 @@ class WebhookModel extends FormModel
     }
 
     /**
-     * @param Webhook      $entity
-     * @param array<mixed> $options
+     * @param Webhook $entity
      *
      * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      */
-    public function createForm($entity, $action = null, $options = []): FormInterface
+    public function createForm($entity, mixed ...$args): FormInterface
     {
+        [$action, $options] = $this->resolveCreateFormArgs($args);
+
         if (!$entity instanceof Webhook) {
             throw new MethodNotAllowedHttpException(['Webhook']);
         }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,7 +5,7 @@ parameters:
 	tmpDir: ./var/phpstan-cache
 	level: 6
 
-	#reportUnmatchedIgnoredErrors: false
+	reportUnmatchedIgnoredErrors: false
 
 	treatPhpDocTypesAsCertain: false
 	parallel:
@@ -222,10 +222,6 @@ parameters:
 			path: app/bundles/ApiBundle/Serializer/Driver/ApiMetadataDriver.php
 		-
 			identifier: typePerfect.noArrayAccessOnObject
-		# @todo the form factory has to move into FormModel::createForm() first, which every model shares
-		-
-			identifier: mautic.noServiceJuggling
-			path: app/bundles/LeadBundle/Model/LeadModel.php
 
 		# mixed return
 		-

--- a/plugins/MauticFocusBundle/Model/FocusModel.php
+++ b/plugins/MauticFocusBundle/Model/FocusModel.php
@@ -76,14 +76,14 @@ class FocusModel extends FormModel implements GlobalSearchInterface
     }
 
     /**
-     * @param object      $entity
-     * @param string|null $action
-     * @param array       $options
+     * @param object $entity
      *
      * @throws NotFoundHttpException
      */
-    public function createForm($entity, $action = null, $options = []): FormInterface
+    public function createForm($entity, mixed ...$args): FormInterface
     {
+        [$action, $options] = $this->resolveCreateFormArgs($args);
+
         if (!$entity instanceof Focus) {
             throw new MethodNotAllowedHttpException(['Focus']);
         }

--- a/plugins/MauticFocusBundle/Model/FocusModel.php
+++ b/plugins/MauticFocusBundle/Model/FocusModel.php
@@ -76,14 +76,14 @@ class FocusModel extends FormModel implements GlobalSearchInterface
     }
 
     /**
-     * @param object $entity
+     * @param object      $entity
+     * @param string|null $action
+     * @param array       $options
      *
      * @throws NotFoundHttpException
      */
-    public function createForm($entity, mixed ...$args): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
-        [$action, $options] = $this->resolveCreateFormArgs($args);
-
         if (!$entity instanceof Focus) {
             throw new MethodNotAllowedHttpException(['Focus']);
         }

--- a/plugins/MauticFocusBundle/Model/FocusModel.php
+++ b/plugins/MauticFocusBundle/Model/FocusModel.php
@@ -30,7 +30,6 @@ use MauticPlugin\MauticFocusBundle\FocusEvents;
 use MauticPlugin\MauticFocusBundle\Form\Type\FocusType;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -83,7 +82,7 @@ class FocusModel extends FormModel implements GlobalSearchInterface
      *
      * @throws NotFoundHttpException
      */
-    public function createForm($entity, FormFactoryInterface $formFactory, $action = null, $options = []): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
         if (!$entity instanceof Focus) {
             throw new MethodNotAllowedHttpException(['Focus']);
@@ -93,7 +92,7 @@ class FocusModel extends FormModel implements GlobalSearchInterface
             $options['action'] = $action;
         }
 
-        return $formFactory->create(FocusType::class, $entity, $options);
+        return $this->formFactory->create(FocusType::class, $entity, $options);
     }
 
     public function getRepository(): FocusRepository

--- a/plugins/MauticSocialBundle/Controller/AjaxController.php
+++ b/plugins/MauticSocialBundle/Controller/AjaxController.php
@@ -6,7 +6,6 @@ use Mautic\CoreBundle\Controller\AjaxController as CommonAjaxController;
 use Mautic\CoreBundle\Controller\AjaxLookupControllerTrait;
 use Mautic\CoreBundle\Helper\InputHelper;
 use MauticPlugin\MauticSocialBundle\Model\MonitoringModel;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -14,7 +13,7 @@ final class AjaxController extends CommonAjaxController
 {
     use AjaxLookupControllerTrait;
 
-    public function getNetworkFormAction(Request $request, MonitoringModel $monitoringModel, FormFactoryInterface $formFactory): JsonResponse
+    public function getNetworkFormAction(Request $request, MonitoringModel $monitoringModel): JsonResponse
     {
         // get the form type
         $type = InputHelper::clean($request->request->get('networkType'));
@@ -31,7 +30,7 @@ final class AjaxController extends CommonAjaxController
             $formType = $monitoringModel->getFormByType($type);
 
             // get the network type form
-            $form = $formFactory->create($formType, [], ['label' => false, 'csrf_protection' => false]);
+            $form = $this->createForm($formType, [], ['label' => false, 'csrf_protection' => false]);
 
             $html = $this->renderView(
                 '@MauticSocial/FormTheme/'.$type.'_widget.html.twig',

--- a/plugins/MauticSocialBundle/Controller/MonitoringController.php
+++ b/plugins/MauticSocialBundle/Controller/MonitoringController.php
@@ -151,7 +151,6 @@ final class MonitoringController extends FormController
         // build the form
         $form = $model->createForm(
             $entity,
-            $this->formFactory,
             $action,
             [
                 // pass through the types and the selected default type
@@ -302,7 +301,6 @@ final class MonitoringController extends FormController
         // build the form
         $form = $this->monitoringModel->createForm(
             $entity,
-            $this->formFactory,
             $action,
             [
                 // pass through the types and the selected default type

--- a/plugins/MauticSocialBundle/Model/MonitoringModel.php
+++ b/plugins/MauticSocialBundle/Model/MonitoringModel.php
@@ -44,12 +44,12 @@ final class MonitoringModel extends FormModel
     ];
 
     /**
-     * @param object $entity
+     * @param object      $entity
+     * @param string|null $action
+     * @param mixed[]     $options
      */
-    public function createForm($entity, mixed ...$args): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
-        [$action, $options] = $this->resolveCreateFormArgs($args);
-
         if (!$entity instanceof Monitoring) {
             throw new MethodNotAllowedHttpException(['Monitoring']);
         }

--- a/plugins/MauticSocialBundle/Model/MonitoringModel.php
+++ b/plugins/MauticSocialBundle/Model/MonitoringModel.php
@@ -44,12 +44,12 @@ final class MonitoringModel extends FormModel
     ];
 
     /**
-     * @param object      $entity
-     * @param string|null $action
-     * @param mixed[]     $options
+     * @param object $entity
      */
-    public function createForm($entity, $action = null, $options = []): FormInterface
+    public function createForm($entity, mixed ...$args): FormInterface
     {
+        [$action, $options] = $this->resolveCreateFormArgs($args);
+
         if (!$entity instanceof Monitoring) {
             throw new MethodNotAllowedHttpException(['Monitoring']);
         }

--- a/plugins/MauticSocialBundle/Model/MonitoringModel.php
+++ b/plugins/MauticSocialBundle/Model/MonitoringModel.php
@@ -10,7 +10,6 @@ use MauticPlugin\MauticSocialBundle\Form\Type\MonitoringType;
 use MauticPlugin\MauticSocialBundle\Form\Type\TwitterHashtagType;
 use MauticPlugin\MauticSocialBundle\Form\Type\TwitterMentionType;
 use MauticPlugin\MauticSocialBundle\SocialEvents;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Contracts\EventDispatcher\Event;
@@ -49,7 +48,7 @@ final class MonitoringModel extends FormModel
      * @param string|null $action
      * @param mixed[]     $options
      */
-    public function createForm($entity, FormFactoryInterface $formFactory, $action = null, $options = []): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
         if (!$entity instanceof Monitoring) {
             throw new MethodNotAllowedHttpException(['Monitoring']);
@@ -59,7 +58,7 @@ final class MonitoringModel extends FormModel
             $options['action'] = $action;
         }
 
-        return $formFactory->create(MonitoringType::class, $entity, $options);
+        return $this->formFactory->create(MonitoringType::class, $entity, $options);
     }
 
     /**

--- a/plugins/MauticSocialBundle/Model/TweetModel.php
+++ b/plugins/MauticSocialBundle/Model/TweetModel.php
@@ -12,7 +12,6 @@ use MauticPlugin\MauticSocialBundle\Entity\TweetStatRepository;
 use MauticPlugin\MauticSocialBundle\Event as Events;
 use MauticPlugin\MauticSocialBundle\Form\Type\TweetType;
 use MauticPlugin\MauticSocialBundle\SocialEvents;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Contracts\EventDispatcher\Event;
@@ -134,7 +133,7 @@ final class TweetModel extends FormModel implements AjaxLookupModelInterface
      * @param Tweet        $entity
      * @param array<mixed> $options
      */
-    public function createForm($entity, FormFactoryInterface $formFactory, $action = null, $options = []): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
         if (!$entity instanceof Tweet) {
             throw new MethodNotAllowedHttpException(['Tweet']);
@@ -144,7 +143,7 @@ final class TweetModel extends FormModel implements AjaxLookupModelInterface
             $options['action'] = $action;
         }
 
-        return $formFactory->create(TweetType::class, $entity, $options);
+        return $this->formFactory->create(TweetType::class, $entity, $options);
     }
 
     /**

--- a/plugins/MauticSocialBundle/Model/TweetModel.php
+++ b/plugins/MauticSocialBundle/Model/TweetModel.php
@@ -130,11 +130,12 @@ final class TweetModel extends FormModel implements AjaxLookupModelInterface
     }
 
     /**
-     * @param Tweet        $entity
-     * @param array<mixed> $options
+     * @param Tweet $entity
      */
-    public function createForm($entity, $action = null, $options = []): FormInterface
+    public function createForm($entity, mixed ...$args): FormInterface
     {
+        [$action, $options] = $this->resolveCreateFormArgs($args);
+
         if (!$entity instanceof Tweet) {
             throw new MethodNotAllowedHttpException(['Tweet']);
         }

--- a/plugins/MauticSocialBundle/Model/TweetModel.php
+++ b/plugins/MauticSocialBundle/Model/TweetModel.php
@@ -130,12 +130,11 @@ final class TweetModel extends FormModel implements AjaxLookupModelInterface
     }
 
     /**
-     * @param Tweet $entity
+     * @param Tweet        $entity
+     * @param array<mixed> $options
      */
-    public function createForm($entity, mixed ...$args): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
-        [$action, $options] = $this->resolveCreateFormArgs($args);
-
         if (!$entity instanceof Tweet) {
             throw new MethodNotAllowedHttpException(['Tweet']);
         }

--- a/plugins/MauticTagManagerBundle/Controller/TagController.php
+++ b/plugins/MauticTagManagerBundle/Controller/TagController.php
@@ -175,7 +175,7 @@ final class TagController extends FormController
         $action    = $this->generateUrl('mautic_tagmanager_action', ['objectAction' => 'new']);
 
         // get the user form factory
-        $form = $this->tagManagerModel->createForm($tag, $this->formFactory, $action);
+        $form = $this->tagManagerModel->createForm($tag, $action);
 
         $response = $this->handleNewActionPost($request, $tagDependencies, $tag, $form, $returnUrl, $page);
         if (null === $response) {
@@ -296,7 +296,7 @@ final class TagController extends FormController
     private function createTagModifyResponse(Request $request, Tag $tag, TagDependencies $tagDependencies, array $postActionVars, string $action, bool $ignorePost): Response
     {
         /** @var FormInterface<FormInterface<Tag>> $form */
-        $form = $this->tagManagerModel->createForm($tag, $this->formFactory, $action);
+        $form = $this->tagManagerModel->createForm($tag, $action);
 
         // /Check for a submitted form and process it
         if (!$ignorePost && 'POST' === $request->getMethod()) {
@@ -368,7 +368,7 @@ final class TagController extends FormController
                     // Re-create the form once more with the fresh tag and action.
                     // The alias was empty on redirect after cloning.
                     $editAction = $this->generateUrl('mautic_tagmanager_action', ['objectAction' => 'edit', 'objectId' => $tag->getId()]);
-                    $form       = $this->tagManagerModel->createForm($tag, $this->formFactory, $editAction);
+                    $form       = $this->tagManagerModel->createForm($tag, $editAction);
 
                     $postActionVars['viewParameters'] = [
                         'objectAction' => 'edit',

--- a/plugins/MauticTagManagerBundle/Model/TagModel.php
+++ b/plugins/MauticTagManagerBundle/Model/TagModel.php
@@ -7,7 +7,6 @@ use Mautic\LeadBundle\Model\TagModel as BaseTagModel;
 use MauticPlugin\MauticTagManagerBundle\Entity\Tag;
 use MauticPlugin\MauticTagManagerBundle\Entity\TagRepository;
 use MauticPlugin\MauticTagManagerBundle\Form\Type\TagEntityType;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Contracts\Service\Attribute\Required;
@@ -33,7 +32,7 @@ final class TagModel extends BaseTagModel implements GlobalSearchInterface
      * @param string|null $action
      * @param array       $options
      */
-    public function createForm($entity, FormFactoryInterface $formFactory, $action = null, $options = []): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
         if (!$entity instanceof \Mautic\LeadBundle\Entity\Tag) {
             throw new MethodNotAllowedHttpException(['Tag']);
@@ -43,6 +42,6 @@ final class TagModel extends BaseTagModel implements GlobalSearchInterface
             $options['action'] = $action;
         }
 
-        return $formFactory->create(TagEntityType::class, $entity, $options);
+        return $this->formFactory->create(TagEntityType::class, $entity, $options);
     }
 }

--- a/plugins/MauticTagManagerBundle/Model/TagModel.php
+++ b/plugins/MauticTagManagerBundle/Model/TagModel.php
@@ -28,12 +28,12 @@ final class TagModel extends BaseTagModel implements GlobalSearchInterface
     }
 
     /**
-     * @param Tag $entity
+     * @param Tag         $entity
+     * @param string|null $action
+     * @param array       $options
      */
-    public function createForm($entity, mixed ...$args): FormInterface
+    public function createForm($entity, $action = null, $options = []): FormInterface
     {
-        [$action, $options] = $this->resolveCreateFormArgs($args);
-
         if (!$entity instanceof \Mautic\LeadBundle\Entity\Tag) {
             throw new MethodNotAllowedHttpException(['Tag']);
         }

--- a/plugins/MauticTagManagerBundle/Model/TagModel.php
+++ b/plugins/MauticTagManagerBundle/Model/TagModel.php
@@ -28,12 +28,12 @@ final class TagModel extends BaseTagModel implements GlobalSearchInterface
     }
 
     /**
-     * @param Tag         $entity
-     * @param string|null $action
-     * @param array       $options
+     * @param Tag $entity
      */
-    public function createForm($entity, $action = null, $options = []): FormInterface
+    public function createForm($entity, mixed ...$args): FormInterface
     {
+        [$action, $options] = $this->resolveCreateFormArgs($args);
+
         if (!$entity instanceof \Mautic\LeadBundle\Entity\Tag) {
             throw new MethodNotAllowedHttpException(['Tag']);
         }


### PR DESCRIPTION
Every `*Model::createForm()` takes the form factory as a method parameter, so every caller has to inject `FormFactoryInterface` only to hand it over. `FormModel` already gets autowired services through `autowireFormModel()` — the form factory belongs there too.

### Before

```php
// Mautic\ReportBundle\Model\ReportModel
public function createForm($entity, FormFactoryInterface $formFactory, $action = null, $options = []): FormInterface
{
    return $formFactory->create(ReportType::class, $entity, $options);
}
```

```php
// caller has to carry the service around
public function editAction(Request $request, FormFactoryInterface $formFactory, $objectId)
{
    $form = $this->reportModel->createForm($entity, $formFactory, $action);
}
```

### After

```php
// Mautic\CoreBundle\Model\FormModel
protected FormFactoryInterface $formFactory;

public function autowireFormModel(
    FormFactoryInterface $formFactory,
): void {
    $this->formFactory = $formFactory;
}
```

```php
// Mautic\ReportBundle\Model\ReportModel
public function createForm($entity, $action = null, $options = []): FormInterface
{
    return $this->formFactory->create(ReportType::class, $entity, $options);
}
```

```php
public function editAction(Request $request, $objectId)
{
    $form = $this->reportModel->createForm($entity, $action);
}
```

Controllers that only needed the factory to build a form directly now use the `createForm()`/`createFormBuilder()` helpers already available on the controller base class.

Split out of #16968 so that PR stays focused on the PHPStan rule itself.
