### PR TITLE
[di] Inject UserPasswordHasherInterface into UserModel instead of passing it to methods

### DIFF
--- a/app/bundles/UserBundle/Controller/Api/UserApiController.php
+++ b/app/bundles/UserBundle/Controller/Api/UserApiController.php
@@ -19,7 +19,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
@@ -40,7 +39,6 @@ final class UserApiController extends CommonApiController
         RouterInterface $router,
         FormFactoryInterface $formFactory,
         AppVersion $appVersion,
-        private readonly UserPasswordHasherInterface $hasher,
         RequestStack $requestStack,
         ManagerRegistry $doctrine,
         ModelFactory $modelFactory,
@@ -86,7 +84,7 @@ final class UserApiController extends CommonApiController
 
         if (isset($parameters['plainPassword']['password'])) {
             $submittedPassword = $parameters['plainPassword']['password'];
-            $entity->setPassword($this->model->checkNewPassword($entity, $this->hasher, $submittedPassword));
+            $entity->setPassword($this->model->checkNewPassword($entity, $submittedPassword));
         }
 
         return $this->processForm($request, $entity, $parameters, 'POST');
@@ -121,7 +119,7 @@ final class UserApiController extends CommonApiController
             $entity = $this->model->getEntity();
             if (isset($parameters['plainPassword']['password'])) {
                 $submittedPassword = $parameters['plainPassword']['password'];
-                $entity->setPassword($this->model->checkNewPassword($entity, $this->hasher, $submittedPassword));
+                $entity->setPassword($this->model->checkNewPassword($entity, $submittedPassword));
             }
         } else {
             // Changing passwords via API is forbidden
@@ -162,7 +160,7 @@ final class UserApiController extends CommonApiController
                     $submittedPassword = $parameters['plainPassword'];
                 }
             }
-            $entity->setPassword($this->model->checkNewPassword($entity, $this->hasher, $submittedPassword, true));
+            $entity->setPassword($this->model->checkNewPassword($entity, $submittedPassword, true));
         }
     }
 

--- a/app/bundles/UserBundle/Controller/ProfileController.php
+++ b/app/bundles/UserBundle/Controller/ProfileController.php
@@ -13,7 +13,6 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Contracts\Service\Attribute\Required;
 
@@ -31,7 +30,7 @@ final class ProfileController extends FormController
     /**
      * Generate's account profile.
      */
-    public function indexAction(Request $request, LanguageHelper $languageHelper, UserPasswordHasherInterface $hasher,
+    public function indexAction(Request $request, LanguageHelper $languageHelper,
         TokenStorageInterface $tokenStorage, SAMLHelper $samlHelper): Response|RedirectResponse
     {
         // get current user
@@ -160,7 +159,7 @@ final class ProfileController extends FormController
             // check to see if the password needs to be rehashed
             $formUser              = $request->request->all()['user'] ?? [];
             $submittedPassword     = $formUser['plainPassword']['password'] ?? null;
-            $overrides['password'] = $this->userModel->checkNewPassword($me, $hasher, $submittedPassword);
+            $overrides['password'] = $this->userModel->checkNewPassword($me, $submittedPassword);
             if (!$cancelled = $this->isFormCancelled($form)) {
                 if ($this->isFormValid($form)) {
                     foreach ($overrides as $k => $v) {

--- a/app/bundles/UserBundle/Controller/PublicController.php
+++ b/app/bundles/UserBundle/Controller/PublicController.php
@@ -14,7 +14,6 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Contracts\Service\Attribute\Required;
 
 final class PublicController extends FormController
@@ -87,7 +86,7 @@ final class PublicController extends FormController
         ]);
     }
 
-    public function passwordResetConfirmAction(Request $request, UserPasswordHasherInterface $hasher): RedirectResponse|Response
+    public function passwordResetConfirmAction(Request $request): RedirectResponse|Response
     {
         $action   = $this->generateUrl('mautic_user_passwordresetconfirm');
         $form     = $this->formFactory->create(PasswordResetConfirmType::class, [], ['action' => $action]);
@@ -102,7 +101,7 @@ final class PublicController extends FormController
         if ('POST' === $request->getMethod()) {
             if ($isValid = $this->isFormValid($form)) {
                 $data     = $form->getData();
-                $response = $this->handlePasswordResetConfirm($request, $hasher, $data);
+                $response = $this->handlePasswordResetConfirm($request, $data);
             }
         }
 
@@ -112,7 +111,7 @@ final class PublicController extends FormController
     /**
      * @param array<string, mixed> $data
      */
-    private function handlePasswordResetConfirm(Request $request, UserPasswordHasherInterface $hasher, array $data): ?Response
+    private function handlePasswordResetConfirm(Request $request, array $data): ?Response
     {
         $response = null;
         $user     = $this->userRepository->findByIdentifier($data['identifier']);
@@ -126,7 +125,7 @@ final class PublicController extends FormController
 
             $response = $this->redirectToRoute('mautic_user_passwordresetconfirm');
         } elseif ($this->userModel->confirmResetToken($user, $request->getSession()->get('resetToken'))) {
-            $encodedPassword = $this->userModel->checkNewPassword($user, $hasher, $data['plainPassword']);
+            $encodedPassword = $this->userModel->checkNewPassword($user, $data['plainPassword']);
             $user->setPassword($encodedPassword);
             $this->userModel->saveEntity($user);
 
@@ -152,7 +151,7 @@ final class PublicController extends FormController
         ]);
     }
 
-    public function inviteAction(Request $request, UserPasswordHasherInterface $hasher, UserModel $model, LoggerInterface $logger): RedirectResponse|Response
+    public function inviteAction(Request $request, UserModel $model, LoggerInterface $logger): RedirectResponse|Response
     {
         $token    = $request->attributes->getString('token');
         $invite   = $model->getInvite($token);
@@ -189,7 +188,7 @@ final class PublicController extends FormController
                         $formUser          = $request->request->all()['user_invite_registration'] ?? [];
                         $submittedPassword = $formUser['plainPassword']['password'] ?? null;
 
-                        $user->setPassword($model->checkNewPassword($user, $hasher, $submittedPassword));
+                        $user->setPassword($model->checkNewPassword($user, $submittedPassword));
                         $model->markInviteUsed($invite);
                         $model->saveEntity($user);
                         $this->addFlashMessage('mautic.user.invite.account_created', [], 'notice', 'flashes');

--- a/app/bundles/UserBundle/Controller/UserController.php
+++ b/app/bundles/UserBundle/Controller/UserController.php
@@ -26,7 +26,6 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Contracts\Service\Attribute\Required;
 
 final class UserController extends FormController
@@ -202,7 +201,7 @@ final class UserController extends FormController
         ]);
     }
 
-    public function newAction(Request $request, LanguageHelper $languageHelper, UserPasswordHasherInterface $hasher, SAMLHelper $samlHelper): JsonResponse|Response
+    public function newAction(Request $request, LanguageHelper $languageHelper, SAMLHelper $samlHelper): JsonResponse|Response
     {
         if (!$this->security->isGranted('user:users:create')) {
             $this->throwAccessDenied();
@@ -218,20 +217,20 @@ final class UserController extends FormController
 
         // Check for a submitted form and process it
         if ('POST' === $request->getMethod()) {
-            $response = $this->handleNewUserPost($request, $languageHelper, $hasher, $samlHelper, $user, $form);
+            $response = $this->handleNewUserPost($request, $languageHelper, $samlHelper, $user, $form);
         }
 
         return $response ?? $this->renderNewUserForm($form, $action);
     }
 
-    private function handleNewUserPost(Request $request, LanguageHelper $languageHelper, UserPasswordHasherInterface $hasher, SAMLHelper $samlHelper, User $user, FormInterface $form): JsonResponse|Response|null
+    private function handleNewUserPost(Request $request, LanguageHelper $languageHelper, SAMLHelper $samlHelper, User $user, FormInterface $form): JsonResponse|Response|null
     {
         $response  = null;
         $cancelled = $this->isFormCancelled($form);
         $valid     = false;
 
         if (!$cancelled) {
-            $valid = $this->saveNewUserIfValid($request, $languageHelper, $hasher, $user, $form);
+            $valid = $this->saveNewUserIfValid($request, $languageHelper, $user, $form);
         }
 
         if ($cancelled || ($valid && $this->getFormButton($form, ['buttons', 'save'])->isClicked())) {
@@ -245,17 +244,17 @@ final class UserController extends FormController
                 ],
             ]);
         } elseif ($valid) {
-            $response = $this->editAction($request, $languageHelper, $hasher, $samlHelper, $user->getId(), true);
+            $response = $this->editAction($request, $languageHelper, $samlHelper, $user->getId(), true);
         }
 
         return $response;
     }
 
-    private function saveNewUserIfValid(Request $request, LanguageHelper $languageHelper, UserPasswordHasherInterface $hasher, User $user, FormInterface $form): bool
+    private function saveNewUserIfValid(Request $request, LanguageHelper $languageHelper, User $user, FormInterface $form): bool
     {
         $formUser          = $request->request->all()['user'] ?? [];
         $submittedPassword = $formUser['plainPassword']['password'] ?? null;
-        $password          = $this->userModel->checkNewPassword($user, $hasher, $submittedPassword);
+        $password          = $this->userModel->checkNewPassword($user, $submittedPassword);
         $valid             = $this->isFormValid($form);
 
         if ($valid) {
@@ -315,7 +314,7 @@ final class UserController extends FormController
      *
      * @return JsonResponse|Response
      */
-    public function editAction(Request $request, LanguageHelper $languageHelper, UserPasswordHasherInterface $hasher, SAMLHelper $samlHelper, $objectId, $ignorePost = false)
+    public function editAction(Request $request, LanguageHelper $languageHelper, SAMLHelper $samlHelper, $objectId, $ignorePost = false)
     {
         if (!$this->security->isGranted('user:users:edit')) {
             $this->throwAccessDenied();
@@ -377,7 +376,7 @@ final class UserController extends FormController
                 // check to see if the password needs to be rehashed
                 $formUser          = $request->request->all()['user'] ?? [];
                 $submittedPassword = $formUser['plainPassword']['password'] ?? null;
-                $password          = $this->userModel->checkNewPassword($user, $hasher, $submittedPassword);
+                $password          = $this->userModel->checkNewPassword($user, $submittedPassword);
                 $newEmail          = $formUser['email'] ?? null;
 
                 if ($valid = $this->isFormValid($form)) {

--- a/app/bundles/UserBundle/Model/UserModel.php
+++ b/app/bundles/UserBundle/Model/UserModel.php
@@ -59,6 +59,7 @@ class UserModel extends FormModel implements GlobalSearchInterface
         private readonly PermissionRepository $permissionRepository,
         private readonly RoleRepository $roleRepository,
         private readonly UserInviteRepository $userInviteRepository,
+        private UserPasswordHasherInterface $userPasswordHasher,
     ) {
         parent::__construct($em, $security, $dispatcher, $router, $translator, $userHelper, $mauticLogger, $coreParametersHelper);
     }
@@ -106,7 +107,7 @@ class UserModel extends FormModel implements GlobalSearchInterface
      * @param string     $submittedPassword
      * @param bool|false $validate
      */
-    public function checkNewPassword(User $entity, UserPasswordHasherInterface $hasher, $submittedPassword, $validate = false): ?string
+    public function checkNewPassword(User $entity, $submittedPassword, $validate = false): ?string
     {
         if ($validate) {
             if (strlen($submittedPassword) < 6) {
@@ -116,7 +117,7 @@ class UserModel extends FormModel implements GlobalSearchInterface
 
         if (!empty($submittedPassword)) {
             // hash the clear password submitted via the form
-            return $hasher->hashPassword($entity, $submittedPassword);
+            return $this->userPasswordHasher->hashPassword($entity, $submittedPassword);
         }
 
         return $entity->getPassword();
@@ -232,9 +233,9 @@ class UserModel extends FormModel implements GlobalSearchInterface
      *
      * @param string $newPassword
      */
-    public function resetPassword(User $user, UserPasswordHasherInterface $hasher, $newPassword): void
+    public function resetPassword(User $user, $newPassword): void
     {
-        $hashedPassword = $this->checkNewPassword($user, $hasher, $newPassword);
+        $hashedPassword = $this->checkNewPassword($user, $newPassword);
 
         $user->setPassword($hashedPassword);
         $this->saveEntity($user);

--- a/app/bundles/UserBundle/Model/UserModel.php
+++ b/app/bundles/UserBundle/Model/UserModel.php
@@ -59,7 +59,7 @@ class UserModel extends FormModel implements GlobalSearchInterface
         private readonly PermissionRepository $permissionRepository,
         private readonly RoleRepository $roleRepository,
         private readonly UserInviteRepository $userInviteRepository,
-        private UserPasswordHasherInterface $userPasswordHasher,
+        private readonly UserPasswordHasherInterface $userPasswordHasher,
     ) {
         parent::__construct($em, $security, $dispatcher, $router, $translator, $userHelper, $mauticLogger, $coreParametersHelper);
     }

--- a/app/bundles/UserBundle/Security/SAML/User/UserCreator.php
+++ b/app/bundles/UserBundle/Security/SAML/User/UserCreator.php
@@ -9,7 +9,6 @@ use Mautic\CoreBundle\Helper\EncryptionHelper;
 use Mautic\UserBundle\Entity\Role;
 use Mautic\UserBundle\Entity\User;
 use Mautic\UserBundle\Model\UserModel;
-use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 
 final class UserCreator implements UserCreatorInterface
@@ -27,7 +26,6 @@ final class UserCreator implements UserCreatorInterface
         private readonly EntityManagerInterface $entityManager,
         private readonly UserMapper $userMapper,
         private readonly UserModel $userModel,
-        private readonly UserPasswordHasherInterface $hasher,
         $defaultRole,
     ) {
         $this->defaultRole   = (int) $defaultRole;
@@ -43,7 +41,7 @@ final class UserCreator implements UserCreatorInterface
         $defaultRole = $this->entityManager->getReference(Role::class, $this->defaultRole);
 
         $user = $this->userMapper->getUser($response);
-        $user->setPassword($this->userModel->checkNewPassword($user, $this->hasher, EncryptionHelper::generateKey()));
+        $user->setPassword($this->userModel->checkNewPassword($user, EncryptionHelper::generateKey()));
         $user->setRole($defaultRole);
 
         $this->validateUser($user);

--- a/app/bundles/UserBundle/Tests/Model/UserModelTest.php
+++ b/app/bundles/UserBundle/Tests/Model/UserModelTest.php
@@ -28,6 +28,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Routing\Router;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Twig\Environment;
 
@@ -115,6 +116,7 @@ final class UserModelTest extends TestCase
             $this->createStub(PermissionRepository::class),
             $this->createStub(RoleRepository::class),
             $this->userInviteRepository,
+            $this->createStub(UserPasswordHasherInterface::class)
         );
     }
 


### PR DESCRIPTION
`UserModel::checkNewPassword()` and `resetPassword()` took the password hasher as a method parameter, so every caller had to fetch `UserPasswordHasherInterface` from the container just to hand it back to the model.

The hasher is a stateless service – inject it once in the constructor:

```diff
 public function __construct(
     ...
     private readonly UserInviteRepository $userInviteRepository,
+    private UserPasswordHasherInterface $userPasswordHasher,
 ) {
```
