### PR TITLE
[NOT-FOR-MERGE] Preserve selected campaign email after inline editing -- Port M5

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/6.forms.js
+++ b/app/bundles/CoreBundle/Assets/js/6.forms.js
@@ -514,7 +514,7 @@ Mautic.updateEntitySelect = function (response) {
         }
 
         newOption.prop('selected', true);
-        mQueryParent(el).trigger("chosen:updated");
+        mQueryParent(el).val(response.id).trigger("chosen:updated").trigger("change");
     }
 
     if (window.opener) {


### PR DESCRIPTION
⚠️ This PR is provided for use as a patch and is not intended for merging into this Mautic release, as that release is no longer maintained.

This is a port of fix https://github.com/mautic/mautic/pull/16972 for M5