### PR TITLE
Deprecating unused EmojiMap classes

### DIFF
--- a/app/bundles/CoreBundle/Helper/EmojiMap/HtmlToUnicodeEmojiMap.php
+++ b/app/bundles/CoreBundle/Helper/EmojiMap/HtmlToUnicodeEmojiMap.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\Helper\EmojiMap;
 
+/**
+ * @deprecated as unused. No replacement.
+ */
 final class HtmlToUnicodeEmojiMap
 {
-    public static $map = [
+    /** @var array<string, string> */
+    public static array $map = [
         "<span class=\x22emoji-outer emoji-sizer\x22><span class=\x22emoji-inner emojia9\x22></span></span>"                                  => "\xc2\xa9",
         "<span class=\x22emoji-outer emoji-sizer\x22><span class=\x22emoji-inner emojiae\x22></span></span>"                                  => "\xc2\xae",
         "<span class=\x22emoji-outer emoji-sizer\x22><span class=\x22emoji-inner emoji203c\x22></span></span>"                                => "\xe2\x80\xbc",

--- a/app/bundles/CoreBundle/Helper/EmojiMap/ShortToUnicodeEmojiMap.php
+++ b/app/bundles/CoreBundle/Helper/EmojiMap/ShortToUnicodeEmojiMap.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\Helper\EmojiMap;
 
+/**
+ * @deprecated as unused. No replacement.
+ */
 final class ShortToUnicodeEmojiMap
 {
-    public static $map = [
+    /** @var array<string, string> */
+    public static array $map = [
         ':copyright:'                                              => "\xc2\xa9",
         ':registered:'                                             => "\xc2\xae",
         ':bangbang:'                                               => "\xe2\x80\xbc",
@@ -1351,7 +1355,8 @@ final class ShortToUnicodeEmojiMap
         ':woman-kiss-woman:'                                       => "\xf0\x9f\x91\xa9\xe2\x80\x8d\xe2\x9d\xa4\xef\xb8\x8f\xe2\x80\x8d\xf0\x9f\x92\x8b\xe2\x80\x8d\xf0\x9f\x91\xa9",
     ];
 
-    public static $exceptions = [
+    /** @var array<string, string> */
+    public static array $exceptions = [
         // Outlook email rendering
         "microsoft-com\xf0\x9f\x8f\xa2office" => 'microsoft-com:office:office',
     ];

--- a/app/bundles/CoreBundle/Helper/EmojiMap/UnicodeToHtmlEmojiMap.php
+++ b/app/bundles/CoreBundle/Helper/EmojiMap/UnicodeToHtmlEmojiMap.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\Helper\EmojiMap;
 
+/**
+ * @deprecated as unused. No replacement.
+ */
 final class UnicodeToHtmlEmojiMap
 {
-    public static $map = [
+    /** @var array<string, string> */
+    public static array $map = [
         "\xc2\xa9"                                                                                                       => "<span class=\x22emoji-outer emoji-sizer\x22><span class=\x22emoji-inner emojia9\x22></span></span>",
         "\xf3\xbe\xac\xa9"                                                                                               => "<span class=\x22emoji-outer emoji-sizer\x22><span class=\x22emoji-inner emojia9\x22></span></span>",
         "\xee\x9c\xb1"                                                                                                   => "<span class=\x22emoji-outer emoji-sizer\x22><span class=\x22emoji-inner emojia9\x22></span></span>",

--- a/app/bundles/CoreBundle/Helper/EmojiMap/UnicodeToShortEmojiMap.php
+++ b/app/bundles/CoreBundle/Helper/EmojiMap/UnicodeToShortEmojiMap.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\Helper\EmojiMap;
 
+/**
+ * @deprecated as unused. No replacement.
+ */
 final class UnicodeToShortEmojiMap
 {
-    public static $map = [
+    /** @var array<string, string> */
+    public static array $map = [
         "\xc2\xa9"                                                                                                     => ':copyright:',
         "\xf3\xbe\xac\xa9"                                                                                             => ':copyright:',
         "\xee\x9c\xb1"                                                                                                 => ':copyright:',

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2380,36 +2380,6 @@ parameters:
 			path: app/bundles/CoreBundle/Helper/DateTimeHelper.php
 
 		-
-			message: '#^Property Mautic\\CoreBundle\\Helper\\EmojiMap\\HtmlToUnicodeEmojiMap\:\:\$map has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/bundles/CoreBundle/Helper/EmojiMap/HtmlToUnicodeEmojiMap.php
-
-		-
-			message: '#^Property Mautic\\CoreBundle\\Helper\\EmojiMap\\ShortToUnicodeEmojiMap\:\:\$exceptions has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/bundles/CoreBundle/Helper/EmojiMap/ShortToUnicodeEmojiMap.php
-
-		-
-			message: '#^Property Mautic\\CoreBundle\\Helper\\EmojiMap\\ShortToUnicodeEmojiMap\:\:\$map has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/bundles/CoreBundle/Helper/EmojiMap/ShortToUnicodeEmojiMap.php
-
-		-
-			message: '#^Property Mautic\\CoreBundle\\Helper\\EmojiMap\\UnicodeToHtmlEmojiMap\:\:\$map has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/bundles/CoreBundle/Helper/EmojiMap/UnicodeToHtmlEmojiMap.php
-
-		-
-			message: '#^Property Mautic\\CoreBundle\\Helper\\EmojiMap\\UnicodeToShortEmojiMap\:\:\$map has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/bundles/CoreBundle/Helper/EmojiMap/UnicodeToShortEmojiMap.php
-
-		-
 			message: '#^Parameter \#1 \$prefix of function uniqid expects string, int\<0, max\> given\.$#'
 			identifier: argument.type
 			count: 1


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

<!-- 📄 DOCUMENTATION REVIEW REQUIRED:

After you open this PR, Promptless automatically creates a documentation PR and leaves a comment here with the link. Once your code PR merges, review the documentation PR, request changes if needed, and approve it promptly.

See "Reviewing documentation PRs from Promptless" in the community handbook for more details: https://contribute.mautic.org/en/latest/contributing/developer.html#reviewing-documentation-prs-from-promptless -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ✔️
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description


I noticed there are 4 big classes that are unused. Let's deprecate them so we could drop them in Mautic 8.

I also fixed the PHPSTAN issues for those.

### 📋 Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers. Do not write steps performed by the CI. These steps are for manual testing.
-->
1. Nothing to test. The classes were unused. Static analysis should confirm in the CI.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->