### PR TITLE
[tests] Bump to PHPUnit 12

### DIFF
--- a/app/bundles/CampaignBundle/Tests/Executioner/Dispatcher/LegacyEventDispatcherTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Dispatcher/LegacyEventDispatcherTest.php
@@ -20,6 +20,7 @@ use Mautic\CampaignBundle\Executioner\Scheduler\EventScheduler;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Tracker\ContactTracker;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Rule\AnyInvokedCount;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -347,7 +348,7 @@ final class LegacyEventDispatcherTest extends TestCase
         $this->contactTracker->expects($this->exactly(2))
             ->method('setSystemContact');
         // Legacy custom event should dispatch
-        $matcher = $this->any();
+        $matcher = new AnyInvokedCount();
 
         // Legacy custom event should dispatch
         $this->dispatcher->expects($matcher)->method('dispatch')
@@ -386,7 +387,8 @@ final class LegacyEventDispatcherTest extends TestCase
 
         $this->contactTracker->expects($this->exactly(2))
             ->method('setSystemContact');
-        $matcher = $this->any();
+
+        $matcher = new AnyInvokedCount();
 
         // Should pass
         $this->dispatcher->expects($matcher)->method('dispatch')

--- a/app/bundles/ConfigBundle/Tests/Form/Helper/RestrictionHelperTest.php
+++ b/app/bundles/ConfigBundle/Tests/Form/Helper/RestrictionHelperTest.php
@@ -50,6 +50,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
  * Mocking a representative ConfigForm by leveraging Symfony's TypeTestCase to test RestrictionHelper.
  */
 #[CoversClass(RestrictionHelper::class)]
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class RestrictionHelperTest extends TypeTestCase
 {
     private string $displayMode = RestrictionHelper::MODE_REMOVE;

--- a/app/bundles/CoreBundle/Tests/Form/ToBcBccFieldsTraitTest.php
+++ b/app/bundles/CoreBundle/Tests/Form/ToBcBccFieldsTraitTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\Validator\ConstraintValidatorFactory;
 use Symfony\Component\Validator\Validation;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ToBcBccFieldsTraitTest extends TypeTestCase
 {
     protected function getExtensions(): array

--- a/app/bundles/CoreBundle/Tests/Form/Type/LookupTypeTest.php
+++ b/app/bundles/CoreBundle/Tests/Form/Type/LookupTypeTest.php
@@ -8,6 +8,7 @@ use Mautic\CoreBundle\Form\Type\LookupType;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\Form\Test\TypeTestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class LookupTypeTest extends TypeTestCase
 {
     /**

--- a/app/bundles/CoreBundle/Tests/Unit/Form/Type/ConfigTypeTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Form/Type/ConfigTypeTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\Validator\Validation;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ConfigTypeTest extends TypeTestCase
 {
     public function testSubmitEmptyTrustedHosts(): void

--- a/app/bundles/EmailBundle/Tests/EventListener/ReportSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/ReportSubscriberTest.php
@@ -25,6 +25,7 @@ use Mautic\ReportBundle\Event\ReportGeneratorEvent;
 use Mautic\ReportBundle\Event\ReportGraphEvent;
 use Mautic\ReportBundle\Helper\ReportHelper;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Rule\AnyInvokedCount;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -218,7 +219,8 @@ final class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
         $eventMock->expects($this->once())
             ->method('getRequestedGraphs')
             ->willReturn(['mautic.email.graph.pie.read.ingored.unsubscribed.bounced']);
-        $matcher = $this->any();
+
+        $matcher = new AnyInvokedCount();
 
         $eventMock->expects($matcher)->method('checkContext')->willReturnCallback(function (...$parameters) use ($matcher): true {
             if (1 === $matcher->numberOfInvocations()) {
@@ -270,7 +272,8 @@ final class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
         $eventMock         = $this->createMock(ReportGraphEvent::class);
         $chartQueryMock    = $this->createStub(ChartQuery::class);
         $translatorMock    = $this->createStub(TranslatorInterface::class);
-        $matcher           = $this->any();
+
+        $matcher           = new AnyInvokedCount();
 
         $eventMock->expects($matcher)
             ->method('checkContext')->willReturnCallback(function (...$parameters) use ($matcher): true {
@@ -329,7 +332,7 @@ final class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
         $eventMock->expects($this->once())
             ->method('getRequestedGraphs')
             ->willReturn(['mautic.email.table.most.emails.failed']);
-        $matcher = $this->any();
+        $matcher = new AnyInvokedCount();
 
         $eventMock->expects($matcher)->method('checkContext')->willReturnCallback(function (...$parameters) use ($matcher) {
             if (1 === $matcher->numberOfInvocations()) {

--- a/app/bundles/EmailBundle/Tests/Form/Type/ConfigTypeTest.php
+++ b/app/bundles/EmailBundle/Tests/Form/Type/ConfigTypeTest.php
@@ -31,6 +31,7 @@ use Symfony\Component\Validator\ConstraintValidatorFactory;
 use Symfony\Component\Validator\Validation;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ConfigTypeTest extends TypeTestCase
 {
     protected function getExtensions(): array

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelFrequencyRuleFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelFrequencyRuleFunctionalTest.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\EmailBundle\Tests\Model;
+
+use Mautic\ChannelBundle\Entity\MessageQueue;
+use Mautic\ChannelBundle\Entity\MessageQueueRepository;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\EmailBundle\Entity\Email;
+use Mautic\EmailBundle\Entity\Stat;
+use Mautic\EmailBundle\Model\EmailModel;
+use Mautic\LeadBundle\Entity\FrequencyRule;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\UserBundle\Entity\User;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Frequency rules are configured by the "email_frequency_number" config parameter, which is read
+ * during the kernel boot. Therefore each test reboots the kernel with the config it needs.
+ * MauticMysqlTestCase forbids re-creating the client while transaction rollback cleanup
+ * is active, so we fall back to resetDatabase() for cleanup instead.
+ */
+final class EmailModelFrequencyRuleFunctionalTest extends MauticMysqlTestCase
+{
+    private const int EMAILS_A_MONTH = 2;
+
+    protected $useCleanupRollback = false;
+
+    private EmailModel $emailModel;
+
+    /**
+     * @return iterable<string, array{bool}>
+     */
+    public static function dataFrequencyRules(): iterable
+    {
+        yield 'Custom Frequency Rules' => [false];
+        yield 'Default Frequency Rules' => [true];
+    }
+
+    #[DataProvider('dataFrequencyRules')]
+    public function testFrequencyRulesAreAppliedWhenSendToDncIsNo(bool $useDefaultFrequencyRules): void
+    {
+        $this->bootWithFrequencyConfig($useDefaultFrequencyRules);
+
+        $contact = $this->createContact();
+        $email   = $this->createTemplateEmail();
+        $this->createFrequencyRule($contact, $useDefaultFrequencyRules);
+        $this->createEmailStats($email, $contact);
+        $this->em->flush();
+
+        $this->sendEmail($email, $contact);
+        $this->assertEmailIsPostponed($email, $contact);
+    }
+
+    #[DataProvider('dataFrequencyRules')]
+    public function testFrequencyRulesAreNotAppliedWhenSendToDncIsTrue(bool $useDefaultFrequencyRules): void
+    {
+        $this->bootWithFrequencyConfig($useDefaultFrequencyRules);
+
+        $contact = $this->createContact();
+        $email   = $this->createTemplateEmail();
+        $email->setSendToDnc(true);
+        $this->em->persist($email);
+        $this->createFrequencyRule($contact, $useDefaultFrequencyRules);
+        $this->createEmailStats($email, $contact);
+        $this->em->flush();
+
+        $this->sendEmail($email, $contact);
+        $this->assertEmailIsNotPostponed();
+    }
+
+    #[DataProvider('dataFrequencyRules')]
+    public function testEmailsWithSendToDncSetToYesAreNotCountedTowardsFrequencyRules(bool $useDefaultFrequencyRules): void
+    {
+        $this->bootWithFrequencyConfig($useDefaultFrequencyRules);
+
+        $contact     = $this->createContact();
+        $emailToSend = $this->createTemplateEmail();
+        $emailDncYes = $this->createTemplateEmail();
+        $emailDncYes->setSendToDnc(true);
+        $this->em->persist($emailToSend);
+        $this->createFrequencyRule($contact, $useDefaultFrequencyRules);
+        $this->createEmailStats($emailDncYes, $contact);
+        $this->em->flush();
+
+        $this->sendEmail($emailToSend, $contact);
+        $this->assertEmailIsNotPostponed();
+    }
+
+    /**
+     * Reboots the kernel so that CoreParametersHelper picks up the frequency configuration.
+     * Default frequency rules are set globally in the configuration, custom ones per contact.
+     */
+    private function bootWithFrequencyConfig(bool $useDefaultFrequencyRules): void
+    {
+        $this->setUpSymfony(array_merge($this->configParams, [
+            'email_frequency_number' => $useDefaultFrequencyRules ? self::EMAILS_A_MONTH : 0,
+            'email_frequency_time'   => 'MONTH',
+        ]));
+
+        // Re-authenticate: setUpSymfony() destroys the previous client and its security token.
+        $user = $this->em->getRepository(User::class)->findOneBy(['username' => 'admin']);
+        $this->assertInstanceOf(User::class, $user);
+        $this->loginUser($user);
+
+        $emailModel = self::getContainer()->get(EmailModel::class);
+        $this->assertInstanceOf(EmailModel::class, $emailModel);
+        $this->emailModel = $emailModel;
+    }
+
+    private function createContact(): Lead
+    {
+        $contact = new Lead();
+        $contact->setEmail('john@doe.com');
+        $contact->setFirstname('John');
+        $contact->setLastname('Doe');
+        $this->em->persist($contact);
+
+        return $contact;
+    }
+
+    private function createTemplateEmail(): Email
+    {
+        $email = new Email();
+        $email->setName('Test');
+        $email->setSubject('Test');
+        $email->setCustomHTML('test EN');
+        $email->setEmailType('template');
+        $email->setLanguage('en');
+        $this->em->persist($email);
+
+        return $email;
+    }
+
+    private function createFrequencyRule(Lead $contact, bool $useDefaultFrequencyRules): void
+    {
+        if ($useDefaultFrequencyRules) {
+            return;
+        }
+
+        $frequencyRule = new FrequencyRule();
+        $frequencyRule->setLead($contact);
+        $frequencyRule->setDateAdded(new \DateTime());
+        $frequencyRule->setChannel('email');
+        $frequencyRule->setFrequencyNumber(self::EMAILS_A_MONTH);
+        $frequencyRule->setFrequencyTime('MONTH');
+        $this->em->persist($frequencyRule);
+    }
+
+    private function createEmailStats(Email $email, Lead $contact): void
+    {
+        $exceedFrequencyRule = self::EMAILS_A_MONTH + 1;
+
+        for ($i = 0; $i < $exceedFrequencyRule; ++$i) {
+            $stat = new Stat();
+            $stat->setEmail($email);
+            $stat->setLead($contact);
+            $stat->setEmailAddress($contact->getEmail());
+            $stat->setDateSent(new \DateTime('-1 day'));
+            $this->em->persist($stat);
+        }
+    }
+
+    private function sendEmail(Email $email, Lead $contact): void
+    {
+        $this->emailModel->sendEmail(
+            $email,
+            [
+                [
+                    'id'        => $contact->getId(),
+                    'email'     => $contact->getEmail(),
+                    'firstname' => $contact->getFirstname(),
+                    'lastname'  => $contact->getLastname(),
+                ],
+            ]
+        );
+    }
+
+    private function assertEmailIsNotPostponed(): void
+    {
+        $messageQueueRepository = $this->em->getRepository(MessageQueue::class);
+        $this->assertInstanceOf(MessageQueueRepository::class, $messageQueueRepository);
+
+        $this->assertSame(0, $messageQueueRepository->count([]), 'Email should not be postponed.');
+    }
+
+    private function assertEmailIsPostponed(Email $email, Lead $contact): void
+    {
+        $messageQueueRepository = $this->em->getRepository(MessageQueue::class);
+        $this->assertInstanceOf(MessageQueueRepository::class, $messageQueueRepository);
+
+        $queuedMessages = $messageQueueRepository->findBy([]);
+        $this->assertCount(1, $queuedMessages, 'Email should be postponed.');
+
+        $queuedMessage = reset($queuedMessages);
+        $this->assertInstanceOf(MessageQueue::class, $queuedMessage);
+        $this->assertSame('email', $queuedMessage->getChannel());
+        $this->assertSame($email->getId(), $queuedMessage->getChannelId());
+        $this->assertSame($contact, $queuedMessage->getLead());
+        $this->assertSame($queuedMessage::STATUS_PENDING, $queuedMessage->getStatus());
+    }
+}

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelFunctionalTest.php
@@ -47,6 +47,7 @@ final class EmailModelFunctionalTest extends MauticMysqlTestCase
 
         $this->configParams['email_frequency_number'] = $this->useDefaultFrequencyRules ? self::EMAILS_A_MONTH : 0;
         $this->configParams['email_frequency_time']   = 'MONTH';
+
         parent::setUp();
 
         /** @var EmailModel $emailModel */
@@ -854,7 +855,7 @@ final class EmailModelFunctionalTest extends MauticMysqlTestCase
         return $email;
     }
 
-    private function createFrequencyRule(Lead $contact): void
+    private function createFrequencyRule(Lead $contact, bool $useDefaultFrequencyRules): void
     {
         if ($this->useDefaultFrequencyRules) {
             return;

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelFunctionalTest.php
@@ -7,8 +7,6 @@ namespace Mautic\EmailBundle\Tests\Model;
 use Doctrine\DBAL\Exception;
 use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\OptimisticLockException;
-use Mautic\ChannelBundle\Entity\MessageQueue;
-use Mautic\ChannelBundle\Entity\MessageQueueRepository;
 use Mautic\CoreBundle\Entity\IpAddress;
 use Mautic\CoreBundle\Entity\VariantEntityInterface;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
@@ -17,7 +15,6 @@ use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Entity\Stat;
 use Mautic\EmailBundle\Model\EmailModel;
 use Mautic\LeadBundle\Entity\DoNotContact;
-use Mautic\LeadBundle\Entity\FrequencyRule;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\ListLead;
@@ -28,26 +25,16 @@ use Mautic\LeadBundle\Model\ListModel;
 use Mautic\PageBundle\Entity\Hit;
 use Mautic\PageBundle\Entity\Redirect;
 use Mautic\PageBundle\Entity\Trackable;
-use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 final class EmailModelFunctionalTest extends MauticMysqlTestCase
 {
     use CreateTestEntitiesTrait;
 
-    private const int EMAILS_A_MONTH = 2;
-
-    private bool $useDefaultFrequencyRules;
-
     private EmailModel $emailModel;
 
     protected function setUp(): void
     {
-        $this->useDefaultFrequencyRules = ' with data set "Default Frequency Rules"' === $this->dataSetAsString();
-
-        $this->configParams['email_frequency_number'] = $this->useDefaultFrequencyRules ? self::EMAILS_A_MONTH : 0;
-        $this->configParams['email_frequency_time']   = 'MONTH';
-
         parent::setUp();
 
         /** @var EmailModel $emailModel */
@@ -636,59 +623,6 @@ final class EmailModelFunctionalTest extends MauticMysqlTestCase
         $this->assertEquals(5, $loadedEmail->getPendingCount());
     }
 
-    /**
-     * @return iterable<string, null[]>
-     */
-    public static function dataFrequencyRules(): iterable
-    {
-        yield 'Custom Frequency Rules' => [null];
-        yield 'Default Frequency Rules' => [null];
-    }
-
-    #[DataProvider('dataFrequencyRules')]
-    public function testFrequencyRulesAreAppliedWhenSendToDncIsNo(): void
-    {
-        $contact = $this->createContact();
-        $email   = $this->createTemplateEmail();
-        $this->createFrequencyRule($contact);
-        $this->createEmailStats($email, $contact);
-        $this->em->flush();
-
-        $this->sendEmail($email, $contact);
-        $this->assertEmailIsPostponed($email, $contact);
-    }
-
-    #[DataProvider('dataFrequencyRules')]
-    public function testFrequencyRulesAreNotAppliedWhenSendToDncIsTrue(): void
-    {
-        $contact = $this->createContact();
-        $email   = $this->createTemplateEmail();
-        $email->setSendToDnc(true);
-        $this->em->persist($email);
-        $this->createFrequencyRule($contact);
-        $this->createEmailStats($email, $contact);
-        $this->em->flush();
-
-        $this->sendEmail($email, $contact);
-        $this->assertEmailIsNotPostponed();
-    }
-
-    #[DataProvider('dataFrequencyRules')]
-    public function testEmailsWithSendToDncSetToYesAreNotCountedTowardsFrequencyRules(): void
-    {
-        $contact     = $this->createContact();
-        $emailToSend = $this->createTemplateEmail();
-        $emailDncYes = $this->createTemplateEmail();
-        $emailDncYes->setSendToDnc(true);
-        $this->em->persist($emailToSend);
-        $this->createFrequencyRule($contact);
-        $this->createEmailStats($emailDncYes, $contact);
-        $this->em->flush();
-
-        $this->sendEmail($emailToSend, $contact);
-        $this->assertEmailIsNotPostponed();
-    }
-
     public function testGetEmailListStatsDateToIncludesTheWholeDay(): void
     {
         $contact  = $this->createContact();
@@ -853,73 +787,5 @@ final class EmailModelFunctionalTest extends MauticMysqlTestCase
         $this->em->persist($email);
 
         return $email;
-    }
-
-    private function createFrequencyRule(Lead $contact, bool $useDefaultFrequencyRules): void
-    {
-        if ($this->useDefaultFrequencyRules) {
-            return;
-        }
-
-        $frequencyRule = new FrequencyRule();
-        $frequencyRule->setLead($contact);
-        $frequencyRule->setDateAdded(new \DateTime());
-        $frequencyRule->setChannel('email');
-        $frequencyRule->setFrequencyNumber(self::EMAILS_A_MONTH);
-        $frequencyRule->setFrequencyTime('MONTH');
-        $this->em->persist($frequencyRule);
-    }
-
-    private function createEmailStats(Email $email, Lead $contact): void
-    {
-        $exceedFrequencyRule = self::EMAILS_A_MONTH + 1;
-
-        for ($i = 0; $i < $exceedFrequencyRule; ++$i) {
-            $stat = new Stat();
-            $stat->setEmail($email);
-            $stat->setLead($contact);
-            $stat->setEmailAddress($contact->getEmail());
-            $stat->setDateSent(new \DateTime('-1 day'));
-            $this->em->persist($stat);
-        }
-    }
-
-    private function sendEmail(Email $email, Lead $contact): void
-    {
-        $this->emailModel->sendEmail(
-            $email,
-            [
-                [
-                    'id'        => $contact->getId(),
-                    'email'     => $contact->getEmail(),
-                    'firstname' => $contact->getFirstname(),
-                    'lastname'  => $contact->getLastname(),
-                ],
-            ]
-        );
-    }
-
-    private function assertEmailIsNotPostponed(): void
-    {
-        $messageQueueRepository = $this->em->getRepository(MessageQueue::class);
-        $this->assertInstanceOf(MessageQueueRepository::class, $messageQueueRepository);
-
-        $this->assertSame(0, $messageQueueRepository->count([]), 'Email should not be postponed.');
-    }
-
-    private function assertEmailIsPostponed(Email $email, Lead $contact): void
-    {
-        $messageQueueRepository = $this->em->getRepository(MessageQueue::class);
-        $this->assertInstanceOf(MessageQueueRepository::class, $messageQueueRepository);
-
-        $queuedMessages = $messageQueueRepository->findBy([]);
-        $this->assertCount(1, $queuedMessages, 'Email should be postponed.');
-
-        $queuedMessage = reset($queuedMessages);
-        $this->assertInstanceOf(MessageQueue::class, $queuedMessage);
-        $this->assertSame('email', $queuedMessage->getChannel());
-        $this->assertSame($email->getId(), $queuedMessage->getChannelId());
-        $this->assertSame($contact, $queuedMessage->getLead());
-        $this->assertSame($queuedMessage::STATUS_PENDING, $queuedMessage->getStatus());
     }
 }

--- a/app/bundles/FormBundle/Tests/Form/Type/FieldTypeTest.php
+++ b/app/bundles/FormBundle/Tests/Form/Type/FieldTypeTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\Validator\Validation;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class FieldTypeTest extends TypeTestCase
 {
     /**

--- a/app/bundles/FormBundle/Tests/Form/Type/FormFieldCheckboxGroupTypeTest.php
+++ b/app/bundles/FormBundle/Tests/Form/Type/FormFieldCheckboxGroupTypeTest.php
@@ -13,6 +13,7 @@ use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\Validator\Validation;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class FormFieldCheckboxGroupTypeTest extends TypeTestCase
 {
     /**

--- a/app/bundles/FormBundle/Tests/Form/Type/FormFieldConditionTypeTest.php
+++ b/app/bundles/FormBundle/Tests/Form/Type/FormFieldConditionTypeTest.php
@@ -9,6 +9,7 @@ use Mautic\FormBundle\Form\Type\FormFieldConditionType;
 use Mautic\FormBundle\Helper\PropertiesAccessor;
 use Mautic\FormBundle\Model\FieldModel;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Rule\AnyInvokedCount;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 
@@ -124,7 +125,8 @@ final class FormFieldConditionTypeTest extends \PHPUnit\Framework\TestCase
             ->method('getChoices')
             ->with(['some_choice_here' => 'Some choice here'])
             ->willReturn(['some_choice_here' => 'Some choice here']);
-        $matcher = $this->any();
+
+        $matcher = new AnyInvokedCount();
 
         $this->formBuilder->expects($matcher)->method('add')
             ->willReturnCallback(

--- a/app/bundles/FormBundle/Tests/Form/Type/FormFieldNumberTypeTest.php
+++ b/app/bundles/FormBundle/Tests/Form/Type/FormFieldNumberTypeTest.php
@@ -11,6 +11,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\Test\TypeTestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class FormFieldNumberTypeTest extends TypeTestCase
 {
     /**

--- a/app/bundles/FormBundle/Tests/Form/Type/FormFieldRatingTypeTest.php
+++ b/app/bundles/FormBundle/Tests/Form/Type/FormFieldRatingTypeTest.php
@@ -15,6 +15,7 @@ use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\Validator\Validation;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class FormFieldRatingTypeTest extends TypeTestCase
 {
     /**

--- a/app/bundles/FormBundle/Tests/Form/Type/FormFieldSliderTypeTest.php
+++ b/app/bundles/FormBundle/Tests/Form/Type/FormFieldSliderTypeTest.php
@@ -10,6 +10,7 @@ use Symfony\Component\Form\PreloadedExtension;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\Validator\Validation;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class FormFieldSliderTypeTest extends TypeTestCase
 {
     protected function getExtensions(): array

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/Executioner/ReferenceResolverTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/Executioner/ReferenceResolverTest.php
@@ -80,7 +80,7 @@ final class ReferenceResolverTest extends TestCase
     {
         $result = $this->createMock(Result::class);
         $result->method('fetchOne')
-            ->willReturnOnConsecutiveCalls('Company name');
+            ->willReturn('Company name');
 
         $queryBuilder = $this->createMock(QueryBuilder::class);
         $queryBuilder->method('executeQuery')

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/Executioner/ReferenceResolverTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/Executioner/ReferenceResolverTest.php
@@ -32,8 +32,16 @@ final class ReferenceResolverTest extends TestCase
 
     public function testResolveLeadReferences(): void
     {
+        $result = $this->createMock(Result::class);
+        $result->method('fetchOne')
+            ->willReturnOnConsecutiveCalls('Company name', false);
+
+        $queryBuilder = $this->createMock(QueryBuilder::class);
+        $queryBuilder->method('executeQuery')
+            ->willReturn($result);
+
         $this->connection->method('createQueryBuilder')
-            ->willReturn($this->createQueryBuilder('Company name', false));
+            ->willReturn($queryBuilder);
 
         $companyReference  = $this->createReference('company', 3);
         $userReference     = $this->createReference('user', 4);
@@ -70,8 +78,16 @@ final class ReferenceResolverTest extends TestCase
 
     public function testResolveCompanyReferences(): void
     {
+        $result = $this->createMock(Result::class);
+        $result->method('fetchOne')
+            ->willReturnOnConsecutiveCalls('Company name');
+
+        $queryBuilder = $this->createMock(QueryBuilder::class);
+        $queryBuilder->method('executeQuery')
+            ->willReturn($result);
+
         $this->connection->method('createQueryBuilder')
-            ->willReturn($this->createQueryBuilder('Company name'));
+            ->willReturn($queryBuilder);
 
         $companyReference  = $this->createReference('company', 3);
 
@@ -93,23 +109,5 @@ final class ReferenceResolverTest extends TestCase
         $reference->setValue($value);
 
         return $reference;
-    }
-
-    /**
-     * @param mixed $returnValues
-     *
-     * @return QueryBuilder&MockObject
-     */
-    private function createQueryBuilder(...$returnValues): MockObject
-    {
-        $result = $this->createMock(Result::class);
-        $result->method('fetchOne')
-            ->willReturnOnConsecutiveCalls(...$returnValues);
-
-        $queryBuilder = $this->createMock(QueryBuilder::class);
-        $queryBuilder->method('executeQuery')
-            ->willReturn($result);
-
-        return $queryBuilder;
     }
 }

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncProcess/SyncProcessTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncProcess/SyncProcessTest.php
@@ -148,7 +148,8 @@ final class SyncProcessTest extends TestCase
         $this->internalSyncDataExchange->expects($this->once())
             ->method('executeSyncOrder')
             ->willReturn($objectMappings);
-        $matcher = $this->any();
+
+        $matcher = $this->exactly(3);
 
         $this->eventDispatcher->expects($matcher)
             ->method('dispatch')->willReturnCallback(function (...$parameters) use ($matcher): object {

--- a/app/bundles/LeadBundle/Tests/EventListener/ReportSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/ReportSubscriberTest.php
@@ -30,6 +30,7 @@ use Mautic\ReportBundle\Helper\ReportHelper;
 use Mautic\StageBundle\Model\StageModel;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Rule\AnyInvokedCount;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 final class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
@@ -303,7 +304,7 @@ final class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
 
     public function testNotRelevantContextBuilder(): void
     {
-        $matcher = $this->any();
+        $matcher = new AnyInvokedCount();
         $this->reportBuilderEventMock->expects($matcher)->method('checkContext')
             ->willReturnCallback(
                 function (...$parameters) use ($matcher): false {
@@ -829,7 +830,7 @@ final class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
     #[DataProvider('eventDataProvider')]
     public function testReportGenerate(string $context): void
     {
-        $matcher = $this->any();
+        $matcher = new AnyInvokedCount();
         $this->reportGeneratorEventMock->expects($matcher)->method('checkContext')
             ->willReturnCallback(
                 function (...$parameters) use ($matcher): true {

--- a/app/bundles/LeadBundle/Tests/EventListener/ReportUtmTagSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/ReportUtmTagSubscriberTest.php
@@ -14,6 +14,7 @@ use Mautic\ReportBundle\Event\ReportBuilderEvent;
 use Mautic\ReportBundle\Event\ReportGeneratorEvent;
 use Mautic\ReportBundle\Helper\ReportHelper;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Rule\AnyInvokedCount;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -240,7 +241,8 @@ final class ReportUtmTagSubscriberTest extends \PHPUnit\Framework\TestCase
             ->method('from')
             ->with(MAUTIC_TABLE_PREFIX.'lead_utmtags', 'utm')
             ->willReturn($queryBuilderMock);
-        $matcher = $this->any();
+
+        $matcher = new AnyInvokedCount();
 
         $queryBuilderMock->expects($matcher)->method('leftJoin')
             ->willReturnCallback(function (...$parameters) use ($matcher, $queryBuilderMock): MockObject {

--- a/app/bundles/LeadBundle/Tests/Tracker/Service/DeviceTrackingService/DeviceTrackingServiceTest.php
+++ b/app/bundles/LeadBundle/Tests/Tracker/Service/DeviceTrackingService/DeviceTrackingServiceTest.php
@@ -12,6 +12,7 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadDevice;
 use Mautic\LeadBundle\Entity\LeadDeviceRepository;
 use Mautic\LeadBundle\Tracker\Service\DeviceTrackingService\DeviceTrackingService;
+use PHPUnit\Framework\MockObject\Rule\AnyInvokedCount;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -259,7 +260,7 @@ final class DeviceTrackingServiceTest extends \PHPUnit\Framework\TestCase
         $this->security->expects($this->once())
             ->method('isAnonymous')
             ->willReturn(true);
-        $matcher = $this->any();
+        $matcher = new AnyInvokedCount();
 
         $this->leadDeviceRepositoryMock->expects($matcher)->method('getByTrackingId')
             ->willReturnCallback(function (...$parameters) use ($matcher, $trackingId, $trackedLeadDeviceMock) {
@@ -291,7 +292,8 @@ final class DeviceTrackingServiceTest extends \PHPUnit\Framework\TestCase
         $leadDeviceMock->expects($this->once())
             ->method('getLead')
             ->willReturn(new Lead());
-        $matcher = $this->any();
+
+        $matcher = new AnyInvokedCount();
 
         $this->cookieHelperMock->expects($matcher)->method('setCookie')
             ->willReturnCallback(function (...$parameters) use ($matcher, $uniqueTrackingIdentifier): void {
@@ -351,7 +353,8 @@ final class DeviceTrackingServiceTest extends \PHPUnit\Framework\TestCase
             ->method('getLead')
             ->willReturn(new Lead());
 
-        $matcher = $this->any();
+        $matcher = new AnyInvokedCount();
+
         $this->cookieHelperMock->expects($matcher)->method('setCookie')
             ->willReturnCallback(function (...$parameters) use ($matcher, $uniqueTrackingIdentifier): void {
                 if (1 === $matcher->numberOfInvocations()) {

--- a/app/bundles/NotificationBundle/Tests/Form/Type/MobileNotificationDetailsTypeTest.php
+++ b/app/bundles/NotificationBundle/Tests/Form/Type/MobileNotificationDetailsTypeTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\Form\PreloadedExtension;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\Validator\Validation;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class MobileNotificationDetailsTypeTest extends TypeTestCase
 {
     /**

--- a/app/bundles/NotificationBundle/Tests/Form/Type/MobileNotificationSendTypeTest.php
+++ b/app/bundles/NotificationBundle/Tests/Form/Type/MobileNotificationSendTypeTest.php
@@ -15,6 +15,7 @@ use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Validator\Validation;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class MobileNotificationSendTypeTest extends TypeTestCase
 {
     /**

--- a/app/bundles/NotificationBundle/Tests/Form/Type/NotificationSendTypeTest.php
+++ b/app/bundles/NotificationBundle/Tests/Form/Type/NotificationSendTypeTest.php
@@ -15,6 +15,7 @@ use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Validator\Validation;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class NotificationSendTypeTest extends TypeTestCase
 {
     /**

--- a/app/bundles/NotificationBundle/Tests/Form/Type/NotificationTypeTest.php
+++ b/app/bundles/NotificationBundle/Tests/Form/Type/NotificationTypeTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Validator\Validation;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class NotificationTypeTest extends TypeTestCase
 {
     /**

--- a/app/bundles/ReportBundle/Tests/Event/ReportGeneratorEventTest.php
+++ b/app/bundles/ReportBundle/Tests/Event/ReportGeneratorEventTest.php
@@ -11,6 +11,7 @@ use Mautic\ReportBundle\Entity\Report;
 use Mautic\ReportBundle\Event\ReportGeneratorEvent;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Rule\AnyInvokedCount;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
@@ -305,7 +306,7 @@ final class ReportGeneratorEventTest extends TestCase
             ->method('andWhere')
             ->with($condition)
             ->willReturn($this->queryBuilder);
-        $matcher = $this->any();
+        $matcher = new AnyInvokedCount();
 
         $this
             ->queryBuilder
@@ -355,7 +356,7 @@ final class ReportGeneratorEventTest extends TestCase
             ->method('andWhere')
             ->with($condition)
             ->willReturn($this->queryBuilder);
-        $matcher = $this->any();
+        $matcher = new AnyInvokedCount();
 
         $this
             ->queryBuilder

--- a/app/bundles/ReportBundle/Tests/Event/ReportGeneratorEventTest.php
+++ b/app/bundles/ReportBundle/Tests/Event/ReportGeneratorEventTest.php
@@ -306,6 +306,7 @@ final class ReportGeneratorEventTest extends TestCase
             ->method('andWhere')
             ->with($condition)
             ->willReturn($this->queryBuilder);
+
         $matcher = new AnyInvokedCount();
 
         $this

--- a/app/bundles/ReportBundle/Tests/Form/Type/DynamicFiltersTypeTest.php
+++ b/app/bundles/ReportBundle/Tests/Form/Type/DynamicFiltersTypeTest.php
@@ -465,6 +465,7 @@ final class DynamicFiltersTypeTest extends TestCase
     }
 }
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class DynamicFiltersTypeIntegrationTest extends TypeTestCase
 {
     public function testFilterWithValueIsSet(): void

--- a/app/bundles/SmsBundle/Tests/Integration/Twilio/ConfigurationTest.php
+++ b/app/bundles/SmsBundle/Tests/Integration/Twilio/ConfigurationTest.php
@@ -11,6 +11,7 @@ use Mautic\SmsBundle\Integration\Twilio\Configuration;
 use PHPUnit\Framework\MockObject\MockObject;
 use Twilio\Exceptions\ConfigurationException;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ConfigurationTest extends \PHPUnit\Framework\TestCase
 {
     private MockObject&IntegrationHelper $integrationHelper;

--- a/app/bundles/UserBundle/Tests/Model/UserModelTest.php
+++ b/app/bundles/UserBundle/Tests/Model/UserModelTest.php
@@ -32,6 +32,7 @@ use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Twig\Environment;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class UserModelTest extends TestCase
 {
     private UserModel $userModel;

--- a/app/bundles/UserBundle/Tests/Model/UserToken/UserTokenServiceTest.php
+++ b/app/bundles/UserBundle/Tests/Model/UserToken/UserTokenServiceTest.php
@@ -11,6 +11,7 @@ use Mautic\UserBundle\Entity\UserTokenRepositoryInterface;
 use Mautic\UserBundle\Model\UserToken\UserTokenService;
 use PHPUnit\Framework\MockObject\MockObject;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class UserTokenServiceTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/UserBundle/Tests/Security/Authenticator/SsoAuthenticatorTest.php
+++ b/app/bundles/UserBundle/Tests/Security/Authenticator/SsoAuthenticatorTest.php
@@ -30,6 +30,7 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\PasswordC
 use Symfony\Component\Security\Http\HttpUtils;
 use Symfony\Component\Security\Http\SecurityRequestAttributes;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class SsoAuthenticatorTest extends TestCase
 {
     #[DataProvider('provideIsPost')]

--- a/app/bundles/UserBundle/Tests/Security/SAML/Store/CredentialsStoreTest.php
+++ b/app/bundles/UserBundle/Tests/Security/SAML/Store/CredentialsStoreTest.php
@@ -11,6 +11,7 @@ use Mautic\UserBundle\Security\SAML\Store\CredentialsStore;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class CredentialsStoreTest extends TestCase
 {
     private string $cacheDir;

--- a/app/bundles/UserBundle/Tests/Security/SAML/Store/IdStoreTest.php
+++ b/app/bundles/UserBundle/Tests/Security/SAML/Store/IdStoreTest.php
@@ -11,6 +11,7 @@ use Mautic\UserBundle\Security\SAML\Store\IdStore;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class IdStoreTest extends TestCase
 {
     /**

--- a/app/bundles/UserBundle/Tests/Security/SAML/Store/Request/RequestStateStoreTest.php
+++ b/app/bundles/UserBundle/Tests/Security/SAML/Store/Request/RequestStateStoreTest.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\CacheItem;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class RequestStateStoreTest extends TestCase
 {
     /**

--- a/app/bundles/UserBundle/Tests/Security/SAML/User/UserMapperTest.php
+++ b/app/bundles/UserBundle/Tests/Security/SAML/User/UserMapperTest.php
@@ -12,6 +12,7 @@ use Mautic\UserBundle\Security\SAML\User\UserMapper;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class UserMapperTest extends TestCase
 {
     private UserMapper $mapper;

--- a/app/bundles/WebhookBundle/Tests/Unit/Controller/WebhookControllerTest.php
+++ b/app/bundles/WebhookBundle/Tests/Unit/Controller/WebhookControllerTest.php
@@ -44,6 +44,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class WebhookControllerTest extends TestCase
 {
     #[DataProvider('provideNewOrUpdate')]

--- a/app/bundles/WebhookBundle/Tests/Unit/Notificator/WebhookKillNotificatorTest.php
+++ b/app/bundles/WebhookBundle/Tests/Unit/Notificator/WebhookKillNotificatorTest.php
@@ -20,6 +20,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class WebhookKillNotificatorTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     "phpstan/phpstan-doctrine": "^2.0.28",
     "phpstan/phpstan-phpunit": "^2.0.18",
     "phpstan/phpstan-symfony": "^2.0.20",
-    "phpunit/phpunit": "^11.5",
+    "phpunit/phpunit": "^12.0",
     "rector/type-perfect": "^2.1.4",
     "rector/rector": "dev-main",
     "symfony/browser-kit": "~7.4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fd15da21d253420e32570e333db93c0f",
+    "content-hash": "e93e10094b4a219460791e15e49dce53",
     "packages": [
         {
             "name": "api-platform/core",
@@ -16868,16 +16868,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "11.0.12",
+            "version": "12.5.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56"
+                "reference": "186dab580576598076de6818596d12b61801880e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2c1ed04922802c15e1de5d7447b4856de949cf56",
-                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/186dab580576598076de6818596d12b61801880e",
+                "reference": "186dab580576598076de6818596d12b61801880e",
                 "shasum": ""
             },
             "require": {
@@ -16885,18 +16885,16 @@
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
                 "nikic/php-parser": "^5.7.0",
-                "php": ">=8.2",
-                "phpunit/php-file-iterator": "^5.1.0",
-                "phpunit/php-text-template": "^4.0.1",
-                "sebastian/code-unit-reverse-lookup": "^4.0.1",
-                "sebastian/complexity": "^4.0.1",
-                "sebastian/environment": "^7.2.1",
-                "sebastian/lines-of-code": "^3.0.1",
-                "sebastian/version": "^5.0.2",
-                "theseer/tokenizer": "^1.3.1"
+                "php": ">=8.3",
+                "phpunit/php-text-template": "^5.0",
+                "sebastian/complexity": "^5.0",
+                "sebastian/environment": "^8.1.2",
+                "sebastian/lines-of-code": "^4.0.1",
+                "sebastian/version": "^6.0",
+                "theseer/tokenizer": "^2.0.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.5.46"
+                "phpunit/phpunit": "^12.5.28"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -16905,7 +16903,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "11.0.x-dev"
+                    "dev-main": "12.5.x-dev"
                 }
             },
             "autoload": {
@@ -16934,7 +16932,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/11.0.12"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.5.7"
             },
             "funding": [
                 {
@@ -16954,32 +16952,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-24T07:01:01+00:00"
+            "time": "2026-06-01T13:24:19+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "5.1.1",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903"
+                "reference": "3d1cd096ef6bea4bf2762ba586e35dbd317cbfd5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/2f3a64888c814fc235386b7387dd5b5ed92ad903",
-                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3d1cd096ef6bea4bf2762ba586e35dbd317cbfd5",
+                "reference": "3d1cd096ef6bea4bf2762ba586e35dbd317cbfd5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.3"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.1-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -17007,7 +17005,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
                 "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/5.1.1"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/6.0.1"
             },
             "funding": [
                 {
@@ -17027,28 +17025,28 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-02T13:52:54+00:00"
+            "time": "2026-02-02T14:04:18+00:00"
         },
         {
             "name": "phpunit/php-invoker",
-            "version": "5.0.1",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2"
+                "reference": "12b54e689b07a25a9b41e57736dfab6ec9ae5406"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/c1ca3814734c07492b3d4c5f794f4b0995333da2",
-                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/12b54e689b07a25a9b41e57736dfab6ec9ae5406",
+                "reference": "12b54e689b07a25a9b41e57736dfab6ec9ae5406",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
                 "ext-pcntl": "*",
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^12.0"
             },
             "suggest": {
                 "ext-pcntl": "*"
@@ -17056,7 +17054,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -17083,7 +17081,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
                 "security": "https://github.com/sebastianbergmann/php-invoker/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-invoker/tree/5.0.1"
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/6.0.0"
             },
             "funding": [
                 {
@@ -17091,32 +17089,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-03T05:07:44+00:00"
+            "time": "2025-02-07T04:58:58+00:00"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "4.0.1",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964"
+                "reference": "e1367a453f0eda562eedb4f659e13aa900d66c53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
-                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/e1367a453f0eda562eedb4f659e13aa900d66c53",
+                "reference": "e1367a453f0eda562eedb4f659e13aa900d66c53",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -17143,7 +17141,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
                 "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/4.0.1"
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/5.0.0"
             },
             "funding": [
                 {
@@ -17151,32 +17149,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-03T05:08:43+00:00"
+            "time": "2025-02-07T04:59:16+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "7.0.1",
+            "version": "8.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3"
+                "reference": "f258ce36aa457f3aa3339f9ed4c81fc66dc8c2cc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
-                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/f258ce36aa457f3aa3339f9ed4c81fc66dc8c2cc",
+                "reference": "f258ce36aa457f3aa3339f9ed4c81fc66dc8c2cc",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "7.0-dev"
+                    "dev-main": "8.0-dev"
                 }
             },
             "autoload": {
@@ -17203,7 +17201,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
                 "security": "https://github.com/sebastianbergmann/php-timer/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/7.0.1"
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/8.0.0"
             },
             "funding": [
                 {
@@ -17211,20 +17209,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-03T05:09:35+00:00"
+            "time": "2025-02-07T04:59:38+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "11.5.56",
+            "version": "12.5.33",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "5f83edffa6967c3db468d48a695ec7bcb02e9256"
+                "reference": "b98e028a26c5c5ba7e4a54be96ccf35f2914d184"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/5f83edffa6967c3db468d48a695ec7bcb02e9256",
-                "reference": "5f83edffa6967c3db468d48a695ec7bcb02e9256",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b98e028a26c5c5ba7e4a54be96ccf35f2914d184",
+                "reference": "b98e028a26c5c5ba7e4a54be96ccf35f2914d184",
                 "shasum": ""
             },
             "require": {
@@ -17237,27 +17235,23 @@
                 "myclabs/deep-copy": "^1.13.4",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
-                "php": ">=8.2",
-                "phpunit/php-code-coverage": "^11.0.12",
-                "phpunit/php-file-iterator": "^5.1.1",
-                "phpunit/php-invoker": "^5.0.1",
-                "phpunit/php-text-template": "^4.0.1",
-                "phpunit/php-timer": "^7.0.1",
-                "sebastian/cli-parser": "^3.0.2",
-                "sebastian/code-unit": "^3.0.3",
-                "sebastian/comparator": "^6.3.3",
-                "sebastian/diff": "^6.0.2",
-                "sebastian/environment": "^7.2.1",
-                "sebastian/exporter": "^6.3.2",
-                "sebastian/global-state": "^7.0.2",
-                "sebastian/object-enumerator": "^6.0.1",
-                "sebastian/recursion-context": "^6.0.3",
-                "sebastian/type": "^5.1.3",
-                "sebastian/version": "^5.0.2",
+                "php": ">=8.3",
+                "phpunit/php-code-coverage": "^12.5.7",
+                "phpunit/php-file-iterator": "^6.0.1",
+                "phpunit/php-invoker": "^6.0.0",
+                "phpunit/php-text-template": "^5.0.0",
+                "phpunit/php-timer": "^8.0.0",
+                "sebastian/cli-parser": "^4.2.1",
+                "sebastian/comparator": "^7.1.8",
+                "sebastian/diff": "^7.0.0",
+                "sebastian/environment": "^8.1.2",
+                "sebastian/exporter": "^7.0.3",
+                "sebastian/global-state": "^8.0.3",
+                "sebastian/object-enumerator": "^7.0.0",
+                "sebastian/recursion-context": "^7.0.1",
+                "sebastian/type": "^6.0.4",
+                "sebastian/version": "^6.0.0",
                 "staabm/side-effects-detector": "^1.0.5"
-            },
-            "suggest": {
-                "ext-soap": "To be able to generate mocks based on WSDL files"
             },
             "bin": [
                 "phpunit"
@@ -17265,7 +17259,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "11.5-dev"
+                    "dev-main": "12.5-dev"
                 }
             },
             "autoload": {
@@ -17297,7 +17291,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.56"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.33"
             },
             "funding": [
                 {
@@ -17305,7 +17299,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2026-07-06T14:52:39+00:00"
+            "time": "2026-07-28T13:58:09+00:00"
         },
         {
             "name": "psy/psysh",
@@ -17967,28 +17961,28 @@
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "3.0.2",
+            "version": "4.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180"
+                "reference": "7d05781b13f7dec9043a629a21d086ed74582a15"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/15c5dd40dc4f38794d383bb95465193f5e0ae180",
-                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/7d05781b13f7dec9043a629a21d086ed74582a15",
+                "reference": "7d05781b13f7dec9043a629a21d086ed74582a15",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^12.5.25"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "4.2-dev"
                 }
             },
             "autoload": {
@@ -18012,152 +18006,51 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
                 "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/3.0.2"
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/4.2.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
-                }
-            ],
-            "time": "2024-07-03T04:41:36+00:00"
-        },
-        {
-            "name": "sebastian/code-unit",
-            "version": "3.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/54391c61e4af8078e5b276ab082b6d3c54c9ad64",
-                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^11.5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
+                },
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Collection of value objects that represent the PHP code units",
-            "homepage": "https://github.com/sebastianbergmann/code-unit",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
-                "security": "https://github.com/sebastianbergmann/code-unit/security/policy",
-                "source": "https://github.com/sebastianbergmann/code-unit/tree/3.0.3"
-            },
-            "funding": [
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
                 {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-03-19T07:56:08+00:00"
-        },
-        {
-            "name": "sebastian/code-unit-reverse-lookup",
-            "version": "4.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "183a9b2632194febd219bb9246eee421dad8d45e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/183a9b2632194febd219bb9246eee421dad8d45e",
-                "reference": "183a9b2632194febd219bb9246eee421dad8d45e",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^11.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "4.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/cli-parser",
+                    "type": "tidelift"
                 }
             ],
-            "description": "Looks up which function or method a line of code belongs to",
-            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "security": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/security/policy",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/4.0.1"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2024-07-03T04:45:54+00:00"
+            "time": "2026-05-17T05:29:34+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "6.3.3",
+            "version": "7.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9"
+                "reference": "7c65c1e79836812819705b473a90c12399542485"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
-                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/7c65c1e79836812819705b473a90c12399542485",
+                "reference": "7c65c1e79836812819705b473a90c12399542485",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-mbstring": "*",
-                "php": ">=8.2",
-                "sebastian/diff": "^6.0",
-                "sebastian/exporter": "^6.0"
+                "php": ">=8.3",
+                "sebastian/diff": "^7.0",
+                "sebastian/exporter": "^7.0.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.4"
+                "phpunit/phpunit": "^12.5.25"
             },
             "suggest": {
                 "ext-bcmath": "For comparing BcMath\\Number objects"
@@ -18165,7 +18058,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.3-dev"
+                    "dev-main": "7.1-dev"
                 }
             },
             "autoload": {
@@ -18205,7 +18098,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
                 "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/6.3.3"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/7.1.8"
             },
             "funding": [
                 {
@@ -18225,33 +18118,33 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-24T09:26:40+00:00"
+            "time": "2026-05-21T04:45:25+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "4.0.1",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0"
+                "reference": "bad4316aba5303d0221f43f8cee37eb58d384bbb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/ee41d384ab1906c68852636b6de493846e13e5a0",
-                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/bad4316aba5303d0221f43f8cee37eb58d384bbb",
+                "reference": "bad4316aba5303d0221f43f8cee37eb58d384bbb",
                 "shasum": ""
             },
             "require": {
                 "nikic/php-parser": "^5.0",
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -18275,7 +18168,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
                 "security": "https://github.com/sebastianbergmann/complexity/security/policy",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/4.0.1"
+                "source": "https://github.com/sebastianbergmann/complexity/tree/5.0.0"
             },
             "funding": [
                 {
@@ -18283,33 +18176,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-03T04:49:50+00:00"
+            "time": "2025-02-07T04:55:25+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "6.0.2",
+            "version": "7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544"
+                "reference": "7ab1ea946c012266ca32390913653d844ecd085f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/b4ccd857127db5d41a5b676f24b51371d76d8544",
-                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7ab1ea946c012266ca32390913653d844ecd085f",
+                "reference": "7ab1ea946c012266ca32390913653d844ecd085f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0",
-                "symfony/process": "^4.2 || ^5"
+                "phpunit/phpunit": "^12.0",
+                "symfony/process": "^7.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -18342,7 +18235,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
                 "security": "https://github.com/sebastianbergmann/diff/security/policy",
-                "source": "https://github.com/sebastianbergmann/diff/tree/6.0.2"
+                "source": "https://github.com/sebastianbergmann/diff/tree/7.0.0"
             },
             "funding": [
                 {
@@ -18350,27 +18243,27 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-03T04:53:05+00:00"
+            "time": "2025-02-07T04:55:46+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "7.2.1",
+            "version": "8.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4"
+                "reference": "9d32c685773823b1983e256ae4ecd48a10d6e439"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/a5c75038693ad2e8d4b6c15ba2403532647830c4",
-                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/9d32c685773823b1983e256ae4ecd48a10d6e439",
+                "reference": "9d32c685773823b1983e256ae4ecd48a10d6e439",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.3"
+                "phpunit/phpunit": "^12.5.26"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -18378,7 +18271,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "7.2-dev"
+                    "dev-main": "8.1-dev"
                 }
             },
             "autoload": {
@@ -18406,7 +18299,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
                 "security": "https://github.com/sebastianbergmann/environment/security/policy",
-                "source": "https://github.com/sebastianbergmann/environment/tree/7.2.1"
+                "source": "https://github.com/sebastianbergmann/environment/tree/8.1.2"
             },
             "funding": [
                 {
@@ -18426,34 +18319,34 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-05-21T11:55:47+00:00"
+            "time": "2026-05-25T13:40:20+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "6.3.2",
+            "version": "7.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74"
+                "reference": "c5e21b5de653ce0a769fb36f5cdfcb5e7a32cf23"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/70a298763b40b213ec087c51c739efcaa90bcd74",
-                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/c5e21b5de653ce0a769fb36f5cdfcb5e7a32cf23",
+                "reference": "c5e21b5de653ce0a769fb36f5cdfcb5e7a32cf23",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
-                "php": ">=8.2",
-                "sebastian/recursion-context": "^6.0"
+                "php": ">=8.3",
+                "sebastian/recursion-context": "^7.0.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.3"
+                "phpunit/phpunit": "^12.5.25"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.3-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -18496,7 +18389,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
                 "security": "https://github.com/sebastianbergmann/exporter/security/policy",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/6.3.2"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/7.0.3"
             },
             "funding": [
                 {
@@ -18516,35 +18409,35 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-24T06:12:51+00:00"
+            "time": "2026-05-20T04:37:17+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "7.0.2",
+            "version": "8.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "3be331570a721f9a4b5917f4209773de17f747d7"
+                "reference": "b164d3274d6537ab462591c5755f76a8f5b1aae9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/3be331570a721f9a4b5917f4209773de17f747d7",
-                "reference": "3be331570a721f9a4b5917f4209773de17f747d7",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b164d3274d6537ab462591c5755f76a8f5b1aae9",
+                "reference": "b164d3274d6537ab462591c5755f76a8f5b1aae9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "sebastian/object-reflector": "^4.0",
-                "sebastian/recursion-context": "^6.0"
+                "php": ">=8.3",
+                "sebastian/object-reflector": "^5.0",
+                "sebastian/recursion-context": "^7.0.1"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^12.5.28"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "7.0-dev"
+                    "dev-main": "8.0-dev"
                 }
             },
             "autoload": {
@@ -18570,41 +18463,53 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
                 "security": "https://github.com/sebastianbergmann/global-state/security/policy",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/7.0.2"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/8.0.3"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-07-03T04:57:36+00:00"
+            "time": "2026-06-01T15:10:33+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "3.0.1",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a"
+                "reference": "d543b8ef219dcd8da262cbb958639a96bedba10e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/d36ad0d782e5756913e42ad87cb2890f4ffe467a",
-                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/d543b8ef219dcd8da262cbb958639a96bedba10e",
+                "reference": "d543b8ef219dcd8da262cbb958639a96bedba10e",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^5.0",
-                "php": ">=8.2"
+                "nikic/php-parser": "^5.7.0",
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^12.5.25"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -18628,42 +18533,54 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
                 "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/3.0.1"
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/4.0.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/lines-of-code",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-07-03T04:58:38+00:00"
+            "time": "2026-05-19T16:22:07+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "6.0.1",
+            "version": "7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "f5b498e631a74204185071eb41f33f38d64608aa"
+                "reference": "1effe8e9b8e068e9ae228e542d5d11b5d16db894"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/f5b498e631a74204185071eb41f33f38d64608aa",
-                "reference": "f5b498e631a74204185071eb41f33f38d64608aa",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/1effe8e9b8e068e9ae228e542d5d11b5d16db894",
+                "reference": "1effe8e9b8e068e9ae228e542d5d11b5d16db894",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "sebastian/object-reflector": "^4.0",
-                "sebastian/recursion-context": "^6.0"
+                "php": ">=8.3",
+                "sebastian/object-reflector": "^5.0",
+                "sebastian/recursion-context": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -18686,7 +18603,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
                 "security": "https://github.com/sebastianbergmann/object-enumerator/security/policy",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/6.0.1"
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/7.0.0"
             },
             "funding": [
                 {
@@ -18694,32 +18611,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-03T05:00:13+00:00"
+            "time": "2025-02-07T04:57:48+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "4.0.1",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9"
+                "reference": "4bfa827c969c98be1e527abd576533293c634f6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/6e1a43b411b2ad34146dee7524cb13a068bb35f9",
-                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/4bfa827c969c98be1e527abd576533293c634f6a",
+                "reference": "4bfa827c969c98be1e527abd576533293c634f6a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -18742,7 +18659,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
                 "security": "https://github.com/sebastianbergmann/object-reflector/security/policy",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/4.0.1"
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/5.0.0"
             },
             "funding": [
                 {
@@ -18750,32 +18667,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-03T05:01:32+00:00"
+            "time": "2025-02-07T04:58:17+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "6.0.3",
+            "version": "7.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc"
+                "reference": "0b01998a7d5b1f122911a66bebcb8d46f0c82d8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/f6458abbf32a6c8174f8f26261475dc133b3d9dc",
-                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/0b01998a7d5b1f122911a66bebcb8d46f0c82d8c",
+                "reference": "0b01998a7d5b1f122911a66bebcb8d46f0c82d8c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.3"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -18806,7 +18723,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
                 "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/6.0.3"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/7.0.1"
             },
             "funding": [
                 {
@@ -18826,32 +18743,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-13T04:42:22+00:00"
+            "time": "2025-08-13T04:44:59+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "5.1.3",
+            "version": "6.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449"
+                "reference": "82ff822c2edc46724be9f7411d3163021f602773"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
-                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/82ff822c2edc46724be9f7411d3163021f602773",
+                "reference": "82ff822c2edc46724be9f7411d3163021f602773",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.3"
+                "phpunit/phpunit": "^12.5.25"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.1-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -18875,7 +18792,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
                 "security": "https://github.com/sebastianbergmann/type/security/policy",
-                "source": "https://github.com/sebastianbergmann/type/tree/5.1.3"
+                "source": "https://github.com/sebastianbergmann/type/tree/6.0.4"
             },
             "funding": [
                 {
@@ -18895,29 +18812,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-09T06:55:48+00:00"
+            "time": "2026-05-20T06:45:45+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "5.0.2",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874"
+                "reference": "3e6ccf7657d4f0a59200564b08cead899313b53c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c687e3387b99f5b03b6caa64c74b63e2936ff874",
-                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/3e6ccf7657d4f0a59200564b08cead899313b53c",
+                "reference": "3e6ccf7657d4f0a59200564b08cead899313b53c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -18941,7 +18858,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
                 "security": "https://github.com/sebastianbergmann/version/security/policy",
-                "source": "https://github.com/sebastianbergmann/version/tree/5.0.2"
+                "source": "https://github.com/sebastianbergmann/version/tree/6.0.0"
             },
             "funding": [
                 {
@@ -18949,7 +18866,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-10-09T05:16:32+00:00"
+            "time": "2025-02-07T05:00:38+00:00"
         },
         {
             "name": "staabm/side-effects-detector",
@@ -19600,23 +19517,23 @@
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.3.1",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
+                "reference": "7989e43bf381af0eac72e4f0ca5bcbfa81658be4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
-                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/7989e43bf381af0eac72e4f0ca5bcbfa81658be4",
+                "reference": "7989e43bf381af0eac72e4f0ca5bcbfa81658be4",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.2 || ^8.0"
+                "php": "^8.1"
             },
             "type": "library",
             "autoload": {
@@ -19638,7 +19555,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
+                "source": "https://github.com/theseer/tokenizer/tree/2.0.1"
             },
             "funding": [
                 {
@@ -19646,7 +19563,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-17T20:03:58+00:00"
+            "time": "2025-12-08T11:19:18+00:00"
         },
         {
             "name": "tomasvotruba/type-coverage",

--- a/plugins/GrapesJsBuilderBundle/Tests/Unit/EventSubscriber/EmailSubscriberTest.php
+++ b/plugins/GrapesJsBuilderBundle/Tests/Unit/EventSubscriber/EmailSubscriberTest.php
@@ -16,6 +16,7 @@ use MauticPlugin\GrapesJsBuilderBundle\Model\GrapesJsBuilderModel;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class EmailSubscriberTest extends TestCase
 {
     /**

--- a/plugins/GrapesJsBuilderBundle/Tests/Unit/EventSubscriber/InjectCustomContentSubscriberTest.php
+++ b/plugins/GrapesJsBuilderBundle/Tests/Unit/EventSubscriber/InjectCustomContentSubscriberTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\RouterInterface;
 use Twig\Environment;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class InjectCustomContentSubscriberTest extends TestCase
 {
     /**

--- a/plugins/MauticClearbitBundle/Tests/Unit/EventListener/ButtonSubscriberTest.php
+++ b/plugins/MauticClearbitBundle/Tests/Unit/EventListener/ButtonSubscriberTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ButtonSubscriberTest extends TestCase
 {
     private MockObject&IntegrationsHelper $integrationsHelper;

--- a/plugins/MauticCrmBundle/Tests/Integration/SalesforceIntegrationTest.php
+++ b/plugins/MauticCrmBundle/Tests/Integration/SalesforceIntegrationTest.php
@@ -18,6 +18,7 @@ use Mautic\PluginBundle\Tests\Integration\AbstractIntegrationTestCase;
 use Mautic\UserBundle\Entity\RoleRepository;
 use MauticPlugin\MauticCrmBundle\Integration\SalesforceIntegration;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Rule\AnyInvokedCount;
 
 final class SalesforceIntegrationTest extends AbstractIntegrationTestCase
 {
@@ -734,14 +735,16 @@ final class SalesforceIntegrationTest extends AbstractIntegrationTestCase
                 }
             );
 
+        $matcher = new AnyInvokedCount();
+
         $this->integrationEntityRepository
-            ->expects($spy = $this->any())
+            ->expects($matcher)
             ->method('getIntegrationsEntityId')
             ->willReturnCallback(
-                function () use ($spy): array {
+                function () use ($matcher): array {
                     // WARNING: this is using a PHPUnit undocumented workaround:
                     // https://github.com/sebastianbergmann/phpunit/issues/3888
-                    $spyParentProperties = $this->getParentPrivateProperties($spy);
+                    $spyParentProperties = $this->getParentPrivateProperties($matcher);
                     $invocations         = $spyParentProperties['invocations'];
 
                     if (count($invocations) > $this->getMaxInvocations('getIntegrationsEntityId')) {

--- a/plugins/MauticFocusBundle/Tests/EventListener/LeadSubscriberTest.php
+++ b/plugins/MauticFocusBundle/Tests/EventListener/LeadSubscriberTest.php
@@ -16,6 +16,7 @@ use MauticPlugin\MauticFocusBundle\FocusEventTypes;
 use MauticPlugin\MauticFocusBundle\Model\FocusModel;
 use PHPUnit\Framework\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Rule\AnyInvokedCount;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Routing\RouterInterface;
 
@@ -47,7 +48,8 @@ final class LeadSubscriberTest extends CommonMocks
         $this->translator     = $this->createMock(Translator::class);
         $this->focusModel     = $this->createMock(FocusModel::class);
         $this->statRepository = $this->createMock(StatRepository::class);
-        $matcher              = $this->any();
+
+        $matcher              =  new AnyInvokedCount();
 
         $this->translator->expects($matcher)
             ->method('trans')->willReturnCallback(function (...$parameters) use ($matcher): string {

--- a/plugins/MauticFocusBundle/Tests/Unit/Helper/TokenHelperTest.php
+++ b/plugins/MauticFocusBundle/Tests/Unit/Helper/TokenHelperTest.php
@@ -12,6 +12,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Routing\RouterInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class TokenHelperTest extends TestCase
 {
     /**

--- a/plugins/MauticGmailBundle/Tests/Unit/Form/Type/GmailKeysTypeTest.php
+++ b/plugins/MauticGmailBundle/Tests/Unit/Form/Type/GmailKeysTypeTest.php
@@ -11,6 +11,7 @@ use Symfony\Component\Form\PreloadedExtension;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\Validator\Validation;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class GmailKeysTypeTest extends TypeTestCase
 {
     /**

--- a/rector.php
+++ b/rector.php
@@ -57,9 +57,6 @@ return RectorConfig::configure()
         // handle later
         Rector\PHPUnit\PHPUnit120\Rector\Class_\AllowMockObjectsForDataProviderRector::class,
 
-        PHPUnit\Metadata\DoesNotPerformAssertions::class => [
-            __DIR__.'/app/bundles/CoreBundle/Tests/Twig/TwigIntegrationTestTrait.php',
-        ],
         Rector\PHPUnit\PHPUnit60\Rector\ClassMethod\AddDoesNotPerformAssertionToNonAssertingTestRector::class => [
             __DIR__.'/app/bundles/CoreBundle/Tests/Twig/TwigIntegrationTestTrait.php',
         ],
@@ -68,15 +65,9 @@ return RectorConfig::configure()
         Rector\Symfony\Symfony73\Rector\Class_\GetFiltersToAsTwigFilterAttributeRector::class,
         Rector\Symfony\Symfony73\Rector\Class_\GetFunctionsToAsTwigFunctionAttributeRector::class,
 
-        Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector::class,
         Rector\EarlyReturn\Rector\If_\ChangeIfElseValueAssignToEarlyReturnRector::class,
         Rector\EarlyReturn\Rector\If_\RemoveAlwaysElseRector::class,
         Rector\PHPUnit\PHPUnit60\Rector\ClassMethod\AddDoesNotPerformAssertionToNonAssertingTestRector::class,
-
-        // intentional parent property assign override
-        Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector::class => [
-            __DIR__.'/app/bundles/ApiBundle/Entity/oAuth2/Client.php',
-        ],
 
         // handle next
         Rector\PHPUnit\PHPUnit120\Rector\Class_\AllowMockObjectsWithoutExpectationsAttributeRector::class,
@@ -86,10 +77,6 @@ return RectorConfig::configure()
         Rector\Symfony\CodeQuality\Rector\Class_\LoadValidatorMetadataToAttributeRector::class,
         Utils\Rector\ModelGetRepositoryToRepositoryServiceRector::class => [
             __DIR__.'/app/bundles/PageBundle/Form/Type/PreferenceCenterListType.php',
-        ],
-
-        Rector\TypeDeclaration\Rector\ClassMethod\AddParamTypeDeclarationRector::class => [
-            __DIR__.'/app/bundles/LeadBundle/Tests/Form/Type/FilterTypeTest.php',
         ],
 
         // preference to compare null over object

--- a/rector.php
+++ b/rector.php
@@ -76,7 +76,7 @@ return RectorConfig::configure()
         ],
 
         // handle next
-        \Rector\PHPUnit\PHPUnit120\Rector\Class_\AllowMockObjectsWithoutExpectationsAttributeRector::class,
+        Rector\PHPUnit\PHPUnit120\Rector\Class_\AllowMockObjectsWithoutExpectationsAttributeRector::class,
 
         Rector\EarlyReturn\Rector\Return_\PreparedValueToEarlyReturnRector::class,
         Rector\EarlyReturn\Rector\StmtsAwareInterface\ReturnEarlyIfVariableRector::class,

--- a/rector.php
+++ b/rector.php
@@ -54,6 +54,9 @@ return RectorConfig::configure()
     ->reportUnusedSkips()
     ->withComposerBased(phpunit: true, symfony: true)
     ->withSkip([
+        // handle later
+        Rector\PHPUnit\PHPUnit120\Rector\Class_\AllowMockObjectsForDataProviderRector::class,
+
         PHPUnit\Metadata\DoesNotPerformAssertions::class => [
             __DIR__.'/app/bundles/CoreBundle/Tests/Twig/TwigIntegrationTestTrait.php',
         ],

--- a/rector.php
+++ b/rector.php
@@ -76,6 +76,8 @@ return RectorConfig::configure()
         ],
 
         // handle next
+        \Rector\PHPUnit\PHPUnit120\Rector\Class_\AllowMockObjectsWithoutExpectationsAttributeRector::class,
+
         Rector\EarlyReturn\Rector\Return_\PreparedValueToEarlyReturnRector::class,
         Rector\EarlyReturn\Rector\StmtsAwareInterface\ReturnEarlyIfVariableRector::class,
         Rector\Symfony\CodeQuality\Rector\Class_\LoadValidatorMetadataToAttributeRector::class,


### PR DESCRIPTION
What's the motivation to bump to PHPUnit 12?

* we used PHPUnit 11, as we run PHP 8.2 and going to PHPUnit 12 needs PHPUnit 8.3+
* we require PHP 8.4 now, which open PHPUnit 13 min version - this is pre-condition
* newer PHPUnit versions tend to have more precise testing and report weird structures early - e.g. using data provider to hack around `setUp()` object construction
* PHPUnit 12 and 13 are more strict, they report weird tests and hacks and make testing more straightfowards :tada: 
* more precise tests are easeir to replicate by both dev and agents 
* better do the upgrade while we're at it, as PHPUnit is one of the biggest surpsigin pains to start upgrading - random asserts removed, random asserts added in every new version

There is a huge shift in enforcing stubs vs mocks https://getrector.com/blog/upgrade-to-phpunit-125-in-7-diffs (I've done couple PRs to prepare for it)


---

The `#[AllowMockObjectsWithoutExpectations]` must be used above classes that extend 3rd party that mocks objects, but allow 0-n expectations. This is now reported by PHPUnit as error. It's possible 3rd party packages will ignore this in `phpunit.xml`, but I'd recommend to avoid it and rather improve tests to be alligned :+1: 

It's possible PHPUnit 15 will hard-require to always use stubs vs mocks strictly without fallback, and this will be a painful blocker. Better handle sooner than pile-up technical debt we know about and tool is clearly reporting :+1: 