### PR TITLE
[di] Autowire translator into CommonRepository instead of passing it around

### DIFF
--- a/app/bundles/AssetBundle/Tests/Entity/AssetRepositoryTest.php
+++ b/app/bundles/AssetBundle/Tests/Entity/AssetRepositoryTest.php
@@ -27,7 +27,7 @@ final class AssetRepositoryTest extends TestCase
             'mautic.asset.asset.searchcommand.ispending' => 'is:pending',
             default                                      => $id,
         });
-        $repository->setTranslator($translator);
+        $repository->autowireCommonRepository($translator);
 
         return $repository;
     }

--- a/app/bundles/CampaignBundle/Controller/CampaignController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignController.php
@@ -239,8 +239,6 @@ class CampaignController extends AbstractStandardFormController
         $objectIds      = json_decode($ids, true);
 
         if (empty($ids)) {
-            $this->campaignRepository->setTranslator($this->translator);
-
             $args = [
                 'filter'           => $filter,
                 'orderBy'          => 'c.id',

--- a/app/bundles/CampaignBundle/Tests/Entity/CampaignRepositoryTest.php
+++ b/app/bundles/CampaignBundle/Tests/Entity/CampaignRepositoryTest.php
@@ -31,7 +31,8 @@ final class CampaignRepositoryTest extends TestCase
             'mautic.campaign.campaign.searchcommand.ispending' => 'is:pending',
             default                                            => $id,
         });
-        $this->repository->setTranslator($translator);
+
+        $this->repository->autowireCommonRepository($translator);
     }
 
     public function testAddSearchCommandWhereClauseHandlesExpirationFilters(): void

--- a/app/bundles/CoreBundle/Entity/CommonRepository.php
+++ b/app/bundles/CoreBundle/Entity/CommonRepository.php
@@ -54,7 +54,7 @@ class CommonRepository extends ServiceEntityRepository
      */
     protected $currentUser;
 
-    protected ?TranslatorInterface $translator = null;
+    protected TranslatorInterface $translator;
 
     /**
      * This eliminates chance for parameter name collision.

--- a/app/bundles/CoreBundle/Entity/CommonRepository.php
+++ b/app/bundles/CoreBundle/Entity/CommonRepository.php
@@ -1729,8 +1729,8 @@ class CommonRepository extends ServiceEntityRepository
                 }
             } elseif ($this->translator->trans($c) == $command || $this->translator->trans($c, [], null, 'en_US') == $command) {
                 return true;
-            } elseif ($this->translator->trans($c) == "{$command}:{$subcommand}"
-                || $this->translator->trans($c, [], null, 'en_US') == "{$command}:{$subcommand}"
+            } elseif ($this->translator->trans($c) === "{$command}:{$subcommand}"
+                || $this->translator->trans($c, [], null, 'en_US') === "{$command}:{$subcommand}"
             ) {
                 $command    = "{$command}:{$subcommand}";
                 $subcommand = '';

--- a/app/bundles/CoreBundle/Entity/CommonRepository.php
+++ b/app/bundles/CoreBundle/Entity/CommonRepository.php
@@ -24,6 +24,7 @@ use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\CoreBundle\Helper\SearchStringHelper;
 use Mautic\UserBundle\Entity\User;
+use Symfony\Contracts\Service\Attribute\Required;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -53,10 +54,7 @@ class CommonRepository extends ServiceEntityRepository
      */
     protected $currentUser;
 
-    /**
-     * @var TranslatorInterface
-     */
-    protected $translator;
+    protected ?TranslatorInterface $translator = null;
 
     /**
      * This eliminates chance for parameter name collision.
@@ -930,8 +928,10 @@ class CommonRepository extends ServiceEntityRepository
         $this->currentUser = $user;
     }
 
-    public function setTranslator(TranslatorInterface $translator): void
-    {
+    #[Required]
+    public function autowireCommonRepository(
+        TranslatorInterface $translator,
+    ): void {
         $this->translator = $translator;
     }
 

--- a/app/bundles/CoreBundle/Helper/AbstractFormFieldHelper.php
+++ b/app/bundles/CoreBundle/Helper/AbstractFormFieldHelper.php
@@ -37,10 +37,7 @@ abstract class AbstractFormFieldHelper
      */
     protected $translationKeyPrefix;
 
-    /**
-     * @var Translator
-     */
-    protected $translator;
+    protected ?Translator $translator = null;
 
     /**
      * @return mixed

--- a/app/bundles/CoreBundle/Helper/AbstractFormFieldHelper.php
+++ b/app/bundles/CoreBundle/Helper/AbstractFormFieldHelper.php
@@ -56,7 +56,9 @@ abstract class AbstractFormFieldHelper
     }
 
     #[Required]
-    public function autowireFormFieldHelper(Translator $translator): void
+    public function autowireFormFieldHelper(
+        Translator $translator
+    ): void
     {
         $this->translator = $translator;
     }

--- a/app/bundles/CoreBundle/Helper/AbstractFormFieldHelper.php
+++ b/app/bundles/CoreBundle/Helper/AbstractFormFieldHelper.php
@@ -9,6 +9,7 @@ use Mautic\CoreBundle\Helper\ListParser\JsonListParser;
 use Mautic\CoreBundle\Helper\ListParser\ListParserInterface;
 use Mautic\CoreBundle\Helper\ListParser\ValueListParser;
 use Mautic\CoreBundle\Translation\Translator;
+use Symfony\Contracts\Service\Attribute\Required;
 
 abstract class AbstractFormFieldHelper
 {
@@ -37,7 +38,7 @@ abstract class AbstractFormFieldHelper
      */
     protected $translationKeyPrefix;
 
-    protected ?Translator $translator = null;
+    protected Translator $translator;
 
     /**
      * @return mixed
@@ -54,7 +55,8 @@ abstract class AbstractFormFieldHelper
         $this->setTranslationKeyPrefix();
     }
 
-    public function setTranslator(Translator $translator): void
+    #[Required]
+    public function autowireFormFieldHelper(Translator $translator): void
     {
         $this->translator = $translator;
     }

--- a/app/bundles/CoreBundle/Helper/AbstractFormFieldHelper.php
+++ b/app/bundles/CoreBundle/Helper/AbstractFormFieldHelper.php
@@ -55,6 +55,14 @@ abstract class AbstractFormFieldHelper
         $this->setTranslationKeyPrefix();
     }
 
+    /**
+     * @deprecated since Mautic 7.2. Translator is now autowired by Symfony container, no need to pass it manually.
+     */
+    public function setTranslator(Translator $translator): void
+    {
+        $this->translator = $translator;
+    }
+
     #[Required]
     public function autowireFormFieldHelper(
         Translator $translator,

--- a/app/bundles/CoreBundle/Helper/AbstractFormFieldHelper.php
+++ b/app/bundles/CoreBundle/Helper/AbstractFormFieldHelper.php
@@ -57,9 +57,8 @@ abstract class AbstractFormFieldHelper
 
     #[Required]
     public function autowireFormFieldHelper(
-        Translator $translator
-    ): void
-    {
+        Translator $translator,
+    ): void {
         $this->translator = $translator;
     }
 

--- a/app/bundles/CoreBundle/Model/AbstractCommonModel.php
+++ b/app/bundles/CoreBundle/Model/AbstractCommonModel.php
@@ -94,12 +94,11 @@ abstract class AbstractCommonModel implements MauticModelInterface
     public function getEntities(array $args = [])
     {
         // set the translator
-        $repo = $this->getRepository();
+        $repository = $this->getRepository();
 
-        $repo->setTranslator($this->translator);
-        $repo->setCurrentUser($this->userHelper->getUser());
+        $repository->setCurrentUser($this->userHelper->getUser());
 
-        return $repo->getEntities($args);
+        return $repository->getEntities($args);
     }
 
     /**

--- a/app/bundles/DynamicContentBundle/Model/DynamicContentModel.php
+++ b/app/bundles/DynamicContentBundle/Model/DynamicContentModel.php
@@ -57,7 +57,6 @@ class DynamicContentModel extends FormModel implements AjaxLookupModelInterface,
 
     public function getRepository(): DynamicContentRepository
     {
-        $this->dynamicContentRepository->setTranslator($this->translator);
         $this->dynamicContentRepository->setCurrentUser($this->userHelper->getUser());
 
         return $this->dynamicContentRepository;

--- a/app/bundles/EmailBundle/Tests/Entity/EmailRepositoryTest.php
+++ b/app/bundles/EmailBundle/Tests/Entity/EmailRepositoryTest.php
@@ -33,7 +33,7 @@ final class EmailRepositoryTest extends TestCase
             'mautic.email.email.searchcommand.ispending' => 'is:pending',
             default                                      => $id,
         });
-        $this->repo->setTranslator($translator);
+        $this->repo->autowireCommonRepository($translator);
     }
 
     /**

--- a/app/bundles/LeadBundle/Controller/AjaxController.php
+++ b/app/bundles/LeadBundle/Controller/AjaxController.php
@@ -55,6 +55,8 @@ final class AjaxController extends CommonAjaxController
 
     private DoNotContactRepository $doNotContactRepository;
 
+    private FormFieldHelper $formFieldHelper;
+
     #[Required]
     public function autowireLeadAjaxController(
         LeadRepository $leadRepository,
@@ -62,12 +64,14 @@ final class AjaxController extends CommonAjaxController
         LeadFieldRepository $leadFieldRepository,
         LeadModel $leadModel,
         DoNotContactRepository $doNotContactRepository,
+        FormFieldHelper $formFieldHelper,
     ): void {
         $this->leadModel = $leadModel;
         $this->doNotContactRepository = $doNotContactRepository;
         $this->leadRepository = $leadRepository;
         $this->emailRepository = $emailRepository;
         $this->leadFieldRepository = $leadFieldRepository;
+        $this->formFieldHelper = $formFieldHelper;
     }
 
     public function userListAction(Request $request): JsonResponse
@@ -706,9 +710,7 @@ final class AjaxController extends CommonAjaxController
                     case 'date':
                     case 'datetime':
                         if ('date' == $operator) {
-                            $fieldHelper = new FormFieldHelper();
-                            $fieldHelper->setTranslator($this->translator);
-                            $options = $fieldHelper->getDateChoices();
+                            $options = $this->formFieldHelper->getDateChoices();
                             $options = array_merge(
                                 [
                                     'custom' => $this->translator->trans('mautic.campaign.event.timed.choice.custom'),

--- a/app/bundles/LeadBundle/Form/Type/CampaignEventLeadFieldValueType.php
+++ b/app/bundles/LeadBundle/Form/Type/CampaignEventLeadFieldValueType.php
@@ -26,6 +26,7 @@ final class CampaignEventLeadFieldValueType extends AbstractType
         private readonly Translator $translator,
         private readonly LeadModel $leadModel,
         private readonly LeadFieldRepository $leadFieldRepository,
+        private readonly FormFieldHelper $formFieldHelper,
     ) {
     }
 
@@ -100,9 +101,7 @@ final class CampaignEventLeadFieldValueType extends AbstractType
                             case 'date':
                             case 'datetime':
                                 if ('date' === $operator) {
-                                    $fieldHelper = new FormFieldHelper();
-                                    $fieldHelper->setTranslator($this->translator);
-                                    $fieldValues = $fieldHelper->getDateChoices();
+                                    $fieldValues = $this->formFieldHelper->getDateChoices();
                                     $customText  = $this->translator->trans('mautic.campaign.event.timed.choice.custom');
                                     $customValue = (empty($data['value']) || isset($fieldValues[$data['value']])) ? 'custom' : $data['value'];
                                     $fieldValues = array_merge(

--- a/app/bundles/LeadBundle/Form/Type/FieldType.php
+++ b/app/bundles/LeadBundle/Form/Type/FieldType.php
@@ -51,6 +51,7 @@ final class FieldType extends AbstractType
         private readonly Translator $translator,
         private readonly IdentifierFields $identifierFields,
         private readonly IndexHelper $indexHelper,
+        private readonly FormFieldHelper $formFieldHelper,
     ) {
     }
 
@@ -98,14 +99,12 @@ final class FieldType extends AbstractType
         $type        = $options['data']->getType();
         $isIndex     = $options['data']->isIsIndex();
         $default     = (empty($type)) ? 'text' : $type;
-        $fieldHelper = new FormFieldHelper();
-        $fieldHelper->setTranslator($this->translator);
 
         $builder->add(
             'type',
             ChoiceType::class,
             [
-                'choices'     => $fieldHelper->getChoiceList(),
+                'choices'     => $this->formFieldHelper->getChoiceList(),
                 'expanded'    => false,
                 'multiple'    => false,
                 'label'       => 'mautic.lead.field.type',

--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -94,7 +94,6 @@ class ListModel extends FormModel implements GlobalSearchInterface
     public function getRepository(): LeadListRepository
     {
         $this->leadListRepository->setDispatcher($this->dispatcher);
-        $this->leadListRepository->setTranslator($this->translator);
 
         return $this->leadListRepository;
     }

--- a/app/bundles/PageBundle/Tests/Entity/PageRepositoryTest.php
+++ b/app/bundles/PageBundle/Tests/Entity/PageRepositoryTest.php
@@ -27,7 +27,7 @@ final class PageRepositoryTest extends TestCase
             'mautic.page.searchcommand.ispending' => 'is:pending',
             default                               => $id,
         });
-        $repository->setTranslator($translator);
+        $repository->autowireCommonRepository($translator);
 
         return $repository;
     }

--- a/plugins/GrapesJsBuilderBundle/Model/GrapesJsBuilderModel.php
+++ b/plugins/GrapesJsBuilderBundle/Model/GrapesJsBuilderModel.php
@@ -43,8 +43,6 @@ class GrapesJsBuilderModel extends AbstractCommonModel
 
     public function getRepository(): GrapesJsBuilderRepository
     {
-        $this->grapesJsBuilderRepository->setTranslator($this->translator);
-
         return $this->grapesJsBuilderRepository;
     }
 

--- a/plugins/GrapesJsBuilderBundle/Tests/Functional/Controller/AssertCustomMjmlTest.php
+++ b/plugins/GrapesJsBuilderBundle/Tests/Functional/Controller/AssertCustomMjmlTest.php
@@ -66,7 +66,7 @@ final class AssertCustomMjmlTest extends MauticMysqlTestCase
         /** @var GrapesJsBuilderRepository $repository */
         $repository = $this->em->getRepository(GrapesJsBuilder::class);
 
-        $repository->setTranslator($this->getTranslatorMock());
+        $repository->autowireCommonRepository($this->getTranslatorMock());
 
         return $repository;
     }


### PR DESCRIPTION
The translator is a service. Repositories can have it autowired directly, instead of every model and controller pushing it in manually before use.

`CommonRepository::setTranslator()` becomes a `#[Required]` autowire method, so Symfony injects the translator when the repository is created:

```diff
-    public function setTranslator(TranslatorInterface $translator): void
-    {
+    #[Required]
+    public function autowireCommonRepository(
+        TranslatorInterface $translator,
+    ): void {
         $this->translator = $translator;
     }
```

All the manual push-in calls then go away:

```diff
 public function getRepository(): DynamicContentRepository
 {
-    $this->dynamicContentRepository->setTranslator($this->translator);
     $this->dynamicContentRepository->setCurrentUser($this->userHelper->getUser());

     return $this->dynamicContentRepository;
 }
```

Same in `AbstractCommonModel::getEntities()`, `ListModel`, `CampaignController` and `GrapesJsBuilderModel`.

Unit tests that build a repository by hand call the new method instead:

```diff
-$repository->setTranslator($translator);
+$repository->autowireCommonRepository($translator);
```

No behaviour change – the translator lands on the repository either way.
