### PR TITLE
[phpstan] Add rule requiring #[\Attribute] on Symfony Constraint classes

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -260,6 +260,7 @@ rules:
 	- Utils\PHPStan\Rule\NoGetModelWithStringInControllerRule
 	- Utils\PHPStan\Rule\NoRequiredMethodWithConstructorInControllerRule
 	- Utils\PHPStan\Rule\CommandMustHaveAsCommandAttributeRule
+	- Utils\PHPStan\Rule\ConstraintMustHaveAttributeRule
 	- Utils\PHPStan\Rule\NoNullableServiceInConstructorRule
 	- Utils\PHPStan\Rule\NoGetRepositoryWithEntityInRepositoryRule
 	- Utils\PHPStan\Rule\NoContainerGetRule

--- a/utils/phpstan/src/Rule/ConstraintMustHaveAttributeRule.php
+++ b/utils/phpstan/src/Rule/ConstraintMustHaveAttributeRule.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Rule;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Every class that extends Symfony Constraint must declare the #[\Attribute] attribute,
+ * so it can be used as a PHP attribute on entity properties.
+ *
+ * @implements Rule<Class_>
+ */
+final class ConstraintMustHaveAttributeRule implements Rule
+{
+    public function __construct(
+        private readonly ReflectionProvider $reflectionProvider,
+    ) {
+    }
+
+    public function getNodeType(): string
+    {
+        return Class_::class;
+    }
+
+    /**
+     * @param Class_ $node
+     *
+     * @return list<\PHPStan\Rules\IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        // an anonymous class carries no name to report, and cannot be used as an attribute
+        if (!$node->name instanceof Node\Identifier) {
+            return [];
+        }
+
+        // abstract base constraints are never used directly
+        if ($node->isAbstract()) {
+            return [];
+        }
+
+        $className = (string) $node->namespacedName;
+        if (!$this->reflectionProvider->hasClass($className)) {
+            return [];
+        }
+
+        if (!$this->reflectionProvider->getClass($className)->is(Constraint::class)) {
+            return [];
+        }
+
+        foreach ($node->attrGroups as $attrGroup) {
+            foreach ($attrGroup->attrs as $attr) {
+                if (\Attribute::class === $attr->name->toString()) {
+                    return [];
+                }
+            }
+        }
+
+        $ruleError = RuleErrorBuilder::message(sprintf(
+            'Class "%s" extends Constraint but is missing the #[\Attribute] attribute. Add it, so the constraint can be used as an attribute on properties, as Symfony convention.',
+            $className
+        ))
+            ->identifier('mautic.constraintAttribute')
+            ->build();
+
+        return [$ruleError];
+    }
+}

--- a/utils/phpstan/tests/Rule/ConstraintMustHaveAttributeRuleTest.php
+++ b/utils/phpstan/tests/Rule/ConstraintMustHaveAttributeRuleTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use Utils\PHPStan\Rule\ConstraintMustHaveAttributeRule;
+
+/**
+ * @extends RuleTestCase<ConstraintMustHaveAttributeRule>
+ */
+final class ConstraintMustHaveAttributeRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new ConstraintMustHaveAttributeRule($this->createReflectionProvider());
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/ConstraintMissingAttribute.php'], [
+            [
+                'Class "Utils\PHPStan\Tests\Rule\Fixture\ConstraintMissingAttribute" extends Constraint but is missing the #[\Attribute] attribute. Add it, so the constraint can be used as an attribute on properties, as Symfony convention.',
+                9,
+            ],
+        ]);
+    }
+
+    public function testSkipConstraintWithAttribute(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/ConstraintWithAttribute.php'], []);
+    }
+
+    public function testSkipAbstractBaseConstraint(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/AbstractBaseConstraint.php'], []);
+    }
+
+    public function testSkipConstraintValidator(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/ConstraintValidatorWithoutAttribute.php'], []);
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/AbstractBaseConstraint.php
+++ b/utils/phpstan/tests/Rule/Fixture/AbstractBaseConstraint.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+use Symfony\Component\Validator\Constraint;
+
+abstract class AbstractBaseConstraint extends Constraint
+{
+}

--- a/utils/phpstan/tests/Rule/Fixture/ConstraintMissingAttribute.php
+++ b/utils/phpstan/tests/Rule/Fixture/ConstraintMissingAttribute.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+use Symfony\Component\Validator\Constraint;
+
+final class ConstraintMissingAttribute extends Constraint
+{
+}

--- a/utils/phpstan/tests/Rule/Fixture/ConstraintValidatorWithoutAttribute.php
+++ b/utils/phpstan/tests/Rule/Fixture/ConstraintValidatorWithoutAttribute.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+final class ConstraintValidatorWithoutAttribute extends ConstraintValidator
+{
+    public function validate($value, Constraint $constraint): void
+    {
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/ConstraintWithAttribute.php
+++ b/utils/phpstan/tests/Rule/Fixture/ConstraintWithAttribute.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+use Symfony\Component\Validator\Constraint;
+
+#[\Attribute]
+final class ConstraintWithAttribute extends Constraint
+{
+}


### PR DESCRIPTION
Adds a PHPStan rule that reports every class extending `Symfony\Component\Validator\Constraint` that is missing the `#[\Attribute]` marker.

Without the marker a constraint cannot be used as a PHP attribute on a property, so validation has to stay in `loadValidatorMetadata()`.

Abstract constraints, anonymous classes and `ConstraintValidator` classes are skipped.

## What the rule reports

```php
// reported
final class SafeRemoteUrl extends Constraint
{
}
```

```php
// passes
#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
final class SafeRemoteUrl extends Constraint
{
}
```

Error message:

```
Class "Mautic\CoreBundle\Validator\SafeRemoteUrl" extends Constraint but is missing the #[\Attribute] attribute.
Add it, so the constraint can be used as an attribute on properties, as Symfony convention.
```

## Order

Split off from #16966. Draft on purpose: the rule reports the 37 existing Mautic constraints until #16974 (the constraint conversion) is merged. Once that lands, this one goes green.
