### PR TITLE
[symfony] Use Request::METHOD_* constants over string literals

### DIFF
--- a/app/bundles/ApiBundle/Tests/Functional/Controller/CommonApiControllerTest.php
+++ b/app/bundles/ApiBundle/Tests/Functional/Controller/CommonApiControllerTest.php
@@ -28,7 +28,7 @@ final class CommonApiControllerTest extends MauticMysqlTestCase
         $this->assertInstanceOf(\DateTimeInterface::class, $email->getCheckedOut());
         $this->assertEquals('Admin User', $email->getCheckedOutByUser());
 
-        $this->client->request('PATCH', '/api/emails/'.$email->getId().'/edit', [
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_PATCH, '/api/emails/'.$email->getId().'/edit', [
             'name' => 'Updated Email',
         ]);
         $response = $this->client->getResponse();
@@ -67,7 +67,7 @@ final class CommonApiControllerTest extends MauticMysqlTestCase
 
         $this->createAndAuthenticateApiUser('api_lead_user', 'api-lead@example.com');
 
-        $this->client->request('PATCH', '/api/contacts/'.$lead->getId().'/edit', [
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_PATCH, '/api/contacts/'.$lead->getId().'/edit', [
             'firstname' => 'Updated Firstname',
         ]);
         $response = $this->client->getResponse();
@@ -94,7 +94,7 @@ final class CommonApiControllerTest extends MauticMysqlTestCase
         ];
 
         $this->client->request(
-            'PATCH',
+            \Symfony\Component\HttpFoundation\Request::METHOD_PATCH,
             '/api/emails/batch/edit',
             [],
             [],

--- a/app/bundles/ApiBundle/Tests/Functional/Serializer/PutOperationTest.php
+++ b/app/bundles/ApiBundle/Tests/Functional/Serializer/PutOperationTest.php
@@ -31,7 +31,7 @@ final class PutOperationTest extends MauticMysqlTestCase
         $projectId = $project->getId();
 
         // Make a GET request to retrieve the project
-        $this->client->request('GET', '/api/v2/projects/'.$projectId);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/api/v2/projects/'.$projectId);
 
         $this->assertResponseIsSuccessful();
 
@@ -62,7 +62,7 @@ final class PutOperationTest extends MauticMysqlTestCase
 
         // Update the page via PUT request
         $this->client->request(
-            'PUT',
+            \Symfony\Component\HttpFoundation\Request::METHOD_PUT,
             '/api/v2/pages/'.$originalId,
             [],
             [],
@@ -107,7 +107,7 @@ final class PutOperationTest extends MauticMysqlTestCase
 
         // Update the project via PUT request
         $this->client->request(
-            'PUT',
+            \Symfony\Component\HttpFoundation\Request::METHOD_PUT,
             '/api/v2/projects/'.$originalId,
             [],
             [],
@@ -147,7 +147,7 @@ final class PutOperationTest extends MauticMysqlTestCase
         $nonExistentId = 99999;
 
         $this->client->request(
-            'PUT',
+            \Symfony\Component\HttpFoundation\Request::METHOD_PUT,
             '/api/v2/projects/'.$nonExistentId,
             [],
             [],
@@ -170,7 +170,7 @@ final class PutOperationTest extends MauticMysqlTestCase
     public function testPostOperationCreatesNewProject(): void
     {
         $this->client->request(
-            'POST',
+            \Symfony\Component\HttpFoundation\Request::METHOD_POST,
             '/api/v2/projects',
             [],
             [],
@@ -219,7 +219,7 @@ final class PutOperationTest extends MauticMysqlTestCase
         // Update the project via PUT request with only name (no description)
         // According to HTTP PUT semantics, this should clear the description
         $this->client->request(
-            'PUT',
+            \Symfony\Component\HttpFoundation\Request::METHOD_PUT,
             '/api/v2/projects/'.$originalId,
             [],
             [],

--- a/app/bundles/AssetBundle/Tests/Controller/Api/AssetApiControllerFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Controller/Api/AssetApiControllerFunctionalTest.php
@@ -34,7 +34,7 @@ final class AssetApiControllerFunctionalTest extends MauticMysqlTestCase
             'storageLocation' => 'remote',
             'title'           => 'title',
         ];
-        $this->client->request('POST', 'api/assets/new', $payload);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_POST, 'api/assets/new', $payload);
         $clientResponse = $this->client->getResponse();
         $this->assertResponseStatusCodeSame(201, $clientResponse->getContent());
         $response = json_decode($clientResponse->getContent(), true);
@@ -64,7 +64,7 @@ final class AssetApiControllerFunctionalTest extends MauticMysqlTestCase
             'storageLocation' => 'remote',
             'title'           => 'title',
         ];
-        $this->client->request('POST', 'api/assets/new', $payload);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_POST, 'api/assets/new', $payload);
         $response = $this->client->getResponse();
         $content  = $response->getContent();
         $this->assertResponseStatusCodeSame(400, $response->getContent());
@@ -90,7 +90,7 @@ final class AssetApiControllerFunctionalTest extends MauticMysqlTestCase
             'storageLocation' => 'remote',
             'title'           => 'title',
         ];
-        $this->client->request('POST', 'api/assets/new', $payload);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_POST, 'api/assets/new', $payload);
         $clientResponse = $this->client->getResponse();
         $content        = $clientResponse->getContent();
 
@@ -113,7 +113,7 @@ final class AssetApiControllerFunctionalTest extends MauticMysqlTestCase
             'storageLocation' => 'local',
             'title'           => 'title',
         ];
-        $this->client->request('POST', 'api/assets/new', $payload);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_POST, 'api/assets/new', $payload);
         $clientResponse = $this->client->getResponse();
         $this->assertResponseStatusCodeSame(201, $clientResponse->getContent());
         $response = json_decode($clientResponse->getContent(), true);
@@ -134,7 +134,7 @@ final class AssetApiControllerFunctionalTest extends MauticMysqlTestCase
         ];
 
         // Create asset first
-        $this->client->request('POST', 'api/assets/new', $payload);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_POST, 'api/assets/new', $payload);
         $createResponse = $this->client->getResponse();
         $this->assertResponseStatusCodeSame(201, $createResponse->getContent());
 
@@ -143,12 +143,12 @@ final class AssetApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertNotEmpty($assetId);
 
         // Delete must not fail with 500 due to post-delete serialization
-        $this->client->request('DELETE', sprintf('/api/assets/%d/delete', $assetId));
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_DELETE, sprintf('/api/assets/%d/delete', $assetId));
         $deleteResponse = $this->client->getResponse();
         $this->assertResponseStatusCodeSame(200, $deleteResponse->getContent());
 
         // Verify the asset is actually removed
-        $this->client->request('GET', sprintf('/api/assets/%d', $assetId));
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, sprintf('/api/assets/%d', $assetId));
         $getDeletedResponse = $this->client->getResponse();
         $this->assertResponseStatusCodeSame(404, $getDeletedResponse->getContent());
     }

--- a/app/bundles/AssetBundle/Tests/Controller/Api/AssetWidgetDataApiControllerFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Controller/Api/AssetWidgetDataApiControllerFunctionalTest.php
@@ -23,7 +23,7 @@ final class AssetWidgetDataApiControllerFunctionalTest extends MauticMysqlTestCa
     #[DataProvider('assetWidgetTypesProvider')]
     public function testAssetWidgetDataEndpointReturnsNonEmptyDataForApiLibraryShape(string $type): void
     {
-        $this->client->request('GET', '/api/data/'.$type);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/api/data/'.$type);
         $response = $this->client->getResponse();
 
         $this->assertNotSame(

--- a/app/bundles/AssetBundle/Tests/Controller/AssetControllerFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Controller/AssetControllerFunctionalTest.php
@@ -51,7 +51,7 @@ final class AssetControllerFunctionalTest extends AbstractAssetTestCase
         $title   = 'Remote image asset with query string';
         $fileUrl = 'https://fastly.picsum.photos/id/13/2500/1667.jpg?hmac=SoX9UoHhN8HyklRA4A3vcCWJMVtiBXUg0W4ljWTor7s';
 
-        $crawlerCreate = $this->client->request('GET', '/s/assets/new');
+        $crawlerCreate = $this->client->request(Request::METHOD_GET, '/s/assets/new');
         $createForm    = $crawlerCreate->selectButton('Save')->form();
         $createForm->setValues([
             'asset[title]'           => $title,
@@ -66,7 +66,7 @@ final class AssetControllerFunctionalTest extends AbstractAssetTestCase
         $asset = $this->em->getRepository(Asset::class)->findOneBy(['title' => $title]);
         $this->assertInstanceOf(Asset::class, $asset, 'Asset should be created successfully');
 
-        $crawlerEdit = $this->client->request('GET', '/s/assets/edit/'.$asset->getId());
+        $crawlerEdit = $this->client->request(Request::METHOD_GET, '/s/assets/edit/'.$asset->getId());
         $editForm    = $crawlerEdit->selectButton('Save')->form();
 
         $crawlerAfterEdit = $this->client->submit($editForm);
@@ -168,7 +168,7 @@ final class AssetControllerFunctionalTest extends AbstractAssetTestCase
 
     public function testAssetSizes(): void
     {
-        $this->client->request('GET', '/s/ajax?action=email:getAttachmentsSize&assets%5B%5D='.$this->asset->getId());
+        $this->client->request(Request::METHOD_GET, '/s/ajax?action=email:getAttachmentsSize&assets%5B%5D='.$this->asset->getId());
         $this->assertResponseIsSuccessful();
         $this->assertSame('{"size":"178 bytes"}', $this->client->getResponse()->getContent());
     }
@@ -178,7 +178,7 @@ final class AssetControllerFunctionalTest extends AbstractAssetTestCase
      */
     public function testPreviewActionStreamByDefault(): void
     {
-        $this->client->request('GET', '/s/assets/preview/'.$this->asset->getId());
+        $this->client->request(Request::METHOD_GET, '/s/assets/preview/'.$this->asset->getId());
         ob_start();
         $response = $this->client->getResponse();
         $response->sendContent();
@@ -196,7 +196,7 @@ final class AssetControllerFunctionalTest extends AbstractAssetTestCase
      */
     public function testPreviewActionStreamIsZero(): void
     {
-        $this->client->request('GET', '/s/assets/preview/'.$this->asset->getId().'?stream=0&download=1');
+        $this->client->request(Request::METHOD_GET, '/s/assets/preview/'.$this->asset->getId().'?stream=0&download=1');
         ob_start();
         $response = $this->client->getResponse();
         $response->sendContent();
@@ -213,7 +213,7 @@ final class AssetControllerFunctionalTest extends AbstractAssetTestCase
      */
     public function testPreviewActionStreamDownloadAreZero(): void
     {
-        $this->client->request('GET', '/s/assets/preview/'.$this->asset->getId().'?stream=0&download=0');
+        $this->client->request(Request::METHOD_GET, '/s/assets/preview/'.$this->asset->getId().'?stream=0&download=0');
         ob_start();
         $response = $this->client->getResponse();
         $response->sendContent();
@@ -347,7 +347,7 @@ final class AssetControllerFunctionalTest extends AbstractAssetTestCase
         $tmpDir = 'tmp_'.substr(md5(uniqid()), 0, 13);
 
         $this->client->request(
-            'POST',
+            Request::METHOD_POST,
             '/s/_uploader/asset/upload',
             ['tempId' => '../../'.$tmpDir],
             ['file'   => $uploadedFile],
@@ -492,7 +492,7 @@ final class AssetControllerFunctionalTest extends AbstractAssetTestCase
         $this->em->flush();
         $this->em->clear();
 
-        $crawler = $this->client->request('GET', '/s/assets/edit/'.$asset->getId());
+        $crawler = $this->client->request(Request::METHOD_GET, '/s/assets/edit/'.$asset->getId());
         $form    = $crawler->selectButton('Save')->form();
         $form['asset[projects]']->setValue((string) $project->getId());
 
@@ -519,7 +519,7 @@ final class AssetControllerFunctionalTest extends AbstractAssetTestCase
     public function testCreateNewRemoteAssetWithValidateRemoteDomainsEnabled(string $file, bool $isAllowed): void
     {
         $message = 'The remote domain in the URL is not allowed due to security reasons.';
-        $crawler = $this->client->request('GET', '/s/assets/new');
+        $crawler = $this->client->request(Request::METHOD_GET, '/s/assets/new');
         $form    = $crawler->selectButton('Save')->form();
         $form->setValues([
             'asset[title]'           => 'Title',

--- a/app/bundles/AssetBundle/Tests/Controller/AssetDetailFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Controller/AssetDetailFunctionalTest.php
@@ -22,7 +22,7 @@ final class AssetDetailFunctionalTest extends MauticMysqlTestCase
         $this->em->flush();
         $this->em->detach($asset);
 
-        $crawler   = $this->client->request('GET', sprintf('/s/assets/view/%d', $asset->getId()));
+        $crawler   = $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, sprintf('/s/assets/view/%d', $asset->getId()));
         $imageTag  = $crawler->filter('.img-thumbnail');
 
         $onError  = $imageTag->attr('onerror');

--- a/app/bundles/AssetBundle/Tests/Controller/PublicControllerFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Controller/PublicControllerFunctionalTest.php
@@ -16,7 +16,7 @@ final class PublicControllerFunctionalTest extends AbstractAssetTestCase
      */
     public function testDownloadActionStreamByDefault(): void
     {
-        $this->client->request('GET', '/asset/'.$this->asset->getSlug());
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/asset/'.$this->asset->getSlug());
         ob_start();
         $response = $this->client->getResponse();
         $response->sendContent();
@@ -34,7 +34,7 @@ final class PublicControllerFunctionalTest extends AbstractAssetTestCase
      */
     public function testDownloadActionStreamIsZero(): void
     {
-        $this->client->request('GET', '/asset/'.$this->asset->getSlug().'?stream=0');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/asset/'.$this->asset->getSlug().'?stream=0');
         ob_start();
         $response = $this->client->getResponse();
         $response->sendContent();
@@ -53,7 +53,7 @@ final class PublicControllerFunctionalTest extends AbstractAssetTestCase
     {
         $assetSlug = $this->asset->getId().':';
 
-        $this->client->request('GET', '/asset/'.$assetSlug.'?stream=0');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/asset/'.$assetSlug.'?stream=0');
         ob_start();
         $response = $this->client->getResponse();
         $response->sendContent();
@@ -73,7 +73,7 @@ final class PublicControllerFunctionalTest extends AbstractAssetTestCase
         $this->logoutUser();
         $assetSlug = $this->asset->getSlug().'?utm_source=test2&utm_medium=test3&utm_campaign=test6&utm_term=test4&utm_content=test5';
 
-        $this->client->request('GET', '/asset/'.$assetSlug);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/asset/'.$assetSlug);
         ob_start();
         $response = $this->client->getResponse();
         $response->sendContent();
@@ -98,7 +98,7 @@ final class PublicControllerFunctionalTest extends AbstractAssetTestCase
 
     public function testDownloadActionWithInvalidSlug(): void
     {
-        $this->client->request('GET', '/asset/1:invalid-slug-with-special-chars!');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/asset/1:invalid-slug-with-special-chars!');
         $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
     }
 
@@ -108,7 +108,7 @@ final class PublicControllerFunctionalTest extends AbstractAssetTestCase
         $asset = $this->createAsset(['title' => 'Unpublished Asset', 'isPublished' => false]);
         $this->em->flush();
 
-        $this->client->request('GET', '/asset/'.$asset->getSlug());
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/asset/'.$asset->getSlug());
         $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
     }
 
@@ -127,7 +127,7 @@ final class PublicControllerFunctionalTest extends AbstractAssetTestCase
 
         // Don't follow redirects automatically
         $this->client->followRedirects(false);
-        $this->client->request('GET', '/asset/'.$asset->getSlug());
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/asset/'.$asset->getSlug());
         $this->assertResponseStatusCodeSame(Response::HTTP_FOUND);
         $this->assertResponseRedirects($remotePath);
     }
@@ -147,7 +147,7 @@ final class PublicControllerFunctionalTest extends AbstractAssetTestCase
         $this->assertFileExists($assetPath, 'Expected asset file to exist before deletion');
         unlink($assetPath);
 
-        $this->client->request('GET', '/asset/'.$this->asset->getSlug());
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/asset/'.$this->asset->getSlug());
 
         $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
     }
@@ -159,7 +159,7 @@ final class PublicControllerFunctionalTest extends AbstractAssetTestCase
         $asset->setDisallow(true);
         $this->em->flush();
 
-        $this->client->request('GET', '/asset/'.$this->asset->getSlug());
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/asset/'.$this->asset->getSlug());
 
         $this->assertResponseIsSuccessful();
         $this->assertSame('noindex, nofollow, noarchive', $this->client->getResponse()->headers->get('X-Robots-Tag'));

--- a/app/bundles/AssetBundle/Tests/Functional/ApiPlatform/DownloadOwnershipApiV2AuthorizationRegressionTest.php
+++ b/app/bundles/AssetBundle/Tests/Functional/ApiPlatform/DownloadOwnershipApiV2AuthorizationRegressionTest.php
@@ -64,7 +64,7 @@ final class DownloadOwnershipApiV2AuthorizationRegressionTest extends OwnershipS
         $this->client->setServerParameter('PHP_AUTH_PW', 'Maut1cR0cks!');
 
         // Try to access the foreign download - should be forbidden
-        $this->client->request('GET', '/api/v2/downloads/'.$foreignDownload->getId());
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/api/v2/downloads/'.$foreignDownload->getId());
 
         self::assertResponseStatusCodeSame(
             Response::HTTP_FORBIDDEN,
@@ -137,7 +137,7 @@ final class DownloadOwnershipApiV2AuthorizationRegressionTest extends OwnershipS
         $this->client->setServerParameter('PHP_AUTH_PW', 'Maut1cR0cks!');
 
         // Request downloads collection
-        $this->client->request('GET', '/api/v2/downloads?page=1&itemsPerPage=10');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/api/v2/downloads?page=1&itemsPerPage=10');
         $response = $this->client->getResponse();
 
         self::assertResponseIsSuccessful($response->getContent());
@@ -215,7 +215,7 @@ final class DownloadOwnershipApiV2AuthorizationRegressionTest extends OwnershipS
         $this->client->setServerParameter('PHP_AUTH_PW', 'Maut1cR0cks!');
 
         // Request page 1 with all items on one page first
-        $this->client->request('GET', '/api/v2/downloads?page=1&itemsPerPage=10');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/api/v2/downloads?page=1&itemsPerPage=10');
         $response = $this->client->getResponse();
 
         self::assertResponseIsSuccessful($response->getContent());

--- a/app/bundles/CampaignBundle/Tests/Command/Api/EventLogApiControllerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Command/Api/EventLogApiControllerTest.php
@@ -116,7 +116,7 @@ final class EventLogApiControllerTest extends MauticMysqlTestCase
             ],
         ];
 
-        $this->client->request('PUT', '/api/campaigns/events/batch/edit', $payload);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_PUT, '/api/campaigns/events/batch/edit', $payload);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 

--- a/app/bundles/CampaignBundle/Tests/Command/TriggerCampaignCommandTest.php
+++ b/app/bundles/CampaignBundle/Tests/Command/TriggerCampaignCommandTest.php
@@ -126,7 +126,7 @@ final class TriggerCampaignCommandTest extends AbstractCampaignCommand
 
         // Now let's simulate email opens
         foreach ($stats as $stat) {
-            $this->client->request('GET', '/email/'.$stat['tracking_hash'].'.gif');
+            $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/email/'.$stat['tracking_hash'].'.gif');
             $this->assertResponseIsSuccessful();
         }
 
@@ -293,7 +293,7 @@ final class TriggerCampaignCommandTest extends AbstractCampaignCommand
 
         // Now let's simulate email opens
         foreach ($stats as $stat) {
-            $this->client->request('GET', '/email/'.$stat['tracking_hash'].'.gif');
+            $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/email/'.$stat['tracking_hash'].'.gif');
             $this->assertResponseIsSuccessful();
         }
 
@@ -453,7 +453,7 @@ final class TriggerCampaignCommandTest extends AbstractCampaignCommand
 
         // Now let's simulate email opens
         foreach ($stats as $stat) {
-            $this->client->request('GET', '/email/'.$stat['tracking_hash'].'.gif');
+            $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/email/'.$stat['tracking_hash'].'.gif');
             $this->assertResponseIsSuccessful();
         }
 

--- a/app/bundles/CampaignBundle/Tests/Controller/CampaignControllerFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/CampaignControllerFunctionalTest.php
@@ -178,7 +178,7 @@ final class CampaignControllerFunctionalTest extends AbstractCampaignTestCase
     {
         $from = date('Y-m-d', strtotime('-2 months'));
         $to   = date('Y-m-d', strtotime('-1 month'));
-        $this->client->request('GET', sprintf('s/campaigns/graph/%d/%s/%s', $campaignId, $from, $to));
+        $this->client->request(Request::METHOD_GET, sprintf('s/campaigns/graph/%d/%s/%s', $campaignId, $from, $to));
         $response      = $this->client->getResponse();
         $body          = json_decode($response->getContent(), true);
         $crawler       = new Crawler($body['newContent']);
@@ -213,7 +213,7 @@ final class CampaignControllerFunctionalTest extends AbstractCampaignTestCase
         $from = date('Y-m-d', strtotime('-2 months'));
         $to   = date('Y-m-d', strtotime('-1 month'));
         $url  = sprintf('s/campaigns/event/stats/%d/%s/%s', $campaignId, $from, $to);
-        $this->client->request('GET', $url);
+        $this->client->request(Request::METHOD_GET, $url);
         $response = $this->client->getResponse();
         $body     = json_decode($response->getContent(), true);
         $this->client->restart();
@@ -356,7 +356,7 @@ final class CampaignControllerFunctionalTest extends AbstractCampaignTestCase
     public function testCampaignView(): void
     {
         $campaign = $this->saveSomeCampaignLeadEventLogs();
-        $crawler  = $this->client->request('GET', sprintf('/s/campaigns/view/%d', $campaign->getId()));
+        $crawler  = $this->client->request(Request::METHOD_GET, sprintf('/s/campaigns/view/%d', $campaign->getId()));
         $response = $this->client->getResponse();
         self::assertResponseIsSuccessful();
         $this->assertStringContainsString('Campaign ABC', (string) $response->getContent());
@@ -371,7 +371,7 @@ final class CampaignControllerFunctionalTest extends AbstractCampaignTestCase
         $from     = date('Y-m-d', strtotime('-2 months'));
         $to       = date('Y-m-d', strtotime('-1 month'));
         $campaign = $this->saveSomeCampaignLeadEventLogs();
-        $this->client->request('GET', sprintf('s/campaigns/event/stats/%d/%s/%s', $campaign->getId(), $from, $to));
+        $this->client->request(Request::METHOD_GET, sprintf('s/campaigns/event/stats/%d/%s/%s', $campaign->getId(), $from, $to));
         $response = $this->client->getResponse();
         self::assertResponseIsSuccessful();
         $body     = json_decode($response->getContent(), true);

--- a/app/bundles/CampaignBundle/Tests/Controller/CampaignControllerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/CampaignControllerTest.php
@@ -17,7 +17,7 @@ final class CampaignControllerTest extends MauticMysqlTestCase
      */
     public function testIndexActionWhenNotFiltered(): void
     {
-        $this->client->request('GET', '/s/campaigns');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/s/campaigns');
         $this->assertResponseIsSuccessful();
     }
 
@@ -26,7 +26,7 @@ final class CampaignControllerTest extends MauticMysqlTestCase
      */
     public function testIndexActionWhenFiltering(): void
     {
-        $this->client->request('GET', '/s/campaigns?search=has%3Aresults&tmpl=list');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/s/campaigns?search=has%3Aresults&tmpl=list');
         $this->assertResponseIsSuccessful();
     }
 
@@ -35,7 +35,7 @@ final class CampaignControllerTest extends MauticMysqlTestCase
      */
     public function testNewActionCampaign(): void
     {
-        $this->client->request('GET', '/s/campaigns/new/');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/s/campaigns/new/');
         $clientResponse = $this->client->getResponse();
         $this->assertEquals(Response::HTTP_OK, $clientResponse->getStatusCode());
     }
@@ -47,7 +47,7 @@ final class CampaignControllerTest extends MauticMysqlTestCase
      */
     public function testNewActionCampaignCancel(): void
     {
-        $crawler = $this->client->request('GET', '/s/campaigns/new/');
+        $crawler = $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/s/campaigns/new/');
         self::assertResponseIsSuccessful();
 
         $form = $crawler->filter('form[name="campaign"]')->selectButton('campaign_buttons_cancel')->form();
@@ -68,7 +68,7 @@ final class CampaignControllerTest extends MauticMysqlTestCase
         $this->em->flush();
         $this->em->clear();
 
-        $crawler = $this->client->request('GET', '/s/campaigns/edit/'.$campaign->getId());
+        $crawler = $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/s/campaigns/edit/'.$campaign->getId());
         $form    = $crawler->selectButton('Save')->form();
         $form['campaign[projects]']->setValue((string) $project->getId());
 
@@ -112,7 +112,7 @@ final class CampaignControllerTest extends MauticMysqlTestCase
         $this->em->clear();
 
         // Request the edit page for the campaign
-        $this->client->request('GET', '/s/campaigns/edit/'.$campaign->getId());
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/s/campaigns/edit/'.$campaign->getId());
         $clientResponse = $this->client->getResponse();
 
         $this->assertResponseIsSuccessful();

--- a/app/bundles/CampaignBundle/Tests/Controller/CampaignMapStatsControllerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/CampaignMapStatsControllerTest.php
@@ -118,7 +118,7 @@ final class CampaignMapStatsControllerTest extends MauticMysqlTestCase
         $this->em->persist($campaign);
         $this->em->flush();
 
-        $this->client->request('GET', "s/campaign-map-stats/{$campaign->getId()}/2023-07-20/2023-07-25");
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, "s/campaign-map-stats/{$campaign->getId()}/2023-07-20/2023-07-25");
         $clientResponse = $this->client->getResponse();
         $crawler        = new Crawler($clientResponse->getContent(), $this->client->getInternalRequest()->getUri());
 
@@ -173,7 +173,7 @@ final class CampaignMapStatsControllerTest extends MauticMysqlTestCase
         ];
         $campaign = $this->createCampaignWithEmail($leadsPayload);
 
-        $this->client->request('GET', "s/campaign-map-stats/{$campaign->getId()}/2023-07-20/2023-07-25");
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, "s/campaign-map-stats/{$campaign->getId()}/2023-07-20/2023-07-25");
         $clientResponse = $this->client->getResponse();
         $crawler        = new Crawler($clientResponse->getContent(), $this->client->getInternalRequest()->getUri());
 

--- a/app/bundles/CampaignBundle/Tests/Controller/CampaignUnpublishedWorkflowFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/CampaignUnpublishedWorkflowFunctionalTest.php
@@ -13,7 +13,7 @@ final class CampaignUnpublishedWorkflowFunctionalTest extends AbstractCampaignTe
     public function testCreateCampaignPageShouldNotContainConformation(): void
     {
         // Check the message in the Campaign edit page
-        $crawler  = $this->client->request('GET', '/s/campaigns/new');
+        $crawler  = $this->client->request(Request::METHOD_GET, '/s/campaigns/new');
         $this->assertResponseIsSuccessful();
 
         $attributes = [
@@ -41,7 +41,7 @@ final class CampaignUnpublishedWorkflowFunctionalTest extends AbstractCampaignTe
         $translator = self::getContainer()->get(TranslatorInterface::class);
 
         // Check the message in the Campaign edit page
-        $crawler  = $this->client->request('GET', sprintf('/s/campaigns/edit/%d', $campaign->getId()));
+        $crawler  = $this->client->request(Request::METHOD_GET, sprintf('/s/campaigns/edit/%d', $campaign->getId()));
         $this->assertResponseIsSuccessful();
 
         $republishBehavior = $translator->trans('mautic.campaignconfig.campaign_republish_behavior.'.$campaign->getRepublishBehavior());
@@ -73,7 +73,7 @@ final class CampaignUnpublishedWorkflowFunctionalTest extends AbstractCampaignTe
         $translator = self::getContainer()->get(TranslatorInterface::class);
 
         // Check the message in the Campaign listing page
-        $crawler  = $this->client->request('GET', '/s/campaigns');
+        $crawler  = $this->client->request(Request::METHOD_GET, '/s/campaigns');
         $this->assertResponseIsSuccessful();
 
         $republishBehavior = $translator->trans('mautic.campaignconfig.campaign_republish_behavior.'.$campaign->getRepublishBehavior());

--- a/app/bundles/CampaignBundle/Tests/Controller/SourceControllerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/SourceControllerTest.php
@@ -27,7 +27,7 @@ final class SourceControllerTest extends MauticMysqlTestCase
 
     public function testNewActionWithNonAjaxRequest(): void
     {
-        $this->client->request('GET', self::NEW_FORMS_URL);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, self::NEW_FORMS_URL);
         $response = $this->client->getResponse();
         $this->assertStringContainsString(self::ACCESS_DENIED, (string) $response->getContent());
     }

--- a/app/bundles/CampaignBundle/Tests/EventListener/CampaignEventSubscriberFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/EventListener/CampaignEventSubscriberFunctionalTest.php
@@ -86,7 +86,7 @@ final class CampaignEventSubscriberFunctionalTest extends MauticMysqlTestCase
             ];
         }
 
-        $this->client->request('POST', '/api/contacts/batch/new', $contacts);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_POST, '/api/contacts/batch/new', $contacts);
         $response = json_decode($this->client->getResponse()->getContent(), true);
         $contacts = $response['contacts'];
         $this->assertCount(150, $contacts);

--- a/app/bundles/CampaignBundle/Tests/Functional/Api/CampaignApiEventDeleteTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Api/CampaignApiEventDeleteTest.php
@@ -44,11 +44,11 @@ final class CampaignApiEventDeleteTest extends MauticMysqlTestCase
         $this->em->persist($campaign);
         $this->em->flush();
         $this->assertGreaterThan(0, $campaign->getId(), 'Campaign should be saved with an ID');
-        $this->client->request('GET', '/api/campaigns');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/api/campaigns');
         $this->assertResponseIsSuccessful();
 
         // Step 1: GET the campaign (like API Library test does)
-        $this->client->request('GET', "/api/campaigns/{$campaign->getId()}");
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, "/api/campaigns/{$campaign->getId()}");
         $this->assertResponseIsSuccessful();
 
         $data   = json_decode($this->client->getResponse()->getContent(), true);
@@ -64,7 +64,7 @@ final class CampaignApiEventDeleteTest extends MauticMysqlTestCase
             'lists'  => [['id' => $segment->getId()]],
         ];
 
-        $this->client->request('PUT', "/api/campaigns/{$campaign->getId()}/edit", $payload);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_PUT, "/api/campaigns/{$campaign->getId()}/edit", $payload);
         $this->assertResponseIsSuccessful();
     }
 }

--- a/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignEventDetailsTimelineFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignEventDetailsTimelineFunctionalTest.php
@@ -84,7 +84,7 @@ final class CampaignEventDetailsTimelineFunctionalTest extends MauticMysqlTestCa
         $this->assertInstanceOf(TranslatorInterface::class, $translator);
         $operator = $translator->trans('mautic.lead.list.form.operator.in');
 
-        $this->client->request('GET', sprintf('/s/contacts/view/%s', $lead1->getId()));
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, sprintf('/s/contacts/view/%s', $lead1->getId()));
         $this->assertStringContainsString(
             $translator->trans('mautic.campaign.event.condition.details', [
                 '%path%'            => 'yes',
@@ -96,7 +96,7 @@ final class CampaignEventDetailsTimelineFunctionalTest extends MauticMysqlTestCa
             (string) $this->client->getResponse()->getContent()
         );
 
-        $this->client->request('GET', sprintf('/s/contacts/view/%s', $lead2->getId()));
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, sprintf('/s/contacts/view/%s', $lead2->getId()));
         $this->assertStringContainsString(
             $translator->trans('mautic.campaign.event.condition.details', [
                 '%path%'            => 'no',

--- a/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignRotationTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignRotationTest.php
@@ -76,7 +76,7 @@ final class CampaignRotationTest extends MauticMysqlTestCase
             $this->campaignWithJump->getId()
         );
 
-        $this->client->request('GET', sprintf('/%s', $this->page->getAlias()));
+        $this->client->request(Request::METHOD_GET, sprintf('/%s', $this->page->getAlias()));
 
         self::assertResponseIsSuccessful();
 
@@ -95,7 +95,7 @@ final class CampaignRotationTest extends MauticMysqlTestCase
             $this->campaignWithJump->getId()
         );
 
-        $this->client->request('GET', sprintf('/%s', $this->page->getAlias()));
+        $this->client->request(Request::METHOD_GET, sprintf('/%s', $this->page->getAlias()));
 
         self::assertResponseIsSuccessful();
 

--- a/app/bundles/CampaignBundle/Tests/Functional/Campaign/DetailsTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Campaign/DetailsTest.php
@@ -41,7 +41,7 @@ final class DetailsTest extends MauticMysqlTestCase
         $this->em->persist($campaign);
         $this->em->flush();
 
-        $this->client->request('GET', sprintf('/s/campaigns/view/%s', $campaign->getId()));
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, sprintf('/s/campaigns/view/%s', $campaign->getId()));
 
         $response = $this->client->getResponse();
         self::assertResponseIsSuccessful();

--- a/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignControllerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignControllerTest.php
@@ -277,7 +277,7 @@ final class CampaignControllerTest extends MauticMysqlTestCase
         $before = $now->modify('-1 month');
         $after  = $now->modify('+1 month');
         $url    = sprintf('s/campaigns/event/stats/%d/%s/%s', $campaign->getId(), $before->format('Y-m-d'), $after->format('Y-m-d'));
-        $this->client->request('GET', $url);
+        $this->client->request(Request::METHOD_GET, $url);
         $response = $this->client->getResponse();
         $body     = json_decode($response->getContent(), true, 512, JSON_THROW_ON_ERROR);
         $this->client->restart();
@@ -323,7 +323,7 @@ final class CampaignControllerTest extends MauticMysqlTestCase
 
         $this->loginOtherUser($nonAdminUser);
 
-        $this->client->request('GET', '/s/campaigns/export/'.$this->campaign->getId());
+        $this->client->request(Request::METHOD_GET, '/s/campaigns/export/'.$this->campaign->getId());
 
         $response = $this->client->getResponse();
 
@@ -338,7 +338,7 @@ final class CampaignControllerTest extends MauticMysqlTestCase
         $this->loginOtherUser($nonAdminUser);
 
         $this->client->request(
-            'GET',
+            Request::METHOD_GET,
             '/s/campaigns/batchExport',
             [
                 'filetype' => 'zip',
@@ -359,7 +359,7 @@ final class CampaignControllerTest extends MauticMysqlTestCase
 
         $this->loginOtherUser($nonAdminUser);
 
-        $this->client->request('GET', '/s/campaigns/export/'.$this->campaign->getId());
+        $this->client->request(Request::METHOD_GET, '/s/campaigns/export/'.$this->campaign->getId());
 
         $response = $this->client->getResponse();
 
@@ -372,7 +372,7 @@ final class CampaignControllerTest extends MauticMysqlTestCase
 
         $this->loginOtherUser($nonAdminUser);
 
-        $this->client->request('GET', '/s/campaigns/export/999999'); // Non-existent campaign ID
+        $this->client->request(Request::METHOD_GET, '/s/campaigns/export/999999'); // Non-existent campaign ID
 
         $response = $this->client->getResponse();
 
@@ -392,7 +392,7 @@ final class CampaignControllerTest extends MauticMysqlTestCase
 
         $this->loginOtherUser($nonAdminUser);
 
-        $this->client->request('GET', '/s/campaigns/export/'.$this->campaign->getId());
+        $this->client->request(Request::METHOD_GET, '/s/campaigns/export/'.$this->campaign->getId());
 
         $response        = $this->client->getResponse();
         $responseContent = $response->getContent();
@@ -415,7 +415,7 @@ final class CampaignControllerTest extends MauticMysqlTestCase
 
         $this->loginOtherUser($nonAdminUser);
 
-        $this->client->request('GET', '/s/campaigns/batchExport');
+        $this->client->request(Request::METHOD_GET, '/s/campaigns/batchExport');
 
         $response = $this->client->getResponse();
 
@@ -428,7 +428,7 @@ final class CampaignControllerTest extends MauticMysqlTestCase
 
         $this->loginOtherUser($nonAdminUser);
 
-        $this->client->request('GET', '/s/campaigns/batchExport', [
+        $this->client->request(Request::METHOD_GET, '/s/campaigns/batchExport', [
             'ids' => json_encode([]), // Empty IDs to trigger query
         ]);
 
@@ -450,7 +450,7 @@ final class CampaignControllerTest extends MauticMysqlTestCase
 
         $this->loginOtherUser($nonAdminUser);
 
-        $this->client->request('GET', '/s/campaigns/batchExport', [
+        $this->client->request(Request::METHOD_GET, '/s/campaigns/batchExport', [
             'ids' => json_encode([$this->campaign->getId()]),
         ]);
 

--- a/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignEventStatsTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignEventStatsTest.php
@@ -89,7 +89,7 @@ final class CampaignEventStatsTest extends MauticMysqlTestCase
         $before = $now->modify('-1 month');
         $after  = $now->modify('+1 month');
         $url    = sprintf('/s/campaigns/event/stats/%d/%s/%s', $campaign->getId(), $before->format('Y-m-d'), $after->format('Y-m-d'));
-        $this->client->request('GET', $url);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $url);
         $response = $this->client->getResponse();
         $body     = \json_decode($response->getContent(), true);
 

--- a/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignImportControllerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignImportControllerTest.php
@@ -72,7 +72,7 @@ final class CampaignImportControllerTest extends MauticMysqlTestCase
         $this->loginUser($user);
 
         // Make a dummy request to initialize session
-        $this->client->request('GET', '/');
+        $this->client->request(Request::METHOD_GET, '/');
         $session = $this->client->getRequest()->getSession();
 
         // Simulate import summary with NEW entities to trigger undo
@@ -87,7 +87,7 @@ final class CampaignImportControllerTest extends MauticMysqlTestCase
         ]);
         $session->save();
 
-        $this->client->request('GET', '/s/campaign/import/undo');
+        $this->client->request(Request::METHOD_GET, '/s/campaign/import/undo');
         $response = $this->client->getResponse();
 
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
@@ -101,7 +101,7 @@ final class CampaignImportControllerTest extends MauticMysqlTestCase
         $this->loginUser($user);
 
         // Dummy request to initialize session
-        $this->client->request('GET', '/');
+        $this->client->request(Request::METHOD_GET, '/');
         $session = $this->client->getRequest()->getSession();
 
         // Simulate import summary with only UPDATE (no NEW data)
@@ -116,7 +116,7 @@ final class CampaignImportControllerTest extends MauticMysqlTestCase
         ]);
         $session->save();
 
-        $this->client->request('GET', '/s/campaign/import/undo');
+        $this->client->request(Request::METHOD_GET, '/s/campaign/import/undo');
         $response = $this->client->getResponse();
 
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
@@ -129,7 +129,7 @@ final class CampaignImportControllerTest extends MauticMysqlTestCase
         $this->assertInstanceOf(User::class, $user);
         $this->loginUser($user);
 
-        $this->client->request('GET', '/');
+        $this->client->request(Request::METHOD_GET, '/');
         $session = $this->client->getRequest()->getSession();
         $session->set('mautic.campaign.import.step', 2);
         $session->set('mautic.campaign.import.file', __DIR__.'/Fixtures/empty.zip');
@@ -139,7 +139,7 @@ final class CampaignImportControllerTest extends MauticMysqlTestCase
         $importHelper->method('readZipFile')->willReturn([]);
         self::getContainer()->set(ImportHelper::class, $importHelper);
 
-        $this->client->request('GET', '/s/campaign/import/progress');
+        $this->client->request(Request::METHOD_GET, '/s/campaign/import/progress');
         $response = $this->client->getResponse();
 
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
@@ -150,7 +150,7 @@ final class CampaignImportControllerTest extends MauticMysqlTestCase
         $user = $this->em->getRepository(User::class)->findOneBy(['username' => 'admin']);
         $this->loginUser($user);
 
-        $this->client->request('GET', '/');
+        $this->client->request(Request::METHOD_GET, '/');
         $session = $this->client->getRequest()->getSession();
 
         $fixturesDir = __DIR__.'/Fixtures';
@@ -169,7 +169,7 @@ final class CampaignImportControllerTest extends MauticMysqlTestCase
         $importHelper->method('readZipFile')->willReturn(FixtureHelper::getPayload());
         self::getContainer()->set(ImportHelper::class, $importHelper);
 
-        $this->client->request('GET', '/s/campaign/import/progress');
+        $this->client->request(Request::METHOD_GET, '/s/campaign/import/progress');
         $response = $this->client->getResponse();
 
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
@@ -182,7 +182,7 @@ final class CampaignImportControllerTest extends MauticMysqlTestCase
         $this->assertInstanceOf(User::class, $user);
         $this->loginUser($user);
 
-        $this->client->request('GET', '/');
+        $this->client->request(Request::METHOD_GET, '/');
         $session = $this->client->getRequest()->getSession();
         $session->set('mautic.campaign.import.step', 3);
         $session->set('mautic.campaign.import.file', __DIR__.'/Fixtures/empty.zip');
@@ -192,7 +192,7 @@ final class CampaignImportControllerTest extends MauticMysqlTestCase
         $importHelper->method('readZipFile')->willReturn([]);
         self::getContainer()->set(ImportHelper::class, $importHelper);
 
-        $this->client->request('GET', '/s/campaign/import/progress');
+        $this->client->request(Request::METHOD_GET, '/s/campaign/import/progress');
         $response = $this->client->getResponse();
 
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
@@ -203,7 +203,7 @@ final class CampaignImportControllerTest extends MauticMysqlTestCase
         $user = $this->em->getRepository(User::class)->findOneBy(['username' => 'admin']);
         $this->loginUser($user);
 
-        $this->client->request('GET', '/');
+        $this->client->request(Request::METHOD_GET, '/');
         $session = $this->client->getRequest()->getSession();
 
         $fixturesDir = __DIR__.'/Fixtures';
@@ -222,7 +222,7 @@ final class CampaignImportControllerTest extends MauticMysqlTestCase
         $importHelper->method('readZipFile')->willReturn(FixtureHelper::getPayload());
         self::getContainer()->set(ImportHelper::class, $importHelper);
 
-        $this->client->request('GET', '/s/campaign/import/progress');
+        $this->client->request(Request::METHOD_GET, '/s/campaign/import/progress');
         $response = $this->client->getResponse();
 
         $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
@@ -247,7 +247,7 @@ final class CampaignImportControllerTest extends MauticMysqlTestCase
         ];
 
         $this->client->request(
-            'POST',
+            Request::METHOD_POST,
             '/s/campaign/import/upload',
             ['campaign_import' => []], // POST data
             ['campaign_import' => ['campaignFile' => $fileArray]]

--- a/app/bundles/CampaignBundle/Tests/Functional/Form/Validator/Constraints/InfiniteLoopValidatorFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Form/Validator/Constraints/InfiniteLoopValidatorFunctionalTest.php
@@ -198,7 +198,7 @@ final class InfiniteLoopValidatorFunctionalTest extends MauticMysqlTestCase
 
         $expectedStatusCode = $success ? 201 : 422;
 
-        $this->client->request('POST', '/api/campaigns/new', $payload);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_POST, '/api/campaigns/new', $payload);
         $response = $this->client->getResponse();
         self::assertResponseStatusCodeSame($expectedStatusCode, $response->getContent());
 

--- a/app/bundles/CategoryBundle/Tests/Controller/Api/CategoryApiControllerFunctionalTest.php
+++ b/app/bundles/CategoryBundle/Tests/Controller/Api/CategoryApiControllerFunctionalTest.php
@@ -30,7 +30,7 @@ final class CategoryApiControllerFunctionalTest extends MauticMysqlTestCase
 
         // Test the correct endpoint /api/v2/categories
         $this->client->request(
-            'GET',
+            \Symfony\Component\HttpFoundation\Request::METHOD_GET,
             '/api/v2/categories',
             [],
             [],
@@ -97,7 +97,7 @@ final class CategoryApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertGreaterThanOrEqual(1, count($allLeadCategories), 'LeadCategory should be in database');
 
         $this->client->request(
-            'GET',
+            \Symfony\Component\HttpFoundation\Request::METHOD_GET,
             '/api/v2/contactcategories',
             [],
             [],
@@ -145,7 +145,7 @@ final class CategoryApiControllerFunctionalTest extends MauticMysqlTestCase
 
         // Filter by contact bundle
         $this->client->request(
-            'GET',
+            \Symfony\Component\HttpFoundation\Request::METHOD_GET,
             '/api/v2/categories?bundle=contact',
             [],
             [],

--- a/app/bundles/CategoryBundle/Tests/Controller/CategoryControllerFunctionalTest.php
+++ b/app/bundles/CategoryBundle/Tests/Controller/CategoryControllerFunctionalTest.php
@@ -58,7 +58,7 @@ final class CategoryControllerFunctionalTest extends MauticMysqlTestCase
      */
     public function testIndexActionWhenNotFiltered(): void
     {
-        $this->client->request('GET', '/s/categories?tmpl=list&bundle=category');
+        $this->client->request(Request::METHOD_GET, '/s/categories?tmpl=list&bundle=category');
         $clientResponse         = $this->client->getResponse();
         $clientResponseContent  = $clientResponse->getContent();
 
@@ -72,7 +72,7 @@ final class CategoryControllerFunctionalTest extends MauticMysqlTestCase
      */
     public function testIndexActionWhenFiltered(): void
     {
-        $this->client->request('GET', '/s/categories/page?tmpl=list&bundle=page');
+        $this->client->request(Request::METHOD_GET, '/s/categories/page?tmpl=list&bundle=page');
         $clientResponse         = $this->client->getResponse();
         $clientResponseContent  = $clientResponse->getContent();
 
@@ -196,7 +196,7 @@ final class CategoryControllerFunctionalTest extends MauticMysqlTestCase
             'validators'
         );
 
-        $this->client->request('POST', 's/categories/category/delete/'.$category->getId(), [], [], [
+        $this->client->request(Request::METHOD_POST, 's/categories/category/delete/'.$category->getId(), [], [], [
             'HTTP_Content-Type'     => 'application/x-www-form-urlencoded; charset=UTF-8',
             'HTTP_X-Requested-With' => 'XMLHttpRequest',
             'HTTP_X-CSRF-Token'     => $this->getCsrfToken('mautic_ajax_post'),
@@ -230,7 +230,7 @@ final class CategoryControllerFunctionalTest extends MauticMysqlTestCase
         );
 
         $parameters = 'ids=["'.$category->getId().'"]';
-        $this->client->request('POST', 's/categories/category/batchDelete?'.$parameters, [], [], [
+        $this->client->request(Request::METHOD_POST, 's/categories/category/batchDelete?'.$parameters, [], [], [
             'HTTP_Content-Type'     => 'application/x-www-form-urlencoded; charset=UTF-8',
             'HTTP_X-Requested-With' => 'XMLHttpRequest',
             'HTTP_X-CSRF-Token'     => $this->getCsrfToken('mautic_ajax_post'),

--- a/app/bundles/ChannelBundle/Tests/Controller/Api/MessageApiControllerTest.php
+++ b/app/bundles/ChannelBundle/Tests/Controller/Api/MessageApiControllerTest.php
@@ -29,7 +29,7 @@ JSON;
 
         $payloadArray = json_decode($payloadJson, true);
 
-        $this->client->request('POST', '/api/messages/new', $payloadArray);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_POST, '/api/messages/new', $payloadArray);
         $responseJson = $this->client->getResponse()->getContent();
         self::assertResponseStatusCodeSame(201, $responseJson);
         $this->assertMessagePayload($payloadArray, json_decode($responseJson, true)['message'], $responseJson);
@@ -58,7 +58,7 @@ JSON;
         $this->em->detach($message);
 
         $patchPayload = ['id' => $message->getId()] + $payload;
-        $this->client->request('PATCH', "/api/messages/{$message->getId()}/edit", $patchPayload);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_PATCH, "/api/messages/{$message->getId()}/edit", $patchPayload);
         $responseJson = $this->client->getResponse()->getContent();
         self::assertResponseIsSuccessful($responseJson);
         $this->assertMessagePayload(
@@ -151,7 +151,7 @@ JSON;
             ['id' => $message1->getId(), 'name' => 'API message 1 (updated)'],
             ['id' => $message2->getId(), 'channels' => ['email' => ['channelId' => 14, 'isEnabled' => false]]],
         ];
-        $this->client->request('PATCH', '/api/messages/batch/edit', $patchPayload);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_PATCH, '/api/messages/batch/edit', $patchPayload);
         $responseJson = $this->client->getResponse()->getContent();
         self::assertResponseIsSuccessful($responseJson);
         $responseArray = json_decode($responseJson, true);

--- a/app/bundles/ChannelBundle/Tests/Controller/MessageControllerFunctionalTest.php
+++ b/app/bundles/ChannelBundle/Tests/Controller/MessageControllerFunctionalTest.php
@@ -23,7 +23,7 @@ final class MessageControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->flush();
         $this->em->clear();
 
-        $crawler = $this->client->request('GET', '/s/messages/edit/'.$message->getId());
+        $crawler = $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/s/messages/edit/'.$message->getId());
         $form    = $crawler->selectButton('Save')->form();
         $form['message[projects]']->setValue((string) $project->getId());
 

--- a/app/bundles/CoreBundle/Test/FunctionalWarmupTest.php
+++ b/app/bundles/CoreBundle/Test/FunctionalWarmupTest.php
@@ -8,7 +8,7 @@ final class FunctionalWarmupTest extends MauticMysqlTestCase
 {
     public function testWarmup(): void
     {
-        $this->client->request('GET', '/404');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/404');
         $this->assertResponseStatusCodeSame(404);
     }
 }

--- a/app/bundles/CoreBundle/Tests/Functional/Controller/AbstractFormControllerTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Controller/AbstractFormControllerTest.php
@@ -15,7 +15,7 @@ final class AbstractFormControllerTest extends MauticMysqlTestCase
         $returnUrl   = 'http://localhost/s/forms';
 
         $this->client->request(
-            'GET',
+            \Symfony\Component\HttpFoundation\Request::METHOD_GET,
             "/s/action/unlock/{$objectModel}/{$objectId}",
             [
                 'returnUrl' => urlencode($returnUrl),
@@ -37,7 +37,7 @@ final class AbstractFormControllerTest extends MauticMysqlTestCase
         $invalidReturnUrl = 'invalid-url';
 
         $this->client->request(
-            'GET',
+            \Symfony\Component\HttpFoundation\Request::METHOD_GET,
             "/s/action/unlock/{$objectModel}/{$objectId}",
             [
                 'returnUrl' => $invalidReturnUrl,
@@ -59,7 +59,7 @@ final class AbstractFormControllerTest extends MauticMysqlTestCase
         $returnUrl   = 'https://malicious.com/s/forms';
 
         $this->client->request(
-            'GET',
+            \Symfony\Component\HttpFoundation\Request::METHOD_GET,
             "/s/action/unlock/{$objectModel}/{$objectId}",
             [
                 'returnUrl' => urlencode($returnUrl),

--- a/app/bundles/CoreBundle/Tests/Functional/Controller/ExportControllerTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Controller/ExportControllerTest.php
@@ -84,7 +84,7 @@ final class ExportControllerTest extends MauticMysqlTestCase
         $this->getContainer()->get(ReportModel::class)->saveEntity($report);
 
         // Check the details page
-        $this->client->request('GET', '/s/reports/view/'.$report->getId());
+        $this->client->request(Request::METHOD_GET, '/s/reports/view/'.$report->getId());
         $this->assertResponseIsSuccessful();
 
         $this->client->request(Request::METHOD_GET, '/s/reports/view/'.$report->getId().'');
@@ -211,7 +211,7 @@ final class ExportControllerTest extends MauticMysqlTestCase
             ],
         ];
 
-        $this->client->request('POST', '/api/forms/new', $formPayload);
+        $this->client->request(Request::METHOD_POST, '/api/forms/new', $formPayload);
         $clientResponse = $this->client->getResponse();
         $this->assertEquals(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
         $response = json_decode($clientResponse->getContent(), true);

--- a/app/bundles/CoreBundle/Tests/Functional/Controller/FileControllerTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Controller/FileControllerTest.php
@@ -14,7 +14,7 @@ final class FileControllerTest extends MauticMysqlTestCase
     public function testImageUploadSuccess(): void
     {
         $image = $this->createUploadFile('png-test.png', 'tmp-png-test.png');
-        $this->client->request('POST', 's/file/upload?editor=ckeditor', [], ['upload' => $image]);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_POST, 's/file/upload?editor=ckeditor', [], ['upload' => $image]);
         $response = $this->client->getResponse();
         self::assertResponseIsSuccessful();
         $responseData = json_decode($response->getContent(), true);
@@ -30,7 +30,7 @@ final class FileControllerTest extends MauticMysqlTestCase
     {
         $image = $this->createUploadFile('test.json', 'tmp-test.json');
 
-        $this->client->request('POST', 's/file/upload?editor=ckeditor', [], ['upload' => $image]);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_POST, 's/file/upload?editor=ckeditor', [], ['upload' => $image]);
         $response = $this->client->getResponse();
         self::assertResponseIsSuccessful();
         $responseData = json_decode($response->getContent(), true);

--- a/app/bundles/CoreBundle/Tests/Functional/Controller/JsControllerTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Controller/JsControllerTest.php
@@ -28,7 +28,7 @@ final class JsControllerTest extends MauticMysqlTestCase
 
     public function testIndexActionRendersSuccessfully(): void
     {
-        $this->client->request('GET', '/mtc.js');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/mtc.js');
         self::assertResponseIsSuccessful();
         $content = (string) $this->client->getResponse()->getContent();
         $this->assertStringContainsString('https://www.googletagmanager.com/gtag/js?id=G-F3825DS9CD', $content);
@@ -42,7 +42,7 @@ final class JsControllerTest extends MauticMysqlTestCase
 
     public function testIndexActionRendersSuccessfullyWithAnonymizeIp(): void
     {
-        $this->client->request('GET', '/mtc.js');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/mtc.js');
         self::assertResponseIsSuccessful();
         $this->assertStringContainsString('https://www.googletagmanager.com/gtag/js?id=G-F3825DS9CD', (string) $this->client->getResponse()->getContent());
         $this->assertStringContainsString('window.gtag(\'config\',\'G-F3825DS9CD\',{"anonymize_ip":!0})', (string) $this->client->getResponse()->getContent());
@@ -50,7 +50,7 @@ final class JsControllerTest extends MauticMysqlTestCase
 
     public function testEssentialEndpointContainsAnonymousRuntimeOnly(): void
     {
-        $this->client->request('GET', '/mautic-essential.js');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/mautic-essential.js');
 
         self::assertResponseIsSuccessful();
         $content = (string) $this->client->getResponse()->getContent();
@@ -73,7 +73,7 @@ final class JsControllerTest extends MauticMysqlTestCase
 
     public function testTrackingEndpointContainsIdentityWithoutRuntime(): void
     {
-        $this->client->request('GET', '/mautic-tracking.js');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/mautic-tracking.js');
 
         self::assertResponseIsSuccessful();
         $content = (string) $this->client->getResponse()->getContent();
@@ -94,7 +94,7 @@ final class JsControllerTest extends MauticMysqlTestCase
     #[DataProvider('scriptEndpointProvider')]
     public function testScriptEndpoints(string $path, bool $containsTracking): void
     {
-        $this->client->request('GET', $path);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $path);
 
         self::assertResponseIsSuccessful();
         self::assertResponseHeaderSame('Content-Type', 'application/javascript');

--- a/app/bundles/CoreBundle/Tests/Functional/Entity/CommonRepositoryTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Entity/CommonRepositoryTest.php
@@ -12,7 +12,7 @@ final class CommonRepositoryTest extends MauticMysqlTestCase
     #[TestDox('Test that is:mine does not throw an exception due to bad DQL')]
     public function testIsMineSearchCommandDoesntCauseExceptionDueToBadDQL(): void
     {
-        $this->client->request('GET', 's/contacts?search=is:mine');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, 's/contacts?search=is:mine');
 
         $this->assertResponseIsSuccessful();
         $this->assertStringContainsString('is:mine', (string) $this->client->getResponse()->getContent());
@@ -20,7 +20,7 @@ final class CommonRepositoryTest extends MauticMysqlTestCase
 
     public function testIsMineSearchCommandDoesntCauseExceptionDueToBadDQLForCompanies(): void
     {
-        $this->client->request('GET', 's/companies?search=is:mine');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, 's/companies?search=is:mine');
 
         $this->assertResponseIsSuccessful();
         $this->assertStringContainsString('is:mine', (string) $this->client->getResponse()->getContent());
@@ -28,7 +28,7 @@ final class CommonRepositoryTest extends MauticMysqlTestCase
 
     public function testIsPublishedSearchCommandDoesntCauseExceptionDueToBadDQLForEmails(): void
     {
-        $this->client->request('GET', 's/emails?search=is:published');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, 's/emails?search=is:published');
 
         $this->assertResponseIsSuccessful();
         $this->assertStringContainsString('is:published', (string) $this->client->getResponse()->getContent());

--- a/app/bundles/DashboardBundle/Tests/Controller/DashboardControllerFunctionalTest.php
+++ b/app/bundles/DashboardBundle/Tests/Controller/DashboardControllerFunctionalTest.php
@@ -242,7 +242,7 @@ final class DashboardControllerFunctionalTest extends MauticMysqlTestCase
 
         $this->em->flush();
 
-        $this->client->request('GET', "/s/dashboard/widget/{$widget->getId()}", [], [], $this->createAjaxHeaders());
+        $this->client->request(Request::METHOD_GET, "/s/dashboard/widget/{$widget->getId()}", [], [], $this->createAjaxHeaders());
 
         self::assertResponseIsSuccessful();
         $this->assertStringContainsString('TestFN TestLN', (string) $this->client->getResponse()->getContent());

--- a/app/bundles/DynamicContentBundle/Tests/Controller/DynamicContentControllerFunctionalTest.php
+++ b/app/bundles/DynamicContentBundle/Tests/Controller/DynamicContentControllerFunctionalTest.php
@@ -87,7 +87,7 @@ final class DynamicContentControllerFunctionalTest extends MauticMysqlTestCase
     public function testForbiddenDeleteAction(): void
     {
         $this->createAndLoginUser();
-        $this->client->request('GET', '/s/dwc/delete');
+        $this->client->request(Request::METHOD_GET, '/s/dwc/delete');
 
         self::assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
     }
@@ -105,7 +105,7 @@ final class DynamicContentControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->flush();
         $this->em->clear();
 
-        $crawler = $this->client->request('GET', '/s/dwc/edit/'.$dynamicContent->getId());
+        $crawler = $this->client->request(Request::METHOD_GET, '/s/dwc/edit/'.$dynamicContent->getId());
         $form    = $crawler->selectButton('Save')->form();
         $form['dwc[projects]']->setValue((string) $project->getId());
 

--- a/app/bundles/EmailBundle/Tests/Controller/Api/EmailApiControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/Api/EmailApiControllerFunctionalTest.php
@@ -175,7 +175,7 @@ final class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
             ],
         ];
 
-        $this->client->request('POST', '/api/segments/batch/new', $payload);
+        $this->client->request(Request::METHOD_POST, '/api/segments/batch/new', $payload);
         $clientResponse  = $this->client->getResponse();
         $segmentResponse = json_decode($clientResponse->getContent(), true);
         $segmentAId      = $segmentResponse['lists'][0]['id'];
@@ -193,7 +193,7 @@ final class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
             'customHtml' => '<h1>Email content created by an API test</h1>',
         ];
 
-        $this->client->request('POST', '/api/emails/new', $payload);
+        $this->client->request(Request::METHOD_POST, '/api/emails/new', $payload);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
         $emailId        = $response['email']['id'];
@@ -216,7 +216,7 @@ final class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
             'publicPreview' => true,
             'sendToDnc'     => true,
         ];
-        $this->client->request('PATCH', "/api/emails/{$emailId}/edit", $patchPayload);
+        $this->client->request(Request::METHOD_PATCH, "/api/emails/{$emailId}/edit", $patchPayload);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
@@ -236,7 +236,7 @@ final class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
         $payload['lists']         = [$segmentAId, $segmentBId];
         $payload['language']      = 'en'; // Must be present for PUT as all empty values are being cleared.
         $payload['publicPreview'] = false; // Must be present for PUT as all empty values are being cleared.
-        $this->client->request('PUT', "/api/emails/{$emailId}/edit", $payload);
+        $this->client->request(Request::METHOD_PUT, "/api/emails/{$emailId}/edit", $payload);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
@@ -253,7 +253,7 @@ final class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertFalse($response['email']['sendToDnc']);
 
         // Get:
-        $this->client->request('GET', "/api/emails/{$emailId}");
+        $this->client->request(Request::METHOD_GET, "/api/emails/{$emailId}");
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
@@ -266,7 +266,7 @@ final class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertEquals($payload['customHtml'], $response['email']['customHtml']);
 
         // Delete:
-        $this->client->request('DELETE', "/api/emails/{$emailId}/delete");
+        $this->client->request(Request::METHOD_DELETE, "/api/emails/{$emailId}/delete");
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
@@ -279,7 +279,7 @@ final class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertEquals($payload['customHtml'], $response['email']['customHtml']);
 
         // Get (ensure it's deleted):
-        $this->client->request('GET', "/api/emails/{$emailId}");
+        $this->client->request(Request::METHOD_GET, "/api/emails/{$emailId}");
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
@@ -287,7 +287,7 @@ final class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertSame(404, $response['errors'][0]['code']);
 
         // Delete also testing segments:
-        $this->client->request('DELETE', "/api/segments/batch/delete?ids={$segmentAId},{$segmentBId}", []);
+        $this->client->request(Request::METHOD_DELETE, "/api/segments/batch/delete?ids={$segmentAId},{$segmentBId}", []);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
@@ -301,7 +301,7 @@ final class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
         $trackingHash = 'tracking_hash_123';
 
         // Create new email reply.
-        $this->client->request('POST', "/api/emails/reply/{$trackingHash}");
+        $this->client->request(Request::METHOD_POST, "/api/emails/reply/{$trackingHash}");
         $response     = $this->client->getResponse();
         $responseData = json_decode($response->getContent(), true);
 
@@ -473,7 +473,7 @@ final class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
             'sendToDnc'  => true,
         ];
         $this->em->clear();
-        $this->client->request('POST', '/api/emails/new', $payload);
+        $this->client->request(Request::METHOD_POST, '/api/emails/new', $payload);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
         $this->assertArrayHasKey('sendToDnc', $response['email'], print_r($response, true));
@@ -496,7 +496,7 @@ final class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
         $statRepository->saveEntity($stat);
 
         // Create new email reply.
-        $this->client->request('POST', "/api/emails/reply/{$trackingHash}");
+        $this->client->request(Request::METHOD_POST, "/api/emails/reply/{$trackingHash}");
         $response = $this->client->getResponse();
 
         $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
@@ -504,7 +504,7 @@ final class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
 
         // Get the email reply that was just created from the stat API.
         $statReplyQuery = ['where' => [['col' => 'stat_id', 'expr' => 'eq', 'val' => $stat->getId()]]];
-        $this->client->request('GET', '/api/stats/email_stat_replies', $statReplyQuery);
+        $this->client->request(Request::METHOD_GET, '/api/stats/email_stat_replies', $statReplyQuery);
         $this->assertResponseIsSuccessful();
         $fetchedReplyData = json_decode($this->client->getResponse()->getContent(), true);
 
@@ -515,7 +515,7 @@ final class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
 
         // Get the email stat that was just updated from the stat API.
         $statQuery = ['where' => [['col' => 'id', 'expr' => 'eq', 'val' => $stat->getId()]]];
-        $this->client->request('GET', '/api/stats/email_stats', $statQuery);
+        $this->client->request(Request::METHOD_GET, '/api/stats/email_stats', $statQuery);
         $fetchedStatData = json_decode($this->client->getResponse()->getContent(), true);
 
         // Check that the email stat was updated correctly/
@@ -598,7 +598,7 @@ final class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
         $emailId = $email->getId();
 
         // Send to segment:
-        $this->client->request('POST', "/api/emails/{$emailId}/send");
+        $this->client->request(Request::METHOD_POST, "/api/emails/{$emailId}/send");
         $clientResponse = $this->client->getResponse();
         $sendResponse   = json_decode($clientResponse->getContent(), true);
 
@@ -622,7 +622,7 @@ final class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->persist($email);
         $this->em->flush();
         $emailId = $email->getId();
-        $this->client->request('POST', "/api/emails/{$emailId}/contact/{$contactId}/send", ['tokens' => ['{custom-token}' => 'custom <b>value</b>']]);
+        $this->client->request(Request::METHOD_POST, "/api/emails/{$emailId}/contact/{$contactId}/send", ['tokens' => ['{custom-token}' => 'custom <b>value</b>']]);
 
         $clientResponse = $this->client->getResponse();
 
@@ -641,7 +641,7 @@ final class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->flush();
         $emailId = $email->getId();
         // Send to segment:
-        $this->client->request('POST', "/api/emails/{$emailId}/send");
+        $this->client->request(Request::METHOD_POST, "/api/emails/{$emailId}/send");
         $clientResponse = $this->client->getResponse();
         $sendResponse   = json_decode($clientResponse->getContent(), true);
 
@@ -667,7 +667,7 @@ final class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->persist($email);
         $this->em->flush();
         $emailId = $email->getId();
-        $this->client->request('POST', "/api/emails/{$emailId}/contact/{$contactId}/send");
+        $this->client->request(Request::METHOD_POST, "/api/emails/{$emailId}/contact/{$contactId}/send");
         $clientResponse = $this->client->getResponse();
 
         $this->assertResponseIsSuccessful();
@@ -685,7 +685,7 @@ final class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->flush();
         $emailId = $email->getId();
 
-        $this->client->request('POST', "/api/emails/{$emailId}/contact/{$contactId}/send");
+        $this->client->request(Request::METHOD_POST, "/api/emails/{$emailId}/contact/{$contactId}/send");
         $clientResponse = $this->client->getResponse();
 
         $this->assertResponseIsSuccessful();

--- a/app/bundles/EmailBundle/Tests/Controller/EmailControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailControllerFunctionalTest.php
@@ -77,7 +77,7 @@ final class EmailControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->flush();
         $this->em->detach($email);
 
-        $this->client->request('GET', '/s/emails');
+        $this->client->request(Request::METHOD_GET, '/s/emails');
         $clientResponse = $this->client->getResponse();
         $this->assertResponseIsSuccessful('Return code must be 200');
         $this->assertStringContainsString('February 7, 2020', (string) $clientResponse->getContent());
@@ -98,7 +98,7 @@ final class EmailControllerFunctionalTest extends MauticMysqlTestCase
      */
     public function testIndexActionWhenFiltering(): void
     {
-        $this->client->request('GET', '/s/emails?search=has%3Aresults&tmpl=list');
+        $this->client->request(Request::METHOD_GET, '/s/emails?search=has%3Aresults&tmpl=list');
         $this->assertResponseIsSuccessful();
     }
 
@@ -886,7 +886,7 @@ final class EmailControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->flush();
         $this->em->clear();
 
-        $crawler = $this->client->request('GET', '/s/emails/edit/'.$email->getId());
+        $crawler = $this->client->request(Request::METHOD_GET, '/s/emails/edit/'.$email->getId());
         $form    = $crawler->selectButton('Save')->form();
         $form['emailform[projects]']->setValue((string) $project->getId());
 
@@ -906,7 +906,7 @@ final class EmailControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->flush();
         $this->assertEmailVersion($email->getId(), $version);
 
-        $crawler = $this->client->request('GET', '/s/emails/edit/'.$email->getId());
+        $crawler = $this->client->request(Request::METHOD_GET, '/s/emails/edit/'.$email->getId());
         $form    = $crawler->selectButton('Save')->form();
         $this->client->submit($form);
         $this->assertResponseIsSuccessful();

--- a/app/bundles/EmailBundle/Tests/Controller/EmailExampleFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailExampleFunctionalTest.php
@@ -152,7 +152,7 @@ final class EmailExampleFunctionalTest extends MauticMysqlTestCase
     {
         // Create custom field
         $this->client->request(
-            'POST',
+            Request::METHOD_POST,
             '/api/fields/contact/new',
             [
                 'label'      => 'bool',
@@ -224,7 +224,7 @@ final class EmailExampleFunctionalTest extends MauticMysqlTestCase
     {
         // Create custom field
         $this->client->request(
-            'POST',
+            Request::METHOD_POST,
             '/api/fields/contact/new',
             [
                 'label'      => 'bool',
@@ -280,7 +280,7 @@ final class EmailExampleFunctionalTest extends MauticMysqlTestCase
 
         // Create some contacts
         $this->client->request(
-            'POST',
+            Request::METHOD_POST,
             '/api/contacts/batch/new',
             [
                 [
@@ -316,7 +316,7 @@ final class EmailExampleFunctionalTest extends MauticMysqlTestCase
     {
         // Create custom field
         $this->client->request(
-            'POST',
+            Request::METHOD_POST,
             '/api/fields/contact/new',
             [
                 'label'      => 'bool',
@@ -372,7 +372,7 @@ final class EmailExampleFunctionalTest extends MauticMysqlTestCase
 
         // Create some contacts
         $this->client->request(
-            'POST',
+            Request::METHOD_POST,
             '/api/contacts/batch/new',
             [
                 [

--- a/app/bundles/EmailBundle/Tests/Controller/EmailMapStatsControllerTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailMapStatsControllerTest.php
@@ -78,7 +78,7 @@ final class EmailMapStatsControllerTest extends MauticMysqlTestCase
         }
         $this->em->flush();
 
-        $this->client->request('GET', "s/emails-map-stats/{$email->getId()}/false/2023-07-20/2023-07-25");
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, "s/emails-map-stats/{$email->getId()}/false/2023-07-20/2023-07-25");
         $clientResponse = $this->client->getResponse();
         $crawler        = new Crawler($clientResponse->getContent(), $this->client->getInternalRequest()->getUri());
 

--- a/app/bundles/EmailBundle/Tests/Controller/PreviewFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/PreviewFunctionalTest.php
@@ -135,7 +135,7 @@ final class PreviewFunctionalTest extends MauticMysqlTestCase
     {
         // Create custom field
         $this->client->request(
-            'POST',
+            Request::METHOD_POST,
             '/api/fields/contact/new',
             [
                 'label'      => 'bool',
@@ -151,7 +151,7 @@ final class PreviewFunctionalTest extends MauticMysqlTestCase
 
         // Create some contacts
         $this->client->request(
-            'POST',
+            Request::METHOD_POST,
             '/api/contacts/batch/new',
             [
                 [

--- a/app/bundles/EmailBundle/Tests/Controller/PublicControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/PublicControllerFunctionalTest.php
@@ -68,7 +68,7 @@ final class PublicControllerFunctionalTest extends MauticMysqlTestCase
 
     public function testMailerCallbackWhenNoTransportProccessesIt(): void
     {
-        $this->client->request('POST', '/mailer/callback');
+        $this->client->request(Request::METHOD_POST, '/mailer/callback');
 
         self::assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
         $this->assertSame('No email transport that could process this callback was found', $this->client->getResponse()->getContent());
@@ -77,7 +77,7 @@ final class PublicControllerFunctionalTest extends MauticMysqlTestCase
     public function testMailerCallbackWhenTransportDoesNotProccessIt(): void
     {
         self::getContainer()->get(EventDispatcherInterface::class)->addListener(EmailEvents::ON_TRANSPORT_WEBHOOK, fn (): null => null /* exists but does nothing */);
-        $this->client->request('POST', '/mailer/callback');
+        $this->client->request(Request::METHOD_POST, '/mailer/callback');
 
         self::assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
         $this->assertSame('No email transport that could process this callback was found', $this->client->getResponse()->getContent());
@@ -86,7 +86,7 @@ final class PublicControllerFunctionalTest extends MauticMysqlTestCase
     public function testMailerCallbackWhenTransportProccessesIt(): void
     {
         self::getContainer()->get(EventDispatcherInterface::class)->addListener(EmailEvents::ON_TRANSPORT_WEBHOOK, fn (TransportWebhookEvent $event) => $event->setResponse(new Response('OK')));
-        $this->client->request('POST', '/mailer/callback');
+        $this->client->request(Request::METHOD_POST, '/mailer/callback');
 
         self::assertResponseIsSuccessful();
         $this->assertSame('OK', $this->client->getResponse()->getContent());
@@ -100,7 +100,7 @@ final class PublicControllerFunctionalTest extends MauticMysqlTestCase
 
         $this->em->flush();
 
-        $crawler = $this->client->request('GET', '/email/unsubscribe/'.$stat->getTrackingHash());
+        $crawler = $this->client->request(Request::METHOD_GET, '/email/unsubscribe/'.$stat->getTrackingHash());
         $this->assertResponseIsSuccessful();
 
         $this->assertStringContainsString('form/submit?formId='.$stat->getEmail()->getUnsubscribeForm()->getId(), (string) $crawler->filter('form')->eq(0)->attr('action'));
@@ -115,7 +115,7 @@ final class PublicControllerFunctionalTest extends MauticMysqlTestCase
 
         $this->em->flush();
 
-        $this->client->request('GET', '/email/unsubscribe/'.$stat->getTrackingHash());
+        $this->client->request(Request::METHOD_GET, '/email/unsubscribe/'.$stat->getTrackingHash());
 
         $this->em->clear();
 
@@ -129,7 +129,7 @@ final class PublicControllerFunctionalTest extends MauticMysqlTestCase
         $stat = $this->getStat(null, $lead);
         $this->em->flush();
 
-        $crawler = $this->client->request('GET', '/email/unsubscribe/'.$stat->getTrackingHash());
+        $crawler = $this->client->request(Request::METHOD_GET, '/email/unsubscribe/'.$stat->getTrackingHash());
 
         self::assertResponseIsSuccessful();
         $form = $crawler->filter('form')->form();
@@ -165,7 +165,7 @@ final class PublicControllerFunctionalTest extends MauticMysqlTestCase
 
         $this->em->flush();
 
-        $crawler = $this->client->request('GET', '/email/unsubscribe/'.$stat->getTrackingHash());
+        $crawler = $this->client->request(Request::METHOD_GET, '/email/unsubscribe/'.$stat->getTrackingHash());
 
         $this->assertStringContainsString('form/submit?formId='.$stat->getEmail()->getUnsubscribeForm()->getId(), (string) $crawler->filter('form')->eq(0)->attr('action'));
         $this->assertResponseIsSuccessful();
@@ -179,7 +179,7 @@ final class PublicControllerFunctionalTest extends MauticMysqlTestCase
 
         $this->em->flush();
 
-        $crawler = $this->client->request('GET', '/email/unsubscribe/'.$stat->getTrackingHash());
+        $crawler = $this->client->request(Request::METHOD_GET, '/email/unsubscribe/'.$stat->getTrackingHash());
 
         $this->assertStringContainsString('form/submit?formId='.$stat->getEmail()->getUnsubscribeForm()->getId(), (string) $crawler->filter('form')->eq(0)->attr('action'));
         $this->assertResponseIsSuccessful();
@@ -193,7 +193,7 @@ final class PublicControllerFunctionalTest extends MauticMysqlTestCase
 
         $this->em->flush();
 
-        $crawler = $this->client->request('GET', '/email/unsubscribe/'.$stat->getTrackingHash());
+        $crawler = $this->client->request(Request::METHOD_GET, '/email/unsubscribe/'.$stat->getTrackingHash());
 
         $this->assertStringNotContainsString('form/submit?formId=', $crawler->html());
         $this->assertResponseIsSuccessful();
@@ -204,7 +204,7 @@ final class PublicControllerFunctionalTest extends MauticMysqlTestCase
         $lead = $this->createLead();
         $stat = $this->getStat(null, $lead);
         $this->em->flush();
-        $this->client->request('POST', '/email/unsubscribe/'.$stat->getTrackingHash(), [
+        $this->client->request(Request::METHOD_POST, '/email/unsubscribe/'.$stat->getTrackingHash(), [
             'List-Unsubscribe' => 'One-Click',
         ]);
         $this->assertResponseIsSuccessful();
@@ -218,7 +218,7 @@ final class PublicControllerFunctionalTest extends MauticMysqlTestCase
         $lead = $this->createLead();
         $stat = $this->getStat(null, $lead);
         $this->em->flush();
-        $this->client->request('HEAD', '/email/unsubscribe/'.$stat->getTrackingHash());
+        $this->client->request(Request::METHOD_HEAD, '/email/unsubscribe/'.$stat->getTrackingHash());
         $this->assertResponseIsSuccessful();
         $dncCollection = $stat->getLead()->getDoNotContact();
         $this->assertCount(0, $dncCollection);
@@ -231,7 +231,7 @@ final class PublicControllerFunctionalTest extends MauticMysqlTestCase
         $preferencesCenter = $this->createCustomPreferencesPage('{segmentlist}{saveprefsbutton}');
         $stat              = $this->getStat(null, $lead, $preferencesCenter);
         $this->em->flush();
-        $crawler = $this->client->request('GET', '/email/unsubscribe/'.$stat->getTrackingHash());
+        $crawler = $this->client->request(Request::METHOD_GET, '/email/unsubscribe/'.$stat->getTrackingHash());
         $this->assertResponseIsSuccessful();
         $tokenInput = $crawler->filter('input[name="lead_contact_frequency_rules[_token]"]');
         $this->assertCount(1, $tokenInput, $this->client->getResponse()->getContent());
@@ -258,7 +258,7 @@ final class PublicControllerFunctionalTest extends MauticMysqlTestCase
         $stat = $this->getStat(null, $lead, $page);
         $this->em->flush();
 
-        $crawler = $this->client->request('GET', '/email/unsubscribe/'.$stat->getTrackingHash());
+        $crawler = $this->client->request(Request::METHOD_GET, '/email/unsubscribe/'.$stat->getTrackingHash());
         $this->assertResponseIsSuccessful();
         $this->assertStringContainsString('Save preferences', $crawler->html());
     }
@@ -326,7 +326,7 @@ final class PublicControllerFunctionalTest extends MauticMysqlTestCase
         $stat = $this->getStat(null, $lead, $page);
         $this->em->flush();
 
-        $crawler = $this->client->request('GET', '/email/unsubscribe/'.$stat->getTrackingHash());
+        $crawler = $this->client->request(Request::METHOD_GET, '/email/unsubscribe/'.$stat->getTrackingHash());
         $this->assertResponseIsSuccessful();
 
         $translator = self::getContainer()->get(TranslatorInterface::class);
@@ -433,7 +433,7 @@ final class PublicControllerFunctionalTest extends MauticMysqlTestCase
         $email->setCustomHtml('some content');
         $this->em->persist($email);
 
-        $this->client->request('GET', '/email/preview/'.$email->getId());
+        $this->client->request(Request::METHOD_GET, '/email/preview/'.$email->getId());
         $this->assertTrue($this->client->getResponse()->isNotFound(), $this->client->getResponse()->getContent());
 
         $email->setPublicPreview(true);
@@ -441,7 +441,7 @@ final class PublicControllerFunctionalTest extends MauticMysqlTestCase
 
         $this->em->flush();
 
-        $this->client->request('GET', '/email/preview/'.$email->getId());
+        $this->client->request(Request::METHOD_GET, '/email/preview/'.$email->getId());
         $this->assertResponseIsSuccessful();
     }
 
@@ -462,7 +462,7 @@ final class PublicControllerFunctionalTest extends MauticMysqlTestCase
 
         $this->em->flush();
 
-        $this->client->request('GET', '/email/preview/'.$email->getId());
+        $this->client->request(Request::METHOD_GET, '/email/preview/'.$email->getId());
         $this->assertResponseIsSuccessful();
     }
 
@@ -628,7 +628,7 @@ final class PublicControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->flush();
 
         // Get the unsubscribe page
-        $crawler = $this->client->request('GET', '/email/unsubscribe/'.$stat->getTrackingHash());
+        $crawler = $this->client->request(Request::METHOD_GET, '/email/unsubscribe/'.$stat->getTrackingHash());
 
         self::assertResponseIsSuccessful();
 
@@ -638,7 +638,7 @@ final class PublicControllerFunctionalTest extends MauticMysqlTestCase
         $href = $unsubscribeAllLink->attr('href');
 
         // Click the link for unsubscribe all
-        $this->client->request('GET', $href);
+        $this->client->request(Request::METHOD_GET, $href);
 
         self::assertResponseIsSuccessful();
 
@@ -672,7 +672,7 @@ final class PublicControllerFunctionalTest extends MauticMysqlTestCase
 
         $this->logoutUser();
 
-        $crawler = $this->client->request('GET', '/email/unsubscribe/'.$stat->getTrackingHash());
+        $crawler = $this->client->request(Request::METHOD_GET, '/email/unsubscribe/'.$stat->getTrackingHash());
 
         $this->assertResponseIsSuccessful();
         $form = $crawler->filter('form')->form();
@@ -706,7 +706,7 @@ final class PublicControllerFunctionalTest extends MauticMysqlTestCase
 
         $this->em->flush();
 
-        $crawler = $this->client->request('GET', '/email/unsubscribe/'.$stat->getTrackingHash());
+        $crawler = $this->client->request(Request::METHOD_GET, '/email/unsubscribe/'.$stat->getTrackingHash());
 
         $this->assertResponseIsSuccessful();
 

--- a/app/bundles/EmailBundle/Tests/Functional/ApiPlatform/EmailOwnershipApiV2AuthorizationRegressionTest.php
+++ b/app/bundles/EmailBundle/Tests/Functional/ApiPlatform/EmailOwnershipApiV2AuthorizationRegressionTest.php
@@ -52,7 +52,7 @@ final class EmailOwnershipApiV2AuthorizationRegressionTest extends OwnershipScop
         $this->client->setServerParameter('PHP_AUTH_USER', $restrictedUser->getUserIdentifier());
         $this->client->setServerParameter('PHP_AUTH_PW', 'Maut1cR0cks!');
 
-        $this->client->request('GET', '/api/v2/emails?page=1&itemsPerPage=10');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/api/v2/emails?page=1&itemsPerPage=10');
         $response = $this->client->getResponse();
 
         self::assertResponseIsSuccessful();
@@ -114,7 +114,7 @@ final class EmailOwnershipApiV2AuthorizationRegressionTest extends OwnershipScop
         $this->client->setServerParameter('PHP_AUTH_PW', 'Maut1cR0cks!');
 
         // Request page 1 with all items on one page first
-        $this->client->request('GET', '/api/v2/emails?page=1&itemsPerPage=10');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/api/v2/emails?page=1&itemsPerPage=10');
         $response = $this->client->getResponse();
 
         self::assertResponseIsSuccessful();

--- a/app/bundles/EmailBundle/Tests/Functional/EmailDependenciesFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Functional/EmailDependenciesFunctionalTest.php
@@ -68,7 +68,7 @@ final class EmailDependenciesFunctionalTest extends MauticMysqlTestCase
         $this->em->persist($email);
         $this->em->flush();
 
-        $this->client->request('GET', "/s/ajax?action=email:getEmailUsages&id={$email->getId()}");
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, "/s/ajax?action=email:getEmailUsages&id={$email->getId()}");
         $clientResponse = $this->client->getResponse();
         $jsonResponse   = json_decode($clientResponse->getContent(), true);
 
@@ -83,7 +83,7 @@ final class EmailDependenciesFunctionalTest extends MauticMysqlTestCase
 
         $campaign = $this->campaignFixturesHelper->createCampaignWithEmailSent($email->getId());
 
-        $this->client->request('GET', "/s/ajax?action=email:getEmailUsages&id={$email->getId()}");
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, "/s/ajax?action=email:getEmailUsages&id={$email->getId()}");
         $clientResponse = $this->client->getResponse();
         $jsonResponse   = json_decode($clientResponse->getContent(), true);
 
@@ -100,7 +100,7 @@ final class EmailDependenciesFunctionalTest extends MauticMysqlTestCase
         $this->createFormActionEmailSend($formWithEmailSend, $email->getId());
         $this->createFormActionEmailSendToUser($formWithEmailSend, $email->getId());
 
-        $this->client->request('GET', "/s/ajax?action=email:getEmailUsages&id={$email->getId()}");
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, "/s/ajax?action=email:getEmailUsages&id={$email->getId()}");
         $clientResponse = $this->client->getResponse();
         $jsonResponse   = json_decode($clientResponse->getContent(), true);
 
@@ -119,7 +119,7 @@ final class EmailDependenciesFunctionalTest extends MauticMysqlTestCase
         $formWithEmailSendToUser = $this->createForm('form-with-email-send-to-user');
         $this->createFormActionEmailSendToUser($formWithEmailSendToUser, $email->getId());
 
-        $this->client->request('GET', "/s/ajax?action=email:getEmailUsages&id={$email->getId()}");
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, "/s/ajax?action=email:getEmailUsages&id={$email->getId()}");
         $clientResponse = $this->client->getResponse();
         $jsonResponse   = json_decode($clientResponse->getContent(), true);
 
@@ -135,7 +135,7 @@ final class EmailDependenciesFunctionalTest extends MauticMysqlTestCase
         $pointActionIsSent = $this->createEmailPointAction($email->getId(), 'email.send');
         $pointActionIsOpen = $this->createEmailPointAction($email->getId(), 'email.open');
 
-        $this->client->request('GET', "/s/ajax?action=email:getEmailUsages&id={$email->getId()}");
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, "/s/ajax?action=email:getEmailUsages&id={$email->getId()}");
         $clientResponse = $this->client->getResponse();
         $jsonResponse   = json_decode($clientResponse->getContent(), true);
 
@@ -150,7 +150,7 @@ final class EmailDependenciesFunctionalTest extends MauticMysqlTestCase
 
         $pointActionIsSent = $this->createPointTriggerWithEmailSendEvent($email->getId(), 'email.send');
 
-        $this->client->request('GET', "/s/ajax?action=email:getEmailUsages&id={$email->getId()}");
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, "/s/ajax?action=email:getEmailUsages&id={$email->getId()}");
         $clientResponse = $this->client->getResponse();
         $jsonResponse   = json_decode($clientResponse->getContent(), true);
 
@@ -166,7 +166,7 @@ final class EmailDependenciesFunctionalTest extends MauticMysqlTestCase
         $emailReport      = $this->createEmailReport($email->getId());
         $emailStatsReport = $this->createEmailStatsReport($email->getId());
 
-        $this->client->request('GET', "/s/ajax?action=email:getEmailUsages&id={$email->getId()}");
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, "/s/ajax?action=email:getEmailUsages&id={$email->getId()}");
         $clientResponse = $this->client->getResponse();
         $jsonResponse   = json_decode($clientResponse->getContent(), true);
 

--- a/app/bundles/FormBundle/Tests/Controller/Api/FormApiControllerFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/Api/FormApiControllerFunctionalTest.php
@@ -95,7 +95,7 @@ final class FormApiControllerFunctionalTest extends MauticMysqlTestCase
     #[DataProvider('formDataProvider')]
     public function testAddAndEditForms(array $payload, array $expectedResponse): void
     {
-        $this->client->request('POST', '/api/forms/new', $payload);
+        $this->client->request(Request::METHOD_POST, '/api/forms/new', $payload);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
@@ -123,7 +123,7 @@ final class FormApiControllerFunctionalTest extends MauticMysqlTestCase
         }
 
         // Edit PATCH:
-        $this->client->request('PATCH', "/api/forms/{$formId}/edit", ['name' => $expectedResponse['newName']]);
+        $this->client->request(Request::METHOD_PATCH, "/api/forms/{$formId}/edit", ['name' => $expectedResponse['newName']]);
         $clientResponse = $this->client->getResponse();
         $responsePatch  = json_decode($clientResponse->getContent(), true);
         $this->assertResponseIsSuccessful();
@@ -468,12 +468,12 @@ final class FormApiControllerFunctionalTest extends MauticMysqlTestCase
         $tag1Payload = ['tag' => 'add this'];
         $tag2Payload = ['tag' => 'remove this'];
 
-        $this->client->request('POST', '/api/tags/new', $tag1Payload);
+        $this->client->request(Request::METHOD_POST, '/api/tags/new', $tag1Payload);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
         $tag1Id         = $response['tag']['id'];
 
-        $this->client->request('POST', '/api/tags/new', $tag2Payload);
+        $this->client->request(Request::METHOD_POST, '/api/tags/new', $tag2Payload);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
         $tag2Id         = $response['tag']['id'];
@@ -507,7 +507,7 @@ final class FormApiControllerFunctionalTest extends MauticMysqlTestCase
         ];
 
         // Create form with lead.changetags action:
-        $this->client->request('POST', '/api/forms/new', $payload);
+        $this->client->request(Request::METHOD_POST, '/api/forms/new', $payload);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
@@ -663,7 +663,7 @@ final class FormApiControllerFunctionalTest extends MauticMysqlTestCase
             ],
         ];
 
-        $this->client->request('POST', '/api/forms/new', $payload);
+        $this->client->request(Request::METHOD_POST, '/api/forms/new', $payload);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true, 512, JSON_THROW_ON_ERROR);
 

--- a/app/bundles/FormBundle/Tests/Controller/Api/FormApiControllerTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/Api/FormApiControllerTest.php
@@ -20,7 +20,7 @@ final class FormApiControllerTest extends MauticMysqlTestCase
     public function testCreateFormWithFieldsAndActions(array $formData, int $expectedStatusCode): void
     {
         $this->client->request(
-            'POST',
+            \Symfony\Component\HttpFoundation\Request::METHOD_POST,
             '/api/forms/new',
             $formData,
         );
@@ -69,7 +69,7 @@ final class FormApiControllerTest extends MauticMysqlTestCase
         $form = $this->createForm($initialFormData);
 
         $this->client->request(
-            'PUT',
+            \Symfony\Component\HttpFoundation\Request::METHOD_PUT,
             '/api/forms/'.$form->getId().'/edit',
             $updateData,
         );
@@ -113,7 +113,7 @@ final class FormApiControllerTest extends MauticMysqlTestCase
         ];
 
         $this->client->request(
-            'POST',
+            \Symfony\Component\HttpFoundation\Request::METHOD_POST,
             '/api/forms/new',
             $formData,
         );
@@ -151,7 +151,7 @@ final class FormApiControllerTest extends MauticMysqlTestCase
         ];
 
         $this->client->request(
-            'POST',
+            \Symfony\Component\HttpFoundation\Request::METHOD_POST,
             '/api/forms/new',
             $formData,
         );
@@ -187,7 +187,7 @@ final class FormApiControllerTest extends MauticMysqlTestCase
         ];
 
         $this->client->request(
-            'PUT',
+            \Symfony\Component\HttpFoundation\Request::METHOD_PUT,
             '/api/forms/'.$form->getId().'/edit',
             $updateData,
         );
@@ -271,7 +271,7 @@ final class FormApiControllerTest extends MauticMysqlTestCase
         // If fields are provided, create them through the API to properly test the preSaveEntity method
         if (isset($data['fields'])) {
             $this->client->request(
-                'PUT',
+                \Symfony\Component\HttpFoundation\Request::METHOD_PUT,
                 '/api/forms/'.$form->getId().'/edit',
                 [
                     'name'   => $form->getName(),

--- a/app/bundles/FormBundle/Tests/Controller/AutoFillReadOnlyFormSubmissionTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/AutoFillReadOnlyFormSubmissionTest.php
@@ -37,7 +37,7 @@ final class AutoFillReadOnlyFormSubmissionTest extends MauticMysqlTestCase
         $this->em->flush();
         $this->em->clear();
 
-        $crawler = $this->client->request('GET', sprintf('/s/forms/edit/%d', $form->getId()));
+        $crawler = $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, sprintf('/s/forms/edit/%d', $form->getId()));
         $this->assertResponseIsSuccessful();
 
         $formElement = $crawler->filterXPath('//form[@name="mauticform"]')->form();
@@ -121,7 +121,7 @@ final class AutoFillReadOnlyFormSubmissionTest extends MauticMysqlTestCase
         $formId = $form->getId();
 
         // Initial request
-        $crawler = $this->client->request('GET', '/form/'.$formId);
+        $crawler = $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/form/'.$formId);
         $this->assertResponseIsSuccessful();
         $this->assertInputCounts($crawler, 0);
 
@@ -137,7 +137,7 @@ final class AutoFillReadOnlyFormSubmissionTest extends MauticMysqlTestCase
         $this->client->submit($form);
 
         // Request the form again
-        $crawler = $this->client->request('GET', '/form/'.$formId);
+        $crawler = $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/form/'.$formId);
         $this->assertResponseIsSuccessful();
         $this->assertInputCounts($crawler, 2);
 

--- a/app/bundles/FormBundle/Tests/Controller/FormControllerFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/FormControllerFunctionalTest.php
@@ -40,7 +40,7 @@ final class FormControllerFunctionalTest extends MauticMysqlTestCase
      */
     public function testIndexActionWhenNotFiltered(): void
     {
-        $this->client->request('GET', '/s/forms');
+        $this->client->request(Request::METHOD_GET, '/s/forms');
         $this->assertResponseIsSuccessful();
     }
 
@@ -49,7 +49,7 @@ final class FormControllerFunctionalTest extends MauticMysqlTestCase
      */
     public function testIndexActionWhenFiltering(): void
     {
-        $this->client->request('GET', '/s/forms?search=has%3Aresults&tmpl=list');
+        $this->client->request(Request::METHOD_GET, '/s/forms?search=has%3Aresults&tmpl=list');
         $this->assertResponseIsSuccessful();
     }
 
@@ -58,7 +58,7 @@ final class FormControllerFunctionalTest extends MauticMysqlTestCase
      */
     public function testNewActionForm(): void
     {
-        $this->client->request('GET', '/s/forms/new/');
+        $this->client->request(Request::METHOD_GET, '/s/forms/new/');
         $this->assertResponseIsSuccessful();
     }
 
@@ -67,7 +67,7 @@ final class FormControllerFunctionalTest extends MauticMysqlTestCase
      */
     public function testSaveActionForm(): void
     {
-        $crawler = $this->client->request('GET', '/s/forms/new/');
+        $crawler = $this->client->request(Request::METHOD_GET, '/s/forms/new/');
         $this->assertResponseIsSuccessful();
 
         $form = $crawler->filterXPath('//form[@name="mauticform"]')->form();
@@ -95,7 +95,7 @@ final class FormControllerFunctionalTest extends MauticMysqlTestCase
 
     public function testNewActionCheckDisplayMessageOptionsForm(): void
     {
-        $this->client->request('GET', '/s/forms/new');
+        $this->client->request(Request::METHOD_GET, '/s/forms/new');
         $this->assertResponseIsSuccessful();
         $clientResponse = $this->client->getResponse();
         self::assertResponseStatusCodeSame(Response::HTTP_OK, $clientResponse->getContent());
@@ -106,7 +106,7 @@ final class FormControllerFunctionalTest extends MauticMysqlTestCase
 
     public function testErrorValidationWithHideFormTypeWithoutMessage(): void
     {
-        $crawler = $this->client->request('GET', '/s/forms/new/');
+        $crawler = $this->client->request(Request::METHOD_GET, '/s/forms/new/');
         $this->assertResponseIsSuccessful();
 
         $selectedValue = $crawler->filter('#mauticform_postAction option:selected')->attr('value');
@@ -130,7 +130,7 @@ final class FormControllerFunctionalTest extends MauticMysqlTestCase
 
     public function testSuccessWithHideForm(): void
     {
-        $crawler = $this->client->request('GET', '/s/forms/new/');
+        $crawler = $this->client->request(Request::METHOD_GET, '/s/forms/new/');
         $this->assertResponseIsSuccessful();
 
         $selectedValue = $crawler->filter('#mauticform_postAction option:selected')->attr('value');
@@ -183,13 +183,13 @@ final class FormControllerFunctionalTest extends MauticMysqlTestCase
                 ],
             ],
         ];
-        $this->client->request('POST', '/api/forms/new', $formPayload);
+        $this->client->request(Request::METHOD_POST, '/api/forms/new', $formPayload);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
         $this->assertResponseStatusCodeSame(Response::HTTP_CREATED, json_encode($languageHelper->getLanguageChoices()));
         $form     = $response['form'];
 
-        $crawler = $this->client->request('GET', '/form/'.$form['id']);
+        $crawler = $this->client->request(Request::METHOD_GET, '/form/'.$form['id']);
         $this->assertStringContainsString('Merci de patienter...', $crawler->html());
         $this->assertStringContainsString('Ceci est requis.', $crawler->html());
 
@@ -210,7 +210,7 @@ final class FormControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->flush();
         $this->em->clear();
 
-        $crawler = $this->client->request('GET', sprintf('/s/forms/edit/%d', $form->getId()));
+        $crawler = $this->client->request(Request::METHOD_GET, sprintf('/s/forms/edit/%d', $form->getId()));
         $this->assertResponseIsSuccessful();
 
         $formElement = $crawler->filterXPath('//form[@name="mauticform"]')->form();
@@ -233,7 +233,7 @@ final class FormControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->flush();
         $this->em->clear();
 
-        $crawler = $this->client->request('GET', sprintf('/s/forms/edit/%d', $form->getId()));
+        $crawler = $this->client->request(Request::METHOD_GET, sprintf('/s/forms/edit/%d', $form->getId()));
         $this->assertResponseIsSuccessful();
 
         $formElement = $crawler->filterXPath('//form[@name="mauticform"]')->form();
@@ -285,11 +285,11 @@ final class FormControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->clear();
 
         // Verify form creation
-        $this->client->request('GET', sprintf('/s/forms/edit/%d', $form->getId()));
+        $this->client->request(Request::METHOD_GET, sprintf('/s/forms/edit/%d', $form->getId()));
         $this->assertResponseIsSuccessful();
 
         // Visit the form preview page
-        $this->client->request('GET', sprintf('/s/forms/preview/%d', $form->getId()));
+        $this->client->request(Request::METHOD_GET, sprintf('/s/forms/preview/%d', $form->getId()));
         $this->assertResponseIsSuccessful();
         $this->assertStringContainsString('First Option', (string) $this->client->getResponse()->getContent());
         $this->assertStringContainsString('Second Option', (string) $this->client->getResponse()->getContent());
@@ -344,7 +344,7 @@ final class FormControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->clear();
 
         // Edit and submit the form to be able to push action into session
-        $crawler     = $this->client->request('GET', sprintf('/s/forms/edit/%d', $form->getId()));
+        $crawler     = $this->client->request(Request::METHOD_GET, sprintf('/s/forms/edit/%d', $form->getId()));
         $formElement = $crawler->filterXPath('//form[@name="mauticform"]')->form();
         $this->client->submit($formElement);
         $this->assertResponseIsSuccessful();
@@ -422,7 +422,7 @@ final class FormControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->flush();
         $this->em->clear();
 
-        $crawler = $this->client->request('GET', sprintf('/s/forms/edit/%d', $form->getId()));
+        $crawler = $this->client->request(Request::METHOD_GET, sprintf('/s/forms/edit/%d', $form->getId()));
         $this->assertResponseIsSuccessful();
 
         $translator = $this->getContainer()->get(TranslatorInterface::class);
@@ -682,7 +682,7 @@ final class FormControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->flush();
         $this->em->clear();
 
-        $crawler     = $this->client->request('GET', '/s/forms/edit/'.$form->getId());
+        $crawler     = $this->client->request(Request::METHOD_GET, '/s/forms/edit/'.$form->getId());
         $formCrawler = $crawler->selectButton('Save')->form();
         $formCrawler['mauticform[projects]']->setValue((string) $project->getId());
 
@@ -703,7 +703,7 @@ final class FormControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->flush();
 
         // Request the form details view
-        $crawler = $this->client->request('GET', sprintf('/s/forms/view/%d', $form->getId()));
+        $crawler = $this->client->request(Request::METHOD_GET, sprintf('/s/forms/view/%d', $form->getId()));
         $this->assertResponseIsSuccessful();
 
         // Check if preview panel exists
@@ -744,7 +744,7 @@ final class FormControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->clear();
 
         // Request the form preview instead of view
-        $crawler = $this->client->request('GET', sprintf('/s/forms/preview/%d', $form->getId()));
+        $crawler = $this->client->request(Request::METHOD_GET, sprintf('/s/forms/preview/%d', $form->getId()));
         $this->assertResponseIsSuccessful();
 
         // Check that the slider input has the oninput attribute

--- a/app/bundles/FormBundle/Tests/Controller/ResultControllerFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/ResultControllerFunctionalTest.php
@@ -46,7 +46,7 @@ final class ResultControllerFunctionalTest extends MauticMysqlTestCase
             'postAction'  => 'return',
         ];
 
-        $this->client->request('POST', '/api/forms/new', $formPayload);
+        $this->client->request(Request::METHOD_POST, '/api/forms/new', $formPayload);
         $clientResponse = $this->client->getResponse();
 
         $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
@@ -98,7 +98,7 @@ final class ResultControllerFunctionalTest extends MauticMysqlTestCase
             'postAction'  => 'return',
         ];
 
-        $this->client->request('POST', '/api/forms/new', $formPayload);
+        $this->client->request(Request::METHOD_POST, '/api/forms/new', $formPayload);
         $clientResponse = $this->client->getResponse();
 
         $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
@@ -107,7 +107,7 @@ final class ResultControllerFunctionalTest extends MauticMysqlTestCase
         $formId   = $form['id'];
 
         // Submit a form result (simulate a contact submission)
-        $this->client->request('POST', "/form/{$formId}", [
+        $this->client->request(Request::METHOD_POST, "/form/{$formId}", [
             'mauticform[email]'  => 'test@example.com',
             'mauticform[formId]' => $formId,
             'mauticform[return]' => '',
@@ -115,7 +115,7 @@ final class ResultControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertResponseIsSuccessful();
 
         // Call the addToSegmentAction
-        $this->client->request('GET', "/s/forms/results/{$formId}/add-to-segment");
+        $this->client->request(Request::METHOD_GET, "/s/forms/results/{$formId}/add-to-segment");
         $response = $this->client->getResponse();
         $this->assertResponseIsSuccessful();
         $this->assertStringContainsString('form', (string) $response->getContent());
@@ -140,7 +140,7 @@ final class ResultControllerFunctionalTest extends MauticMysqlTestCase
             'postAction'  => 'return',
         ];
 
-        $this->client->request('POST', '/api/forms/new', $formPayload);
+        $this->client->request(Request::METHOD_POST, '/api/forms/new', $formPayload);
         $clientResponse = $this->client->getResponse();
 
         $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);

--- a/app/bundles/FormBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
@@ -60,7 +60,7 @@ final class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
         ];
 
         // Creating the form via API so it would create the submission table.
-        $this->client->request('POST', '/api/forms/new', $formPayload);
+        $this->client->request(Request::METHOD_POST, '/api/forms/new', $formPayload);
         $clientResponse = $this->client->getResponse();
 
         $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);

--- a/app/bundles/FormBundle/Tests/EventListener/CustomFieldSubscriberFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/EventListener/CustomFieldSubscriberFunctionalTest.php
@@ -90,7 +90,7 @@ final class CustomFieldSubscriberFunctionalTest extends MauticMysqlTestCase
             ],
         ];
 
-        $this->client->request('POST', '/api/fields/contact/new', $fieldPayload);
+        $this->client->request(Request::METHOD_POST, '/api/fields/contact/new', $fieldPayload);
         $clientResponse = $this->client->getResponse();
         $this->assertEquals(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
         $response = json_decode($clientResponse->getContent(), true);
@@ -124,7 +124,7 @@ final class CustomFieldSubscriberFunctionalTest extends MauticMysqlTestCase
             'postAction' => 'return',
         ];
 
-        $this->client->request('POST', '/api/forms/new', $formPayload);
+        $this->client->request(Request::METHOD_POST, '/api/forms/new', $formPayload);
         $clientResponse = $this->client->getResponse();
         $this->assertEquals(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
         $response = json_decode($clientResponse->getContent(), true);
@@ -152,7 +152,7 @@ final class CustomFieldSubscriberFunctionalTest extends MauticMysqlTestCase
                 </html>',
         ];
 
-        $this->client->request('POST', '/api/pages/new', $pagePayload);
+        $this->client->request(Request::METHOD_POST, '/api/pages/new', $pagePayload);
         $clientResponse = $this->client->getResponse();
         $this->assertEquals(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
     }
@@ -171,7 +171,7 @@ final class CustomFieldSubscriberFunctionalTest extends MauticMysqlTestCase
             ],
         ];
 
-        $this->client->request('PATCH', "/api/fields/contact/{$customFieldId}/edit", $updatePayload);
+        $this->client->request(Request::METHOD_PATCH, "/api/fields/contact/{$customFieldId}/edit", $updatePayload);
         $clientResponse = $this->client->getResponse();
         $this->assertEquals(Response::HTTP_OK, $clientResponse->getStatusCode(), $clientResponse->getContent());
     }

--- a/app/bundles/FormBundle/Tests/Model/FormModelFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Model/FormModelFunctionalTest.php
@@ -177,7 +177,7 @@ final class FormModelFunctionalTest extends MauticMysqlTestCase
             'postAction'  => 'return',
         ];
 
-        $this->client->request('POST', '/api/forms/new', $formPayload);
+        $this->client->request(Request::METHOD_POST, '/api/forms/new', $formPayload);
         $clientResponse = $this->client->getResponse();
         $this->assertEquals(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
         $response = json_decode($clientResponse->getContent(), true);
@@ -206,7 +206,7 @@ final class FormModelFunctionalTest extends MauticMysqlTestCase
             </html>',
         ];
 
-        $this->client->request('POST', '/api/pages/new', $pagePayload);
+        $this->client->request(Request::METHOD_POST, '/api/pages/new', $pagePayload);
         $clientResponse = $this->client->getResponse();
         $this->assertEquals(Response::HTTP_CREATED, $clientResponse->getStatusCode(), $clientResponse->getContent());
     }
@@ -236,7 +236,7 @@ final class FormModelFunctionalTest extends MauticMysqlTestCase
         $contactTracker = $this->getContainer()->get(ContactTracker::class);
         $contactTracker->setTrackedContact($lead);
 
-        $this->client->request('GET', "/form/{$formId}");
+        $this->client->request(Request::METHOD_GET, "/form/{$formId}");
         $formCrawler = $this->client->getCrawler();
         $checkboxA   = $formCrawler->filter('[id*="mauticform_checkboxgrp_checkbox_"][id$="_a0"]')->attr('checked');
         $checkboxB   = $formCrawler->filter('[id*="mauticform_checkboxgrp_checkbox_"][id$="_b1"]')->attr('checked');

--- a/app/bundles/IntegrationsBundle/Tests/Functional/EventListener/UIContactIntegrationsTabSubscriberTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Functional/EventListener/UIContactIntegrationsTabSubscriberTest.php
@@ -28,7 +28,7 @@ final class UIContactIntegrationsTabSubscriberTest extends MauticMysqlTestCase
         $this->em->flush();
         $this->em->clear();
 
-        $this->client->request('GET', "/s/contacts/view/{$contact->getId()}");
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, "/s/contacts/view/{$contact->getId()}");
         self::assertResponseIsSuccessful();
         $this->assertStringContainsString('<dt>Object</dt><dd>testobject</dd>', (string) $this->client->getResponse()->getContent());
         $this->assertStringContainsString('<dt>Object ID</dt><dd>testid</dd>', (string) $this->client->getResponse()->getContent());

--- a/app/bundles/LeadBundle/Tests/Controller/Api/CompanyApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/CompanyApiControllerFunctionalTest.php
@@ -46,7 +46,7 @@ final class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
         ];
 
         // create 3 new companies
-        $this->client->request('POST', '/api/companies/batch/new', $payload);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_POST, '/api/companies/batch/new', $payload);
         $clientResponse = $this->client->getResponse();
 
         self::assertResponseStatusCodeSame(Response::HTTP_CREATED);
@@ -71,7 +71,7 @@ final class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
         ];
 
         // use unique field to not create new company
-        $this->client->request('POST', '/api/companies/batch/new', $payload);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_POST, '/api/companies/batch/new', $payload);
         $clientResponse = $this->client->getResponse();
 
         self::assertResponseStatusCodeSame(Response::HTTP_CREATED);
@@ -92,7 +92,7 @@ final class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
         ];
 
         // use both unique fields and create new, because use AND operator between unique fields
-        $this->client->request('POST', '/api/companies/batch/new', $payload);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_POST, '/api/companies/batch/new', $payload);
         $clientResponse = $this->client->getResponse();
 
         self::assertResponseStatusCodeSame(Response::HTTP_CREATED);
@@ -111,7 +111,7 @@ final class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
             'companyname'            => 'API',
         ];
 
-        $this->client->request('POST', '/api/companies/new', $payload);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_POST, '/api/companies/new', $payload);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
         $companyId      = $response['company']['id'];
@@ -119,7 +119,7 @@ final class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertEquals($payload['companyname'], $response['company']['fields']['all']['companyname']);
 
         // Lets try to create the same company
-        $this->client->request('POST', '/api/companies/new', $payload);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_POST, '/api/companies/new', $payload);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
@@ -131,7 +131,7 @@ final class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
         ];
 
         // Lets try to create the new company because use unique fields with AND operator
-        $this->client->request('POST', '/api/companies/new', $payload);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_POST, '/api/companies/new', $payload);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
@@ -147,7 +147,7 @@ final class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
     public function testCreateCompanyViaApiPlatform(array $companyData, int $expectedStatusCode): void
     {
         $this->client->request(
-            'POST',
+            \Symfony\Component\HttpFoundation\Request::METHOD_POST,
             '/api/v2/companies',
             [],
             [],
@@ -212,7 +212,7 @@ final class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
             'companyphone'    => '123456789',
             'companywebsite'  => 'https://company.com',
         ];
-        $this->client->request('POST', '/api/companies/new', $payload);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_POST, '/api/companies/new', $payload);
 
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
@@ -253,7 +253,7 @@ final class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
                 'companywebsite'  => 'https://company.b.com',
             ],
         ];
-        $this->client->request('POST', '/api/companies/batch/new', $payload);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_POST, '/api/companies/batch/new', $payload);
 
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
@@ -274,7 +274,7 @@ final class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
     public function testDeleteCompanyInBackground(): void
     {
         $company = $this->createCompany();
-        $this->client->request('DELETE', sprintf('/api/companies/%d/delete', $company->getId()));
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_DELETE, sprintf('/api/companies/%d/delete', $company->getId()));
 
         $this->client->getResponse();
         $this->assertResponseIsSuccessful();
@@ -288,7 +288,7 @@ final class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
     {
         $company   = $this->createCompany();
         $companyId = $company->getId();
-        $this->client->request('DELETE', sprintf('/api/companies/%d/delete', $company->getId()));
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_DELETE, sprintf('/api/companies/%d/delete', $company->getId()));
 
         $this->client->getResponse();
         $this->assertResponseIsSuccessful();
@@ -309,7 +309,7 @@ final class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
             $companyId2,
         ];
 
-        $this->client->request('DELETE', sprintf('/api/companies/batch/delete?ids=%s', implode(',', $payload)));
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_DELETE, sprintf('/api/companies/batch/delete?ids=%s', implode(',', $payload)));
 
         $this->client->getResponse();
         $this->assertResponseIsSuccessful();
@@ -329,7 +329,7 @@ final class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
             $company2->getId(),
         ];
 
-        $this->client->request('DELETE', sprintf('/api/companies/batch/delete?ids=%s', implode(',', $payload)));
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_DELETE, sprintf('/api/companies/batch/delete?ids=%s', implode(',', $payload)));
 
         $this->client->getResponse();
         $this->assertResponseIsSuccessful();
@@ -370,7 +370,7 @@ final class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
             ],
         ];
 
-        $this->client->request('PATCH', '/api/companies/batch/edit', $payload);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_PATCH, '/api/companies/batch/edit', $payload);
         $this->client->getResponse();
         $this->em->clear();
 
@@ -403,7 +403,7 @@ final class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
             'companyname' => $company1UpdatedName,
         ];
 
-        $this->client->request('PATCH', sprintf('/api/companies/%d/edit', $company1Id), $payload);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_PATCH, sprintf('/api/companies/%d/edit', $company1Id), $payload);
         $this->client->getResponse();
         $this->em->clear();
 

--- a/app/bundles/LeadBundle/Tests/Controller/Api/FieldApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/FieldApiControllerFunctionalTest.php
@@ -218,7 +218,7 @@ final class FieldApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->clear();
 
         // Call endpoint
-        $this->client->request('GET', '/api/contacts/'.$contact->getId());
+        $this->client->request(Request::METHOD_GET, '/api/contacts/'.$contact->getId());
         $clientResponse = $this->client->getResponse();
         $this->assertResponseIsSuccessful();
         $responseJson = \json_decode($clientResponse->getContent(), true, 512, \JSON_THROW_ON_ERROR);
@@ -236,7 +236,7 @@ final class FieldApiControllerFunctionalTest extends MauticMysqlTestCase
         ];
 
         $this->client->request(
-            'PATCH',
+            Request::METHOD_PATCH,
             sprintf('/api/contacts/%d/edit', $contact->getId()),
             $updatedValues
         );
@@ -256,7 +256,7 @@ final class FieldApiControllerFunctionalTest extends MauticMysqlTestCase
         ];
 
         $this->client->request(
-            'PATCH',
+            Request::METHOD_PATCH,
             sprintf('/api/contacts/%d/edit', $contact->getId()),
             $updatedValues
         );
@@ -330,7 +330,7 @@ final class FieldApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->clear();
 
         // Call endpoint
-        $this->client->request('GET', '/api/contacts/'.$contact->getId());
+        $this->client->request(Request::METHOD_GET, '/api/contacts/'.$contact->getId());
         $clientResponse = $this->client->getResponse();
         $this->assertResponseIsSuccessful();
         $responseJson = \json_decode($clientResponse->getContent(), true, 512, \JSON_THROW_ON_ERROR);
@@ -348,7 +348,7 @@ final class FieldApiControllerFunctionalTest extends MauticMysqlTestCase
         ];
 
         $this->client->request(
-            'PATCH',
+            Request::METHOD_PATCH,
             sprintf('/api/contacts/%d/edit', $contact->getId()),
             $updatedValues
         );
@@ -368,7 +368,7 @@ final class FieldApiControllerFunctionalTest extends MauticMysqlTestCase
         ];
 
         $this->client->request(
-            'PATCH',
+            Request::METHOD_PATCH,
             sprintf('/api/contacts/%d/edit', $contact->getId()),
             $updatedValues
         );
@@ -399,7 +399,7 @@ final class FieldApiControllerFunctionalTest extends MauticMysqlTestCase
         // Test creating a new field
 
         $typeSafePayload = $this->generateTypeSafePayload($payload);
-        $this->client->request('POST', '/api/fields/contact/new', $typeSafePayload);
+        $this->client->request(Request::METHOD_POST, '/api/fields/contact/new', $typeSafePayload);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
@@ -428,7 +428,7 @@ final class FieldApiControllerFunctionalTest extends MauticMysqlTestCase
     private function assertGetResponse(array $payload, int $id): void
     {
         // Test get and that the field was published
-        $this->client->request('GET', sprintf('/api/fields/contact/%s', $id));
+        $this->client->request(Request::METHOD_GET, sprintf('/api/fields/contact/%s', $id));
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
         $this->assertEquals(Response::HTTP_OK, $clientResponse->getStatusCode());
@@ -446,7 +446,7 @@ final class FieldApiControllerFunctionalTest extends MauticMysqlTestCase
     private function assertPatchResponse(array $payload, int $id, string $alias): void
     {
         $typeSafePayload = $this->generateTypeSafePayload($payload);
-        $this->client->request('PATCH', sprintf('/api/fields/contact/%s/edit', $id), $typeSafePayload);
+        $this->client->request(Request::METHOD_PATCH, sprintf('/api/fields/contact/%s/edit', $id), $typeSafePayload);
         $clientResponse = $this->client->getResponse();
         $this->assertEquals(Response::HTTP_OK, $clientResponse->getStatusCode());
         $response = json_decode($clientResponse->getContent(), true);
@@ -470,7 +470,7 @@ final class FieldApiControllerFunctionalTest extends MauticMysqlTestCase
     private function assertDeleteResponse(array $payload, int $id, string $alias, bool $isBackground): void
     {
         // Test the field is deleted
-        $this->client->request('DELETE', sprintf('/api/fields/contact/%s/delete', $id));
+        $this->client->request(Request::METHOD_DELETE, sprintf('/api/fields/contact/%s/delete', $id));
         $clientResponse = $this->client->getResponse();
         $this->assertEquals(Response::HTTP_OK, $clientResponse->getStatusCode());
         $response = json_decode($clientResponse->getContent(), true);
@@ -573,12 +573,12 @@ final class FieldApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->flush();
 
         // Try deleting field which is used in segment.
-        $this->client->request('DELETE', sprintf('/api/fields/contact/%s/delete', $id));
+        $this->client->request(Request::METHOD_DELETE, sprintf('/api/fields/contact/%s/delete', $id));
         $clientResponse = $this->client->getResponse();
         $this->assertEquals(Response::HTTP_CONFLICT, $clientResponse->getStatusCode());
 
         // Test with Bulk Delete.
-        $this->client->request('DELETE', sprintf('/api/fields/contact/batch/delete?ids=%s', $id));
+        $this->client->request(Request::METHOD_DELETE, sprintf('/api/fields/contact/batch/delete?ids=%s', $id));
         $clientResponse = $this->client->getResponse();
         $this->assertEquals(Response::HTTP_OK, $clientResponse->getStatusCode());
         $this->assertStringContainsString(

--- a/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerFunctionalTest.php
@@ -53,7 +53,7 @@ final class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
 
     public function testDisabledApi(): void
     {
-        $this->client->request('POST', '/api/contacts/new', ['email' => 'apiemail1@email.com']);
+        $this->client->request(Request::METHOD_POST, '/api/contacts/new', ['email' => 'apiemail1@email.com']);
         $clientResponse = $this->client->getResponse();
         $this->assertEquals(Response::HTTP_FORBIDDEN, $clientResponse->getStatusCode(), $clientResponse->getContent());
         $this->assertEquals(
@@ -64,7 +64,7 @@ final class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
 
     public function testActivityApi(): void
     {
-        $this->client->request('GET', '/api/contacts/activity');
+        $this->client->request(Request::METHOD_GET, '/api/contacts/activity');
         self::assertResponseIsSuccessful();
         $this->assertArrayHasKey('events', json_decode($this->client->getResponse()->getContent(), true));
         $this->assertArrayHasKey('filters', json_decode($this->client->getResponse()->getContent(), true));
@@ -211,7 +211,7 @@ final class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
             ],
         ];
 
-        $this->client->request('POST', '/api/contacts/batch/new', $payload);
+        $this->client->request(Request::METHOD_POST, '/api/contacts/batch/new', $payload);
         $clientResponse = $this->client->getResponse();
 
         $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
@@ -264,7 +264,7 @@ final class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
             ],
         ];
 
-        $this->client->request('PUT', '/api/contacts/batch/edit', $payload);
+        $this->client->request(Request::METHOD_PUT, '/api/contacts/batch/edit', $payload);
         $clientResponse = $this->client->getResponse();
 
         $this->assertResponseIsSuccessful();
@@ -506,7 +506,7 @@ final class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
      */
     public function testEmptyResponseReturnsJsonObject(): void
     {
-        $this->client->request('GET', '/api/contacts?where[0][val]=unicorn&where[0][col]=email&where[0][expr]=eq');
+        $this->client->request(Request::METHOD_GET, '/api/contacts?where[0][val]=unicorn&where[0][col]=email&where[0][expr]=eq');
         $clientResponse = $this->client->getResponse();
         $this->assertResponseIsSuccessful();
         $this->assertEquals('{"total":"0","contacts":{}}', $clientResponse->getContent());
@@ -525,7 +525,7 @@ final class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
             ['email' => 'batcheditcontact1-updated@gmail.com', 'id' => $contact->getId()],
         ];
 
-        $this->client->request('PUT', '/api/contacts/batch/edit', $payload);
+        $this->client->request(Request::METHOD_PUT, '/api/contacts/batch/edit', $payload);
         $clientResponse = $this->client->getResponse();
 
         self::assertResponseIsSuccessful($clientResponse->getContent());
@@ -543,7 +543,7 @@ final class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
             ['email' => 'batchemail1@email.com', 'id' => 'rubbish'],
         ];
 
-        $this->client->request('PUT', '/api/contacts/batch/edit', $payload);
+        $this->client->request(Request::METHOD_PUT, '/api/contacts/batch/edit', $payload);
         $clientResponse = $this->client->getResponse();
 
         self::assertResponseIsSuccessful($clientResponse->getContent());
@@ -565,7 +565,7 @@ final class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
 
         // Test with an apostropy with URL encoding.
         $this->client->request(
-            'GET',
+            Request::METHOD_GET,
             '/api/contacts',
             [
                 'where' => [
@@ -690,7 +690,7 @@ final class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         // test: create the same contact, merge it based on unique identifier (email) - without loosing the owner and stage
         unset($updatedValues['owner']);
 
-        $this->client->request('POST', '/api/contacts/new', $updatedValues);
+        $this->client->request(Request::METHOD_POST, '/api/contacts/new', $updatedValues);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
@@ -753,7 +753,7 @@ final class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         ];
 
         $this->client->request(
-            'PATCH',
+            Request::METHOD_PATCH,
             sprintf('/api/contacts/%d/edit', $contactId),
             $updatedValues
         );
@@ -836,7 +836,7 @@ final class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
             ],
         ];
 
-        $this->client->request('POST', '/api/contacts/batch/new', $payload);
+        $this->client->request(Request::METHOD_POST, '/api/contacts/batch/new', $payload);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
         $contactId      = $response['contacts'][0]['id'];
@@ -858,7 +858,7 @@ final class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         $payload[0]['lastname'] = '';
 
         // Lets try to create the same contact to see that the values are not re-setted
-        $this->client->request('POST', '/api/contacts/batch/new', $payload);
+        $this->client->request(Request::METHOD_POST, '/api/contacts/batch/new', $payload);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
@@ -881,7 +881,7 @@ final class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         $payload[0]['lastname']           = '';
 
         // Lets try to create the same contact to see that the values are not re-setted
-        $this->client->request('POST', '/api/contacts/batch/new', $payload);
+        $this->client->request(Request::METHOD_POST, '/api/contacts/batch/new', $payload);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
@@ -898,7 +898,7 @@ final class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         $payload[0]['lastname']           = '';
 
         // Lets try to create the same contact to see that the values are not re-setted
-        $this->client->request('POST', '/api/contacts/batch/new', $payload);
+        $this->client->request(Request::METHOD_POST, '/api/contacts/batch/new', $payload);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
@@ -927,7 +927,7 @@ final class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
             ],
         ];
 
-        $this->client->request('POST', '/api/contacts/batch/new', $updatedValues);
+        $this->client->request(Request::METHOD_POST, '/api/contacts/batch/new', $updatedValues);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
@@ -946,7 +946,7 @@ final class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertEquals($updatedValues[0]['owner'], $response['contacts'][0]['owner']['id']);
 
         // Test getting a contact
-        $this->client->request('GET', '/api/contacts/'.$contactId);
+        $this->client->request(Request::METHOD_GET, '/api/contacts/'.$contactId);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
@@ -965,7 +965,7 @@ final class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
 
         // Test fetching the batch of contacts
         $this->client->request(
-            'GET', '/api/contacts');
+            Request::METHOD_GET, '/api/contacts');
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
@@ -997,7 +997,7 @@ final class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
             ],
         ];
 
-        $this->client->request('PATCH', '/api/contacts/batch/edit', $updatedValues);
+        $this->client->request(Request::METHOD_PATCH, '/api/contacts/batch/edit', $updatedValues);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
@@ -1023,7 +1023,7 @@ final class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
             ],
         ];
 
-        $this->client->request('PATCH', '/api/contacts/batch/edit', $updatedValues);
+        $this->client->request(Request::METHOD_PATCH, '/api/contacts/batch/edit', $updatedValues);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
@@ -1171,7 +1171,7 @@ final class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertSame($dncChannel, $dncResponse['contact']['doNotContact'][0]['channel']);
 
         // Check DNC is recorded in the contact activity.
-        $this->client->request('GET', "/api/contacts/{$contactId}/activity");
+        $this->client->request(Request::METHOD_GET, "/api/contacts/{$contactId}/activity");
         $clientResponse = $this->client->getResponse();
         self::assertResponseIsSuccessful($clientResponse->getContent());
         $activityResponse = json_decode($clientResponse->getContent(), true);
@@ -1272,7 +1272,7 @@ final class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->flush();
 
         // Call endpoint
-        $this->client->request('GET', '/api/contacts/activity');
+        $this->client->request(Request::METHOD_GET, '/api/contacts/activity');
         $clientResponse = $this->client->getResponse();
         $this->assertResponseIsSuccessful();
         $responseJson = json_decode($clientResponse->getContent());
@@ -1300,7 +1300,7 @@ final class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         $expectedDatesOrder = ['2013-03-25', '2013-03-20', '2013-03-15', '2013-03-10', '2013-03-05'];
 
         // Call endpoint
-        $this->client->request('GET', '/api/contacts/'.$contact->getId().'/activity');
+        $this->client->request(Request::METHOD_GET, '/api/contacts/'.$contact->getId().'/activity');
         $clientResponse = $this->client->getResponse();
         $this->assertResponseIsSuccessful();
         $responseJson = json_decode($clientResponse->getContent());
@@ -1352,7 +1352,7 @@ final class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->clear();
 
         // Test API endpoint for campaign 1
-        $this->client->request('GET', '/api/contacts', ['search' => 'campaign:'.$campaign1->getId()]);
+        $this->client->request(Request::METHOD_GET, '/api/contacts', ['search' => 'campaign:'.$campaign1->getId()]);
         $clientResponse = $this->client->getResponse();
         $this->assertResponseIsSuccessful();
         $response = json_decode($clientResponse->getContent(), true);
@@ -1364,7 +1364,7 @@ final class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertArrayNotHasKey($contact4->getId(), $response['contacts']);
 
         // Test API endpoint for campaign 2
-        $this->client->request('GET', '/api/contacts', ['search' => 'campaign:'.$campaign2->getId()]);
+        $this->client->request(Request::METHOD_GET, '/api/contacts', ['search' => 'campaign:'.$campaign2->getId()]);
         $clientResponse = $this->client->getResponse();
         $this->assertResponseIsSuccessful();
         $response = json_decode($clientResponse->getContent(), true);
@@ -1385,7 +1385,7 @@ final class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         $contact = $this->createContactWithNote($owner, 'contact-notes-ok@test.com');
 
         $this->authenticateApiUser($owner);
-        $this->client->request('GET', '/api/contacts/'.$contact->getId().'/notes');
+        $this->client->request(Request::METHOD_GET, '/api/contacts/'.$contact->getId().'/notes');
 
         $response = $this->client->getResponse();
         $this->assertResponseIsSuccessful($response->getContent());
@@ -1400,7 +1400,7 @@ final class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         $contact = $this->createContactWithNote($owner, 'contact-notes-denied@test.com');
 
         $this->authenticateApiUser($owner);
-        $this->client->request('GET', '/api/contacts/'.$contact->getId().'/notes');
+        $this->client->request(Request::METHOD_GET, '/api/contacts/'.$contact->getId().'/notes');
 
         $response = $this->client->getResponse();
         $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN, $response->getContent());

--- a/app/bundles/LeadBundle/Tests/Controller/Api/ListApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/ListApiControllerFunctionalTest.php
@@ -161,7 +161,7 @@ final class ListApiControllerFunctionalTest extends MauticMysqlTestCase
         ];
 
         // Create:
-        $this->client->request('POST', '/api/segments/new', $payload);
+        $this->client->request(Request::METHOD_POST, '/api/segments/new', $payload);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
@@ -229,7 +229,7 @@ final class ListApiControllerFunctionalTest extends MauticMysqlTestCase
         );
 
         // Edit:
-        $this->client->request('PATCH', "/api/segments/{$segmentId}/edit", ['name' => 'API segment renamed']);
+        $this->client->request(Request::METHOD_PATCH, "/api/segments/{$segmentId}/edit", ['name' => 'API segment renamed']);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
@@ -239,7 +239,7 @@ final class ListApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertEquals($payload['description'], $response['list']['description']);
 
         // Get:
-        $this->client->request('GET', "/api/segments/{$segmentId}");
+        $this->client->request(Request::METHOD_GET, "/api/segments/{$segmentId}");
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
@@ -249,7 +249,7 @@ final class ListApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertEquals($payload['description'], $response['list']['description']);
 
         // Delete:
-        $this->client->request('DELETE', "/api/segments/{$segmentId}/delete");
+        $this->client->request(Request::METHOD_DELETE, "/api/segments/{$segmentId}/delete");
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
@@ -259,7 +259,7 @@ final class ListApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertEquals($payload['description'], $response['list']['description']);
 
         // Get (ensure it's deleted):
-        $this->client->request('GET', "/api/segments/{$segmentId}");
+        $this->client->request(Request::METHOD_GET, "/api/segments/{$segmentId}");
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
@@ -301,7 +301,7 @@ final class ListApiControllerFunctionalTest extends MauticMysqlTestCase
             ],
         ];
 
-        $this->client->request('POST', '/api/segments/batch/new', $payload);
+        $this->client->request(Request::METHOD_POST, '/api/segments/batch/new', $payload);
         $clientResponse  = $this->client->getResponse();
         $response1       = json_decode($clientResponse->getContent(), true);
 
@@ -327,7 +327,7 @@ final class ListApiControllerFunctionalTest extends MauticMysqlTestCase
         }
 
         // Lets try to create the same segment to see that the values are not re-setted
-        $this->client->request('PATCH', '/api/segments/batch/edit', $response1['lists']);
+        $this->client->request(Request::METHOD_PATCH, '/api/segments/batch/edit', $response1['lists']);
         $clientResponse  = $this->client->getResponse();
         $response2       = json_decode($clientResponse->getContent(), true);
 
@@ -400,7 +400,7 @@ final class ListApiControllerFunctionalTest extends MauticMysqlTestCase
             'leadlist_id'   => $segment->getId(),
         ]);
 
-        $this->client->request('PATCH', "/api/segments/{$segment->getId()}/edit", ['isPublished' => 0]);
+        $this->client->request(Request::METHOD_PATCH, "/api/segments/{$segment->getId()}/edit", ['isPublished' => 0]);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
         self::assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
@@ -433,7 +433,7 @@ final class ListApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->persist($campaign);
         $this->em->flush();
 
-        $this->client->request('PATCH', "/api/segments/{$segment->getId()}/edit", ['isPublished' => 0]);
+        $this->client->request(Request::METHOD_PATCH, "/api/segments/{$segment->getId()}/edit", ['isPublished' => 0]);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
         self::assertResponseIsSuccessful();
@@ -465,7 +465,7 @@ final class ListApiControllerFunctionalTest extends MauticMysqlTestCase
         $list2 = $this->saveSegment('s2', 's2', $filter);
         $this->em->clear();
 
-        $this->client->request('PATCH', "/api/segments/{$list1->getId()}/edit", ['name' => 'API segment renamed', 'isPublished' => false]);
+        $this->client->request(Request::METHOD_PATCH, "/api/segments/{$list1->getId()}/edit", ['name' => 'API segment renamed', 'isPublished' => false]);
         $expectedErrorMessage = sprintf('isPublished: The segment %s is used in %s, please go back and check segments before unpublishing', 'API segment renamed', $list2->getName());
 
         $clientResponse = $this->client->getResponse();
@@ -505,7 +505,7 @@ final class ListApiControllerFunctionalTest extends MauticMysqlTestCase
             ['id' => $list2->getId(), 'isPublished' => false],
         ];
 
-        $this->client->request('PATCH', '/api/segments/batch/edit', $segments);
+        $this->client->request(Request::METHOD_PATCH, '/api/segments/batch/edit', $segments);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
@@ -540,7 +540,7 @@ final class ListApiControllerFunctionalTest extends MauticMysqlTestCase
         $list2 = $this->saveSegment('s2', 's2', $filter);
         $this->em->clear();
 
-        $this->client->request('PATCH', "/api/segments/{$list1->getId()}/edit", ['isPublished' => false]);
+        $this->client->request(Request::METHOD_PATCH, "/api/segments/{$list1->getId()}/edit", ['isPublished' => false]);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
         self::assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
@@ -562,7 +562,7 @@ final class ListApiControllerFunctionalTest extends MauticMysqlTestCase
             'alias'  => 'kitty',
             'bundle' => 'segment',
         ];
-        $this->client->request('POST', '/api/categories/new', $categoryPayload);
+        $this->client->request(Request::METHOD_POST, '/api/categories/new', $categoryPayload);
         $clientResponse     = $this->client->getResponse();
         $response           = json_decode($clientResponse->getContent(), true);
         $categoryId         = $response['category']['id'];
@@ -574,7 +574,7 @@ final class ListApiControllerFunctionalTest extends MauticMysqlTestCase
         ];
 
         // Create:
-        $this->client->request('POST', '/api/segments/new', $segmentPayload);
+        $this->client->request(Request::METHOD_POST, '/api/segments/new', $segmentPayload);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
         if (!empty($response['errors'][0])) {
@@ -584,7 +584,7 @@ final class ListApiControllerFunctionalTest extends MauticMysqlTestCase
         $segmentId = $response['list']['id'];
 
         // Get segment with category by id:
-        $this->client->request('GET', "/api/segments/{$segmentId}");
+        $this->client->request(Request::METHOD_GET, "/api/segments/{$segmentId}");
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
@@ -592,7 +592,7 @@ final class ListApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertEquals($segmentPayload['category'], $response['list']['category']['id']);
 
         // Search segments by category:
-        $this->client->request('GET', '/api/segments?search=category:kitty');
+        $this->client->request(Request::METHOD_GET, '/api/segments?search=category:kitty');
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
@@ -700,7 +700,7 @@ final class ListApiControllerFunctionalTest extends MauticMysqlTestCase
             'leadlist_id' => $segment->getId(),
         ]);
 
-        $this->client->request('DELETE', "/api/segments/{$segment->getId()}/delete");
+        $this->client->request(Request::METHOD_DELETE, "/api/segments/{$segment->getId()}/delete");
 
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
@@ -753,7 +753,7 @@ final class ListApiControllerFunctionalTest extends MauticMysqlTestCase
         ]);
 
         $ids = $segment1->getId().','.$segment2->getId();
-        $this->client->request('DELETE', "/api/segments/batch/delete?ids={$ids}");
+        $this->client->request(Request::METHOD_DELETE, "/api/segments/batch/delete?ids={$ids}");
 
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);

--- a/app/bundles/LeadBundle/Tests/Controller/Api/NoteApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/NoteApiControllerFunctionalTest.php
@@ -33,7 +33,7 @@ final class NoteApiControllerFunctionalTest extends MauticMysqlTestCase
         ], 'Note API Role');
         $this->authenticateApiUser($apiUser);
 
-        $this->client->request('GET', '/api/notes/'.$note->getId());
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/api/notes/'.$note->getId());
         $getResponse = $this->client->getResponse();
 
         $this->assertResponseIsSuccessful($getResponse->getContent());
@@ -41,7 +41,7 @@ final class NoteApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertSame($note->getId(), $getPayload['note']['id']);
         $this->assertSame('Existing API note', $getPayload['note']['text']);
 
-        $this->client->request('POST', '/api/notes/new', [
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_POST, '/api/notes/new', [
             'lead' => $contact->getId(),
             'text' => 'Created from API',
         ]);
@@ -71,7 +71,7 @@ final class NoteApiControllerFunctionalTest extends MauticMysqlTestCase
         ], 'Note API Role');
         $this->authenticateApiUser($apiUser);
 
-        $this->client->request('POST', '/api/notes/new', [
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_POST, '/api/notes/new', [
             'lead' => $contact->getId(),
             'text' => 'Forbidden note creation',
         ]);

--- a/app/bundles/LeadBundle/Tests/Controller/Api/TagApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/TagApiControllerFunctionalTest.php
@@ -16,7 +16,7 @@ final class TagApiControllerFunctionalTest extends MauticMysqlTestCase
         $tag1Payload = ['tag' => 'test_tag'];
 
         // Create new tag
-        $this->client->request('POST', '/api/tags/new', $tag1Payload);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_POST, '/api/tags/new', $tag1Payload);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
         $tagId          = $response['tag']['id'];
@@ -26,7 +26,7 @@ final class TagApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertEquals($tag1Payload['tag'], $response['tag']['tag']);
 
         // Try to create tag with same name
-        $this->client->request('POST', '/api/tags/new', $tag1Payload);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_POST, '/api/tags/new', $tag1Payload);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
         $this->assertResponseIsSuccessful('Return code must be 200.');
@@ -36,7 +36,7 @@ final class TagApiControllerFunctionalTest extends MauticMysqlTestCase
 
         // Edit tag name
         $tag1RenamePayload = ['tag' => 'tag_renamed'];
-        $this->client->request('PATCH', "/api/tags/{$tagId}/edit", $tag1RenamePayload);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_PATCH, "/api/tags/{$tagId}/edit", $tag1RenamePayload);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
         $this->assertResponseIsSuccessful('Return code must be 200.');
@@ -44,7 +44,7 @@ final class TagApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertEquals($tag1RenamePayload['tag'], $response['tag']['tag']);
 
         // Get tag
-        $this->client->request('GET', "/api/tags/{$tagId}");
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, "/api/tags/{$tagId}");
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
         $this->assertResponseIsSuccessful();
@@ -52,12 +52,12 @@ final class TagApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertEquals($tag1RenamePayload['tag'], $response['tag']['tag']);
 
         // Delete:
-        $this->client->request('DELETE', "/api/tags/{$tagId}/delete");
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_DELETE, "/api/tags/{$tagId}/delete");
         $clientResponse = $this->client->getResponse();
         $this->assertResponseIsSuccessful($clientResponse->getContent());
 
         // Get (ensure it's deleted):
-        $this->client->request('GET', "/api/tags/{$tagId}");
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, "/api/tags/{$tagId}");
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
@@ -74,7 +74,7 @@ final class TagApiControllerFunctionalTest extends MauticMysqlTestCase
         $whitespaceTestPayload = ['test', 'test ', ' test', "test\t", "\ttest"];
         $tagId                 = null;
         foreach ($whitespaceTestPayload as $payload) {
-            $this->client->request('POST', '/api/tags/new', ['tag' => $payload]);
+            $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_POST, '/api/tags/new', ['tag' => $payload]);
             $clientResponse = $this->client->getResponse();
             $response       = json_decode($clientResponse->getContent(), true);
 
@@ -95,7 +95,7 @@ final class TagApiControllerFunctionalTest extends MauticMysqlTestCase
     {
         $tagInputName    = 'hello" world';
 
-        $this->client->request('POST', '/api/tags/new', ['tag' => $tagInputName]);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_POST, '/api/tags/new', ['tag' => $tagInputName]);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
         $tagId          = $response['tag']['id'];
@@ -103,7 +103,7 @@ final class TagApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertEquals($tagInputName, $response['tag']['tag']);
 
         // Try to create duplicate
-        $this->client->request('POST', '/api/tags/new', ['tag' => $tagInputName]);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_POST, '/api/tags/new', ['tag' => $tagInputName]);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
         $this->assertSame($tagId, $response['tag']['id'], 'ID of created tag does not match. Possible duplicates.');
@@ -113,7 +113,7 @@ final class TagApiControllerFunctionalTest extends MauticMysqlTestCase
     {
         // Sending an empty payload should return a 500 server error
         // TODO ensure that the server sends back a 400 status code instead
-        $this->client->request('POST', '/api/tags/new', []);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_POST, '/api/tags/new', []);
 
         $this->assertResponseStatusCodeSame(500);
     }
@@ -129,7 +129,7 @@ final class TagApiControllerFunctionalTest extends MauticMysqlTestCase
         $tagRepository->saveEntity($matchingTag, false);
         $tagRepository->saveEntity($otherTag);
 
-        $this->client->request('GET', '/api/tags?limit=1&search=test');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/api/tags?limit=1&search=test');
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 

--- a/app/bundles/LeadBundle/Tests/Controller/AuditLogControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/AuditLogControllerTest.php
@@ -27,7 +27,7 @@ final class AuditLogControllerTest extends MauticMysqlTestCase
         $this->em->persist($contact);
         $this->em->flush();
 
-        $this->client->request('GET', '/s/contacts/auditlog/batchExport/'.$contact->getId());
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/s/contacts/auditlog/batchExport/'.$contact->getId());
         $this->assertResponseIsSuccessful();
     }
 
@@ -40,7 +40,7 @@ final class AuditLogControllerTest extends MauticMysqlTestCase
         $user = $this->em->getRepository(User::class)->findOneBy(['username' => self::SALES_USER]);
         $this->assertInstanceOf(User::class, $user);
         $this->loginUser($user);
-        $this->client->request('GET', '/s/contacts/auditlog/batchExport/'.$contact->getId());
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/s/contacts/auditlog/batchExport/'.$contact->getId());
         $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
     }
 }

--- a/app/bundles/LeadBundle/Tests/Controller/CompanyControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/CompanyControllerTest.php
@@ -73,7 +73,7 @@ final class CompanyControllerTest extends MauticMysqlTestCase
      */
     public function testViewActionCompany(): void
     {
-        $crawler                = $this->client->request('GET', '/s/companies/view/'.$this->company1Id);
+        $crawler                = $this->client->request(Request::METHOD_GET, '/s/companies/view/'.$this->company1Id);
         $clientResponse         = $this->client->getResponse();
         $clientResponseContent  = $clientResponse->getContent();
         /** @var CompanyModel $model */
@@ -91,7 +91,7 @@ final class CompanyControllerTest extends MauticMysqlTestCase
         $this->createLead();
         $segment = $this->createSegment();
         $this->testSymfonyCommand('mautic:segments:update', ['--list-id' => $segment->getId()]);
-        $crawler  = $this->client->request('GET', "s/company/graph/{$this->company1Id}");
+        $crawler  = $this->client->request(Request::METHOD_GET, "s/company/graph/{$this->company1Id}");
         $response = $this->client->getResponse();
         $this->assertResponseIsSuccessful();
         $body           = json_decode($response->getContent(), true);
@@ -111,7 +111,7 @@ final class CompanyControllerTest extends MauticMysqlTestCase
      */
     public function testEditActionCompany(): void
     {
-        $crawler                = $this->client->request('GET', '/s/companies/edit/'.$this->company1Id);
+        $crawler                = $this->client->request(Request::METHOD_GET, '/s/companies/edit/'.$this->company1Id);
         $clientResponse         = $this->client->getResponse();
         $clientResponseContent  = $clientResponse->getContent();
         /** @var CompanyModel $model */
@@ -130,7 +130,7 @@ final class CompanyControllerTest extends MauticMysqlTestCase
 
     public function testEditAndCancelActionCompany(): void
     {
-        $crawler = $this->client->request('GET', '/s/companies/edit/'.$this->company1Id);
+        $crawler = $this->client->request(Request::METHOD_GET, '/s/companies/edit/'.$this->company1Id);
         $this->assertResponseIsSuccessful();
         $buttonCrawler = $crawler->selectButton('Cancel');
         $form          = $buttonCrawler->form();
@@ -175,7 +175,7 @@ final class CompanyControllerTest extends MauticMysqlTestCase
             ->setEmail('example@idstart.com');
         $leadModel->saveEntity($lead3);
 
-        $crawler        = $this->client->request('GET', '/s/company/'.$this->company1Id.'/contacts/');
+        $crawler        = $this->client->request(Request::METHOD_GET, '/s/company/'.$this->company1Id.'/contacts/');
         $leadsTableRows = $crawler->filterXPath("//table[@id='leadTable']//tbody//tr");
 
         $this->assertResponseIsSuccessful();
@@ -186,7 +186,7 @@ final class CompanyControllerTest extends MauticMysqlTestCase
         $this->assertStringContainsString('/s/contacts/view/'.$lead1->getId(), (string) $clientResponse->getContent());
         $this->assertStringContainsString('1 item', (string) $clientResponse->getContent());
 
-        $crawler        = $this->client->request('GET', '/s/company/'.$this->company2Id.'/contacts/');
+        $crawler        = $this->client->request(Request::METHOD_GET, '/s/company/'.$this->company2Id.'/contacts/');
         $leadsTableRows = $crawler->filterXPath("//table[@id='leadTable']//tbody//tr");
 
         $this->assertResponseIsSuccessful();
@@ -306,7 +306,7 @@ final class CompanyControllerTest extends MauticMysqlTestCase
      */
     public function testNewActionCompany(): void
     {
-        $this->client->request('GET', '/s/companies/new/');
+        $this->client->request(Request::METHOD_GET, '/s/companies/new/');
         $clientResponse         = $this->client->getResponse();
         $this->assertEquals(Response::HTTP_OK, $clientResponse->getStatusCode());
     }
@@ -323,7 +323,7 @@ final class CompanyControllerTest extends MauticMysqlTestCase
 
     public function testNewCompanyMergeButtonVisible(): void
     {
-        $this->client->request('GET', '/s/companies/new/');
+        $this->client->request(Request::METHOD_GET, '/s/companies/new/');
         $clientResponse         = $this->client->getResponse();
         $clientResponseContent  = $clientResponse->getContent();
         $this->assertEquals(Response::HTTP_OK, $clientResponse->getStatusCode());
@@ -352,7 +352,7 @@ final class CompanyControllerTest extends MauticMysqlTestCase
         $this->em->flush();
         $this->em->clear();
 
-        $crawler = $this->client->request('GET', '/s/companies/edit/'.$this->company1Id);
+        $crawler = $this->client->request(Request::METHOD_GET, '/s/companies/edit/'.$this->company1Id);
         $form    = $crawler->selectButton('Save')->form();
         $form['company[projects]']->setValue((string) $project->getId());
 
@@ -370,7 +370,7 @@ final class CompanyControllerTest extends MauticMysqlTestCase
         $leadA = $this->createLead();
         $leadB = $this->createLead('F1', 'L1', 'f@l.com', '123');
 
-        $crawler = $this->client->request('GET', '/s/companies/edit/'.$this->company1Id);
+        $crawler = $this->client->request(Request::METHOD_GET, '/s/companies/edit/'.$this->company1Id);
         $this->assertResponseIsSuccessful();
 
         $buttonCrawler = $crawler->selectButton('Save & Close');
@@ -405,7 +405,7 @@ final class CompanyControllerTest extends MauticMysqlTestCase
 
     public function testIndexAction(): void
     {
-        $this->client->request('GET', '/s/companies');
+        $this->client->request(Request::METHOD_GET, '/s/companies');
         $clientResponse = $this->client->getResponse();
         $this->assertEquals(Response::HTTP_OK, $clientResponse->getStatusCode());
 

--- a/app/bundles/LeadBundle/Tests/Controller/LeadCompanyControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/LeadCompanyControllerTest.php
@@ -16,7 +16,7 @@ final class LeadCompanyControllerTest extends MauticMysqlTestCase
 
     public function testSimpleCompanyFeature(): void
     {
-        $crawler     = $this->client->request('GET', 's/contacts/new/');
+        $crawler     = $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, 's/contacts/new/');
         $multiple    = $crawler->filterXPath('//*[@id="lead_companies"]')->attr('multiple');
         $this->assertNull($multiple);
     }

--- a/app/bundles/LeadBundle/Tests/Controller/LeadControllerListingPageTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/LeadControllerListingPageTest.php
@@ -28,7 +28,7 @@ final class LeadControllerListingPageTest extends MauticMysqlTestCase
     {
         $this->createContact($location);
 
-        $crawler    = $this->client->request('GET', 's/contacts');
+        $crawler    = $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, 's/contacts');
         $rowContent = $crawler->filterXPath("//table[@id='leadTable']//tbody//tr");
 
         $this->assertStringEndsWith($expected, $rowContent->text());

--- a/app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
@@ -383,7 +383,7 @@ final class LeadControllerTest extends MauticMysqlTestCase
         $this->em->persist($company);
         $this->em->flush();
 
-        $crawler = $this->client->request('GET', 's/contacts/new/');
+        $crawler = $this->client->request(Request::METHOD_GET, 's/contacts/new/');
         $form    = $crawler->filterXPath('//form[@name="lead"]')->form();
         $form->setValues(
             [
@@ -537,7 +537,7 @@ final class LeadControllerTest extends MauticMysqlTestCase
     #[TestDox('Ensure correct Preferred Timezone placeholder on add/edit contact page')]
     public function testEnsureCorrectPreferredTimeZonePlaceHolderOnContactPage(): void
     {
-        $crawler             = $this->client->request('GET', '/s/contacts/new');
+        $crawler             = $this->client->request(Request::METHOD_GET, '/s/contacts/new');
         $elementPlaceholder  = $crawler->filter('#lead_timezone')->filter('select')->attr('data-placeholder');
         $expectedPlaceholder = self::getContainer()->get(TranslatorInterface::class)->trans('mautic.lead.field.timezone');
         $this->assertEquals($expectedPlaceholder, $elementPlaceholder);
@@ -551,7 +551,7 @@ final class LeadControllerTest extends MauticMysqlTestCase
 
     public function testQuickAddAction(): void
     {
-        $this->client->request('GET', '/s/contacts/quickAdd');
+        $this->client->request(Request::METHOD_GET, '/s/contacts/quickAdd');
 
         $this->assertEquals(Response::HTTP_OK, $this->client->getResponse()->getStatusCode(), $this->client->getResponse()->getContent());
     }
@@ -565,7 +565,7 @@ final class LeadControllerTest extends MauticMysqlTestCase
         $firstnameField->setIsRequired(true);
         $fieldModel->getRepository()->saveEntity($firstnameField);
 
-        $crawler = $this->client->request('GET', 's/contacts/new/');
+        $crawler = $this->client->request(Request::METHOD_GET, 's/contacts/new/');
         $form    = $crawler->filterXPath('//form[@name="lead"]')->form();
         $form->setValues(
             [
@@ -580,7 +580,7 @@ final class LeadControllerTest extends MauticMysqlTestCase
 
     public function testAddContactsErrorMessageForEmailWithTwoDots(): void
     {
-        $crawler = $this->client->request('GET', 's/contacts/new/');
+        $crawler = $this->client->request(Request::METHOD_GET, 's/contacts/new/');
         $form    = $crawler->filterXPath('//form[@name="lead"]')->form();
         $form->setValues(
             [
@@ -733,7 +733,7 @@ EMAIL;
 
     public function testLookupTypeFieldOnError(): void
     {
-        $crawler = $this->client->request('GET', 's/contacts/new/');
+        $crawler = $this->client->request(Request::METHOD_GET, 's/contacts/new/');
         $form    = $crawler->filterXPath('//form[@name="lead"]')->form();
         $form->setValues(
             [
@@ -750,7 +750,7 @@ EMAIL;
     {
         $email = 'duplicate@email.a';
         $this->createContact($email);
-        $crawler = $this->client->request('GET', 's/contacts/quickAdd');
+        $crawler = $this->client->request(Request::METHOD_GET, 's/contacts/quickAdd');
         $form    = $crawler->filter('form[name="lead"]')->form([
             'lead' => [
                 'email' => $email,
@@ -769,7 +769,7 @@ EMAIL;
     {
         $email = 'duplicate@email.a';
         $this->createContact($email);
-        $crawler = $this->client->request('GET', 's/contacts/new');
+        $crawler = $this->client->request(Request::METHOD_GET, 's/contacts/new');
         $form    = $crawler->filter('form[name="lead"]')->form([
             'lead' => [
                 'email' => $email,
@@ -930,7 +930,7 @@ EMAIL;
         $this->em->persist($company);
         $this->em->flush();
 
-        $crawler = $this->client->request('GET', 's/contacts/new/');
+        $crawler = $this->client->request(Request::METHOD_GET, 's/contacts/new/');
         $form    = $crawler->filterXPath('//form[@name="lead"]')->form();
         $form->setValues(
             [
@@ -1142,7 +1142,7 @@ EMAIL;
 
     public function testMultipleCompanyFeature(): void
     {
-        $crawler     = $this->client->request('GET', 's/contacts/new/');
+        $crawler     = $this->client->request(Request::METHOD_GET, 's/contacts/new/');
         $multiple    = $crawler->filterXPath('//*[@id="lead_companies"]')->attr('multiple');
         $this->assertSame('multiple', $multiple);
     }

--- a/app/bundles/LeadBundle/Tests/Controller/LeadDetailFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/LeadDetailFunctionalTest.php
@@ -79,7 +79,7 @@ final class LeadDetailFunctionalTest extends MauticMysqlTestCase
 
         $expectedLabels = array_merge(['Created on', 'ID'], $expectedLabels);
 
-        $crawler = $this->client->request('GET', sprintf('/s/contacts/view/%d', $lead->getId()));
+        $crawler = $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, sprintf('/s/contacts/view/%d', $lead->getId()));
 
         // get actual core labels
         $actualLabels = $crawler->filter('#lead-details table')
@@ -100,7 +100,7 @@ final class LeadDetailFunctionalTest extends MauticMysqlTestCase
         $this->em->flush();
         $this->em->clear();
 
-        $crawler = $this->client->request('GET', sprintf('/s/contacts/view/%d', $lead->getId()));
+        $crawler = $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, sprintf('/s/contacts/view/%d', $lead->getId()));
 
         $anchorTag  = $crawler->filter('#toolbar ul.dropdown-menu-right li')->first()->filter('a');
         $mouseOver  = $anchorTag->attr('onmouseover');
@@ -121,7 +121,7 @@ final class LeadDetailFunctionalTest extends MauticMysqlTestCase
         $this->em->flush();
         $this->em->clear();
 
-        $crawler = $this->client->request('GET', 's/contacts/view/'.$contact->getId());
+        $crawler = $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, 's/contacts/view/'.$contact->getId());
         $data    = $crawler->filterXPath('//div[@id="social"]//td');
         $this->assertCount(1, $data);
 
@@ -131,7 +131,7 @@ final class LeadDetailFunctionalTest extends MauticMysqlTestCase
 
     public function testLeadDetailPageForSocialTabInDetailsCollapsible(): void
     {
-        $crawler = $this->client->request('GET', 's/contacts/new/');
+        $crawler = $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, 's/contacts/new/');
 
         $fbLink  = 'https://fb.com/john_doe_test';
         $form    = $crawler->selectButton('Save & Close')->form();

--- a/app/bundles/LeadBundle/Tests/Controller/ListControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/ListControllerFunctionalTest.php
@@ -520,7 +520,7 @@ final class ListControllerFunctionalTest extends MauticMysqlTestCase
             'validators'
         );
 
-        $this->client->request('POST', 's/segments/delete/'.$list1->getId(), [], [], $this->createAjaxHeaders());
+        $this->client->request(Request::METHOD_POST, 's/segments/delete/'.$list1->getId(), [], [], $this->createAjaxHeaders());
 
         $clientResponse     = $this->client->getResponse();
         $clientResponseBody = json_decode($clientResponse->getContent(), true);
@@ -559,7 +559,7 @@ final class ListControllerFunctionalTest extends MauticMysqlTestCase
         );
 
         $parameters = 'ids=["'.$list1->getId().'","'.$list2->getId().'"]';
-        $this->client->request('POST', 's/segments/batchDelete?'.$parameters, [], [], $this->createAjaxHeaders());
+        $this->client->request(Request::METHOD_POST, 's/segments/batchDelete?'.$parameters, [], [], $this->createAjaxHeaders());
 
         $clientResponse = $this->client->getResponse();
         $this->assertResponseIsSuccessful();
@@ -913,7 +913,7 @@ final class ListControllerFunctionalTest extends MauticMysqlTestCase
         $dnc->setDateAdded(new \DateTime());
         $this->em->persist($dnc);
         $this->em->flush();
-        $this->client->request('GET', sprintf('/s/segments/view/%d', $segment->getId()));
+        $this->client->request(Request::METHOD_GET, sprintf('/s/segments/view/%d', $segment->getId()));
         $response = $this->client->getResponse();
         $this->assertResponseIsSuccessful();
         $html = $response->getContent();

--- a/app/bundles/LeadBundle/Tests/Controller/ListControllerPermissionFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/ListControllerPermissionFunctionalTest.php
@@ -654,7 +654,7 @@ final class ListControllerPermissionFunctionalTest extends MauticMysqlTestCase
         $this->assertTrue($segment->isPublished());
 
         $this->client->request(
-            'POST',
+            Request::METHOD_POST,
             '/s/ajax',
             [
                 'action' => 'togglePublishStatus',
@@ -689,7 +689,7 @@ final class ListControllerPermissionFunctionalTest extends MauticMysqlTestCase
         $segment = $this->createSegment('Segment Without Publish', $user);
 
         $this->client->request(
-            'POST',
+            Request::METHOD_POST,
             '/s/ajax',
             [
                 'action' => 'togglePublishStatus',

--- a/app/bundles/LeadBundle/Tests/Controller/ListControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/ListControllerTest.php
@@ -49,7 +49,7 @@ final class ListControllerTest extends MauticMysqlTestCase
         $this->em->flush();
         $this->em->clear();
 
-        $this->client->request('GET', '/s/segments');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/s/segments');
         $clientResponse = $this->client->getResponse();
         $this->assertResponseIsSuccessful();
         $this->assertStringContainsString('February 7, 2020', (string) $clientResponse->getContent());
@@ -62,7 +62,7 @@ final class ListControllerTest extends MauticMysqlTestCase
      */
     public function testIndexActionWhenFiltering(): void
     {
-        $this->client->request('GET', '/s/segments?search=has%3Aresults&tmpl=list');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/s/segments?search=has%3Aresults&tmpl=list');
         $this->assertResponseIsSuccessful('Return code must be 200.');
     }
 
@@ -70,7 +70,7 @@ final class ListControllerTest extends MauticMysqlTestCase
     {
         $contacts = $this->createContacts();
         $segment  = $this->addContactsToSegment($contacts, 'MySeg');
-        $this->client->request('GET', sprintf('/s/segments/view/%d', $segment->getId()));
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, sprintf('/s/segments/view/%d', $segment->getId()));
         $response = $this->client->getResponse();
         self::assertResponseIsSuccessful();
         $this->assertStringContainsString('MySeg', (string) $response->getContent());
@@ -86,7 +86,7 @@ final class ListControllerTest extends MauticMysqlTestCase
         $pageId   = 1;
         $contacts = $this->createContacts();
         $segment  = $this->addContactsToSegment($contacts, 'MySeg');
-        $this->client->request('GET', sprintf('/s/segment/view/%d/contact/%d', $segment->getId(), $pageId));
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, sprintf('/s/segment/view/%d/contact/%d', $segment->getId(), $pageId));
         $response = $this->client->getResponse();
         self::assertResponseIsSuccessful();
         $this->assertStringContainsString('Kane', (string) $response->getContent());
@@ -185,7 +185,7 @@ final class ListControllerTest extends MauticMysqlTestCase
         $this->em->flush();
         $this->em->clear();
 
-        $this->client->request('GET', sprintf('/s/segments/clone/%d', $list->getId()));
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, sprintf('/s/segments/clone/%d', $list->getId()));
 
         $clientResponse = $this->client->getResponse();
         $this->assertResponseIsSuccessful('Return code must be 200.');
@@ -211,7 +211,7 @@ final class ListControllerTest extends MauticMysqlTestCase
         $this->em->persist($segment);
         $this->em->flush();
 
-        $this->client->request('GET', '/api/segments?search=filters_field:custom_field_test');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/api/segments?search=filters_field:custom_field_test');
         $clientResponse = $this->client->getResponse();
         $this->assertResponseIsSuccessful();
         $this->assertStringContainsString('Segment filter', (string) $clientResponse->getContent());

--- a/app/bundles/LeadBundle/Tests/Controller/TimelineControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/TimelineControllerTest.php
@@ -22,7 +22,7 @@ final class TimelineControllerTest extends MauticMysqlTestCase
         $contact = $this->createLead('TestFirstName');
         $this->em->flush();
 
-        $this->client->request('GET', '/s/contacts/timeline/'.$contact->getId());
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/s/contacts/timeline/'.$contact->getId());
         $this->assertResponseIsSuccessful();
     }
 
@@ -37,7 +37,7 @@ final class TimelineControllerTest extends MauticMysqlTestCase
         ]);
         $this->em->flush();
 
-        $this->client->request('POST', '/s/contacts/timeline/'.$contact->getId(), [
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_POST, '/s/contacts/timeline/'.$contact->getId(), [
             'search' => 'test',
             'leadId' => $contact->getId(),
         ]);
@@ -55,7 +55,7 @@ final class TimelineControllerTest extends MauticMysqlTestCase
         $this->em->persist($contact);
         $this->em->flush();
 
-        $this->client->request('GET', '/s/contacts/timeline/batchExport/'.$contact->getId());
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/s/contacts/timeline/batchExport/'.$contact->getId());
         $this->assertResponseIsSuccessful();
     }
 
@@ -68,7 +68,7 @@ final class TimelineControllerTest extends MauticMysqlTestCase
         $user = $this->em->getRepository(User::class)->findOneBy(['username' => self::SALES_USER]);
         $this->assertInstanceOf(User::class, $user);
         $this->loginUser($user);
-        $this->client->request('GET', '/s/contacts/timeline/batchExport/'.$contact->getId());
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/s/contacts/timeline/batchExport/'.$contact->getId());
         $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
     }
 }

--- a/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
@@ -540,7 +540,7 @@ final class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
     private function createStages(): array
     {
         foreach ($this->stages as $key => $stage) {
-            $this->client->request('POST', '/api/stages/new', $stage);
+            $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_POST, '/api/stages/new', $stage);
             $clientResponse = $this->client->getResponse();
             $response       = json_decode($clientResponse->getContent(), true);
 
@@ -558,7 +558,7 @@ final class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
     private function addStageToContacts(array $contacts, int $stageId): void
     {
         foreach ($contacts as $contact) {
-            $this->client->request('POST', "/api/stages/{$stageId}/contact/{$contact->getId()}/add");
+            $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_POST, "/api/stages/{$stageId}/contact/{$contact->getId()}/add");
             $clientResponse = $this->client->getResponse();
 
             $this->assertEquals(Response::HTTP_OK, $clientResponse->getStatusCode(), $clientResponse->getContent());

--- a/app/bundles/LeadBundle/Tests/EventListener/Issue9488Test.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/Issue9488Test.php
@@ -90,7 +90,7 @@ final class Issue9488Test extends MauticMysqlTestCase
      */
     private function createContacts(): array
     {
-        $this->client->request('POST', '/api/contacts/batch/new', $this->contacts);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_POST, '/api/contacts/batch/new', $this->contacts);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true, 512, JSON_THROW_ON_ERROR);
 

--- a/app/bundles/LeadBundle/Tests/EventListener/SearchSubscriberFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/SearchSubscriberFunctionalTest.php
@@ -42,7 +42,7 @@ final class SearchSubscriberFunctionalTest extends MauticMysqlTestCase
         $this->prepareTestData();
         $this->em->flush();
 
-        $crawler = $this->client->request('GET', sprintf('/s/contacts?search=email_pending:%d', $this->email->getId()));
+        $crawler = $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, sprintf('/s/contacts?search=email_pending:%d', $this->email->getId()));
         self::assertResponseIsSuccessful();
 
         $text = $crawler->text();

--- a/app/bundles/LeadBundle/Tests/EventListener/SegmentLogReportSubscriberFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/SegmentLogReportSubscriberFunctionalTest.php
@@ -39,7 +39,7 @@ final class SegmentLogReportSubscriberFunctionalTest extends MauticMysqlTestCase
         $this->em->flush();
         $this->em->clear();
 
-        $this->client->request('GET', 'api/reports/'.$report->getId());
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, 'api/reports/'.$report->getId());
         $clientResponse = $this->client->getResponse();
         $this->assertResponseStatusCodeSame(200, $clientResponse->getContent());
 

--- a/app/bundles/LeadBundle/Tests/Functional/ApiPlatform/CompanyOwnershipApiV2AuthorizationRegressionTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/ApiPlatform/CompanyOwnershipApiV2AuthorizationRegressionTest.php
@@ -51,7 +51,7 @@ final class CompanyOwnershipApiV2AuthorizationRegressionTest extends OwnershipSc
         $this->client->setServerParameter('PHP_AUTH_USER', $restrictedUser->getUserIdentifier());
         $this->client->setServerParameter('PHP_AUTH_PW', 'Maut1cR0cks!');
 
-        $this->client->request('GET', '/api/v2/companies?page=1&itemsPerPage=10');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/api/v2/companies?page=1&itemsPerPage=10');
         $response = $this->client->getResponse();
 
         self::assertResponseIsSuccessful();
@@ -113,7 +113,7 @@ final class CompanyOwnershipApiV2AuthorizationRegressionTest extends OwnershipSc
         $this->client->setServerParameter('PHP_AUTH_PW', 'Maut1cR0cks!');
 
         // Request page 1 with all items on one page first
-        $this->client->request('GET', '/api/v2/companies?page=1&itemsPerPage=10');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/api/v2/companies?page=1&itemsPerPage=10');
         $response = $this->client->getResponse();
 
         self::assertResponseIsSuccessful();
@@ -173,7 +173,7 @@ final class CompanyOwnershipApiV2AuthorizationRegressionTest extends OwnershipSc
         $this->client->setServerParameter('PHP_AUTH_USER', $newOwner->getUserIdentifier());
         $this->client->setServerParameter('PHP_AUTH_PW', 'Maut1cR0cks!');
 
-        $this->client->request('GET', '/api/v2/companies?page=1&itemsPerPage=10');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/api/v2/companies?page=1&itemsPerPage=10');
         $response = $this->client->getResponse();
 
         self::assertResponseIsSuccessful();
@@ -189,7 +189,7 @@ final class CompanyOwnershipApiV2AuthorizationRegressionTest extends OwnershipSc
         $this->client->setServerParameter('PHP_AUTH_USER', $originalOwner->getUserIdentifier());
         $this->client->setServerParameter('PHP_AUTH_PW', 'Maut1cR0cks!');
 
-        $this->client->request('GET', '/api/v2/companies?page=1&itemsPerPage=10');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/api/v2/companies?page=1&itemsPerPage=10');
         $response = $this->client->getResponse();
 
         self::assertResponseIsSuccessful();

--- a/app/bundles/LeadBundle/Tests/Functional/ApiPlatform/ContactOwnershipApiV2AuthorizationRegressionTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/ApiPlatform/ContactOwnershipApiV2AuthorizationRegressionTest.php
@@ -51,7 +51,7 @@ final class ContactOwnershipApiV2AuthorizationRegressionTest extends OwnershipSc
         $this->client->setServerParameter('PHP_AUTH_PW', 'Maut1cR0cks!');
 
         $endpoint = sprintf($endpointTemplate, $foreignContact->getId());
-        $this->client->request('GET', $endpoint);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $endpoint);
 
         self::assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
     }
@@ -112,7 +112,7 @@ final class ContactOwnershipApiV2AuthorizationRegressionTest extends OwnershipSc
         $this->client->setServerParameter('PHP_AUTH_USER', $attacker->getUserIdentifier());
         $this->client->setServerParameter('PHP_AUTH_PW', 'Maut1cR0cks!');
 
-        $this->client->request('GET', '/api/contacts?limit=100');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/api/contacts?limit=100');
         self::assertResponseIsSuccessful();
 
         $legacyCollection = json_decode($this->client->getResponse()->getContent(), true);
@@ -128,7 +128,7 @@ final class ContactOwnershipApiV2AuthorizationRegressionTest extends OwnershipSc
         $this->assertContains($ownContact->getId(), $legacyIds);
         $this->assertNotContains($foreignContact->getId(), $legacyIds);
 
-        $this->client->request('GET', '/api/v2/contacts?page=1');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/api/v2/contacts?page=1');
         self::assertResponseIsSuccessful();
 
         $v2Collection = json_decode($this->client->getResponse()->getContent(), true);
@@ -179,7 +179,7 @@ final class ContactOwnershipApiV2AuthorizationRegressionTest extends OwnershipSc
         $this->client->setServerParameter('PHP_AUTH_USER', $viewer->getUserIdentifier());
         $this->client->setServerParameter('PHP_AUTH_PW', 'Maut1cR0cks!');
 
-        $this->client->request('GET', '/api/v2/contacts?page=1&itemsPerPage=2');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/api/v2/contacts?page=1&itemsPerPage=2');
         self::assertResponseIsSuccessful();
 
         $firstPage = json_decode($this->client->getResponse()->getContent(), true);
@@ -198,7 +198,7 @@ final class ContactOwnershipApiV2AuthorizationRegressionTest extends OwnershipSc
             $this->assertContains($id, $ownedContactIds);
         }
 
-        $this->client->request('GET', '/api/v2/contacts?page=2&itemsPerPage=2');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/api/v2/contacts?page=2&itemsPerPage=2');
         self::assertResponseIsSuccessful();
 
         $secondPage = json_decode($this->client->getResponse()->getContent(), true);
@@ -263,7 +263,7 @@ final class ContactOwnershipApiV2AuthorizationRegressionTest extends OwnershipSc
         $this->client->setServerParameter('PHP_AUTH_USER', $viewOtherUser->getUserIdentifier());
         $this->client->setServerParameter('PHP_AUTH_PW', 'Maut1cR0cks!');
 
-        $this->client->request('GET', '/api/contacts?start=0&limit=10');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/api/contacts?start=0&limit=10');
         self::assertResponseIsSuccessful();
 
         $legacyCollection = json_decode($this->client->getResponse()->getContent(), true);
@@ -279,7 +279,7 @@ final class ContactOwnershipApiV2AuthorizationRegressionTest extends OwnershipSc
         $this->assertContains($ownContact->getId(), $legacyIds);
         $this->assertContains($foreignContact->getId(), $legacyIds);
 
-        $this->client->request('GET', '/api/v2/contacts?page=1&itemsPerPage=10');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/api/v2/contacts?page=1&itemsPerPage=10');
         self::assertResponseIsSuccessful();
 
         $collection = json_decode($this->client->getResponse()->getContent(), true);
@@ -341,7 +341,7 @@ final class ContactOwnershipApiV2AuthorizationRegressionTest extends OwnershipSc
         $this->client->setServerParameter('PHP_AUTH_USER', $newOwner->getUserIdentifier());
         $this->client->setServerParameter('PHP_AUTH_PW', 'Maut1cR0cks!');
 
-        $this->client->request('GET', '/api/v2/contacts?page=1&itemsPerPage=10');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/api/v2/contacts?page=1&itemsPerPage=10');
         $response = $this->client->getResponse();
 
         self::assertResponseIsSuccessful();
@@ -357,7 +357,7 @@ final class ContactOwnershipApiV2AuthorizationRegressionTest extends OwnershipSc
         $this->client->setServerParameter('PHP_AUTH_USER', $originalOwner->getUserIdentifier());
         $this->client->setServerParameter('PHP_AUTH_PW', 'Maut1cR0cks!');
 
-        $this->client->request('GET', '/api/v2/contacts?page=1&itemsPerPage=10');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/api/v2/contacts?page=1&itemsPerPage=10');
         $response = $this->client->getResponse();
 
         self::assertResponseIsSuccessful();

--- a/app/bundles/LeadBundle/Tests/Functional/Controller/CompanyControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Controller/CompanyControllerTest.php
@@ -16,14 +16,14 @@ final class CompanyControllerTest extends MauticMysqlTestCase
 
     public function testMergeAction(): void
     {
-        $this->client->request('GET', '/s/companies/merge/1');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/s/companies/merge/1');
         $this->assertResponseIsSuccessful();
     }
 
     public function testMergeActionWithoutPermission(): void
     {
         $this->createAndLoginUser();
-        $this->client->request('GET', '/s/companies/merge/1');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/s/companies/merge/1');
         $clientResponse         = $this->client->getResponse();
         $this->assertEquals(403, $clientResponse->getStatusCode());
     }

--- a/app/bundles/LeadBundle/Tests/Functional/Controller/CompanyListColumnConfigurationFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Controller/CompanyListColumnConfigurationFunctionalTest.php
@@ -25,7 +25,7 @@ final class CompanyListColumnConfigurationFunctionalTest extends MauticMysqlTest
         $this->em->persist($company);
         $this->em->flush();
 
-        $crawler = $this->client->request('GET', '/s/companies');
+        $crawler = $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/s/companies');
 
         $this->assertResponseIsSuccessful();
 

--- a/app/bundles/LeadBundle/Tests/Functional/Entity/CompanyRepositoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Entity/CompanyRepositoryTest.php
@@ -149,7 +149,7 @@ final class CompanyRepositoryTest extends MauticMysqlTestCase
             $payload['lists'] = [$segmentId];
         }
 
-        $this->client->request('POST', '/api/emails/new', $payload);
+        $this->client->request(Request::METHOD_POST, '/api/emails/new', $payload);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
@@ -169,7 +169,7 @@ final class CompanyRepositoryTest extends MauticMysqlTestCase
 
     private function sendEmailViaApi(int $emailId): void
     {
-        $this->client->request('POST', "/api/emails/{$emailId}/send");
+        $this->client->request(Request::METHOD_POST, "/api/emails/{$emailId}/send");
         $clientResponse = $this->client->getResponse();
         self::assertResponseIsSuccessful();
         $this->assertSame(json_decode($clientResponse->getContent(), true, 512, JSON_THROW_ON_ERROR), [

--- a/app/bundles/LeadBundle/Tests/Segment/SegmentFilterFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/SegmentFilterFunctionalTest.php
@@ -106,7 +106,7 @@ final class SegmentFilterFunctionalTest extends MauticMysqlTestCase
         ];
 
         // Create:
-        $this->client->request('POST', '/api/segments/new', $payload);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_POST, '/api/segments/new', $payload);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 

--- a/app/bundles/MarketplaceBundle/Tests/Functional/Controller/DetailControllerTest.php
+++ b/app/bundles/MarketplaceBundle/Tests/Functional/Controller/DetailControllerTest.php
@@ -28,7 +28,7 @@ final class DetailControllerTest extends MauticMysqlTestCase
         $allowlist = self::getContainer()->get(Allowlist::class);
         $allowlist->clearCache();
 
-        $this->client->request('GET', "s/marketplace/detail/{$requestedPackage}");
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, "s/marketplace/detail/{$requestedPackage}");
 
         $responseContent = $this->client->getResponse()->getContent();
 

--- a/app/bundles/MarketplaceBundle/Tests/Functional/Controller/ListControllerTest.php
+++ b/app/bundles/MarketplaceBundle/Tests/Functional/Controller/ListControllerTest.php
@@ -35,7 +35,7 @@ final class ListControllerTest extends MauticMysqlTestCase
         $allowlist = self::getContainer()->get(Allowlist::class);
         $allowlist->clearCache();
 
-        $crawler = $this->client->request('GET', 's/marketplace');
+        $crawler = $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, 's/marketplace');
 
         self::assertResponseIsSuccessful($this->client->getResponse()->getContent());
 
@@ -66,7 +66,7 @@ final class ListControllerTest extends MauticMysqlTestCase
         $allowlist = self::getContainer()->get(Allowlist::class);
         $allowlist->clearCache();
 
-        $crawler = $this->client->request('GET', 's/marketplace');
+        $crawler = $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, 's/marketplace');
 
         self::assertResponseIsSuccessful();
 

--- a/app/bundles/PageBundle/Tests/Controller/PageControllerFunctionalTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PageControllerFunctionalTest.php
@@ -92,7 +92,7 @@ final class PageControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->flush();
         $this->em->clear();
 
-        $crawler = $this->client->request('GET', '/s/pages/edit/'.$page->getId());
+        $crawler = $this->client->request(Request::METHOD_GET, '/s/pages/edit/'.$page->getId());
         $form    = $crawler->selectButton('Save')->form();
         $form['page[projects]']->setValue((string) $project->getId());
 
@@ -139,7 +139,7 @@ final class PageControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->flush();
         $this->assertPageVersion($page->getId(), $version);
 
-        $crawler = $this->client->request('GET', '/s/pages/edit/'.$page->getId());
+        $crawler = $this->client->request(Request::METHOD_GET, '/s/pages/edit/'.$page->getId());
         $form    = $crawler->selectButton('Save')->form();
         $this->client->submit($form);
         $this->assertResponseIsSuccessful();

--- a/app/bundles/PageBundle/Tests/Controller/PageControllerTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PageControllerTest.php
@@ -78,7 +78,7 @@ final class PageControllerTest extends MauticMysqlTestCase
         ]);
         $leadsBeforeTest   = $this->connection->fetchAllAssociative('SELECT `id` FROM `'.$this->prefix.'leads`;');
         $leadIdsBeforeTest = array_column($leadsBeforeTest, 'id');
-        $this->client->request('GET', '/page-page-landingPageTracking');
+        $this->client->request(Request::METHOD_GET, '/page-page-landingPageTracking');
         $this->assertResponseIsSuccessful();
 
         $sql = 'SELECT `id` FROM `'.$this->prefix.'leads`';
@@ -117,7 +117,7 @@ final class PageControllerTest extends MauticMysqlTestCase
         ]);
         $leadsBeforeTest   = $this->connection->fetchAllAssociative('SELECT `id` FROM `'.$this->prefix.'leads`;');
         $leadIdsBeforeTest = array_column($leadsBeforeTest, 'id');
-        $this->client->request('GET', '/page-page-landingPageTrackingSecondVisit');
+        $this->client->request(Request::METHOD_GET, '/page-page-landingPageTrackingSecondVisit');
         $this->assertResponseIsSuccessful();
         $sql = 'SELECT `id` FROM `'.$this->prefix.'leads`';
         if ([] !== $leadIdsBeforeTest) {
@@ -134,7 +134,7 @@ final class PageControllerTest extends MauticMysqlTestCase
         );
         $this->assertCount(1, $eventLogsAfterFirstVisit);
         $this->assertSame('created_contact', reset($eventLogsAfterFirstVisit)['action']);
-        $this->client->request('GET', '/page-page-landingPageTrackingSecondVisit');
+        $this->client->request(Request::METHOD_GET, '/page-page-landingPageTrackingSecondVisit');
         $this->assertResponseIsSuccessful();
         $eventLogsAfterSecondVisit = $this->connection->fetchAllAssociative('
           SELECT `id`, `action`
@@ -156,7 +156,7 @@ final class PageControllerTest extends MauticMysqlTestCase
         $timestamp  = \time();
         $page       = $this->createTestPage();
 
-        $this->client->request('GET', "/{$page->getAlias()}?utm_source=linkedin&utm_medium=social&utm_campaign=mautic&utm_content=".$timestamp);
+        $this->client->request(Request::METHOD_GET, "/{$page->getAlias()}?utm_source=linkedin&utm_medium=social&utm_campaign=mautic&utm_content=".$timestamp);
         $clientResponse = $this->client->getResponse();
         $this->assertEquals(Response::HTTP_OK, $clientResponse->getStatusCode(), $clientResponse->getContent());
 
@@ -199,7 +199,7 @@ final class PageControllerTest extends MauticMysqlTestCase
      */
     public function testViewActionPage(): void
     {
-        $this->client->request('GET', '/s/pages/view/'.$this->id);
+        $this->client->request(Request::METHOD_GET, '/s/pages/view/'.$this->id);
         $clientResponse         = $this->client->getResponse();
         $clientResponseContent  = $clientResponse->getContent();
         /** @var PageModel $model */
@@ -215,7 +215,7 @@ final class PageControllerTest extends MauticMysqlTestCase
      */
     public function testNewActionPage(): void
     {
-        $this->client->request('GET', '/s/pages/new/');
+        $this->client->request(Request::METHOD_GET, '/s/pages/new/');
         $clientResponse = $this->client->getResponse();
         $this->assertEquals(Response::HTTP_OK, $clientResponse->getStatusCode());
     }
@@ -223,7 +223,7 @@ final class PageControllerTest extends MauticMysqlTestCase
     /* Get landing page's submissions list */
     public function testListLandingPageSubmissions(): void
     {
-        $this->client->request('GET', 's/pages/results/'.$this->id);
+        $this->client->request(Request::METHOD_GET, 's/pages/results/'.$this->id);
         $clientResponse         = $this->client->getResponse();
 
         $this->assertEquals(Response::HTTP_OK, $clientResponse->getStatusCode());

--- a/app/bundles/PageBundle/Tests/Controller/PublicControllerFunctionalTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PublicControllerFunctionalTest.php
@@ -16,7 +16,7 @@ final class PublicControllerFunctionalTest extends MauticMysqlTestCase
 {
     public function testTrackingImageAction(): void
     {
-        $this->client->request('GET', '/mtracking.gif?url=http%3A%2F%2Fmautic.org');
+        $this->client->request(Request::METHOD_GET, '/mtracking.gif?url=http%3A%2F%2Fmautic.org');
 
         $this->assertResponseStatusCodeSame(200);
     }
@@ -115,7 +115,7 @@ final class PublicControllerFunctionalTest extends MauticMysqlTestCase
     {
         $this->logoutUser();
 
-        $this->client->request('POST', '/mtc/event', [
+        $this->client->request(Request::METHOD_POST, '/mtc/event', [
             'page_url' => 'https://example.com?Company=%3Cimg+src+onerror%3Dalert%28%27Company%27%29%3E',
         ]);
         $this->assertResponseIsSuccessful();
@@ -124,13 +124,13 @@ final class PublicControllerFunctionalTest extends MauticMysqlTestCase
 
         $response = json_decode($this->client->getResponse()->getContent(), true);
 
-        $this->client->request('GET', sprintf('/s/contacts/view/%d', $response['id']));
+        $this->client->request(Request::METHOD_GET, sprintf('/s/contacts/view/%d', $response['id']));
         $this->assertResponseIsSuccessful();
         $content = $this->client->getResponse()->getContent();
 
         $this->assertStringNotContainsString('<img src onerror=alert(\'Company\')>', (string) $content);
 
-        $crawler = $this->client->request('GET', sprintf('/s/contacts/edit/%d', $response['id']));
+        $crawler = $this->client->request(Request::METHOD_GET, sprintf('/s/contacts/edit/%d', $response['id']));
         $this->assertResponseIsSuccessful();
         $content = $this->client->getResponse()->getContent();
 

--- a/app/bundles/PageBundle/Tests/Functional/EventListener/BuilderSubscriberTest.php
+++ b/app/bundles/PageBundle/Tests/Functional/EventListener/BuilderSubscriberTest.php
@@ -89,7 +89,7 @@ final class BuilderSubscriberTest extends MauticMysqlTestCase
             'secretHash' => $mailHashHelper->getEmailHash($lead->getEmail()),
         ], UrlGeneratorInterface::ABSOLUTE_PATH);
 
-        $crawler = $this->client->request('GET', $unsubscribeUrl);
+        $crawler = $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $unsubscribeUrl);
 
         $this->assertTrue($this->client->getResponse()->isSuccessful(), $this->client->getResponse()->getContent());
 

--- a/app/bundles/PointBundle/Tests/Controller/Api/PointGroupsApiControllerTest.php
+++ b/app/bundles/PointBundle/Tests/Controller/Api/PointGroupsApiControllerTest.php
@@ -20,7 +20,7 @@ final class PointGroupsApiControllerTest extends MauticMysqlTestCase
         $translator = self::getContainer()->get(TranslatorInterface::class);
 
         // Create a new point group
-        $this->client->request('POST', '/api/points/groups/new', [
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_POST, '/api/points/groups/new', [
             'name'        => 'New Point Group',
             'description' => 'Description of the new point group',
         ]);
@@ -36,7 +36,7 @@ final class PointGroupsApiControllerTest extends MauticMysqlTestCase
         $this->assertEquals('Description of the new point group', $createdData['description']);
 
         // Retrieve all point groups
-        $this->client->request('GET', '/api/points/groups');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/api/points/groups');
         $getAllResponse = $this->client->getResponse();
 
         $this->assertResponseIsSuccessful();
@@ -54,7 +54,7 @@ final class PointGroupsApiControllerTest extends MauticMysqlTestCase
             'description' => 'Updated description of the point group',
         ];
 
-        $this->client->request('PATCH', "/api/points/groups/{$createdData['id']}/edit", $updatePayload);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_PATCH, "/api/points/groups/{$createdData['id']}/edit", $updatePayload);
         $updateResponse = $this->client->getResponse();
 
         $this->assertResponseIsSuccessful();
@@ -65,7 +65,7 @@ final class PointGroupsApiControllerTest extends MauticMysqlTestCase
         $this->assertEquals('Updated description of the point group', $updatedData['description']);
 
         // Delete the created point group
-        $this->client->request('DELETE', "/api/points/groups/{$createdData['id']}/delete");
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_DELETE, "/api/points/groups/{$createdData['id']}/delete");
         $deleteResponse = $this->client->getResponse();
 
         $this->assertResponseIsSuccessful();
@@ -76,7 +76,7 @@ final class PointGroupsApiControllerTest extends MauticMysqlTestCase
         $this->assertEquals('Updated description of the point group', $deleteData['description']);
 
         // Try to GET the group that should no longer exist
-        $this->client->request('GET', "/api/points/groups/{$createdData['id']}");
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, "/api/points/groups/{$createdData['id']}");
         $getResponse = $this->client->getResponse();
         $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
         $responseData = json_decode($getResponse->getContent(), true);
@@ -137,7 +137,7 @@ final class PointGroupsApiControllerTest extends MauticMysqlTestCase
         ]);
 
         // Try to GET the group points that should not exist
-        $this->client->request('GET', "/api/contacts/{$contact->getId()}/points/groups/0");
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, "/api/contacts/{$contact->getId()}/points/groups/0");
         $response = $this->client->getResponse();
         $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
         $responseData = json_decode($response->getContent(), true);
@@ -147,7 +147,7 @@ final class PointGroupsApiControllerTest extends MauticMysqlTestCase
         $this->assertSame($translator->trans('mautic.lead.event.api.point.group.not.found'), $responseData['errors'][0]['message']);
 
         // Try to GET the group points for a contact that should not exist
-        $this->client->request('GET', '/api/contacts/0/points/groups/0');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/api/contacts/0/points/groups/0');
         $response = $this->client->getResponse();
         $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
         $responseData = json_decode($response->getContent(), true);
@@ -159,7 +159,7 @@ final class PointGroupsApiControllerTest extends MauticMysqlTestCase
 
     private function adjustPointsAndAssert(Lead $contact, Group $pointGroup, string $operator, int $value, int $expectedScore): void
     {
-        $this->client->request('POST', "/api/contacts/{$contact->getId()}/points/groups/{$pointGroup->getId()}/{$operator}/{$value}");
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_POST, "/api/contacts/{$contact->getId()}/points/groups/{$pointGroup->getId()}/{$operator}/{$value}");
         $adjustResponse = $this->client->getResponse();
         $this->assertResponseIsSuccessful();
         $responseData = json_decode($adjustResponse->getContent(), true);
@@ -171,7 +171,7 @@ final class PointGroupsApiControllerTest extends MauticMysqlTestCase
      */
     private function assertContactPointGroups(Lead $contact, array $expectedGroups): void
     {
-        $this->client->request('GET', "/api/contacts/{$contact->getId()}/points/groups");
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, "/api/contacts/{$contact->getId()}/points/groups");
         $response = $this->client->getResponse();
         $this->assertResponseIsSuccessful();
         $responseData = json_decode($response->getContent(), true);
@@ -181,7 +181,7 @@ final class PointGroupsApiControllerTest extends MauticMysqlTestCase
 
     private function assertContactSinglePointGroup(Lead $contact, Group $pointGroup, int $expectedScore): void
     {
-        $this->client->request('GET', "/api/contacts/{$contact->getId()}/points/groups/{$pointGroup->getId()}");
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, "/api/contacts/{$contact->getId()}/points/groups/{$pointGroup->getId()}");
         $response = $this->client->getResponse();
         $this->assertResponseIsSuccessful();
         $responseData = json_decode($response->getContent(), true);

--- a/app/bundles/PointBundle/Tests/Controller/Api/PointInsightApiControllerTest.php
+++ b/app/bundles/PointBundle/Tests/Controller/Api/PointInsightApiControllerTest.php
@@ -19,7 +19,7 @@ final class PointInsightApiControllerTest extends MauticMysqlTestCase
         /** @var Translator $translator */
         $translator = self::getContainer()->get(TranslatorInterface::class);
 
-        $this->client->request('POST', '/api/points/insights/new', [
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_POST, '/api/points/insights/new', [
             'name'          => 'New Point Insight',
             'description'   => 'Description of the new point insight',
             'insightType'   => PointInsight::INSIGHT_TYPE_COMPARE_POINT_GROUPS,
@@ -40,7 +40,7 @@ final class PointInsightApiControllerTest extends MauticMysqlTestCase
         $this->assertArrayHasKey('insightAction', $createdData);
         $this->assertEquals(PointInsight::INSIGHT_ACTION_SET_CUSTOM_FIELD, $createdData['insightAction']);
 
-        $this->client->request('GET', '/api/points/insights');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/api/points/insights');
         $getAllResponse = $this->client->getResponse();
 
         $this->assertResponseIsSuccessful();
@@ -58,7 +58,7 @@ final class PointInsightApiControllerTest extends MauticMysqlTestCase
             'insightAction' => PointInsight::INSIGHT_ACTION_SET_CUSTOM_FIELD,
         ];
 
-        $this->client->request('PATCH', "/api/points/insights/{$createdData['id']}/edit", $updatePayload);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_PATCH, "/api/points/insights/{$createdData['id']}/edit", $updatePayload);
         $updateResponse = $this->client->getResponse();
 
         $this->assertResponseIsSuccessful();
@@ -67,7 +67,7 @@ final class PointInsightApiControllerTest extends MauticMysqlTestCase
         $updatedData = $responseData['insight'];
         $this->assertEquals(self::UPDATED_NAME, $updatedData['name']);
 
-        $this->client->request('DELETE', "/api/points/insights/{$createdData['id']}/delete");
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_DELETE, "/api/points/insights/{$createdData['id']}/delete");
         $deleteResponse = $this->client->getResponse();
 
         $this->assertResponseIsSuccessful();
@@ -76,7 +76,7 @@ final class PointInsightApiControllerTest extends MauticMysqlTestCase
         $deleteData = $responseData['insight'];
         $this->assertEquals(self::UPDATED_NAME, $deleteData['name']);
 
-        $this->client->request('GET', "/api/points/insights/{$createdData['id']}");
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, "/api/points/insights/{$createdData['id']}");
         $getResponse = $this->client->getResponse();
         $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
         $responseData = json_decode($getResponse->getContent(), true);

--- a/app/bundles/PointBundle/Tests/Functional/Controller/PointControllerTest.php
+++ b/app/bundles/PointBundle/Tests/Functional/Controller/PointControllerTest.php
@@ -24,7 +24,7 @@ final class PointControllerTest extends MauticMysqlTestCase
         $this->em->flush();
         $this->em->clear();
 
-        $crawler = $this->client->request('GET', '/s/points/edit/'.$point->getId());
+        $crawler = $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/s/points/edit/'.$point->getId());
         $form    = $crawler->selectButton('Save')->form();
         $form['point[projects]']->setValue((string) $project->getId());
 

--- a/app/bundles/PointBundle/Tests/Functional/Controller/TriggerControllerTest.php
+++ b/app/bundles/PointBundle/Tests/Functional/Controller/TriggerControllerTest.php
@@ -23,7 +23,7 @@ final class TriggerControllerTest extends MauticMysqlTestCase
         $this->em->flush();
         $this->em->clear();
 
-        $crawler = $this->client->request('GET', '/s/points/triggers/edit/'.$trigger->getId());
+        $crawler = $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/s/points/triggers/edit/'.$trigger->getId());
         $form    = $crawler->selectButton('Save')->form();
         $form['pointtrigger[projects]']->setValue((string) $project->getId());
 

--- a/app/bundles/PointBundle/Tests/Functional/PointActionFunctionalTest.php
+++ b/app/bundles/PointBundle/Tests/Functional/PointActionFunctionalTest.php
@@ -28,7 +28,7 @@ final class PointActionFunctionalTest extends MauticMysqlTestCase
         $trackingHash = 'tracking_hash_123';
         $this->createEmailStat($lead, $email, $trackingHash);
         $pointAction = $this->createReadEmailAction(5);
-        $this->client->request('GET', '/email/'.$trackingHash.'.gif');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/email/'.$trackingHash.'.gif');
 
         $lead = $leadModel->getEntity($lead->getId());
         $this->assertInstanceOf(Lead::class, $lead);
@@ -50,7 +50,7 @@ final class PointActionFunctionalTest extends MauticMysqlTestCase
         $trackingHash = 'tracking_hash_123';
         $this->createEmailStat($lead, $email, $trackingHash);
         $pointAction = $this->createReadEmailAction(5, $group);
-        $this->client->request('GET', '/email/'.$trackingHash.'.gif');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/email/'.$trackingHash.'.gif');
         $this->em->clear();
         $lead        = $leadModel->getEntity($lead->getId());
         $this->assertInstanceOf(Lead::class, $lead);
@@ -74,7 +74,7 @@ final class PointActionFunctionalTest extends MauticMysqlTestCase
         // Note: No point actions created for email.open type
 
         $initialPoints = $lead->getPoints();
-        $this->client->request('GET', '/email/'.$trackingHash.'.gif');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/email/'.$trackingHash.'.gif');
 
         $lead = $leadModel->getEntity($lead->getId());
         $this->assertInstanceOf(Lead::class, $lead);

--- a/app/bundles/PointBundle/Tests/Functional/SegmentFilterFunctionalTest.php
+++ b/app/bundles/PointBundle/Tests/Functional/SegmentFilterFunctionalTest.php
@@ -67,7 +67,7 @@ final class SegmentFilterFunctionalTest extends MauticMysqlTestCase
 
         $this->assertSame(0, $exitCode, $applicationTester->getDisplay());
 
-        $this->client->request('GET', '/api/contacts?search=segment:group-a-points-gte1');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/api/contacts?search=segment:group-a-points-gte1');
         $clientResponse = $this->client->getResponse();
         $this->assertResponseIsSuccessful();
         $response = json_decode($clientResponse->getContent(), true);

--- a/app/bundles/ProjectBundle/Tests/Functional/Controller/AjaxControllerTest.php
+++ b/app/bundles/ProjectBundle/Tests/Functional/Controller/AjaxControllerTest.php
@@ -35,7 +35,7 @@ final class AjaxControllerTest extends MauticMysqlTestCase
         );
 
         $this->client->request(
-            'POST',
+            \Symfony\Component\HttpFoundation\Request::METHOD_POST,
             '/s/ajax?action=project:addProjects',
             [
                 'newProjectNames'    => json_encode(['Green Project']),
@@ -85,7 +85,7 @@ final class AjaxControllerTest extends MauticMysqlTestCase
         );
 
         $this->client->request(
-            'POST',
+            \Symfony\Component\HttpFoundation\Request::METHOD_POST,
             '/s/ajax?action=project:addProjects',
             [
                 'newProjectNames'    => json_encode(['yellow project']),
@@ -100,7 +100,7 @@ final class AjaxControllerTest extends MauticMysqlTestCase
         );
 
         $this->client->request(
-            'POST',
+            \Symfony\Component\HttpFoundation\Request::METHOD_POST,
             '/s/ajax?action=project:addProjects',
             [
                 'newProjectNames'    => json_encode(['green project']),
@@ -141,7 +141,7 @@ final class AjaxControllerTest extends MauticMysqlTestCase
 
         // Request the project options via AJAX without selecting the malicious project
         $this->client->request(
-            'POST',
+            \Symfony\Component\HttpFoundation\Request::METHOD_POST,
             '/s/ajax?action=project:addProjects',
             [
                 'newProjectNames'    => json_encode([]),
@@ -170,7 +170,7 @@ final class AjaxControllerTest extends MauticMysqlTestCase
 
         // Verify the malicious project can still be selected and associated normally
         $this->client->request(
-            'POST',
+            \Symfony\Component\HttpFoundation\Request::METHOD_POST,
             '/s/ajax?action=project:addProjects',
             [
                 'newProjectNames'    => json_encode([]),
@@ -234,7 +234,7 @@ final class AjaxControllerTest extends MauticMysqlTestCase
 
         // Request project options with the special char project selected
         $this->client->request(
-            'POST',
+            \Symfony\Component\HttpFoundation\Request::METHOD_POST,
             '/s/ajax?action=project:addProjects',
             [
                 'newProjectNames'    => json_encode([]),
@@ -261,7 +261,7 @@ final class AjaxControllerTest extends MauticMysqlTestCase
 
         // Test that we can change selection (deselect the special char project, select the other)
         $this->client->request(
-            'POST',
+            \Symfony\Component\HttpFoundation\Request::METHOD_POST,
             '/s/ajax?action=project:addProjects',
             [
                 'newProjectNames'    => json_encode([]),

--- a/app/bundles/ProjectBundle/Tests/Functional/Controller/ProjectAddEntityTest.php
+++ b/app/bundles/ProjectBundle/Tests/Functional/Controller/ProjectAddEntityTest.php
@@ -47,7 +47,7 @@ final class ProjectAddEntityTest extends MauticMysqlTestCase
     {
         $url = '/s/projects/selectEntityType/'.$this->testProject->getId();
 
-        $this->client->request('GET', $url);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $url);
         $response = $this->client->getResponse();
         $content  = $response->getContent();
 
@@ -59,7 +59,7 @@ final class ProjectAddEntityTest extends MauticMysqlTestCase
     public function testSelectEntityTypeActionNotFound(): void
     {
         $this->client->followRedirects(false);
-        $this->client->request('GET', '/s/projects/selectEntityType/99999');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/s/projects/selectEntityType/99999');
         $this->assertResponseStatusCodeSame(404);
     }
 
@@ -67,7 +67,7 @@ final class ProjectAddEntityTest extends MauticMysqlTestCase
     {
         $url = '/s/projects/addEntity/'.$this->testProject->getId().'?entityType=email';
 
-        $this->client->request('GET', $url);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $url);
         $response = $this->client->getResponse();
         $content  = $response->getContent();
 
@@ -89,7 +89,7 @@ final class ProjectAddEntityTest extends MauticMysqlTestCase
 
         // View project page to verify email was added
         $url = '/s/projects/view/'.$this->testProject->getId();
-        $this->client->request('GET', $url);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $url);
 
         $response = $this->client->getResponse();
         $content  = $response->getContent();
@@ -104,7 +104,7 @@ final class ProjectAddEntityTest extends MauticMysqlTestCase
         $url = '/s/projects/addEntity/'.$this->testProject->getId().'?entityType=email';
 
         // Get the form
-        $crawler = $this->client->request('GET', $url);
+        $crawler = $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $url);
         $this->assertResponseIsSuccessful();
 
         // Submit form with no entities selected
@@ -119,7 +119,7 @@ final class ProjectAddEntityTest extends MauticMysqlTestCase
         $url = '/s/projects/addEntity/'.$this->testProject->getId().'?entityType=email';
 
         // Get the form
-        $crawler = $this->client->request('GET', $url);
+        $crawler = $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $url);
         $this->assertResponseIsSuccessful();
 
         // Submit form normally (simulating any button press)
@@ -135,7 +135,7 @@ final class ProjectAddEntityTest extends MauticMysqlTestCase
 
         // Get request with invalid entity type should redirect with error
         $this->client->followRedirects();
-        $this->client->request('GET', $url);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $url);
 
         $response = $this->client->getResponse();
         $this->assertResponseIsSuccessful();
@@ -148,7 +148,7 @@ final class ProjectAddEntityTest extends MauticMysqlTestCase
     public function testAddEntityActionNotFound(): void
     {
         $this->client->followRedirects(false);
-        $this->client->request('GET', '/s/projects/addEntity/99999?entityType=email');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/s/projects/addEntity/99999?entityType=email');
         $this->assertResponseStatusCodeSame(404);
     }
 
@@ -157,7 +157,7 @@ final class ProjectAddEntityTest extends MauticMysqlTestCase
         $this->createAndLoginUser();
 
         $url = '/s/projects/addEntity/'.$this->testProject->getId().'?entityType=email';
-        $this->client->request('GET', $url);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $url);
 
         $this->assertResponseStatusCodeSame(403);
     }

--- a/app/bundles/ProjectBundle/Tests/Functional/Controller/ProjectControllerTest.php
+++ b/app/bundles/ProjectBundle/Tests/Functional/Controller/ProjectControllerTest.php
@@ -47,7 +47,7 @@ final class ProjectControllerTest extends MauticMysqlTestCase
     #[DataProvider('indexUrlsProvider')]
     public function testIndexActionDisplaysProjects(string $url): void
     {
-        $this->client->request('GET', $url);
+        $this->client->request(Request::METHOD_GET, $url);
         $clientResponse        = $this->client->getResponse();
         $clientResponseContent = $clientResponse->getContent();
 
@@ -67,7 +67,7 @@ final class ProjectControllerTest extends MauticMysqlTestCase
 
     public function testIndexActionWhenFiltered(): void
     {
-        $this->client->request('GET', '/s/projects?search=project1');
+        $this->client->request(Request::METHOD_GET, '/s/projects?search=project1');
         $clientResponse         = $this->client->getResponse();
         $clientResponseContent  = $clientResponse->getContent();
 
@@ -91,7 +91,7 @@ final class ProjectControllerTest extends MauticMysqlTestCase
 
         $projectId = $project->getId();
 
-        $this->client->request('POST', '/s/projects/delete/'.$projectId);
+        $this->client->request(Request::METHOD_POST, '/s/projects/delete/'.$projectId);
 
         $this->assertResponseIsSuccessful();
         $this->assertNull($this->projectRepository->find($projectId), 'Assert that project is deleted');
@@ -102,7 +102,7 @@ final class ProjectControllerTest extends MauticMysqlTestCase
     {
         $project = $this->projectRepository->findOneBy([]);
 
-        $this->client->request('GET', '/s/projects/view/'.$project->getId());
+        $this->client->request(Request::METHOD_GET, '/s/projects/view/'.$project->getId());
         $clientResponse         = $this->client->getResponse();
         $clientResponseContent  = $clientResponse->getContent();
         $this->assertResponseIsSuccessful();
@@ -112,7 +112,7 @@ final class ProjectControllerTest extends MauticMysqlTestCase
     public function testViewActionNotFound(): void
     {
         $this->client->followRedirects(false);
-        $this->client->request('GET', '/s/projects/view/99999');
+        $this->client->request(Request::METHOD_GET, '/s/projects/view/99999');
         $clientResponse = $this->client->getResponse();
         $this->assertTrue($clientResponse->isRedirection(), 'Must be redirect response.');
     }
@@ -121,7 +121,7 @@ final class ProjectControllerTest extends MauticMysqlTestCase
     {
         $projectName            = 'Test project';
         $project                = $this->projectRepository->findOneBy([]);
-        $crawler                = $this->client->request('GET', '/s/projects/edit/'.$project->getId());
+        $crawler                = $this->client->request(Request::METHOD_GET, '/s/projects/edit/'.$project->getId());
         $clientResponse         = $this->client->getResponse();
         $clientResponseContent  = $clientResponse->getContent();
         $this->assertResponseIsSuccessful();
@@ -137,7 +137,7 @@ final class ProjectControllerTest extends MauticMysqlTestCase
     public function testEditActionNotFound(): void
     {
         $this->client->followRedirects(false);
-        $this->client->request('GET', '/s/projects/edit/99999');
+        $this->client->request(Request::METHOD_GET, '/s/projects/edit/99999');
         $clientResponse = $this->client->getResponse();
         $this->assertTrue($clientResponse->isRedirection(), 'Must be redirect response.');
     }
@@ -145,7 +145,7 @@ final class ProjectControllerTest extends MauticMysqlTestCase
     public function testNewAction(): void
     {
         $projectName = 'Test project';
-        $crawler     = $this->client->request('GET', '/s/projects/new');
+        $crawler     = $this->client->request(Request::METHOD_GET, '/s/projects/new');
         $this->assertResponseIsSuccessful();
 
         $form = $crawler->selectButton('Save')->form();
@@ -159,7 +159,7 @@ final class ProjectControllerTest extends MauticMysqlTestCase
     {
         $projects   = $this->projectRepository->findAll();
         $projectsId = array_map(fn (Project $project): ?int => $project->getId(), $projects);
-        $this->client->request('POST', '/s/projects/batchDelete?ids='.json_encode($projectsId));
+        $this->client->request(Request::METHOD_POST, '/s/projects/batchDelete?ids='.json_encode($projectsId));
         $this->assertResponseIsSuccessful();
         $this->assertEmpty($this->projectRepository->count([]), 'All projects must be deleted.');
     }

--- a/app/bundles/ProjectBundle/Tests/Functional/Controller/ProjectEntityLookupLimitTest.php
+++ b/app/bundles/ProjectBundle/Tests/Functional/Controller/ProjectEntityLookupLimitTest.php
@@ -42,7 +42,7 @@ final class ProjectEntityLookupLimitTest extends MauticMysqlTestCase
         $this->createTestEmails();
 
         // Act: trigger AJAX lookup endpoint
-        $this->client->request('GET', self::LOOKUP_CHOICE_LIST_URL, [
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, self::LOOKUP_CHOICE_LIST_URL, [
             'entityType' => 'email',
             'filter'     => 'Common',
         ]);

--- a/app/bundles/ProjectBundle/Tests/Functional/Controller/ProjectPopoverSecurityTest.php
+++ b/app/bundles/ProjectBundle/Tests/Functional/Controller/ProjectPopoverSecurityTest.php
@@ -35,7 +35,7 @@ final class ProjectPopoverSecurityTest extends MauticMysqlTestCase
         $emailModel = self::getContainer()->get(EmailModel::class);
         $emailModel->saveEntity($email);
 
-        $this->client->request('GET', '/s/emails/view/'.$email->getId());
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/s/emails/view/'.$email->getId());
         $this->assertResponseIsSuccessful();
 
         $content = (string) $this->client->getResponse()->getContent();

--- a/app/bundles/ReportBundle/Tests/Controller/Api/ReportApiControllerTest.php
+++ b/app/bundles/ReportBundle/Tests/Controller/Api/ReportApiControllerTest.php
@@ -22,35 +22,35 @@ final class ReportApiControllerTest extends MauticMysqlTestCase
     public function testGetReportFailByNoCorrectAccessRoleEmpty(): void
     {
         $reportId = $this->createReportStructure('Maut1cR0cks!!!!!', []);
-        $this->client->request('GET', '/api/reports/'.$reportId);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/api/reports/'.$reportId);
         $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
     }
 
     public function testGetReportSuccessByCorrectAccessIsAdmin(): void
     {
         $reportId = $this->createReportStructure('Maut1cR0cks!!!!!', [], false, true);
-        $this->client->request('GET', '/api/reports/'.$reportId);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/api/reports/'.$reportId);
         $this->assertResponseIsSuccessful();
     }
 
     public function testGetReportSuccessByNoCorrectAccessToViewOther(): void
     {
         $reportId = $this->createReportStructure('Maut1cR0cks!!!!!', ['report:reports'=>['viewother']]);
-        $this->client->request('GET', '/api/reports/'.$reportId);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/api/reports/'.$reportId);
         $this->assertResponseIsSuccessful();
     }
 
     public function testReportFailByNoCorrectAccessToViewOwn(): void
     {
         $reportId = $this->createReportStructure('Maut1cR0cks!!!!!', ['report:reports'=>['viewown']]);
-        $this->client->request('GET', '/api/reports/'.$reportId);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/api/reports/'.$reportId);
         $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
     }
 
     public function testReportSuccessViewOwnBySameUser(): void
     {
         $reportId = $this->createReportStructure('Maut1cR0cks!!!!!', ['report:reports'=>['viewown']], true);
-        $this->client->request('GET', '/api/reports/'.$reportId);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/api/reports/'.$reportId);
         $this->assertResponseIsSuccessful();
     }
 

--- a/app/bundles/ReportBundle/Tests/Controller/ReportControllerFunctionalTest.php
+++ b/app/bundles/ReportBundle/Tests/Controller/ReportControllerFunctionalTest.php
@@ -62,7 +62,7 @@ final class ReportControllerFunctionalTest extends MauticMysqlTestCase
         ]);
 
         // Check the details page
-        $this->client->request('GET', '/s/reports/view/'.$report->getId());
+        $this->client->request(Request::METHOD_GET, '/s/reports/view/'.$report->getId());
 
         self::assertResponseIsSuccessful();
     }
@@ -82,7 +82,7 @@ final class ReportControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->persist($report);
         $this->em->flush();
 
-        $crawler = $this->client->request('GET', '/s/reports/view/'.$report->getId().'?tmpl=list&name=report.'.$report->getId());
+        $crawler = $this->client->request(Request::METHOD_GET, '/s/reports/view/'.$report->getId().'?tmpl=list&name=report.'.$report->getId());
 
         $crawlerReportTable = $crawler->filterXPath('//table[@id="reportTable"]')->first();
         $crawlerReportTable = $this->domTableToArray($crawlerReportTable);
@@ -93,7 +93,7 @@ final class ReportControllerFunctionalTest extends MauticMysqlTestCase
             ['3', 'test page 3', '30'],
         ], array_slice($crawlerReportTable, 1, 3));
 
-        $crawler            = $this->client->request('GET', '/s/reports/view/'.$report->getId().'?tmpl=list&name=report.'.$report->getId().'&orderby=p.hits');
+        $crawler            = $this->client->request(Request::METHOD_GET, '/s/reports/view/'.$report->getId().'?tmpl=list&name=report.'.$report->getId().'&orderby=p.hits');
         $crawlerReportTable = $crawler->filterXPath('//table[@id="reportTable"]')->first();
         $crawlerReportTable = $this->domTableToArray($crawlerReportTable);
 
@@ -161,7 +161,7 @@ final class ReportControllerFunctionalTest extends MauticMysqlTestCase
         // Check sql injection in parameter id
         $this->assertSqlInjectionNotWork('/s/reports/view/'.$report->getId().'\'?tmpl=list&name=report.'.$report->getId().'&orderby=a_id');
 
-        $this->client->request('GET', '/s/reports/view/'.$report->getId().'?tmpl=list&name=report.'.$report->getId().'&orderby=a_id');
+        $this->client->request(Request::METHOD_GET, '/s/reports/view/'.$report->getId().'?tmpl=list&name=report.'.$report->getId().'&orderby=a_id');
         self::assertResponseIsSuccessful();
     }
 
@@ -180,7 +180,7 @@ final class ReportControllerFunctionalTest extends MauticMysqlTestCase
         self::getContainer()->get(ReportModel::class)->saveEntity($report);
 
         // Check the details page
-        $this->client->request('GET', '/s/reports/view/'.$report->getId());
+        $this->client->request(Request::METHOD_GET, '/s/reports/view/'.$report->getId());
         self::assertResponseIsSuccessful();
     }
 
@@ -280,7 +280,7 @@ final class ReportControllerFunctionalTest extends MauticMysqlTestCase
         ];
 
         // Get report view
-        $this->client->request('GET', '/s/reports/view/'.$report->getId());
+        $this->client->request(Request::METHOD_GET, '/s/reports/view/'.$report->getId());
         $response = $this->client->getResponse();
         self::assertResponseIsSuccessful();
 
@@ -335,7 +335,7 @@ final class ReportControllerFunctionalTest extends MauticMysqlTestCase
         $this->getContainer()->get(ReportModel::class)->saveEntity($report);
 
         // Check the details page
-        $this->client->request('GET', '/s/reports/view/'.$report->getId());
+        $this->client->request(Request::METHOD_GET, '/s/reports/view/'.$report->getId());
         self::assertResponseIsSuccessful();
         $response = $this->client->getResponse();
 
@@ -364,7 +364,7 @@ final class ReportControllerFunctionalTest extends MauticMysqlTestCase
         $this->getContainer()->get(ReportModel::class)->saveEntity($report);
 
         // Check the details page
-        $this->client->request('GET', '/s/reports/view/'.$report->getId());
+        $this->client->request(Request::METHOD_GET, '/s/reports/view/'.$report->getId());
         self::assertResponseIsSuccessful();
     }
 
@@ -450,13 +450,13 @@ final class ReportControllerFunctionalTest extends MauticMysqlTestCase
         self::getContainer()->get(ReportModel::class)->saveEntity($report);
 
         // Check the details page
-        $this->client->request('GET', '/s/reports/'.$report->getId());
+        $this->client->request(Request::METHOD_GET, '/s/reports/'.$report->getId());
         $clientResponse        = $this->client->getResponse();
         $clientResponseContent = $clientResponse->getContent();
         $this->assertStringContainsString('<small><b>This is allowed HTML</b></small>', (string) $clientResponseContent);
 
         // Check the list
-        $this->client->request('GET', '/s/reports');
+        $this->client->request(Request::METHOD_GET, '/s/reports');
         $clientResponse        = $this->client->getResponse();
         $clientResponseContent = $clientResponse->getContent();
         $this->assertStringContainsString('<small><b>This is allowed HTML</b></small>', (string) $clientResponseContent);
@@ -479,13 +479,13 @@ final class ReportControllerFunctionalTest extends MauticMysqlTestCase
         $report->setColumns($coulmns);
         $this->getContainer()->get(ReportModel::class)->saveEntity($report);
         $xssHeader     = '<script>alert(1)</script>';
-        $this->client->request('GET', '/mtracking.gif?page_url='.$xssHeader);
+        $this->client->request(Request::METHOD_GET, '/mtracking.gif?page_url='.$xssHeader);
         $this->assertResponseStatusCodeSame(200);
-        $this->client->request('GET', '/s/reports/view/'.$report->getId());
+        $this->client->request(Request::METHOD_GET, '/s/reports/view/'.$report->getId());
         $this->assertResponseStatusCodeSame(200);
         $this->assertStringNotContainsString($xssHeader, (string) $this->client->getResponse()->getContent());
 
-        $this->client->request('GET', '/s/reports/view/'.$report->getId().'/export/html');
+        $this->client->request(Request::METHOD_GET, '/s/reports/view/'.$report->getId().'/export/html');
         $this->assertStringNotContainsString($xssHeader, (string) $this->client->getResponse()->getContent());
     }
 
@@ -635,7 +635,7 @@ final class ReportControllerFunctionalTest extends MauticMysqlTestCase
 
     private function assertSqlInjectionNotWork(string $url): void
     {
-        $this->client->request('GET', $url);
+        $this->client->request(Request::METHOD_GET, $url);
         $this->assertStringNotContainsString(
             'You have an error in your SQL syntax',
             (string) $this->client->getResponse()->getContent()
@@ -664,7 +664,7 @@ final class ReportControllerFunctionalTest extends MauticMysqlTestCase
 
         $this->getContainer()->get(ReportModel::class)->saveEntity($report);
 
-        $this->client->request('GET', '/s/reports/view/'.$report->getId());
+        $this->client->request(Request::METHOD_GET, '/s/reports/view/'.$report->getId());
         self::assertResponseIsSuccessful();
 
         $content  = $this->client->getResponse()->getcontent();
@@ -709,7 +709,7 @@ final class ReportControllerFunctionalTest extends MauticMysqlTestCase
         $reportModel->method('getFilterList')->willReturn($filterDefinitions);
         self::getContainer()->set('mautic.report.model.report', $reportModel);
 
-        $this->client->request('GET', '/s/reports/view/'.$report->getId());
+        $this->client->request(Request::METHOD_GET, '/s/reports/view/'.$report->getId());
         self::assertResponseIsSuccessful();
 
         $content = $this->client->getResponse()->getContent();

--- a/app/bundles/SmsBundle/Tests/Controller/SMSControllerFunctionalTest.php
+++ b/app/bundles/SmsBundle/Tests/Controller/SMSControllerFunctionalTest.php
@@ -34,7 +34,7 @@ final class SMSControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->flush();
         $this->em->clear();
 
-        $crawler = $this->client->request('GET', self::EDIT_SMS_PATH.$sms->getId());
+        $crawler = $this->client->request(Request::METHOD_GET, self::EDIT_SMS_PATH.$sms->getId());
         $form    = $crawler->selectButton('Save')->form();
         $form['sms[projects]']->setValue((string) $project->getId());
 

--- a/app/bundles/StageBundle/Tests/Functional/Controller/StageControllerFunctionalTest.php
+++ b/app/bundles/StageBundle/Tests/Functional/Controller/StageControllerFunctionalTest.php
@@ -41,7 +41,7 @@ final class StageControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->flush();
         $this->em->clear();
 
-        $crawler = $this->client->request('GET', '/s/stages/edit/'.$stage->getId());
+        $crawler = $this->client->request(Request::METHOD_GET, '/s/stages/edit/'.$stage->getId());
         $form    = $crawler->selectButton('Save')->form();
         $form['stage[projects]']->setValue((string) $project->getId());
 

--- a/app/bundles/UserBundle/Tests/Controller/Api/UserApiControllerFunctionalTest.php
+++ b/app/bundles/UserBundle/Tests/Controller/Api/UserApiControllerFunctionalTest.php
@@ -209,7 +209,7 @@ final class UserApiControllerFunctionalTest extends MauticMysqlTestCase
         $userData['role'] = sprintf('/api/v2/roles/%d', $role->getId());
 
         $this->client->request(
-            'POST',
+            Request::METHOD_POST,
             '/api/v2/users',
             [],
             [],
@@ -250,7 +250,7 @@ final class UserApiControllerFunctionalTest extends MauticMysqlTestCase
 
             // Verify we can log in with the new user (simulates authentication)
             $this->loginUser($user);
-            $this->client->request('GET', '/s/dashboard');
+            $this->client->request(Request::METHOD_GET, '/s/dashboard');
 
             // Assert we can access the dashboard successfully
             $this->assertResponseIsSuccessful();

--- a/app/bundles/UserBundle/Tests/Functional/ApiPlatform/UserApiTest.php
+++ b/app/bundles/UserBundle/Tests/Functional/ApiPlatform/UserApiTest.php
@@ -40,7 +40,7 @@ final class UserApiTest extends MauticMysqlTestCase
         $userId = $adminUser->getId();
 
         // Test GET - password should not be in response
-        $this->client->request('GET', "/api/v2/users/{$userId}");
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, "/api/v2/users/{$userId}");
         $this->assertResponseIsSuccessful();
 
         $responseData = json_decode($this->client->getResponse()->getContent(), true);
@@ -58,7 +58,7 @@ final class UserApiTest extends MauticMysqlTestCase
     public function testPasswordNotExposedInCollection(): void
     {
         // Test GET collection
-        $this->client->request('GET', '/api/v2/users');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/api/v2/users');
         $this->assertResponseIsSuccessful();
 
         $responseData = json_decode($this->client->getResponse()->getContent(), true);

--- a/app/bundles/UserBundle/Tests/Functional/Controller/RoleControllerFunctionalTest.php
+++ b/app/bundles/UserBundle/Tests/Functional/Controller/RoleControllerFunctionalTest.php
@@ -212,14 +212,14 @@ final class RoleControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->persist($this->createUser('user3', $role2));
         $this->em->flush();
 
-        $crawler = $this->client->request('GET', '/s/roles?tmpl=list&search='.$uniquePrefix.'&orderby=user_count&orderbydir=DESC');
+        $crawler = $this->client->request(Request::METHOD_GET, '/s/roles?tmpl=list&search='.$uniquePrefix.'&orderby=user_count&orderbydir=DESC');
         $rows    = $crawler->filter('#roleTable tbody tr');
 
         $this->assertSame($uniquePrefix.' 1', trim($rows->eq(0)->filter('td')->eq(1)->text()));
         $this->assertSame($uniquePrefix.' 2', trim($rows->eq(1)->filter('td')->eq(1)->text()));
         $this->assertSame($uniquePrefix.' 3', trim($rows->eq(2)->filter('td')->eq(1)->text()));
 
-        $crawler = $this->client->request('GET', '/s/roles?tmpl=list&search='.$uniquePrefix.'&orderby=user_count&orderbydir=ASC');
+        $crawler = $this->client->request(Request::METHOD_GET, '/s/roles?tmpl=list&search='.$uniquePrefix.'&orderby=user_count&orderbydir=ASC');
         $rows    = $crawler->filter('#roleTable tbody tr');
 
         $this->assertSame($uniquePrefix.' 3', trim($rows->eq(0)->filter('td')->eq(1)->text()));

--- a/app/bundles/UserBundle/Tests/Functional/Controller/UserControllerFunctionalTest.php
+++ b/app/bundles/UserBundle/Tests/Functional/Controller/UserControllerFunctionalTest.php
@@ -22,13 +22,13 @@ final class UserControllerFunctionalTest extends MauticMysqlTestCase
 
     public function testEditGetPage(): void
     {
-        $this->client->request('GET', '/s/users/edit/1');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/s/users/edit/1');
         $this->assertResponseIsSuccessful();
     }
 
     public function testRedirectNonExistingUser(): void
     {
-        $crawler = $this->client->request('GET', '/s/users/edit/00000');
+        $crawler = $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/s/users/edit/00000');
         $this->assertResponseIsSuccessful();
         $this->assertStringContainsString('Users', $crawler->filter('h1')->text());
         $this->assertStringContainsString('User not found with', $crawler->filter('#flashes')->text());
@@ -36,7 +36,7 @@ final class UserControllerFunctionalTest extends MauticMysqlTestCase
 
     public function testEditActionFormSubmissionValid(): void
     {
-        $crawler                 = $this->client->request('GET', '/s/users/edit/1');
+        $crawler                 = $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/s/users/edit/1');
         $buttonCrawlerNode       = $crawler->selectButton('Save & Close');
         $form                    = $buttonCrawlerNode->form();
         $form['user[firstName]'] = 'test';
@@ -49,7 +49,7 @@ final class UserControllerFunctionalTest extends MauticMysqlTestCase
 
     public function testEditActionFormSubmissionInvalid(): void
     {
-        $crawler = $this->client->request('GET', '/s/users/edit/1');
+        $crawler = $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/s/users/edit/1');
 
         $form = $crawler->selectButton('Save')->form([
             'user[firstName]'               => '',
@@ -66,7 +66,7 @@ final class UserControllerFunctionalTest extends MauticMysqlTestCase
 
     public function testIndexIncludesInviteForm(): void
     {
-        $crawler = $this->client->request('GET', '/s/users');
+        $crawler = $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/s/users');
 
         $this->assertResponseIsSuccessful();
         $this->assertGreaterThan(0, $crawler->filter('#invite-user-form')->count());
@@ -74,7 +74,7 @@ final class UserControllerFunctionalTest extends MauticMysqlTestCase
 
     public function testInviteActionShowsForm(): void
     {
-        $crawler = $this->client->request('GET', '/s/users/invite');
+        $crawler = $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/s/users/invite');
 
         $this->assertResponseIsSuccessful();
         $this->assertGreaterThan(0, $crawler->filter('#invite-user-form')->count());
@@ -82,7 +82,7 @@ final class UserControllerFunctionalTest extends MauticMysqlTestCase
 
     public function testInviteActionReturnsInvalidForm(): void
     {
-        $this->client->request('POST', '/s/users/invite');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_POST, '/s/users/invite');
 
         $this->assertResponseIsSuccessful();
         $this->assertStringContainsString('name="user_invite"', (string) $this->client->getResponse()->getContent());
@@ -94,7 +94,7 @@ final class UserControllerFunctionalTest extends MauticMysqlTestCase
     #[DataProvider('dataNewUserForPasswordField')]
     public function testNewUserForPasswordField(array $data, string $message): void
     {
-        $crawler = $this->client->request('GET', '/s/users/new');
+        $crawler = $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/s/users/new');
 
         $formData = [
             'user[firstName]' => 'John',
@@ -153,7 +153,7 @@ final class UserControllerFunctionalTest extends MauticMysqlTestCase
     #[DataProvider('dataForEditUserForPasswordField')]
     public function testEditUserForPasswordField(array $data, string $message): void
     {
-        $crawler = $this->client->request('GET', '/s/users/edit/1');
+        $crawler = $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/s/users/edit/1');
 
         $form = $crawler->selectButton('Save')->form($data);
 

--- a/app/bundles/UserBundle/Tests/Functional/SearchTest.php
+++ b/app/bundles/UserBundle/Tests/Functional/SearchTest.php
@@ -11,7 +11,7 @@ final class SearchTest extends MauticMysqlTestCase
 {
     public function testSearchingUsersByName(): void
     {
-        $this->client->request('GET', 's/users?search=name:admin');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, 's/users?search=name:admin');
 
         $this->assertEquals(Response::HTTP_OK, $this->client->getResponse()->getStatusCode(), $this->client->getResponse()->getContent());
         $this->assertStringContainsString('admin', (string) $this->client->getResponse()->getContent());

--- a/app/bundles/WebhookBundle/Tests/Form/Type/ConfigTypeFunctionalTest.php
+++ b/app/bundles/WebhookBundle/Tests/Form/Type/ConfigTypeFunctionalTest.php
@@ -11,7 +11,7 @@ final class ConfigTypeFunctionalTest extends MauticMysqlTestCase
 {
     public function testSendEmailDetailsToggleIsOnByDefault(): void
     {
-        $crawler = $this->client->request('GET', '/s/config/edit');
+        $crawler = $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/s/config/edit');
 
         // Updated CSS selector based on the new ID
         $yesSpan = $crawler->filter('#config_webhookconfig_webhook_email_details_label > div > span');

--- a/plugins/GrapesJsBuilderBundle/Tests/Functional/Controller/AssertCustomMjmlTest.php
+++ b/plugins/GrapesJsBuilderBundle/Tests/Functional/Controller/AssertCustomMjmlTest.php
@@ -32,7 +32,7 @@ final class AssertCustomMjmlTest extends MauticMysqlTestCase
         $emailId = $email->getId();
 
         // Get the Email via API and assert customMjml.
-        $this->client->request('GET', '/api/emails/'.$emailId);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/api/emails/'.$emailId);
         $this->assertResponseStatusCodeSame(200);
         $content = json_decode($this->client->getResponse()->getContent(), true);
         $this->assertNotEmpty($content['email']['grapesjsbuilder']['customMjml']);
@@ -51,7 +51,7 @@ final class AssertCustomMjmlTest extends MauticMysqlTestCase
         $this->addToGrapesJsBuilder($email);
 
         // Get email & check for both customHtml & customMjml in the response.
-        $this->client->request('GET', '/api/emails/'.$emailId);
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/api/emails/'.$emailId);
         $this->assertResponseStatusCodeSame(200);
         $content = json_decode($this->client->getResponse()->getContent(), true);
         $this->assertNotEmpty($content['email']['customHtml']);
@@ -116,7 +116,7 @@ final class AssertCustomMjmlTest extends MauticMysqlTestCase
             'isPublished' => true,
         ];
 
-        $this->client->request('POST', '/api/emails/new', [], [], ['CONTENT_TYPE' => 'application/json'], json_encode($emailData));
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_POST, '/api/emails/new', [], [], ['CONTENT_TYPE' => 'application/json'], json_encode($emailData));
         $this->assertResponseStatusCodeSame(201);
 
         return json_decode($this->client->getResponse()->getContent(), true);

--- a/plugins/MauticClearbitBundle/Tests/Functional/Controller/ConfigControllerTest.php
+++ b/plugins/MauticClearbitBundle/Tests/Functional/Controller/ConfigControllerTest.php
@@ -68,7 +68,7 @@ final class ConfigControllerTest extends MauticMysqlTestCase
     {
         $this->saveConfigForm();
 
-        $crawler = $this->client->request('GET', $this->configRoute);
+        $crawler = $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $this->configRoute);
         $this->assertResponseIsSuccessful();
         $this->assertSame(self::API_KEY, $crawler->filter('#integration_config_apiKeys_apikey')->attr('value'));
         $this->assertNotNull($crawler->filter('#integration_config_isPublished_1')->attr('checked'));
@@ -77,7 +77,7 @@ final class ConfigControllerTest extends MauticMysqlTestCase
 
     private function saveConfigForm(): void
     {
-        $crawler = $this->client->request('GET', $this->configRoute);
+        $crawler = $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, $this->configRoute);
         $this->assertResponseIsSuccessful();
 
         $form = $crawler->selectButton('Save & Close')->form();

--- a/plugins/MauticFocusBundle/Tests/Functional/Controller/FocusControllerTest.php
+++ b/plugins/MauticFocusBundle/Tests/Functional/Controller/FocusControllerTest.php
@@ -25,7 +25,7 @@ final class FocusControllerTest extends MauticMysqlTestCase
         $this->em->flush();
         $this->em->clear();
 
-        $crawler = $this->client->request('GET', '/s/focus/edit/'.$focus->getId());
+        $crawler = $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/s/focus/edit/'.$focus->getId());
         $form    = $crawler->selectButton('Save')->form();
         $form['focus[projects]']->setValue((string) $project->getId());
 

--- a/plugins/MauticSocialBundle/Tests/Functional/Controller/MonitoringControllerTest.php
+++ b/plugins/MauticSocialBundle/Tests/Functional/Controller/MonitoringControllerTest.php
@@ -16,26 +16,26 @@ final class MonitoringControllerTest extends MauticMysqlTestCase
 
     public function testIndex(): void
     {
-        $this->client->request('GET', '/s/monitoring');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/s/monitoring');
         $this->assertResponseIsSuccessful();
     }
 
     public function testNew(): void
     {
-        $this->client->request('GET', '/s/monitoring/new');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/s/monitoring/new');
         $this->assertResponseIsSuccessful();
     }
 
     public function testEdit(): void
     {
-        $this->client->request('GET', '/s/monitoring/edit/1');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/s/monitoring/edit/1');
         $this->assertResponseIsSuccessful();
     }
 
     public function testIndexWithoutPermission(): void
     {
         $this->createAndLoginUser();
-        $this->client->request('GET', '/s/monitoring');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/s/monitoring');
         $response = $this->client->getResponse();
         $this->assertEquals(403, $response->getStatusCode());
     }
@@ -43,7 +43,7 @@ final class MonitoringControllerTest extends MauticMysqlTestCase
     public function testNewWithoutPermission(): void
     {
         $this->createAndLoginUser();
-        $this->client->request('GET', '/s/monitoring/new');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/s/monitoring/new');
         $response = $this->client->getResponse();
         $this->assertEquals(403, $response->getStatusCode());
     }
@@ -51,7 +51,7 @@ final class MonitoringControllerTest extends MauticMysqlTestCase
     public function testEditWithoutPermission(): void
     {
         $this->createAndLoginUser();
-        $this->client->request('GET', '/s/monitoring/edit/1');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/s/monitoring/edit/1');
         $response = $this->client->getResponse();
         $this->assertEquals(403, $response->getStatusCode());
     }

--- a/plugins/MauticSocialBundle/Tests/Functional/Controller/TweetControllerTest.php
+++ b/plugins/MauticSocialBundle/Tests/Functional/Controller/TweetControllerTest.php
@@ -58,7 +58,7 @@ final class TweetControllerTest extends MauticMysqlTestCase
         $tweet = $this->tweetsRepo->findOneBy([]);
         $this->assertInstanceOf(Tweet::class, $tweet);
 
-        $crawler               = $this->client->request('GET', '/s/tweets/edit/'.$tweet->getId());
+        $crawler               = $this->client->request(Request::METHOD_GET, '/s/tweets/edit/'.$tweet->getId());
         $clientResponse        = $this->client->getResponse();
         $clientResponseContent = $clientResponse->getContent();
         $this->assertResponseIsSuccessful();

--- a/plugins/MauticSocialBundle/Tests/Functional/SocialMonitoringFunctionalTest.php
+++ b/plugins/MauticSocialBundle/Tests/Functional/SocialMonitoringFunctionalTest.php
@@ -12,18 +12,18 @@ final class SocialMonitoringFunctionalTest extends MauticMysqlTestCase
 {
     public function testHideSocialMonitoring(): void
     {
-        $crawler = $this->client->request('GET', '/s/config/edit');
+        $crawler = $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/s/config/edit');
         $this->assertStringNotContainsString('Social Settings', $crawler->filter('.list-group-tabs')->text());
         $this->assertStringNotContainsString('Social Monitoring', $crawler->filter('.sidebar-left .sidebar-content')->text());
 
-        $crawler = $this->client->request('GET', '/s/forms/new');
+        $crawler = $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/s/forms/new');
         $this->assertStringNotContainsString('Social Login', $crawler->filter('#fields-container select.form-builder-new-component')->text());
     }
 
     public function testShowSocialMonitoring(): void
     {
         $this->createIntegration();
-        $crawler = $this->client->request('GET', '/s/config/edit');
+        $crawler = $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/s/config/edit');
         $this->assertStringContainsString('Social Settings', $crawler->filter('.list-group-tabs')->text());
     }
 

--- a/plugins/MauticTagManagerBundle/Tests/Functional/Controller/BatchControllerTest.php
+++ b/plugins/MauticTagManagerBundle/Tests/Functional/Controller/BatchControllerTest.php
@@ -44,7 +44,7 @@ final class BatchControllerTest extends MauticMysqlTestCase
 
     public function testBatchViewAction(): void
     {
-        $this->client->request('GET', '/s/tags/batch/view');
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/s/tags/batch/view');
         $this->assertResponseIsSuccessful();
         $this->assertStringContainsString('Add tags', (string) $this->client->getResponse()->getContent());
         $this->assertStringContainsString('Remove tags', (string) $this->client->getResponse()->getContent());
@@ -52,7 +52,7 @@ final class BatchControllerTest extends MauticMysqlTestCase
 
     public function testAddTagBatchSetAction(): void
     {
-        $crawler                                = $this->client->request('GET', '/s/tags/batch/view');
+        $crawler                                = $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/s/tags/batch/view');
         $form                                   = $crawler->filter('form[name=batch_tag]')->form();
         $values                                 = $form->getValues();
         $values['batch_tag[tags][add_tags]']    = [$this->tags[0]->getId(), $this->tags[1]->getId()];
@@ -81,7 +81,7 @@ final class BatchControllerTest extends MauticMysqlTestCase
         $this->leads[0]->addTag($this->tags[2]);
         $leadModel->saveEntity($this->leads[0]);
 
-        $crawler                                = $this->client->request('GET', '/s/tags/batch/view');
+        $crawler                                = $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/s/tags/batch/view');
         $form                                   = $crawler->filter('form[name=batch_tag]')->form();
         $values                                 = $form->getValues();
         $values['batch_tag[tags][remove_tags]'] = [$this->tags[1]->getId()];

--- a/plugins/MauticTagManagerBundle/Tests/Functional/Controller/TagControllerTest.php
+++ b/plugins/MauticTagManagerBundle/Tests/Functional/Controller/TagControllerTest.php
@@ -52,7 +52,7 @@ final class TagControllerTest extends MauticMysqlTestCase
      */
     public function testIndexActionWhenNotFiltered(): void
     {
-        $this->client->request('GET', '/s/tags');
+        $this->client->request(Request::METHOD_GET, '/s/tags');
         $clientResponse         = $this->client->getResponse();
         $clientResponseContent  = $clientResponse->getContent();
 
@@ -66,7 +66,7 @@ final class TagControllerTest extends MauticMysqlTestCase
      */
     public function testIndexActionWhenFiltered(): void
     {
-        $this->client->request('GET', '/s/tags?search=tag1');
+        $this->client->request(Request::METHOD_GET, '/s/tags?search=tag1');
         $clientResponse         = $this->client->getResponse();
         $clientResponseContent  = $clientResponse->getContent();
 
@@ -87,7 +87,7 @@ final class TagControllerTest extends MauticMysqlTestCase
         $otherTag->setDescription('No related content.');
         $this->tagRepository->saveEntity($otherTag);
 
-        $this->client->request('GET', '/s/tags?search=test');
+        $this->client->request(Request::METHOD_GET, '/s/tags?search=test');
         $clientResponse        = $this->client->getResponse();
         $clientResponseContent = $clientResponse->getContent();
 
@@ -99,7 +99,7 @@ final class TagControllerTest extends MauticMysqlTestCase
     public function testTagDeletion(): void
     {
         $tagId = $this->tagRepository->findOneBy([])->getId();
-        $this->client->request('POST', '/s/tags/delete/'.$tagId);
+        $this->client->request(Request::METHOD_POST, '/s/tags/delete/'.$tagId);
         $this->assertResponseIsSuccessful();
         $this->assertNotInstanceOf(Tag::class, $this->tagRepository->find($tagId), 'Assert that tag is deleted');
     }
@@ -119,7 +119,7 @@ final class TagControllerTest extends MauticMysqlTestCase
 
         $this->assertSame(1, $this->countLeadTagAssociations($tagId));
 
-        $this->client->request('POST', '/s/tags/delete/'.$tagId);
+        $this->client->request(Request::METHOD_POST, '/s/tags/delete/'.$tagId);
         $this->assertResponseIsSuccessful();
         $this->assertNotInstanceOf(Tag::class, $this->tagRepository->find($tagId), 'Assert that tag is deleted');
         $this->assertSame(0, $this->countLeadTagAssociations($tagId));
@@ -133,7 +133,7 @@ final class TagControllerTest extends MauticMysqlTestCase
         $tag = $this->tagRepository->findOneBy([]);
         $this->assertInstanceOf(Tag::class, $tag);
 
-        $this->client->request('GET', '/s/tags/view/'.$tag->getId());
+        $this->client->request(Request::METHOD_GET, '/s/tags/view/'.$tag->getId());
         $clientResponse         = $this->client->getResponse();
         $clientResponseContent  = $clientResponse->getContent();
         $this->assertResponseIsSuccessful();
@@ -143,7 +143,7 @@ final class TagControllerTest extends MauticMysqlTestCase
     public function testViewActionNotFound(): void
     {
         $this->client->followRedirects(false);
-        $this->client->request('GET', '/s/tags/view/99999');
+        $this->client->request(Request::METHOD_GET, '/s/tags/view/99999');
         $clientResponse = $this->client->getResponse();
         $this->assertTrue($clientResponse->isRedirection(), 'Must be redirect response.');
     }
@@ -168,7 +168,7 @@ final class TagControllerTest extends MauticMysqlTestCase
         $tag     = $this->tagRepository->findOneBy([]);
         $this->assertInstanceOf(Tag::class, $tag);
 
-        $crawler                = $this->client->request('GET', '/s/tags/edit/'.$tag->getId());
+        $crawler                = $this->client->request(Request::METHOD_GET, '/s/tags/edit/'.$tag->getId());
         $clientResponse         = $this->client->getResponse();
         $clientResponseContent  = $clientResponse->getContent();
         $this->assertResponseIsSuccessful();
@@ -184,7 +184,7 @@ final class TagControllerTest extends MauticMysqlTestCase
     public function testEditActionNotFound(): void
     {
         $this->client->followRedirects(false);
-        $this->client->request('GET', '/s/tags/edit/99999');
+        $this->client->request(Request::METHOD_GET, '/s/tags/edit/99999');
         $clientResponse = $this->client->getResponse();
         $this->assertTrue($clientResponse->isRedirection(), 'Must be redirect response.');
     }
@@ -195,7 +195,7 @@ final class TagControllerTest extends MauticMysqlTestCase
     public function testNewAction(): void
     {
         $TagName        = 'Test tag';
-        $crawler        = $this->client->request('GET', '/s/tags/new');
+        $crawler        = $this->client->request(Request::METHOD_GET, '/s/tags/new');
         $this->assertResponseIsSuccessful();
 
         $form = $crawler->selectButton('Save')->form();
@@ -207,7 +207,7 @@ final class TagControllerTest extends MauticMysqlTestCase
 
     public function testNewActionValidation(): void
     {
-        $crawler = $this->client->request('GET', '/s/tags/new');
+        $crawler = $this->client->request(Request::METHOD_GET, '/s/tags/new');
         $this->assertResponseIsSuccessful();
 
         $buttonCrawler  = $crawler->selectButton('Save');
@@ -221,7 +221,7 @@ final class TagControllerTest extends MauticMysqlTestCase
     public function testNewActionDuplicateTag(): void
     {
         $TagName        = $this->tagRepository->findOneBy([])->getTag();
-        $crawler        = $this->client->request('GET', '/s/tags/new');
+        $crawler        = $this->client->request(Request::METHOD_GET, '/s/tags/new');
         $this->assertResponseIsSuccessful();
 
         $form = $crawler->selectButton('Save')->form();
@@ -235,7 +235,7 @@ final class TagControllerTest extends MauticMysqlTestCase
     {
         $tags   = $this->tagRepository->findAll();
         $tagsId = array_map(fn (Tag $tag) => $tag->getId(), $tags);
-        $this->client->request('POST', '/s/tags/batchDelete?ids='.json_encode($tagsId), [], [], $this->createAjaxHeaders());
+        $this->client->request(Request::METHOD_POST, '/s/tags/batchDelete?ids='.json_encode($tagsId), [], [], $this->createAjaxHeaders());
         $this->assertResponseIsSuccessful();
         $this->assertEmpty($this->tagRepository->count([]), 'All tags must be deleted.');
     }
@@ -271,7 +271,7 @@ final class TagControllerTest extends MauticMysqlTestCase
         $tags       = $this->tagRepository->findAll();
         $primaryTag = $tags[0];
 
-        $this->client->request('GET', self::MERGE_ROUTE_BASE.$primaryTag->getId());
+        $this->client->request(Request::METHOD_GET, self::MERGE_ROUTE_BASE.$primaryTag->getId());
         $this->client->getResponse();
         $this->assertResponseIsSuccessful('Return code must be 200.');
 
@@ -284,7 +284,7 @@ final class TagControllerTest extends MauticMysqlTestCase
         $tags       = $this->tagRepository->findAll();
         $currentTag = $tags[0];
 
-        $this->client->request('GET', self::MERGE_ROUTE_BASE.$currentTag->getId());
+        $this->client->request(Request::METHOD_GET, self::MERGE_ROUTE_BASE.$currentTag->getId());
         $clientResponse = $this->client->getResponse();
         $this->assertResponseIsSuccessful('Return code must be 200.');
 
@@ -303,7 +303,7 @@ final class TagControllerTest extends MauticMysqlTestCase
 
     public function testMergeActionWithInvalidTag(): void
     {
-        $this->client->request('GET', self::MERGE_ROUTE_BASE.'999999');
+        $this->client->request(Request::METHOD_GET, self::MERGE_ROUTE_BASE.'999999');
         $this->client->getResponse();
         $this->assertResponseIsSuccessful('Return code must be 200 (redirect with error).');
     }
@@ -317,7 +317,7 @@ final class TagControllerTest extends MauticMysqlTestCase
         $secondaryTagId = (int) $secondaryTag->getId();
 
         // Test that the merge action returns the correct response
-        $this->client->request('GET', self::MERGE_ROUTE_BASE.$secondaryTagId);
+        $this->client->request(Request::METHOD_GET, self::MERGE_ROUTE_BASE.$secondaryTagId);
         $response = $this->client->getResponse();
 
         // Debug: check what status code and content we're getting

--- a/plugins/MauticTagManagerBundle/Tests/Functional/Stats/TagDependenciesTest.php
+++ b/plugins/MauticTagManagerBundle/Tests/Functional/Stats/TagDependenciesTest.php
@@ -26,7 +26,7 @@ final class TagDependenciesTest extends MauticMysqlTestCase
         $campaign  = $this->createCampaignWithChangeTag($tag);
         $campaign2 = $this->createCampaignWithTagCondition($tag);
 
-        $this->client->request('GET', "/s/tags/view/{$tag->getId()}");
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, "/s/tags/view/{$tag->getId()}");
         $clientResponse = $this->client->getResponse();
         $content        = $clientResponse->getContent();
         $searchIds      = implode(',', [$campaign->getId(), $campaign2->getId()]);
@@ -54,7 +54,7 @@ final class TagDependenciesTest extends MauticMysqlTestCase
 
         $this->createSegment('other');
 
-        $this->client->request('GET', "/s/tags/view/{$tag->getId()}");
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, "/s/tags/view/{$tag->getId()}");
         $clientResponse = $this->client->getResponse();
         $content        = $clientResponse->getContent();
         $searchIds      = implode(',', [$segmentWithTag->getId()]);
@@ -68,7 +68,7 @@ final class TagDependenciesTest extends MauticMysqlTestCase
         $form = $this->createForm('form-with-tag-action');
         $this->createFormActionChangeTags($form, $tag->getTag());
 
-        $this->client->request('GET', "/s/tags/view/{$tag->getId()}");
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, "/s/tags/view/{$tag->getId()}");
         $clientResponse = $this->client->getResponse();
         $content        = $clientResponse->getContent();
         $searchIds      = implode(',', [$form->getId()]);
@@ -81,7 +81,7 @@ final class TagDependenciesTest extends MauticMysqlTestCase
 
         $pointActionIsSent = $this->createPointTriggerWithChangeTagsEvent($tag);
 
-        $this->client->request('GET', "/s/tags/view/{$tag->getId()}");
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, "/s/tags/view/{$tag->getId()}");
         $clientResponse = $this->client->getResponse();
         $content        = $clientResponse->getContent();
         $searchIds      = implode(',', [$pointActionIsSent->getId()]);
@@ -92,7 +92,7 @@ final class TagDependenciesTest extends MauticMysqlTestCase
     {
         $tag         = $this->createTag('TagA');
         $report      = $this->createReportWithTag($tag->getId());
-        $this->client->request('GET', "/s/tags/view/{$tag->getId()}");
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, "/s/tags/view/{$tag->getId()}");
         $clientResponse = $this->client->getResponse();
         $content        = $clientResponse->getContent();
         $searchIds      = implode(',', [$report->getId()]);
@@ -103,7 +103,7 @@ final class TagDependenciesTest extends MauticMysqlTestCase
     {
         $tag         = $this->createTag('TagA');
         $this->createReportWithTagEmpty();
-        $this->client->request('GET', "/s/tags/view/{$tag->getId()}");
+        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, "/s/tags/view/{$tag->getId()}");
         $this->assertResponseIsSuccessful();
     }
 


### PR DESCRIPTION
Split out of #16991, so the symfony code-quality set can be enabled in smaller steps.

Applies a single Rector rule — `LiteralGetToRequestClassConstantRector` — that replaces HTTP method string literals with `Symfony\Component\HttpFoundation\Request` class constants.

```diff
-$this->client->request('GET', '/s/assets/new');
+$this->client->request(Request::METHOD_GET, '/s/assets/new');
```

```diff
-$this->client->request('POST', 'api/assets/new', $payload);
+$this->client->request(Request::METHOD_POST, 'api/assets/new', $payload);
```

Typo-proof and IDE-navigable. No behaviour change — the constants hold the same strings.

The rule itself is enabled by the set in #16991; this PR only lands the code changes so that PR stays reviewable.
