### PR TITLE
[symfony] Use Response::HTTP_* constants over status code numbers

### DIFF
--- a/app/bundles/ApiBundle/Controller/oAuth2/SecurityController.php
+++ b/app/bundles/ApiBundle/Controller/oAuth2/SecurityController.php
@@ -47,6 +47,6 @@ final class SecurityController extends CommonController
 
     public function loginCheckAction(): Response
     {
-        return new Response('', 400);
+        return new Response('', Response::HTTP_BAD_REQUEST);
     }
 }

--- a/app/bundles/ApiBundle/EventListener/ApiSubscriber.php
+++ b/app/bundles/ApiBundle/EventListener/ApiSubscriber.php
@@ -59,7 +59,7 @@ final readonly class ApiSubscriber implements EventSubscriberInterface
                         ],
                     ],
                 ],
-                403
+                \Symfony\Component\HttpFoundation\Response::HTTP_FORBIDDEN
             );
 
             $event->setResponse($response);
@@ -82,7 +82,7 @@ final readonly class ApiSubscriber implements EventSubscriberInterface
                         ],
                     ],
                 ],
-                403
+                \Symfony\Component\HttpFoundation\Response::HTTP_FORBIDDEN
             );
 
             $event->setResponse($response);

--- a/app/bundles/ApiBundle/Tests/EventListener/ApiSubscriberTest.php
+++ b/app/bundles/ApiBundle/Tests/EventListener/ApiSubscriberTest.php
@@ -83,7 +83,7 @@ final class ApiSubscriberTest extends CommonMocks
             ->with($this->isInstanceOf(JsonResponse::class))
             ->willReturnCallback(
                 function (JsonResponse $response): void {
-                    $this->assertSame(403, $response->getStatusCode());
+                    $this->assertSame(\Symfony\Component\HttpFoundation\Response::HTTP_FORBIDDEN, $response->getStatusCode());
                 }
             );
 

--- a/app/bundles/AssetBundle/Tests/Controller/Api/AssetWidgetDataApiControllerFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Controller/Api/AssetWidgetDataApiControllerFunctionalTest.php
@@ -27,7 +27,7 @@ final class AssetWidgetDataApiControllerFunctionalTest extends MauticMysqlTestCa
         $response = $this->client->getResponse();
 
         $this->assertNotSame(
-            404,
+            \Symfony\Component\HttpFoundation\Response::HTTP_NOT_FOUND,
             $response->getStatusCode(),
             'Unexpected 404 for widget "'.$type.'". Body: '.$response->getContent()
         );

--- a/app/bundles/CampaignBundle/Controller/CampaignController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignController.php
@@ -169,7 +169,7 @@ class CampaignController extends AbstractStandardFormController
             return new JsonResponse([
                 'error'   => $this->translator->trans('mautic.campaign.error.export.file_not_found', ['%path%' => $filePath], 'flashes'),
                 'flashes' => $this->getFlashContent(),
-            ], 400);
+            ], Response::HTTP_BAD_REQUEST);
         }
 
         return $exportHelper->downloadAsZip($filePath, $exportFileName);
@@ -260,7 +260,7 @@ class CampaignController extends AbstractStandardFormController
             return new JsonResponse([
                 'error'   => $this->translator->trans('mautic.campaign.error.export.no_campaigns_selected', [], 'flashes'),
                 'flashes' => $this->getFlashContent(),
-            ], 400);
+            ], Response::HTTP_BAD_REQUEST);
         }
 
         foreach ($objectIds as $objectId) {

--- a/app/bundles/CampaignBundle/Controller/EventController.php
+++ b/app/bundles/CampaignBundle/Controller/EventController.php
@@ -526,7 +526,7 @@ final class EventController extends CommonFormController
         if (empty($event)) {
             return new JsonResponse([
                 'error' => $this->translator->trans('mautic.campaign.event.clone.request.missing'),
-            ], 400);
+            ], \Symfony\Component\HttpFoundation\Response::HTTP_BAD_REQUEST);
         }
         $session->remove('mautic.campaign.events.clone.storage');
 

--- a/app/bundles/CampaignBundle/Tests/Controller/Api/CampaignApiControllerFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/Api/CampaignApiControllerFunctionalTest.php
@@ -402,7 +402,7 @@ final class CampaignApiControllerFunctionalTest extends MauticMysqlTestCase
         $response = $this->client->getResponse();
 
         // Assert that access is denied
-        $this->assertEquals(403, $response->getStatusCode());
+        $this->assertEquals(Response::HTTP_FORBIDDEN, $response->getStatusCode());
     }
 
     public function testImportCampaignActionJson(): void
@@ -422,7 +422,7 @@ final class CampaignApiControllerFunctionalTest extends MauticMysqlTestCase
         $clientResponse = $this->client->getResponse();
 
         // Debug early exit if something fails
-        if (201 !== $clientResponse->getStatusCode()) {
+        if (Response::HTTP_CREATED !== $clientResponse->getStatusCode()) {
             $this->fail('Import failed with error: '.$clientResponse->getContent());
         }
 
@@ -469,7 +469,7 @@ final class CampaignApiControllerFunctionalTest extends MauticMysqlTestCase
         unlink($zipPath);
         unlink($asset);
 
-        if (201 !== $response->getStatusCode()) {
+        if (Response::HTTP_CREATED !== $response->getStatusCode()) {
             $this->fail('Import failed with error: '.$response->getContent());
         }
 

--- a/app/bundles/CoreBundle/Controller/CommonController.php
+++ b/app/bundles/CoreBundle/Controller/CommonController.php
@@ -297,7 +297,7 @@ class CommonController extends AbstractController implements MauticController
      */
     public function removeTrailingSlashAction(Request $request, TrailingSlashHelper $trailingSlashHelper): RedirectResponse
     {
-        return $this->redirect($trailingSlashHelper->getSafeRedirectUrl($request), 301);
+        return $this->redirect($trailingSlashHelper->getSafeRedirectUrl($request), Response::HTTP_MOVED_PERMANENTLY);
     }
 
     /**

--- a/app/bundles/CoreBundle/Controller/JsController.php
+++ b/app/bundles/CoreBundle/Controller/JsController.php
@@ -49,7 +49,7 @@ final class JsController extends CommonController
             $this->dispatcher->dispatch($event, CoreEvents::BUILD_MAUTIC_JS);
         }
 
-        return new Response($event->getJs(), 200, ['Content-Type' => 'application/javascript']);
+        return new Response($event->getJs(), Response::HTTP_OK, ['Content-Type' => 'application/javascript']);
     }
 
     /**

--- a/app/bundles/CoreBundle/Controller/KeepAliveController.php
+++ b/app/bundles/CoreBundle/Controller/KeepAliveController.php
@@ -10,6 +10,6 @@ final class KeepAliveController
 {
     public function keepAliveAction(): Response
     {
-        return new Response('', 200);
+        return new Response('', Response::HTTP_OK);
     }
 }

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/ExportHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/ExportHelperTest.php
@@ -89,7 +89,7 @@ final class ExportHelperTest extends TestCase
 
         $response = $this->exportHelper->downloadAsZip($zipFilePath, 'exported.zip');
 
-        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame(\Symfony\Component\HttpFoundation\Response::HTTP_OK, $response->getStatusCode());
         $this->assertSame('application/zip', $response->headers->get('Content-Type'));
         $this->assertSame('attachment; filename="exported.zip"', $response->headers->get('Content-Disposition'));
     }
@@ -177,7 +177,7 @@ final class ExportHelperTest extends TestCase
     {
         $stream = $this->exportHelper->exportDataAs($this->dummyData, ExportHelper::EXPORT_TYPE_CSV, 'demo-file.csv');
 
-        $this->assertSame(200, $stream->getStatusCode());
+        $this->assertSame(\Symfony\Component\HttpFoundation\Response::HTTP_OK, $stream->getStatusCode());
         $this->assertFalse($stream->isEmpty());
 
         ob_start();
@@ -199,7 +199,7 @@ final class ExportHelperTest extends TestCase
     {
         $stream = $this->exportHelper->exportDataAs($this->dummyData, ExportHelper::EXPORT_TYPE_EXCEL, 'demo-file.xlsx');
 
-        $this->assertSame(200, $stream->getStatusCode());
+        $this->assertSame(\Symfony\Component\HttpFoundation\Response::HTTP_OK, $stream->getStatusCode());
         $this->assertFalse($stream->isEmpty());
 
         ob_start();
@@ -274,7 +274,7 @@ final class ExportHelperTest extends TestCase
     public function testExportDataAsExcel(): void
     {
         $stream = $this->exportHelper->exportDataAs($this->dummyData, ExportHelper::EXPORT_TYPE_EXCEL, 'demo.xlsx');
-        $this->assertSame(200, $stream->getStatusCode());
+        $this->assertSame(\Symfony\Component\HttpFoundation\Response::HTTP_OK, $stream->getStatusCode());
         $this->assertFalse($stream->isEmpty());
 
         ob_start();

--- a/app/bundles/EmailBundle/Tests/Controller/EmailControllerTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailControllerTest.php
@@ -162,7 +162,7 @@ final class EmailControllerTest extends TestCase
             ->willReturn($this->sessionMock);
         $this->requestStack->push($request);
         $response = $this->controller->sendAction($request, 5);
-        $this->assertSame(302, $response->getStatusCode());
+        $this->assertSame(\Symfony\Component\HttpFoundation\Response::HTTP_FOUND, $response->getStatusCode());
     }
 
     public function testSendActionWhenEntityFoundButNotPublished(): void
@@ -194,7 +194,7 @@ final class EmailControllerTest extends TestCase
             ->willReturn($this->sessionMock);
         $this->requestStack->push($request);
         $response = $this->controller->sendAction($request, 5);
-        $this->assertSame(302, $response->getStatusCode());
+        $this->assertSame(\Symfony\Component\HttpFoundation\Response::HTTP_FOUND, $response->getStatusCode());
     }
 
     public function testThatExampleEmailsHaveTestStringInTheirSubject(): void

--- a/app/bundles/InstallBundle/Tests/Controller/InstallControllerTest.php
+++ b/app/bundles/InstallBundle/Tests/Controller/InstallControllerTest.php
@@ -91,6 +91,6 @@ final class InstallControllerTest extends \PHPUnit\Framework\TestCase
             $this->createStub(PathsHelper::class),
             InstallService::CHECK_STEP
         );
-        $this->assertSame(302, $response->getStatusCode());
+        $this->assertSame(\Symfony\Component\HttpFoundation\Response::HTTP_FOUND, $response->getStatusCode());
     }
 }

--- a/app/bundles/LeadBundle/Controller/Api/ListApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/ListApiController.php
@@ -101,7 +101,7 @@ final class ListApiController extends CommonApiController
         $withCounts = $request->query->has('withCounts');
         $response   = parent::getEntitiesAction($request, $userHelper);
 
-        if ($withCounts && $response instanceof Response && 200 === $response->getStatusCode()) {
+        if ($withCounts && $response instanceof Response && Response::HTTP_OK === $response->getStatusCode()) {
             $content = json_decode($response->getContent(), true);
 
             if (isset($content['lists']) && is_array($content['lists'])) {

--- a/app/bundles/LeadBundle/Tests/Controller/AjaxControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/AjaxControllerFunctionalTest.php
@@ -122,7 +122,7 @@ final class AjaxControllerFunctionalTest extends MauticMysqlTestCase
 
         $this->setCsrfHeader();
         $this->client->xmlHttpRequest(Request::METHOD_POST, '/s/ajax', $payload);
-        $this->assertEquals(403, $this->client->getResponse()->getStatusCode(), 'The user without campaign edit own/others permissions should not access toggle lead campaign action.');
+        $this->assertEquals(\Symfony\Component\HttpFoundation\Response::HTTP_FORBIDDEN, $this->client->getResponse()->getStatusCode(), 'The user without campaign edit own/others permissions should not access toggle lead campaign action.');
     }
 
     public function testSegmentDependencyTreeWithNotExistingSegment(): void

--- a/app/bundles/LeadBundle/Tests/Controller/ListControllerPermissionFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/ListControllerPermissionFunctionalTest.php
@@ -698,7 +698,7 @@ final class ListControllerPermissionFunctionalTest extends MauticMysqlTestCase
             ]
         );
 
-        $this->assertEquals(403, $this->client->getResponse()->getStatusCode());
+        $this->assertEquals(Response::HTTP_FORBIDDEN, $this->client->getResponse()->getStatusCode());
 
         $this->em->refresh($segment);
         $this->assertTrue($segment->isPublished());

--- a/app/bundles/LeadBundle/Tests/Functional/Controller/CompanyControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Controller/CompanyControllerTest.php
@@ -25,7 +25,7 @@ final class CompanyControllerTest extends MauticMysqlTestCase
         $this->createAndLoginUser();
         $this->client->request('GET', '/s/companies/merge/1');
         $clientResponse         = $this->client->getResponse();
-        $this->assertEquals(403, $clientResponse->getStatusCode());
+        $this->assertEquals(\Symfony\Component\HttpFoundation\Response::HTTP_FORBIDDEN, $clientResponse->getStatusCode());
     }
 
     private function createAndLoginUser(): User

--- a/app/bundles/MarketplaceBundle/Tests/Functional/Controller/AjaxControllerTest.php
+++ b/app/bundles/MarketplaceBundle/Tests/Functional/Controller/AjaxControllerTest.php
@@ -56,7 +56,7 @@ final class AjaxControllerTest extends AbstractMauticTestCase
         $response = $controller->installPackageAction($request);
 
         $this->assertSame('{"success":true}', $response->getContent());
-        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame(\Symfony\Component\HttpFoundation\Response::HTTP_OK, $response->getStatusCode());
     }
 
     public function testRemovePackageAction(): void
@@ -74,7 +74,7 @@ final class AjaxControllerTest extends AbstractMauticTestCase
         $response = $controller->removePackageAction($request);
 
         $this->assertSame('{"success":true}', $response->getContent());
-        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame(\Symfony\Component\HttpFoundation\Response::HTTP_OK, $response->getStatusCode());
     }
 
     private function generateController(bool $isPackageInstalled): AjaxController

--- a/app/bundles/NotificationBundle/Controller/Api/NotificationApiController.php
+++ b/app/bundles/NotificationBundle/Controller/Api/NotificationApiController.php
@@ -64,9 +64,9 @@ final class NotificationApiController extends CommonApiController
                 $this->leadModel->saveEntity($currentLead);
             }
 
-            return new JsonResponse(['success' => true, 'osid' => $osid], 200, ['Access-Control-Allow-Origin' => '*']);
+            return new JsonResponse(['success' => true, 'osid' => $osid], \Symfony\Component\HttpFoundation\Response::HTTP_OK, ['Access-Control-Allow-Origin' => '*']);
         }
 
-        return new JsonResponse(['success' => 'false'], 200, ['Access-Control-Allow-Origin' => '*']);
+        return new JsonResponse(['success' => 'false'], \Symfony\Component\HttpFoundation\Response::HTTP_OK, ['Access-Control-Allow-Origin' => '*']);
     }
 }

--- a/app/bundles/NotificationBundle/Controller/JsController.php
+++ b/app/bundles/NotificationBundle/Controller/JsController.php
@@ -22,7 +22,7 @@ final class JsController extends CommonController
 
         return new Response(
             json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES),
-            200,
+            Response::HTTP_OK,
             [
                 'Content-Type' => 'application/json',
             ]
@@ -33,7 +33,7 @@ final class JsController extends CommonController
     {
         return new Response(
             "importScripts('https://cdn.onesignal.com/sdks/OneSignalSDK.js');",
-            200,
+            Response::HTTP_OK,
             [
                 'Service-Worker-Allowed' => '/',
                 'Content-Type'           => 'application/javascript',
@@ -45,7 +45,7 @@ final class JsController extends CommonController
     {
         return new Response(
             "importScripts('https://cdn.onesignal.com/sdks/OneSignalSDK.js');",
-            200,
+            Response::HTTP_OK,
             [
                 'Service-Worker-Allowed' => '/',
                 'Content-Type'           => 'application/javascript',

--- a/app/bundles/PageBundle/Controller/PublicController.php
+++ b/app/bundles/PageBundle/Controller/PublicController.php
@@ -109,7 +109,7 @@ final class PublicController extends AbstractFormController
                 if ($requestUri != $url) {
                     $model->hitPage($entity, $request, 301, $lead, $query);
 
-                    return $this->redirect($url, 301);
+                    return $this->redirect($url, Response::HTTP_MOVED_PERMANENTLY);
                 }
             }
 
@@ -121,7 +121,7 @@ final class PublicController extends AbstractFormController
                 $model->hitPage($entity, $request, 301, $lead, $query);
                 $url = $model->generateUrl($parentVariant, false);
 
-                return $this->redirect($url, 301);
+                return $this->redirect($url, Response::HTTP_MOVED_PERMANENTLY);
             }
 
             // First determine the A/B test to display if applicable
@@ -236,7 +236,7 @@ final class PublicController extends AbstractFormController
                             $url = $model->generateUrl($translatedEntity, false);
                             $model->hitPage($entity, $request, 302, $lead, $query);
 
-                            return $this->redirect($url, 302);
+                            return $this->redirect($url, Response::HTTP_FOUND);
                         }
                     }
                 }

--- a/app/bundles/SmsBundle/Helper/ReplyHelper.php
+++ b/app/bundles/SmsBundle/Helper/ReplyHelper.php
@@ -62,9 +62,9 @@ final readonly class ReplyHelper
                 }
             }
         } catch (BadRequestHttpException) {
-            return new Response('invalid request', 400);
+            return new Response('invalid request', Response::HTTP_BAD_REQUEST);
         } catch (NotFoundHttpException) {
-            return new Response('', 404);
+            return new Response('', Response::HTTP_NOT_FOUND);
         } catch (NumberNotFoundException $exception) {
             $this->logger->debug(
                 sprintf(

--- a/plugins/MauticClearbitBundle/Controller/ClearbitController.php
+++ b/plugins/MauticClearbitBundle/Controller/ClearbitController.php
@@ -119,7 +119,7 @@ final class ClearbitController extends FormController
             );
         }
 
-        return new Response('Bad Request', 400);
+        return new Response('Bad Request', Response::HTTP_BAD_REQUEST);
     }
 
     /**
@@ -269,7 +269,7 @@ final class ClearbitController extends FormController
             );
         }
 
-        return new Response('Bad Request', 400);
+        return new Response('Bad Request', Response::HTTP_BAD_REQUEST);
     }
 
     /* COMPANY */
@@ -362,7 +362,7 @@ final class ClearbitController extends FormController
             );
         }
 
-        return new Response('Bad Request', 400);
+        return new Response('Bad Request', Response::HTTP_BAD_REQUEST);
     }
 
     /**
@@ -511,6 +511,6 @@ final class ClearbitController extends FormController
             );
         }
 
-        return new Response('Bad Request', 400);
+        return new Response('Bad Request', Response::HTTP_BAD_REQUEST);
     }
 }

--- a/plugins/MauticFocusBundle/Controller/PublicController.php
+++ b/plugins/MauticFocusBundle/Controller/PublicController.php
@@ -37,7 +37,7 @@ final class PublicController extends CommonController
 
             $content = $this->focusModel->generateJavascript($focus);
 
-            return new Response($content, 200, ['Content-Type' => 'application/javascript']);
+            return new Response($content, Response::HTTP_OK, ['Content-Type' => 'application/javascript']);
         }
 
         return new Response('', Response::HTTP_NOT_FOUND);

--- a/plugins/MauticFullContactBundle/Controller/FullContactController.php
+++ b/plugins/MauticFullContactBundle/Controller/FullContactController.php
@@ -119,7 +119,7 @@ final class FullContactController extends FormController
             );
         }
 
-        return new Response('Bad Request', 400);
+        return new Response('Bad Request', Response::HTTP_BAD_REQUEST);
     }
 
     /**
@@ -269,7 +269,7 @@ final class FullContactController extends FormController
             );
         }
 
-        return new Response('Bad Request', 400);
+        return new Response('Bad Request', Response::HTTP_BAD_REQUEST);
     }
 
     /* COMPANY */
@@ -362,7 +362,7 @@ final class FullContactController extends FormController
             );
         }
 
-        return new Response('Bad Request', 400);
+        return new Response('Bad Request', Response::HTTP_BAD_REQUEST);
     }
 
     /**
@@ -511,6 +511,6 @@ final class FullContactController extends FormController
             );
         }
 
-        return new Response('Bad Request', 400);
+        return new Response('Bad Request', Response::HTTP_BAD_REQUEST);
     }
 }

--- a/plugins/MauticSocialBundle/Controller/JsController.php
+++ b/plugins/MauticSocialBundle/Controller/JsController.php
@@ -53,7 +53,7 @@ JS;
 
         return new Response(
             $js,
-            200,
+            Response::HTTP_OK,
             [
                 'Content-Type'           => 'application/javascript',
             ]

--- a/plugins/MauticSocialBundle/Tests/Functional/Controller/MonitoringControllerTest.php
+++ b/plugins/MauticSocialBundle/Tests/Functional/Controller/MonitoringControllerTest.php
@@ -37,7 +37,7 @@ final class MonitoringControllerTest extends MauticMysqlTestCase
         $this->createAndLoginUser();
         $this->client->request('GET', '/s/monitoring');
         $response = $this->client->getResponse();
-        $this->assertEquals(403, $response->getStatusCode());
+        $this->assertEquals(\Symfony\Component\HttpFoundation\Response::HTTP_FORBIDDEN, $response->getStatusCode());
     }
 
     public function testNewWithoutPermission(): void
@@ -45,7 +45,7 @@ final class MonitoringControllerTest extends MauticMysqlTestCase
         $this->createAndLoginUser();
         $this->client->request('GET', '/s/monitoring/new');
         $response = $this->client->getResponse();
-        $this->assertEquals(403, $response->getStatusCode());
+        $this->assertEquals(\Symfony\Component\HttpFoundation\Response::HTTP_FORBIDDEN, $response->getStatusCode());
     }
 
     public function testEditWithoutPermission(): void
@@ -53,7 +53,7 @@ final class MonitoringControllerTest extends MauticMysqlTestCase
         $this->createAndLoginUser();
         $this->client->request('GET', '/s/monitoring/edit/1');
         $response = $this->client->getResponse();
-        $this->assertEquals(403, $response->getStatusCode());
+        $this->assertEquals(\Symfony\Component\HttpFoundation\Response::HTTP_FORBIDDEN, $response->getStatusCode());
     }
 
     private function createAndLoginUser(): User


### PR DESCRIPTION
Split out of #16991, so the symfony code-quality set can be enabled in smaller steps.

Applies a single Rector rule — `ResponseStatusCodeRector` — that replaces magic HTTP status code numbers with `Symfony\Component\HttpFoundation\Response` class constants.

```diff
-return new Response('', 400);
+return new Response('', Response::HTTP_BAD_REQUEST);
```

```diff
-$this->assertSame(404, $response->getStatusCode());
+$this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
```

No behaviour change — the constants hold the same integers, but the intent is readable without looking the number up.

The rule itself is enabled by the set in #16991; this PR only lands the code changes so that PR stays reviewable.
