### PR TITLE
[phpstan] add rule to keep services injected, not passed as method parameters

### DIFF
--- a/utils/phpstan/src/Rule/NoServiceInMethodParameterRule.php
+++ b/utils/phpstan/src/Rule/NoServiceInMethodParameterRule.php
@@ -1,0 +1,325 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Rule;
+
+use PhpParser\Node;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * A shared service must be injected, not passed around as a method parameter.
+ *
+ * Passing e.g. a FormFactoryInterface into "createForm($entity, FormFactoryInterface $formFactory)" hides the real
+ * dependency of the class in every call site, and forces each caller to have the service itself. The class that uses
+ * the service should ask for it once - in the constructor, or in an autowire*() method for classes that cannot use a
+ * constructor (controllers).
+ *
+ * Only the injection entry points are allowed to take a service: "__construct()" and "autowire*()"/#[Required] methods.
+ *
+ * @implements Rule<ClassMethod>
+ */
+final class NoServiceInMethodParameterRule implements Rule
+{
+    /**
+     * Services that are always container-provided singletons. Subtypes are matched too, so RouterInterface covers
+     * UrlGeneratorInterface implementations as well. Value objects that Symfony passes by design - Request, Response,
+     * events, form builders, console input/output - are deliberately absent.
+     *
+     * @var string[]
+     */
+    private const SERVICE_TYPES = [
+        'Doctrine\\ORM\\EntityManagerInterface',
+        'Doctrine\\Persistence\\ManagerRegistry',
+        'Psr\\Cache\\CacheItemPoolInterface',
+        'Psr\\Log\\LoggerInterface',
+        'Symfony\\Component\\Filesystem\\Filesystem',
+        'Symfony\\Component\\Form\\FormFactoryInterface',
+        'Symfony\\Component\\HttpFoundation\\RequestStack',
+        'Symfony\\Component\\HttpKernel\\KernelInterface',
+        'Symfony\\Component\\Mailer\\MailerInterface',
+        'Symfony\\Component\\Messenger\\MessageBusInterface',
+        'Symfony\\Component\\PasswordHasher\\Hasher\\UserPasswordHasherInterface',
+        'Symfony\\Component\\Routing\\Generator\\UrlGeneratorInterface',
+        'Symfony\\Component\\Security\\Core\\Authentication\\Token\\Storage\\TokenStorageInterface',
+        'Symfony\\Component\\Security\\Core\\Authorization\\AuthorizationCheckerInterface',
+        'Symfony\\Component\\Security\\Csrf\\CsrfTokenManagerInterface',
+        'Symfony\\Component\\Serializer\\SerializerInterface',
+        'Symfony\\Component\\Validator\\Validator\\ValidatorInterface',
+        'Symfony\\Contracts\\Cache\\CacheInterface',
+        'Symfony\\Contracts\\EventDispatcher\\EventDispatcherInterface',
+        'Symfony\\Contracts\\HttpClient\\HttpClientInterface',
+        'Symfony\\Contracts\\Translation\\TranslatorInterface',
+        'Twig\\Environment',
+    ];
+
+    /**
+     * The container builder is only ever handed to a DI extension or a compiler pass, both of which get it as a
+     * method parameter by Symfony design - there is nothing to inject there. The Mautic translator is a different
+     * kind of translator than the contract one, and is passed around on purpose.
+     *
+     * @var string[]
+     */
+    private const SKIPPED_TYPES = [
+        'Symfony\\Component\\DependencyInjection\\ContainerBuilder',
+        'Mautic\\CoreBundle\\Translation\\Translator',
+    ];
+
+    /**
+     * Methods whose signature is dictated by a shared parent class, so a single child cannot drop the service
+     * parameter on its own.
+     *
+     * @var array<string, string>
+     */
+    private const SKIPPED_PARENT_CLASS_METHODS = ['Mautic\\CoreBundle\\Model\\FormModel' => 'createform'];
+
+    /**
+     * A test case has no container to inject from - it fetches services itself and hands them to its own data
+     * builders and helper methods.
+     *
+     * @var string
+     */
+    private const TEST_CASE_CLASS = 'PHPUnit\\Framework\\TestCase';
+
+    /**
+     * An event or an entity is created by the code that uses it, never by the container, so a service it needs can
+     * only arrive through a method parameter. A Twig extension gets the environment handed to its functions by Twig
+     * itself, and the FOS authorize controller is no real controller either - it is instantiated by the bundle, so
+     * its methods are plain calls.
+     *
+     * @var string[]
+     */
+    private const SKIPPED_CLASS_TYPES = [
+        'Symfony\\Contracts\\EventDispatcher\\Event',
+        'Symfony\\Component\\EventDispatcher\\Event',
+        'Mautic\\CoreBundle\\Entity\\CommonEntity',
+        'Twig\\Extension\\AbstractExtension',
+        'FOS\\OAuthServerBundle\\Controller\\AuthorizeController',
+    ];
+
+    /**
+     * A controller action gets its services from the Symfony argument resolver, which is a container injection of
+     * its own - there is no call site that would have to carry the service.
+     *
+     * @var string
+     */
+    private const CONTROLLER_SUFFIX = 'Controller';
+
+    /**
+     * @var string
+     */
+    private const ACTION_SUFFIX = 'action';
+
+    /**
+     * A create*() method is a factory: it builds the object for its caller, so the service it builds with belongs to
+     * the caller, not to the factory.
+     *
+     * @var string
+     */
+    private const CREATE_PREFIX = 'create';
+
+    /**
+     * @var string
+     */
+    private const AUTOWIRE_PREFIX = 'autowire';
+
+    /**
+     * @var string
+     */
+    private const REQUIRED_ATTRIBUTE = 'Symfony\\Contracts\\Service\\Attribute\\Required';
+
+    public function __construct(
+        private readonly ReflectionProvider $reflectionProvider,
+    ) {
+    }
+
+    public function getNodeType(): string
+    {
+        return ClassMethod::class;
+    }
+
+    /**
+     * @param ClassMethod $node
+     *
+     * @return list<\PHPStan\Rules\IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if ($this->isInjectionMethod($node)) {
+            return [];
+        }
+
+        if ($this->isInheritedParentClassMethod($node, $scope)) {
+            return [];
+        }
+
+        // a trait method is reported once per class using it, and the trait has no constructor of its own to inject in
+        if ($scope->isInTrait()) {
+            return [];
+        }
+
+        if ($this->isInTestCase($scope)) {
+            return [];
+        }
+
+        if ($this->isInSkippedClassType($scope)) {
+            return [];
+        }
+
+        if ($this->isControllerAction($node, $scope)) {
+            return [];
+        }
+
+        if (str_starts_with($node->name->toLowerString(), self::CREATE_PREFIX)) {
+            return [];
+        }
+
+        // a static method has no instance to inject into, so its caller has to hand the service over
+        if ($node->isStatic()) {
+            return [];
+        }
+
+        $methodName = $node->name->toString();
+
+        $ruleErrors = [];
+
+        foreach ($node->params as $param) {
+            if (!$param->type instanceof Name) {
+                continue;
+            }
+
+            $paramType = $scope->resolveName($param->type);
+            if (!$this->isServiceType($paramType)) {
+                continue;
+            }
+
+            $parameterName = $param->var instanceof Node\Expr\Variable && is_string($param->var->name)
+                ? '$'.$param->var->name
+                : '';
+
+            $ruleErrors[] = RuleErrorBuilder::message(sprintf(
+                'Service "%s" of type "%s" is passed to method "%s()". Inject it in the constructor or an autowire*() method instead.',
+                $parameterName,
+                $paramType,
+                $methodName
+            ))
+                ->identifier('mautic.noServiceInMethodParameter')
+                ->line($param->getStartLine())
+                ->build();
+        }
+
+        return $ruleErrors;
+    }
+
+    private function isInjectionMethod(ClassMethod $classMethod): bool
+    {
+        $methodName = $classMethod->name->toLowerString();
+
+        if ('__construct' === $methodName) {
+            return true;
+        }
+
+        if (str_starts_with($methodName, self::AUTOWIRE_PREFIX)) {
+            return true;
+        }
+
+        foreach ($classMethod->attrGroups as $attrGroup) {
+            foreach ($attrGroup->attrs as $attr) {
+                if (self::REQUIRED_ATTRIBUTE === $attr->name->toString()) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * The parent class itself is skipped too, as it declares the signature every child has to keep.
+     */
+    private function isInheritedParentClassMethod(ClassMethod $classMethod, Scope $scope): bool
+    {
+        $classReflection = $scope->getClassReflection();
+        if (!$classReflection instanceof \PHPStan\Reflection\ClassReflection) {
+            return false;
+        }
+
+        $methodName = $classMethod->name->toLowerString();
+
+        foreach (self::SKIPPED_PARENT_CLASS_METHODS as $parentClass => $skippedMethodName) {
+            if ($methodName === $skippedMethodName && $classReflection->is($parentClass)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function isControllerAction(ClassMethod $classMethod, Scope $scope): bool
+    {
+        if (!str_ends_with($classMethod->name->toLowerString(), self::ACTION_SUFFIX)) {
+            return false;
+        }
+
+        $classReflection = $scope->getClassReflection();
+        if (!$classReflection instanceof \PHPStan\Reflection\ClassReflection) {
+            return false;
+        }
+
+        return str_ends_with($classReflection->getName(), self::CONTROLLER_SUFFIX);
+    }
+
+    private function isInSkippedClassType(Scope $scope): bool
+    {
+        $classReflection = $scope->getClassReflection();
+        if (!$classReflection instanceof \PHPStan\Reflection\ClassReflection) {
+            return false;
+        }
+
+        foreach (self::SKIPPED_CLASS_TYPES as $skippedClassType) {
+            if ($classReflection->is($skippedClassType)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function isInTestCase(Scope $scope): bool
+    {
+        $classReflection = $scope->getClassReflection();
+        if (!$classReflection instanceof \PHPStan\Reflection\ClassReflection) {
+            return false;
+        }
+
+        return $classReflection->is(self::TEST_CASE_CLASS);
+    }
+
+    private function isServiceType(string $className): bool
+    {
+        if (!$this->reflectionProvider->hasClass($className)) {
+            return false;
+        }
+
+        $classReflection = $this->reflectionProvider->getClass($className);
+
+        foreach (self::SKIPPED_TYPES as $skippedType) {
+            if ($classReflection->is($skippedType)) {
+                return false;
+            }
+        }
+
+        foreach (self::SERVICE_TYPES as $serviceType) {
+            if ($classReflection->is($serviceType)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/CreateFormInChildFormModel.php
+++ b/utils/phpstan/tests/Rule/Fixture/CreateFormInChildFormModel.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+use Mautic\CoreBundle\Model\FormModel;
+use Symfony\Component\Form\FormInterface;
+
+/**
+ * @extends FormModel<object>
+ */
+final class CreateFormInChildFormModel extends FormModel
+{
+    /**
+     * @param mixed[] $options
+     */
+    public function createForm($entity, $action = null, $options = []): FormInterface
+    {
+        return $this->formFactory->create($entity::class, $entity, $options);
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/NonServiceInMethodParameter.php
+++ b/utils/phpstan/tests/Rule/Fixture/NonServiceInMethodParameter.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+use Mautic\CoreBundle\Translation\Translator;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class NonServiceInMethodParameter
+{
+    public function handle(Request $request): Response
+    {
+        return new Response($request->getPathInfo());
+    }
+
+    /**
+     * @param mixed[] $options
+     */
+    public function buildForm(FormBuilderInterface $formBuilder, array $options): void
+    {
+        $formBuilder->add('name');
+    }
+
+    public function setContainer(ContainerInterface $container): void
+    {
+        $container->get('some.service');
+    }
+
+    public function process(ContainerBuilder $containerBuilder): void
+    {
+        $containerBuilder->setParameter('some_parameter', true);
+    }
+
+    public function translateWithMauticTranslator(Translator $translator, string $key): string
+    {
+        return $translator->trans($key);
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $output->writeln((string) $input->getArgument('name'));
+
+        return 0;
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/ServiceInControllerActionController.php
+++ b/utils/phpstan/tests/Rule/Fixture/ServiceInControllerActionController.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
+
+final class ServiceInControllerActionController
+{
+    public function newAction(object $entity, FormFactoryInterface $formFactory): FormInterface
+    {
+        return $formFactory->create($entity::class, $entity);
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/ServiceInCreateMethod.php
+++ b/utils/phpstan/tests/Rule/Fixture/ServiceInCreateMethod.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+use Doctrine\ORM\EntityManagerInterface;
+
+final class ServiceInCreateMethod
+{
+    public function createForEntityManager(EntityManagerInterface $entityManager): object
+    {
+        return $entityManager->getConnection();
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/ServiceInEntityMethod.php
+++ b/utils/phpstan/tests/Rule/Fixture/ServiceInEntityMethod.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+use Mautic\CoreBundle\Entity\CommonEntity;
+use Mautic\CoreBundle\Translation\Translator;
+
+final class ServiceInEntityMethod extends CommonEntity
+{
+    /**
+     * @return string[]
+     */
+    public function getRowStatusesPieChart(Translator $translator): array
+    {
+        return [$translator->trans('mautic.core.success')];
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/ServiceInEventMethod.php
+++ b/utils/phpstan/tests/Rule/Fixture/ServiceInEventMethod.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+use Symfony\Contracts\EventDispatcher\Event;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class ServiceInEventMethod extends Event
+{
+    private TranslatorInterface $translator;
+
+    public function setTranslator(TranslatorInterface $translator): void
+    {
+        $this->translator = $translator;
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/ServiceInFosAuthorizeController.php
+++ b/utils/phpstan/tests/Rule/Fixture/ServiceInFosAuthorizeController.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+use FOS\OAuthServerBundle\Controller\AuthorizeController;
+use Twig\Environment;
+
+final class ServiceInFosAuthorizeController extends AuthorizeController
+{
+    private function renderAuthorize(Environment $twig, string $template): string
+    {
+        return $twig->render($template);
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/ServiceInInjectionMethod.php
+++ b/utils/phpstan/tests/Rule/Fixture/ServiceInInjectionMethod.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Contracts\Service\Attribute\Required;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class ServiceInInjectionMethod
+{
+    private RouterInterface $router;
+
+    private TranslatorInterface $translator;
+
+    public function __construct(
+        private readonly FormFactoryInterface $formFactory,
+    ) {
+    }
+
+    public function autowireServiceInInjectionMethod(RouterInterface $router): void
+    {
+        $this->router = $router;
+    }
+
+    #[Required]
+    public function setTranslator(
+        TranslatorInterface $translator,
+    ): void {
+        $this->translator = $translator;
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/ServiceInMethodParameter.php
+++ b/utils/phpstan/tests/Rule/Fixture/ServiceInMethodParameter.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class ServiceInMethodParameter
+{
+    /**
+     * @param mixed[] $options
+     */
+    public function buildForm(object $entity, FormFactoryInterface $formFactory, ?string $action = null, array $options = []): FormInterface
+    {
+        return $formFactory->create($entity::class, $entity, $options);
+    }
+
+    public function translate(TranslatorInterface $translator, string $key): string
+    {
+        return $translator->trans($key);
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/ServiceInStaticMethod.php
+++ b/utils/phpstan/tests/Rule/Fixture/ServiceInStaticMethod.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+use Symfony\Component\Routing\RouterInterface;
+
+final class ServiceInStaticMethod
+{
+    public static function build(RouterInterface $router): string
+    {
+        return $router->generate('some_route');
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/ServiceInTestCaseMethod.php
+++ b/utils/phpstan/tests/Rule/Fixture/ServiceInTestCaseMethod.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+final class ServiceInTestCaseMethod extends TestCase
+{
+    private function createRecord(EntityManagerInterface $entityManager): void
+    {
+        $entityManager->flush();
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/ServiceInTraitMethod.php
+++ b/utils/phpstan/tests/Rule/Fixture/ServiceInTraitMethod.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+trait ServiceInTraitMethod
+{
+    private function writeCounts(TranslatorInterface $translator, string $key): string
+    {
+        return $translator->trans($key);
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/ServiceInTwigExtensionMethod.php
+++ b/utils/phpstan/tests/Rule/Fixture/ServiceInTwigExtensionMethod.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+use Twig\Environment;
+use Twig\Extension\AbstractExtension;
+
+final class ServiceInTwigExtensionMethod extends AbstractExtension
+{
+    /**
+     * @param mixed[] $context
+     */
+    public function includeWithEvent(Environment $environment, array $context, string $template): string
+    {
+        return $environment->render($template, $context);
+    }
+}

--- a/utils/phpstan/tests/Rule/NoServiceInMethodParameterRuleTest.php
+++ b/utils/phpstan/tests/Rule/NoServiceInMethodParameterRuleTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use Utils\PHPStan\Rule\NoServiceInMethodParameterRule;
+
+/**
+ * @extends RuleTestCase<NoServiceInMethodParameterRule>
+ */
+final class NoServiceInMethodParameterRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new NoServiceInMethodParameterRule($this->createReflectionProvider());
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/ServiceInMethodParameter.php'], [
+            [
+                'Service "$formFactory" of type "Symfony\Component\Form\FormFactoryInterface" is passed to method "buildForm()". Inject it in the constructor or an autowire*() method instead.',
+                16,
+            ],
+            [
+                'Service "$translator" of type "Symfony\Contracts\Translation\TranslatorInterface" is passed to method "translate()". Inject it in the constructor or an autowire*() method instead.',
+                21,
+            ],
+        ]);
+    }
+
+    public function testSkipConstructorAutowireAndRequiredMethod(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/ServiceInInjectionMethod.php'], []);
+    }
+
+    public function testSkipCreateFormInChildFormModel(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/CreateFormInChildFormModel.php'], []);
+    }
+
+    public function testSkipControllerAction(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/ServiceInControllerActionController.php'], []);
+    }
+
+    public function testSkipStaticMethod(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/ServiceInStaticMethod.php'], []);
+    }
+
+    public function testSkipCreateMethod(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/ServiceInCreateMethod.php'], []);
+    }
+
+    public function testSkipFosAuthorizeController(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/ServiceInFosAuthorizeController.php'], []);
+    }
+
+    public function testSkipTwigExtensionClass(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/ServiceInTwigExtensionMethod.php'], []);
+    }
+
+    public function testSkipEntityClass(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/ServiceInEntityMethod.php'], []);
+    }
+
+    public function testSkipEventClass(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/ServiceInEventMethod.php'], []);
+    }
+
+    public function testSkipTraitMethod(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/ServiceInTraitMethod.php'], []);
+    }
+
+    public function testSkipTestCaseMethod(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/ServiceInTestCaseMethod.php'], []);
+    }
+
+    public function testSkipNonServiceParameter(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/NonServiceInMethodParameter.php'], []);
+    }
+}


### PR DESCRIPTION
Split out of #16968 so the rule can be reviewed on its own.

Adds `NoServiceInMethodParameterRule`: a shared service must be injected, not passed around as a method parameter.

Passing a service into a method hides the real dependency of the class in every call site, and forces each caller to hold the service itself. The class that uses the service should ask for it once — in the constructor, or in an `autowire*()`/`#[Required]` method for classes that cannot use a constructor (controllers).

Reported error:

> Service "$formFactory" of type "Symfony\Component\Form\FormFactoryInterface" is passed to method "createForm()". Inject it in the constructor or an autowire*() method instead.

### Bad

```php
final class SomeModel
{
    public function createForm($entity, FormFactoryInterface $formFactory): FormInterface
    {
        return $formFactory->create(SomeType::class, $entity);
    }
}
```

### Good

```php
final class SomeModel
{
    public function __construct(
        private FormFactoryInterface $formFactory,
    ) {
    }

    public function createForm($entity): FormInterface
    {
        return $this->formFactory->create(SomeType::class, $entity);
    }
}
```
