### PR TITLE
[phpstan] inject mautic logger via constructor instead of controller action parameter

### DIFF
--- a/app/bundles/CoreBundle/Controller/Api/FileApiController.php
+++ b/app/bundles/CoreBundle/Controller/Api/FileApiController.php
@@ -44,6 +44,7 @@ final class FileApiController extends CommonApiController
         ModelFactory $modelFactory,
         EventDispatcherInterface $dispatcher,
         CoreParametersHelper $coreParametersHelper,
+        private readonly LoggerInterface $mauticLogger,
     ) {
         $this->entityNameOne     = 'file';
         $this->entityNameMulti   = 'files';
@@ -57,10 +58,10 @@ final class FileApiController extends CommonApiController
      *
      * @return Response
      */
-    public function createAction(Request $request, PathsHelper $pathsHelper, LoggerInterface $mauticLogger, $dir)
+    public function createAction(Request $request, PathsHelper $pathsHelper, $dir)
     {
         try {
-            $path = $this->getAbsolutePath($request, $pathsHelper, $mauticLogger, $dir, true);
+            $path = $this->getAbsolutePath($request, $pathsHelper, $dir, true);
         } catch (\Exception $e) {
             return $this->returnError($e->getMessage(), Response::HTTP_NOT_ACCEPTABLE);
         }
@@ -96,10 +97,10 @@ final class FileApiController extends CommonApiController
      *
      * @return Response
      */
-    public function listAction(Request $request, PathsHelper $pathsHelper, LoggerInterface $mauticLogger, $dir)
+    public function listAction(Request $request, PathsHelper $pathsHelper, $dir)
     {
         try {
-            $filePath = $this->getAbsolutePath($request, $pathsHelper, $mauticLogger, $dir);
+            $filePath = $this->getAbsolutePath($request, $pathsHelper, $dir);
         } catch (\Exception $e) {
             return $this->returnError($e->getMessage(), Response::HTTP_NOT_ACCEPTABLE);
         }
@@ -127,12 +128,12 @@ final class FileApiController extends CommonApiController
      *
      * @return Response
      */
-    public function deleteAction(Request $request, PathsHelper $pathsHelper, LoggerInterface $mauticLogger, $dir, $file)
+    public function deleteAction(Request $request, PathsHelper $pathsHelper, $dir, $file)
     {
         $response = ['success' => false];
 
         try {
-            $filePath = $this->getAbsolutePath($request, $pathsHelper, $mauticLogger, $dir).'/'.basename($file);
+            $filePath = $this->getAbsolutePath($request, $pathsHelper, $dir).'/'.basename($file);
         } catch (\Exception $e) {
             return $this->returnError($e->getMessage(), Response::HTTP_NOT_ACCEPTABLE);
         }
@@ -157,7 +158,7 @@ final class FileApiController extends CommonApiController
      * @param string $dir
      * @param bool   $createDir
      */
-    protected function getAbsolutePath(Request $request, PathsHelper $pathsHelper, LoggerInterface $mauticLogger, $dir, $createDir = false): string
+    protected function getAbsolutePath(Request $request, PathsHelper $pathsHelper, $dir, $createDir = false): string
     {
         try {
             $possibleDirs = ['media', 'images'];
@@ -204,7 +205,7 @@ final class FileApiController extends CommonApiController
 
             return $path;
         } catch (\Exception $e) {
-            $mauticLogger->error($e->getMessage(), ['exception' => $e]);
+            $this->mauticLogger->error($e->getMessage(), ['exception' => $e]);
 
             throw $e;
         }

--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -39,7 +39,6 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Contracts\Service\Attribute\Required;
 use Symfony\Contracts\Translation\LocaleAwareInterface;
-use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class PublicController extends CommonFormController
 {
@@ -51,15 +50,19 @@ final class PublicController extends CommonFormController
 
     private LeadModel $leadModel;
 
+    private LoggerInterface $mauticLogger;
+
     #[Required]
     public function autowirePublicController(
         LeadModel $leadModel,
         EmailModel $emailModel,
         LeadRepository $leadRepository,
+        LoggerInterface $mauticLogger,
     ): void {
         $this->leadModel = $leadModel;
         $this->emailModel = $emailModel;
         $this->leadRepository = $leadRepository;
+        $this->mauticLogger = $mauticLogger;
     }
 
     public function indexAction(Request $request, AnalyticsHelper $analyticsHelper, $idHash): Response
@@ -202,9 +205,9 @@ final class PublicController extends CommonFormController
 
             if (!$isHeadRequest && (!$showContactPreferences || $isUnsubscribeAll)) {
                 if (!empty($stat)) {
-                    $message = $this->getUnsubscribeMessage($idHash, $model, $stat, $this->translator);
+                    $message = $this->getUnsubscribeMessage($idHash, $model, $stat);
                 } elseif ($lead && $lead instanceof Lead) {
-                    $message = $this->getUnsubscribeMessageLead($idHash, $model, $lead, $this->translator, $urlEmail);
+                    $message = $this->getUnsubscribeMessageLead($idHash, $model, $lead, $urlEmail);
                 }
             } elseif ($lead) {
                 $params = ['idHash' => $idHash, 'urlEmail' => $urlEmail];
@@ -556,14 +559,12 @@ final class PublicController extends CommonFormController
     /**
      * @throws \Exception
      */
-    private function doTracking(Request $request, IntegrationHelper $integrationHelper, MailHelper $mailer, LoggerInterface $mauticLogger, $integration): void
+    private function doTracking(Request $request, IntegrationHelper $integrationHelper, MailHelper $mailer, $integration): void
     {
-        $logger = $mauticLogger;
-
         // if additional data were sent with the tracking pixel
         $query_string = $request->server->get('QUERY_STRING');
         if (!$query_string) {
-            $logger->log('error', $integration.': query string is not available');
+            $this->mauticLogger->log('error', $integration.': query string is not available');
 
             return;
         }
@@ -576,7 +577,7 @@ final class PublicController extends CommonFormController
 
         // URL attr 'd' is encoded so let's decode it first.
         if (!isset($query['d'], $query['sig'])) {
-            $logger->log('error', $integration.': query variables are not found');
+            $this->mauticLogger->log('error', $integration.': query variables are not found');
 
             return;
         }
@@ -585,7 +586,7 @@ final class PublicController extends CommonFormController
         $myIntegration = $integrationHelper->getIntegrationObject($integration);
 
         if (!$myIntegration) {
-            $logger->log('error', $integration.': integration not found');
+            $this->mauticLogger->log('error', $integration.': integration not found');
 
             return;
         }
@@ -607,19 +608,19 @@ final class PublicController extends CommonFormController
             parse_str($gz, $query);
         } else {
             // signatures don't match: stop
-            $logger->log('error', $integration.': signatures don\'t match');
+            $this->mauticLogger->log('error', $integration.': signatures don\'t match');
 
             unset($query);
         }
 
         if (empty($query) || !isset($query['email'], $query['subject'], $query['body'])) {
-            $logger->log('error', $integration.': query variables are empty');
+            $this->mauticLogger->log('error', $integration.': query variables are empty');
 
             return;
         }
 
         if (MAUTIC_ENV === 'dev') {
-            $logger->log('error', $integration.': '.json_encode($query, JSON_PRETTY_PRINT));
+            $this->mauticLogger->log('error', $integration.': '.json_encode($query, JSON_PRETTY_PRINT));
         }
 
         // email is a semicolon delimited list of emails
@@ -653,9 +654,9 @@ final class PublicController extends CommonFormController
         }
     }
 
-    public function pluginTrackingGifAction(Request $request, IntegrationHelper $integrationHelper, MailHelper $mailer, LoggerInterface $mauticLogger, $integration): Response
+    public function pluginTrackingGifAction(Request $request, IntegrationHelper $integrationHelper, MailHelper $mailer, $integration): Response
     {
-        $this->doTracking($request, $integrationHelper, $mailer, $mauticLogger, $integration);
+        $this->doTracking($request, $integrationHelper, $mailer, $integration);
 
         return TrackingPixelHelper::getResponse($request); // send gif
     }
@@ -704,25 +705,25 @@ final class PublicController extends CommonFormController
         return $this->leadRepository->getLeadByEmail($email);
     }
 
-    public function getUnsubscribeMessage(string $idHash, $model, $stat, TranslatorInterface $translator): string
+    public function getUnsubscribeMessage(string $idHash, $model, $stat): string
     {
-        $model->setDoNotContact($stat, $translator->trans('mautic.email.dnc.unsubscribed'), DoNotContact::UNSUBSCRIBED);
+        $model->setDoNotContact($stat, $this->translator->trans('mautic.email.dnc.unsubscribed'), DoNotContact::UNSUBSCRIBED);
 
-        return $this->getUnsubscribeText($translator, $stat->getEmailAddress(), $idHash);
+        return $this->getUnsubscribeText($stat->getEmailAddress(), $idHash);
     }
 
-    public function getUnsubscribeMessageLead(string $idHash, EmailModel $model, Lead $lead, TranslatorInterface $translator, string $urlEmail): string
+    public function getUnsubscribeMessageLead(string $idHash, EmailModel $model, Lead $lead, string $urlEmail): string
     {
-        $model->setDoNotContactLead($lead, $translator->trans('mautic.email.dnc.unsubscribed'), DoNotContact::UNSUBSCRIBED);
+        $model->setDoNotContactLead($lead, $this->translator->trans('mautic.email.dnc.unsubscribed'), DoNotContact::UNSUBSCRIBED);
 
-        return $this->getUnsubscribeText($translator, $urlEmail, $idHash);
+        return $this->getUnsubscribeText($urlEmail, $idHash);
     }
 
-    private function getUnsubscribeText(TranslatorInterface $translator, string $email, string $idHash): string
+    private function getUnsubscribeText(string $email, string $idHash): string
     {
         $message = $this->coreParametersHelper->get('unsubscribe_message');
         if (!$message) {
-            $message = $translator->trans(
+            $message = $this->translator->trans(
                 'mautic.email.unsubscribed.success',
                 [
                     '%resubscribeUrl%' => '|URL|',


### PR DESCRIPTION
Split out of #16968.

`mauticLogger` was passed into controller actions as a method parameter, then handed down to private helpers. Injecting it once makes the dependency explicit and shortens every call site.

```diff
-    public function createAction(Request $request, PathsHelper $pathsHelper, LoggerInterface $mauticLogger, $dir)
+    public function createAction(Request $request, PathsHelper $pathsHelper, $dir)
     {
         try {
-            $path = $this->getAbsolutePath($request, $pathsHelper, $mauticLogger, $dir, true);
+            $path = $this->getAbsolutePath($request, $pathsHelper, $dir, true);
```

`FileApiController` gets it via the constructor, `PublicController` via the existing `autowirePublicController()` method. `PublicController` also stops passing `TranslatorInterface` around, as `$this->translator` is already available there.
