### PR TITLE
[types] [bc-break] apply type changes on *Common classes to be extended

### DIFF
--- a/app/bundles/ApiBundle/Controller/CommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/CommonApiController.php
@@ -388,12 +388,8 @@ class CommonApiController extends FetchCommonApiController
      * Convert posted parameters into what the form needs in order to successfully bind.
      *
      * @param mixed[] $parameters
-     * @param object  $entity
-     * @param string  $action
-     *
-     * @return mixed
      */
-    protected function prepareParametersForBinding(Request $request, $parameters, $entity, $action)
+    protected function prepareParametersForBinding(Request $request, array $parameters, object $entity, string $action): array
     {
         return $parameters;
     }

--- a/app/bundles/ApiBundle/Controller/CommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/CommonApiController.php
@@ -72,10 +72,8 @@ class CommonApiController extends FetchCommonApiController
 
     /**
      * Delete a batch of entities.
-     *
-     * @return array|Response
      */
-    public function deleteEntitiesAction(Request $request)
+    public function deleteEntitiesAction(Request $request): Response
     {
         $parameters = $request->query->all();
 
@@ -163,10 +161,8 @@ class CommonApiController extends FetchCommonApiController
 
     /**
      * Edit a batch of entities.
-     *
-     * @return array|Response
      */
-    public function editEntitiesAction(Request $request)
+    public function editEntitiesAction(Request $request): Response
     {
         $parameters = $request->request->all();
 
@@ -268,10 +264,8 @@ class CommonApiController extends FetchCommonApiController
 
     /**
      * Create a batch of new entities.
-     *
-     * @return array|Response
      */
-    public function newEntitiesAction(Request $request)
+    public function newEntitiesAction(Request $request): Response
     {
         $entity = $this->model->getEntity();
 
@@ -408,7 +402,7 @@ class CommonApiController extends FetchCommonApiController
      * @param mixed[] $errors
      * @param mixed[] $entities
      */
-    protected function processBatchForm(Request $request, $key, $entity, $params, $method, &$errors, &$entities)
+    protected function processBatchForm(Request $request, $key, $entity, $params, $method, array &$errors, array &$entities)
     {
         $this->inBatchMode = true;
         $formResponse      = $this->processForm($request, $entity, $params, $method);

--- a/app/bundles/ApiBundle/Controller/CommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/CommonApiController.php
@@ -388,10 +388,8 @@ class CommonApiController extends FetchCommonApiController
      * Convert posted parameters into what the form needs in order to successfully bind.
      *
      * @param mixed[] $parameters
-     *
-     * @return mixed[]|Response
      */
-    protected function prepareParametersForBinding(Request $request, array $parameters, object $entity, string $action)
+    protected function prepareParametersForBinding(Request $request, array $parameters, object $entity, string $action): array|Response
     {
         return $parameters;
     }

--- a/app/bundles/ApiBundle/Controller/CommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/CommonApiController.php
@@ -388,8 +388,10 @@ class CommonApiController extends FetchCommonApiController
      * Convert posted parameters into what the form needs in order to successfully bind.
      *
      * @param mixed[] $parameters
+     *
+     * @return mixed[]|Response
      */
-    protected function prepareParametersForBinding(Request $request, array $parameters, object $entity, string $action): array
+    protected function prepareParametersForBinding(Request $request, array $parameters, object $entity, string $action)
     {
         return $parameters;
     }

--- a/app/bundles/ApiBundle/Controller/FetchCommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/FetchCommonApiController.php
@@ -29,14 +29,13 @@ use Mautic\CoreBundle\Model\MauticModelInterface;
 use Mautic\CoreBundle\Security\Exception\PermissionException;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\CoreBundle\Translation\Translator;
-use Symfony\Component\DependencyInjection\ParameterBag\ContainerBagInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
- * @template E of object
+ * @template TEntity of object
  */
 class FetchCommonApiController extends AbstractFOSRestController implements MauticController
 {
@@ -45,88 +44,73 @@ class FetchCommonApiController extends AbstractFOSRestController implements Maut
 
     /**
      * If set to true, serializer will not return null values.
-     *
-     * @var bool
      */
-    protected $customSelectRequested = false;
+    protected bool $customSelectRequested = false;
 
     /**
      * Class for the entity.
      *
-     * @var class-string<E>
+     * @var string|class-string<TEntity>
      */
-    protected $entityClass;
+    protected string $entityClass = '';
 
     /**
      * Key to return for entity lists.
-     *
-     * @var string
      */
-    protected $entityNameMulti;
+    protected string $entityNameMulti;
 
     /**
      * Key to return for a single entity.
-     *
-     * @var string
      */
-    protected $entityNameOne;
+    protected string $entityNameOne;
 
     /**
      * Custom JMS strategies to add to the view's context.
      *
      * @var array<int, ExclusionStrategyInterface>
      */
-    protected $exclusionStrategies = [];
+    protected array $exclusionStrategies = [];
 
     /**
      * Pass to the model's getEntities() method.
      *
      * @var array<mixed>
      */
-    protected $extraGetEntitiesArguments = [];
+    protected array $extraGetEntitiesArguments = [];
 
-    /**
-     * @var bool
-     */
-    protected $inBatchMode = false;
+    protected bool $inBatchMode = false;
 
     /**
      * Used to set default filters for entity lists such as restricting to owning user.
      *
      * @var array<array<string, mixed>>
      */
-    protected $listFilters = [];
+    protected array $listFilters = [];
 
     /**
      * Model object for processing the entity.
      *
-     * @var AbstractCommonModel<E>|null
+     * @var AbstractCommonModel<TEntity>|null
      */
     protected $model;
 
     /**
      * The level parent/children should stop loading if applicable.
-     *
-     * @var int
      */
-    protected $parentChildrenLevelDepth = 3;
+    protected int $parentChildrenLevelDepth = 3;
 
     /**
      * Permission base for the entity such as page:pages.
-     *
-     * @var string|null
      */
-    protected $permissionBase;
+    protected ?string $permissionBase = null;
 
     /**
      * @var array<int, string>
      */
-    protected $serializerGroups = [];
-
-    protected ContainerBagInterface $parametersContainer;
+    protected array $serializerGroups = [];
 
     /**
-     * @param ModelFactory<E> $modelFactory
+     * @param ModelFactory<TEntity> $modelFactory
      */
     public function __construct(
         protected CorePermissions $security,
@@ -144,7 +128,7 @@ class FetchCommonApiController extends AbstractFOSRestController implements Maut
         }
 
         $event = new ApiInitializeEvent(
-            (string) $this->entityClass,
+            $this->entityClass,
             $this->serializerGroups,
             $this->exclusionStrategies,
         );
@@ -495,7 +479,7 @@ class FetchCommonApiController extends AbstractFOSRestController implements Maut
     /**
      * Get the default properties of an entity and parents.
      *
-     * @param E $entity
+     * @param TEntity $entity
      *
      * @return array<mixed>
      */
@@ -556,7 +540,7 @@ class FetchCommonApiController extends AbstractFOSRestController implements Maut
     /**
      * Gives child controllers opportunity to analyze and do whatever to an entity before going through serializer.
      *
-     * @param E $entity
+     * @param TEntity $entity
      */
     protected function preSerializeEntity(object $entity, string $action = 'view'): void
     {
@@ -565,7 +549,7 @@ class FetchCommonApiController extends AbstractFOSRestController implements Maut
     /**
      * Prepares entities returned from repository getEntities().
      *
-     * @param array<mixed>|Paginator<E> $results
+     * @param array<mixed>|Paginator<TEntity> $results
      *
      * @return array{0: array<mixed>|\ArrayObject<int,mixed>, 1: int}
      */
@@ -580,8 +564,8 @@ class FetchCommonApiController extends AbstractFOSRestController implements Maut
     }
 
     /**
-     * @param array<mixed>|Paginator<E> $results
-     * @param callable|null             $callback
+     * @param array<mixed>|Paginator<TEntity> $results
+     * @param callable|null                   $callback
      *
      * @return array{0: array<mixed>|\ArrayObject<int,mixed>, 1: int}
      */
@@ -651,8 +635,8 @@ class FetchCommonApiController extends AbstractFOSRestController implements Maut
 
     /**
      * @param array<int, array<string|int>> $errors
-     * @param E|null                        $entity
-     * @param array<int, E|null>            $entities
+     * @param TEntity|null                  $entity
+     * @param array<int, TEntity|null>      $entities
      */
     protected function setBatchError(int $key, string $msg, int $code, array &$errors, array &$entities = [], ?object $entity = null): void
     {

--- a/app/bundles/ApiBundle/Controller/FetchCommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/FetchCommonApiController.php
@@ -156,10 +156,8 @@ class FetchCommonApiController extends AbstractFOSRestController implements Maut
 
     /**
      * Obtains a list of entities as defined by the API URL.
-     *
-     * @return Response
      */
-    public function getEntitiesAction(Request $request, UserHelper $userHelper)
+    public function getEntitiesAction(Request $request, UserHelper $userHelper): Response
     {
         $repo          = $this->model->getRepository();
         $tableAlias    = $repo->getTableAlias();
@@ -305,10 +303,8 @@ class FetchCommonApiController extends AbstractFOSRestController implements Maut
      * Obtains a specific entity as defined by the API URL.
      *
      * @param int $id Entity ID
-     *
-     * @return Response
      */
-    public function getEntityAction(Request $request, $id)
+    public function getEntityAction(Request $request, $id): Response
     {
         $args = [];
         if ($select = InputHelper::cleanArray($request->get('select', []))) {
@@ -376,11 +372,9 @@ class FetchCommonApiController extends AbstractFOSRestController implements Maut
     /**
      * Returns a 403 Access Denied.
      *
-     * @param string $msg
-     *
      * @return Response
      */
-    protected function accessDenied($msg = 'mautic.core.error.accessdenied')
+    protected function accessDenied(string $msg = 'mautic.core.error.accessdenied')
     {
         return $this->returnError($msg, Response::HTTP_FORBIDDEN);
     }
@@ -393,11 +387,9 @@ class FetchCommonApiController extends AbstractFOSRestController implements Maut
     /**
      * Returns a 400 Bad Request.
      *
-     * @param string $msg
-     *
      * @return Response
      */
-    protected function badRequest($msg = 'mautic.core.error.badrequest')
+    protected function badRequest(string $msg = 'mautic.core.error.badrequest')
     {
         return $this->returnError($msg, Response::HTTP_BAD_REQUEST);
     }
@@ -442,7 +434,7 @@ class FetchCommonApiController extends AbstractFOSRestController implements Maut
      *
      * @return mixed[]
      */
-    protected function getBatchEntities($parameters, &$errors, $prepareForSerialization = false, $requestIdColumn = 'id', $model = null, $returnWithOriginalKeys = true): array
+    protected function getBatchEntities($parameters, array &$errors, $prepareForSerialization = false, $requestIdColumn = 'id', $model = null, $returnWithOriginalKeys = true): array
     {
         $idHelper = new BatchIdToEntityHelper($parameters, $requestIdColumn);
 

--- a/app/bundles/AssetBundle/Controller/Api/AssetApiController.php
+++ b/app/bundles/AssetBundle/Controller/Api/AssetApiController.php
@@ -71,10 +71,8 @@ final class AssetApiController extends CommonApiController
 
     /**
      * Convert posted parameters into what the form needs in order to successfully bind.
-     *
-     * @return mixed
      */
-    protected function prepareParametersForBinding(Request $request, $parameters, $entity, $action)
+    protected function prepareParametersForBinding(Request $request, array $parameters, object $entity, string $action): array
     {
         $assetDir = $this->parametersHelper->get('upload_dir');
         $entity->setUploadDir($assetDir);

--- a/app/bundles/AssetBundle/Controller/Api/AssetApiController.php
+++ b/app/bundles/AssetBundle/Controller/Api/AssetApiController.php
@@ -71,8 +71,10 @@ final class AssetApiController extends CommonApiController
 
     /**
      * Convert posted parameters into what the form needs in order to successfully bind.
+     *
+     * @return mixed[]|Response
      */
-    protected function prepareParametersForBinding(Request $request, array $parameters, object $entity, string $action): array
+    protected function prepareParametersForBinding(Request $request, array $parameters, object $entity, string $action)
     {
         $assetDir = $this->parametersHelper->get('upload_dir');
         $entity->setUploadDir($assetDir);

--- a/app/bundles/AssetBundle/Controller/Api/AssetApiController.php
+++ b/app/bundles/AssetBundle/Controller/Api/AssetApiController.php
@@ -71,10 +71,8 @@ final class AssetApiController extends CommonApiController
 
     /**
      * Convert posted parameters into what the form needs in order to successfully bind.
-     *
-     * @return mixed[]|Response
      */
-    protected function prepareParametersForBinding(Request $request, array $parameters, object $entity, string $action)
+    protected function prepareParametersForBinding(Request $request, array $parameters, object $entity, string $action): array|Response
     {
         $assetDir = $this->parametersHelper->get('upload_dir');
         $entity->setUploadDir($assetDir);

--- a/app/bundles/CampaignBundle/Controller/CampaignController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignController.php
@@ -570,7 +570,7 @@ class CampaignController extends AbstractStandardFormController
      * @param Campaign $campaign
      * @param Campaign $oldCampaign
      */
-    protected function afterEntityClone($campaign, $oldCampaign)
+    protected function afterEntityClone($campaign, $oldCampaign): array
     {
         $tempId   = 'mautic_'.sha1(uniqid(mt_rand(), true));
         $objectId = $oldCampaign->getId();
@@ -1072,10 +1072,8 @@ class CampaignController extends AbstractStandardFormController
 
     /**
      * @param bool $isClone
-     *
-     * @return array
      */
-    protected function prepareCampaignEventsForEdit($entity, $objectId, $isClone = false)
+    protected function prepareCampaignEventsForEdit($entity, $objectId, $isClone = false): array
     {
         // load existing events into session
         $campaignEvents = [];

--- a/app/bundles/CampaignBundle/Entity/LeadRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadRepository.php
@@ -428,10 +428,7 @@ class LeadRepository extends CommonRepository
         return $contacts;
     }
 
-    /**
-     * @param int $campaignId
-     */
-    public function getCountsForOrphanedContactsBySegments($campaignId, ContactLimiter $limiter): CountResult
+    public function getCountsForOrphanedContactsBySegments(?int $campaignId, ContactLimiter $limiter): CountResult
     {
         $segments = $this->getCampaignSegments($campaignId);
 
@@ -454,7 +451,7 @@ class LeadRepository extends CommonRepository
         return new CountResult($result['the_count'], $result['min_id'], $result['max_id']);
     }
 
-    public function getOrphanedContacts($campaignId, ContactLimiter $limiter): array
+    public function getOrphanedContacts(?int $campaignId, ContactLimiter $limiter): array
     {
         $segments = $this->getCampaignSegments($campaignId);
 

--- a/app/bundles/CoreBundle/Controller/AbstractFormController.php
+++ b/app/bundles/CoreBundle/Controller/AbstractFormController.php
@@ -14,10 +14,7 @@ abstract class AbstractFormController extends CommonController
 {
     protected ?string $permissionBase = null;
 
-    /**
-     * @param string $objectModel
-     */
-    public function unlockAction(Request $request, $objectId, $objectModel): RedirectResponse
+    public function unlockAction(Request $request, $objectId, string $objectModel): RedirectResponse
     {
         $model                = $this->getModel($objectModel);
         $entity               = $model->getEntity($objectId);
@@ -61,12 +58,11 @@ abstract class AbstractFormController extends CommonController
      *
      * @param array  $postActionVars
      * @param object $entity
-     * @param string $model
      * @param bool   $batch          Flag if a batch action is being performed
      *
      * @return ($batch is true ? array : \Symfony\Component\HttpFoundation\JsonResponse|RedirectResponse)
      */
-    protected function isLocked($postActionVars, $entity, $model, $batch = false)
+    protected function isLocked($postActionVars, $entity, string $model, $batch = false)
     {
         $date                   = $entity->getCheckedOut();
         $postActionVars         = $this->refererPostActionVars($postActionVars);

--- a/app/bundles/CoreBundle/Controller/AbstractFormController.php
+++ b/app/bundles/CoreBundle/Controller/AbstractFormController.php
@@ -16,10 +16,8 @@ abstract class AbstractFormController extends CommonController
 
     /**
      * @param string $objectModel
-     *
-     * @return RedirectResponse
      */
-    public function unlockAction(Request $request, $objectId, $objectModel)
+    public function unlockAction(Request $request, $objectId, $objectModel): RedirectResponse
     {
         $model                = $this->getModel($objectModel);
         $entity               = $model->getEntity($objectId);
@@ -222,7 +220,7 @@ abstract class AbstractFormController extends CommonController
      *
      * @return array
      */
-    protected function refererPostActionVars($vars)
+    protected function refererPostActionVars(array $vars)
     {
         $request = $this->getCurrentRequest();
         if (empty($request->server->get('HTTP_REFERER'))) {

--- a/app/bundles/CoreBundle/Controller/AbstractStandardFormController.php
+++ b/app/bundles/CoreBundle/Controller/AbstractStandardFormController.php
@@ -649,10 +649,8 @@ abstract class AbstractStandardFormController extends AbstractFormController
 
     /**
      * Provide the direction for default ordering.
-     *
-     * @return string
      */
-    protected function getDefaultOrderDirection()
+    protected function getDefaultOrderDirection(): string
     {
         return 'ASC';
     }
@@ -1144,7 +1142,7 @@ abstract class AbstractStandardFormController extends AbstractFormController
         );
     }
 
-    protected function getDataForExport(AbstractCommonModel $model, array $args, ?callable $resultsCallback = null, ?int $start = 0)
+    protected function getDataForExport(AbstractCommonModel $model, array $args, ?callable $resultsCallback = null, ?int $start = 0): ?array
     {
         return parent::getDataForExport($model, $args, $resultsCallback, $start);
     }

--- a/app/bundles/CoreBundle/Controller/AjaxLookupControllerTrait.php
+++ b/app/bundles/CoreBundle/Controller/AjaxLookupControllerTrait.php
@@ -77,11 +77,9 @@ trait AjaxLookupControllerTrait
     /**
      * Get a model instance from the service container.
      *
-     * @param string $modelNameKey
-     *
      * @return AbstractCommonModel<object>
      */
-    abstract protected function getModel($modelNameKey): MauticModelInterface;
+    abstract protected function getModel(string $modelNameKey): MauticModelInterface;
 
     /**
      * Get's the content of error page.

--- a/app/bundles/CoreBundle/Controller/CommonController.php
+++ b/app/bundles/CoreBundle/Controller/CommonController.php
@@ -115,8 +115,6 @@ class CommonController extends AbstractController implements MauticController
      *
      * For long return map @see https://phpstan.org/blog/phpstan-1-6-0-with-conditional-return-types
      *
-     * @param string $modelNameKey
-     *
      * @return ($modelNameKey is 'asset' ? \Mautic\AssetBundle\Model\AssetModel
      * : ($modelNameKey is 'campaign' ? \Mautic\CampaignBundle\Model\CampaignModel
      * : ($modelNameKey is 'campaign.event' ? \Mautic\CampaignBundle\Model\EventModel
@@ -168,7 +166,7 @@ class CommonController extends AbstractController implements MauticController
      * : ($modelNameKey is 'webhook' ? \Mautic\WebhookBundle\Model\WebhookModel
      *     : \Mautic\CoreBundle\Model\AbstractCommonModel<object>)))))))))))))))))))))))))))))))))))))))))))))))))
      */
-    protected function getModel($modelNameKey): MauticModelInterface
+    protected function getModel(string $modelNameKey): MauticModelInterface
     {
         return $this->modelFactory->getModel($modelNameKey);
     }
@@ -183,7 +181,7 @@ class CommonController extends AbstractController implements MauticController
      *
      * @return Response A Response instance
      */
-    public function forwardWithPost($controller, array $request = [], array $path = [], array $query = [])
+    public function forwardWithPost($controller, array $request = [], array $path = [], array $query = []): Response
     {
         $path['_controller'] = $controller;
         $subRequest          = $this->requestStack->getCurrentRequest()->duplicate($query, $request, $path);
@@ -281,7 +279,7 @@ class CommonController extends AbstractController implements MauticController
      * Determines if a redirect response should be returned or a Json response directing the ajax call to force a page
      * refresh.
      */
-    public function delegateRedirect($url): JsonResponse|RedirectResponse
+    public function delegateRedirect(string $url): JsonResponse|RedirectResponse
     {
         $request = $this->getCurrentRequest();
 
@@ -353,7 +351,7 @@ class CommonController extends AbstractController implements MauticController
      *
      * @param array $args [parameters, contentTemplate, passthroughVars, forwardController]
      */
-    public function ajaxAction(Request $request, $args = []): Response
+    public function ajaxAction(Request $request, array $args = []): Response
     {
         defined('MAUTIC_AJAX_VIEW') || define('MAUTIC_AJAX_VIEW', 1);
 
@@ -496,10 +494,8 @@ class CommonController extends AbstractController implements MauticController
      * @param int    $objectId
      * @param int    $objectSubId
      * @param string $objectModel
-     *
-     * @return Response
      */
-    public function executeAction(Request $request, $objectAction, $objectId = 0, $objectSubId = 0, $objectModel = '')
+    public function executeAction(Request $request, $objectAction, $objectId = 0, $objectSubId = 0, $objectModel = ''): Response
     {
         if (method_exists($this, $objectAction.'Action')) {
             return $this->forward(
@@ -549,7 +545,7 @@ class CommonController extends AbstractController implements MauticController
      *
      * @throws AccessDeniedHttpException
      */
-    public function accessDenied($batch = false, $msg = 'mautic.core.url.error.401'): array
+    public function accessDenied($batch = false, string $msg = 'mautic.core.url.error.401'): array
     {
         if ($this->security->isAnonymous() || !$batch) {
             $this->throwAccessDenied($msg);
@@ -561,11 +557,9 @@ class CommonController extends AbstractController implements MauticController
     /**
      * Generate 404 not found message.
      *
-     * @param string $msg
-     *
      * @return Response
      */
-    public function notFound($msg = 'mautic.core.url.error.404')
+    public function notFound(string $msg = 'mautic.core.url.error.404')
     {
         $request = $this->getCurrentRequest();
         $page404 = $this->coreParametersHelper->get('404_page');
@@ -598,10 +592,8 @@ class CommonController extends AbstractController implements MauticController
 
     /**
      * Returns a json encoded access denied error for modal windows.
-     *
-     * @param string $msg
      */
-    public function modalAccessDenied($msg = 'mautic.core.error.accessdenied'): JsonResponse
+    public function modalAccessDenied(string $msg = 'mautic.core.error.accessdenied'): JsonResponse
     {
         return new JsonResponse([
             'error' => $this->translator->trans($msg, [], 'flashes'),
@@ -704,7 +696,7 @@ class CommonController extends AbstractController implements MauticController
      * @param string|null  $domain
      * @param bool|null    $addNotification
      */
-    public function addFlashMessage($message, $messageVars = [], $level = FlashBag::LEVEL_NOTICE, $domain = 'flashes', $addNotification = false): void
+    public function addFlashMessage($message, array $messageVars = [], $level = FlashBag::LEVEL_NOTICE, $domain = 'flashes', $addNotification = false): void
     {
         $this->flashBag->add($message, $messageVars, $level, $domain, $addNotification);
     }
@@ -734,20 +726,15 @@ class CommonController extends AbstractController implements MauticController
      * Overwrite in your controller if required.
      *
      * @param AbstractCommonModel<object> $model
-     *
-     * @return array
      */
-    protected function getDataForExport(AbstractCommonModel $model, array $args, ?callable $resultsCallback = null, ?int $start = 0)
+    protected function getDataForExport(AbstractCommonModel $model, array $args, ?callable $resultsCallback = null, ?int $start = 0): ?array
     {
         $data = new DataExporterHelper();
 
         return $data->getDataForExport($start, $model, $args, $resultsCallback);
     }
 
-    /**
-     * @return string
-     */
-    protected function getDefaultOrderDirection()
+    protected function getDefaultOrderDirection(): string
     {
         return 'ASC';
     }

--- a/app/bundles/CoreBundle/Controller/CommonController.php
+++ b/app/bundles/CoreBundle/Controller/CommonController.php
@@ -469,10 +469,8 @@ class CommonController extends AbstractController implements MauticController
 
     /**
      * Get's the content of error page.
-     *
-     * @return Response
      */
-    public function renderException(\Exception $e)
+    public function renderException(\Exception $e): Response
     {
         $request = $this->getCurrentRequest();
 

--- a/app/bundles/CoreBundle/Controller/FormController.php
+++ b/app/bundles/CoreBundle/Controller/FormController.php
@@ -73,18 +73,12 @@ class FormController extends AbstractStandardFormController
         return $this->deprecatedModelName;
     }
 
-    /**
-     * @return mixed
-     */
-    protected function getJsLoadMethodPrefix()
+    protected function getJsLoadMethodPrefix(): ?string
     {
         return $this->deprecatedMauticContent;
     }
 
-    /**
-     * @return mixed
-     */
-    protected function getRouteBase()
+    protected function getRouteBase(): ?string
     {
         return $this->deprecatedRouteBase;
     }
@@ -97,26 +91,17 @@ class FormController extends AbstractStandardFormController
         return $this->deprecatedSessionBase ?? parent::getSessionBase($objectId);
     }
 
-    /**
-     * @return mixed
-     */
-    protected function getTemplateBase()
+    protected function getTemplateBase(): ?string
     {
         return $this->deprecatedTemplateBase;
     }
 
-    /**
-     * @return mixed
-     */
-    protected function getTranslationBase()
+    protected function getTranslationBase(): ?string
     {
         return $this->deprecatedTranslationBase;
     }
 
-    /**
-     * @return mixed
-     */
-    protected function getPermissionBase()
+    protected function getPermissionBase(): ?string
     {
         return $this->deprecatedPermissionBase;
     }

--- a/app/bundles/CoreBundle/Entity/CommonRepository.php
+++ b/app/bundles/CoreBundle/Entity/CommonRepository.php
@@ -136,7 +136,7 @@ class CommonRepository extends ServiceEntityRepository
      * @throws \Doctrine\ORM\Mapping\MappingException
      * @throws \Exception
      */
-    public function createFromArray($className, &$data): object
+    public function createFromArray($className, array &$data): object
     {
         $entity        = new $className();
         $meta          = $this->_em->getClassMetadata($className);
@@ -189,10 +189,9 @@ class CommonRepository extends ServiceEntityRepository
     /**
      * Delete an entity through the repository.
      *
-     * @param object $entity
-     * @param bool   $flush  true by default; use false if persisting in batches
+     * @param bool $flush true by default; use false if persisting in batches
      */
-    public function deleteEntity($entity, $flush = true): void
+    public function deleteEntity(object $entity, $flush = true): void
     {
         // delete entity
         $this->_em->remove($entity);
@@ -209,10 +208,7 @@ class CommonRepository extends ServiceEntityRepository
         }
     }
 
-    /**
-     * @param object $entity
-     */
-    public function detachEntity($entity): void
+    public function detachEntity(object $entity): void
     {
         $this->getEntityManager()->detach($entity);
     }
@@ -428,10 +424,7 @@ class CommonRepository extends ServiceEntityRepository
         return $entity;
     }
 
-    /**
-     * @return ExpressionBuilder
-     */
-    public function getExpressionBuilder()
+    public function getExpressionBuilder(): ExpressionBuilder
     {
         if (null === $this->expressionBuilder) {
             $this->expressionBuilder = new ExpressionBuilder();
@@ -816,10 +809,9 @@ class CommonRepository extends ServiceEntityRepository
     /**
      * Save an entity through the repository.
      *
-     * @param object $entity
-     * @param bool   $flush  true by default; use false if persisting in batches
+     * @param bool $flush true by default; use false if persisting in batches
      */
-    public function saveEntity($entity, $flush = true): void
+    public function saveEntity(object $entity, $flush = true): void
     {
         $this->getEntityManager()->persist($entity);
 
@@ -940,11 +932,9 @@ class CommonRepository extends ServiceEntityRepository
      *
      * @param array $clause ['col' => 'column_a', 'dir' => 'ASC']
      *
-     * @return array
-     *
      * @throws \InvalidArgumentException
      */
-    protected function validateOrderByClause($clause)
+    protected function validateOrderByClause(array $clause): array
     {
         $msg = '"%s" is missing in the order by clause array.';
         if (empty($clause['col'])) {
@@ -1794,11 +1784,8 @@ class CommonRepository extends ServiceEntityRepository
 
     /**
      * Sanitizes a string to alphanum plus characters in the second argument.
-     *
-     * @param string $sqlAttr
-     * @param array  $allowedCharacters
      */
-    protected function sanitize($sqlAttr, $allowedCharacters = []): string
+    protected function sanitize(string $sqlAttr, array $allowedCharacters = []): string
     {
         return InputHelper::alphanum($sqlAttr, false, null, $allowedCharacters);
     }

--- a/app/bundles/CoreBundle/Security/Permissions/AbstractPermissions.php
+++ b/app/bundles/CoreBundle/Security/Permissions/AbstractPermissions.php
@@ -183,11 +183,10 @@ abstract class AbstractPermissions
     /**
      * Determines if the user has access to the specified permission.
      *
-     * @param array  $userPermissions
      * @param string $name
      * @param string $level
      */
-    public function isGranted($userPermissions, $name, $level): bool
+    public function isGranted(array $userPermissions, $name, $level): bool
     {
         [$name, $level] = $this->getSynonym($name, $level);
 
@@ -357,10 +356,9 @@ abstract class AbstractPermissions
      * @param string               $bundle
      * @param string               $level
      * @param FormBuilderInterface $builder
-     * @param array                $data
      * @param bool                 $includePublish
      */
-    protected function addStandardFormFields($bundle, $level, &$builder, $data, $includePublish = true)
+    protected function addStandardFormFields($bundle, $level, &$builder, array $data, $includePublish = true)
     {
         $choices = [
             'mautic.core.permissions.view'   => 'view',
@@ -424,9 +422,8 @@ abstract class AbstractPermissions
      * @param string               $bundle
      * @param string               $level
      * @param FormBuilderInterface $builder
-     * @param array                $data
      */
-    protected function addManageFormFields($bundle, $level, &$builder, $data)
+    protected function addManageFormFields($bundle, $level, &$builder, array $data)
     {
         $choices = [
             'mautic.core.permissions.manage' => 'manage',
@@ -483,10 +480,9 @@ abstract class AbstractPermissions
      * @param string               $bundle
      * @param string               $level
      * @param FormBuilderInterface $builder
-     * @param array                $data
      * @param bool                 $includePublish
      */
-    protected function addExtendedFormFields($bundle, $level, &$builder, $data, $includePublish = true)
+    protected function addExtendedFormFields($bundle, $level, &$builder, array $data, $includePublish = true)
     {
         $choices = [
             'mautic.core.permissions.viewown'     => 'viewown',

--- a/app/bundles/CoreBundle/Tests/Functional/Security/Permissions/CorePermissionsTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Security/Permissions/CorePermissionsTest.php
@@ -58,7 +58,7 @@ final class CorePermissionsTest extends MauticMysqlTestCase
             /**
              * @param mixed[] $userPermissions
              */
-            public function isGranted($userPermissions, $name, $level): bool
+            public function isGranted(array $userPermissions, $name, $level): bool
             {
                 throw new \BadMethodCallException('This method should not be invoked.');
             }

--- a/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
+++ b/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
@@ -42,7 +42,7 @@ final class EmailApiController extends CommonApiController
     /**
      * @var array<string, mixed>
      */
-    protected $extraGetEntitiesArguments = ['ignoreListJoin' => true];
+    protected array $extraGetEntitiesArguments = ['ignoreListJoin' => true];
 
     public function __construct(
         CorePermissions $security,

--- a/app/bundles/EmailBundle/Security/Permissions/EmailPermissions.php
+++ b/app/bundles/EmailBundle/Security/Permissions/EmailPermissions.php
@@ -41,7 +41,7 @@ final class EmailPermissions extends AbstractPermissions
      * @param mixed[]              $data
      * @param bool                 $includePublish
      */
-    protected function addExtendedFormFields($bundle, $level, &$builder, $data, $includePublish = true): void
+    protected function addExtendedFormFields($bundle, $level, &$builder, array $data, $includePublish = true): void
     {
         $choices = [
             'mautic.core.permissions.viewown'     => 'viewown',

--- a/app/bundles/FormBundle/Entity/SubmissionRepository.php
+++ b/app/bundles/FormBundle/Entity/SubmissionRepository.php
@@ -21,7 +21,7 @@ class SubmissionRepository extends CommonRepository
      * @param Submission $entity
      * @param bool       $flush
      */
-    public function saveEntity($entity, $flush = true): void
+    public function saveEntity(object $entity, $flush = true): void
     {
         parent::saveEntity($entity, $flush);
 

--- a/app/bundles/InstallBundle/Helper/SchemaHelper.php
+++ b/app/bundles/InstallBundle/Helper/SchemaHelper.php
@@ -1,4 +1,4 @@
-r<?php
+<?php
 
 namespace Mautic\InstallBundle\Helper;
 

--- a/app/bundles/InstallBundle/Helper/SchemaHelper.php
+++ b/app/bundles/InstallBundle/Helper/SchemaHelper.php
@@ -1,4 +1,4 @@
-<?php
+r<?php
 
 namespace Mautic\InstallBundle\Helper;
 

--- a/app/bundles/IntegrationsBundle/Sync/SyncProcess/Direction/Integration/ObjectChangeGenerator.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncProcess/Direction/Integration/ObjectChangeGenerator.php
@@ -33,7 +33,7 @@ class ObjectChangeGenerator
         ObjectMappingDAO $objectMapping,
         ReportObjectDAO $internalObject,
         ReportObjectDAO $integrationObject,
-    ): \Mautic\IntegrationsBundle\Sync\DAO\Sync\Order\ObjectChangeDAO {
+    ): ObjectChangeDAO {
         $objectChange = new ObjectChangeDAO(
             $mappingManual->getIntegration(),
             $integrationObject->getObject(),

--- a/app/bundles/IntegrationsBundle/Sync/SyncProcess/Direction/Integration/ObjectChangeGenerator.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncProcess/Direction/Integration/ObjectChangeGenerator.php
@@ -25,8 +25,6 @@ class ObjectChangeGenerator
     }
 
     /**
-     * @return ObjectChangeDAO
-     *
      * @throws ObjectNotFoundException
      */
     public function getSyncObjectChange(
@@ -35,7 +33,7 @@ class ObjectChangeGenerator
         ObjectMappingDAO $objectMapping,
         ReportObjectDAO $internalObject,
         ReportObjectDAO $integrationObject,
-    ) {
+    ): \Mautic\IntegrationsBundle\Sync\DAO\Sync\Order\ObjectChangeDAO {
         $objectChange = new ObjectChangeDAO(
             $mappingManual->getIntegration(),
             $integrationObject->getObject(),

--- a/app/bundles/IntegrationsBundle/Sync/SyncProcess/Direction/Internal/ObjectChangeGenerator.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncProcess/Direction/Internal/ObjectChangeGenerator.php
@@ -43,8 +43,6 @@ class ObjectChangeGenerator
     }
 
     /**
-     * @return ObjectChangeDAO
-     *
      * @throws ObjectNotFoundException
      */
     public function getSyncObjectChange(
@@ -53,7 +51,7 @@ class ObjectChangeGenerator
         ObjectMappingDAO $objectMapping,
         ReportObjectDAO $internalObject,
         ReportObjectDAO $integrationObject,
-    ) {
+    ): \Mautic\IntegrationsBundle\Sync\DAO\Sync\Order\ObjectChangeDAO {
         $objectChange = new ObjectChangeDAO(
             $mappingManual->getIntegration(),
             $internalObject->getObject(),

--- a/app/bundles/IntegrationsBundle/Sync/SyncProcess/Direction/Internal/ObjectChangeGenerator.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncProcess/Direction/Internal/ObjectChangeGenerator.php
@@ -51,7 +51,7 @@ class ObjectChangeGenerator
         ObjectMappingDAO $objectMapping,
         ReportObjectDAO $internalObject,
         ReportObjectDAO $integrationObject,
-    ): \Mautic\IntegrationsBundle\Sync\DAO\Sync\Order\ObjectChangeDAO {
+    ): ObjectChangeDAO {
         $objectChange = new ObjectChangeDAO(
             $mappingManual->getIntegration(),
             $internalObject->getObject(),

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncProcess/Direction/Integration/ObjectChangeGeneratorTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncProcess/Direction/Integration/ObjectChangeGeneratorTest.php
@@ -54,7 +54,7 @@ final class ObjectChangeGeneratorTest extends TestCase
             $integrationReportObject
         );
 
-        $this->assertEquals($integration, $objectChangeDAO->getIntegration());
+        $this->assertSame($integration, $objectChangeDAO->getIntegration());
 
         // object and object ID should be the integrations (from the integration's POV)
         $this->assertEquals($objectName, $objectChangeDAO->getObject());
@@ -103,7 +103,7 @@ final class ObjectChangeGeneratorTest extends TestCase
             $integrationReportObject
         );
 
-        $this->assertEquals($integration, $objectChangeDAO->getIntegration());
+        $this->assertSame($integration, $objectChangeDAO->getIntegration());
 
         // object and object ID should be the integrations (from the integration's POV)
         $this->assertEquals($objectName, $objectChangeDAO->getObject());

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncProcess/Direction/Internal/ObjectChangeGeneratorTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncProcess/Direction/Internal/ObjectChangeGeneratorTest.php
@@ -78,7 +78,7 @@ final class ObjectChangeGeneratorTest extends TestCase
             $syncReport->getObject($objectName, 2)
         );
 
-        $this->assertEquals($integration, $objectChangeDAO->getIntegration());
+        $this->assertSame($integration, $objectChangeDAO->getIntegration());
 
         // object and object ID should be Mautic's (from the Mautic's POV)
         $this->assertEquals(Contact::NAME, $objectChangeDAO->getObject());
@@ -145,7 +145,7 @@ final class ObjectChangeGeneratorTest extends TestCase
             $syncReport->getObject($objectName, 2)
         );
 
-        $this->assertEquals($integration, $objectChangeDAO->getIntegration());
+        $this->assertSame($integration, $objectChangeDAO->getIntegration());
 
         // object and object ID should be Mautic's (from the Mautic's POV)
         $this->assertEquals(Contact::NAME, $objectChangeDAO->getObject());

--- a/app/bundles/LeadBundle/Controller/Api/CustomFieldsApiControllerTrait.php
+++ b/app/bundles/LeadBundle/Controller/Api/CustomFieldsApiControllerTrait.php
@@ -32,7 +32,7 @@ trait CustomFieldsApiControllerTrait
      *
      * @return mixed|void
      */
-    protected function prepareParametersForBinding(Request $request, $parameters, $entity, $action)
+    protected function prepareParametersForBinding(Request $request, array $parameters, $entity, $action): array
     {
         if ('company' === $this->entityNameOne) {
             $object = 'company';

--- a/app/bundles/LeadBundle/Controller/Api/CustomFieldsApiControllerTrait.php
+++ b/app/bundles/LeadBundle/Controller/Api/CustomFieldsApiControllerTrait.php
@@ -28,11 +28,10 @@ trait CustomFieldsApiControllerTrait
      *
      * @param mixed[]      $parameters
      * @param Lead|Company $entity
-     * @param string       $action
      *
-     * @return mixed|void
+     * @return mixed[]
      */
-    protected function prepareParametersForBinding(Request $request, array $parameters, $entity, $action): array
+    protected function prepareParametersForBinding(Request $request, array $parameters, object $entity, string $action): array
     {
         if ('company' === $this->entityNameOne) {
             $object = 'company';

--- a/app/bundles/LeadBundle/Controller/Api/FieldApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/FieldApiController.php
@@ -111,9 +111,9 @@ final class FieldApiController extends CommonApiController
     }
 
     /**
-     * @return mixed|void
+     * @return mixed[]
      */
-    protected function prepareParametersForBinding(Request $request, $parameters, $entity, $action)
+    protected function prepareParametersForBinding(Request $request, array $parameters, object $entity, string $action): array
     {
         $parameters['object'] = $this->fieldObject;
         // Workaround for mispelled isUniqueIdentifer.

--- a/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
@@ -539,7 +539,7 @@ final class LeadApiController extends CommonApiController
         return $this->model->checkForDuplicateContact($params);
     }
 
-    protected function prepareParametersForBinding(Request $request, $parameters, $entity, $action)
+    protected function prepareParametersForBinding(Request $request, array $parameters, object $entity, string $action): array
     {
         // Unset the tags from params to avoid a validation error
         if (isset($parameters['tags'])) {

--- a/app/bundles/LeadBundle/Controller/Api/ListApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/ListApiController.php
@@ -72,7 +72,7 @@ final class ListApiController extends CommonApiController
      * Those fields were moved to 'properties' subarray. We have to ensure BC and remove them
      * from filter root array so Symfony forms would not fail with unknown field error.
      */
-    protected function prepareParametersForBinding(Request $request, $parameters, $entity, $action)
+    protected function prepareParametersForBinding(Request $request, array $parameters, object $entity, string $action): array
     {
         if (empty($parameters['filters']) || !is_array($parameters['filters'])) {
             return $parameters;

--- a/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
+++ b/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
@@ -257,10 +257,9 @@ trait CustomFieldRepositoryTrait
     }
 
     /**
-     * @param object $entity
-     * @param bool   $flush
+     * @param bool $flush
      */
-    public function saveEntity($entity, $flush = true): void
+    public function saveEntity(object $entity, $flush = true): void
     {
         $this->preSaveEntity($entity);
 

--- a/app/bundles/LeadBundle/Entity/TagRepository.php
+++ b/app/bundles/LeadBundle/Entity/TagRepository.php
@@ -16,7 +16,7 @@ class TagRepository extends CommonRepository
      * @param Tag  $entity
      * @param bool $flush  true by default; use false if persisting in batches
      */
-    public function deleteEntity($entity, $flush = true): void
+    public function deleteEntity(object $entity, $flush = true): void
     {
         if ($entity instanceof Tag && null !== $entity->getId()) {
             $this->deleteLeadAssociations((int) $entity->getId());

--- a/app/bundles/PageBundle/Controller/Api/PageApiController.php
+++ b/app/bundles/PageBundle/Controller/Api/PageApiController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Mautic\PageBundle\Controller\Api;
 
 use Doctrine\Persistence\ManagerRegistry;

--- a/app/bundles/PluginBundle/Helper/IntegrationHelper.php
+++ b/app/bundles/PluginBundle/Helper/IntegrationHelper.php
@@ -404,7 +404,7 @@ class IntegrationHelper
      *
      * @return array
      */
-    public function getUserProfiles($lead, $fields = [], $refresh = false, $specificIntegration = null, $persistLead = true, $returnSettings = false)
+    public function getUserProfiles(object $lead, $fields = [], $refresh = false, $specificIntegration = null, $persistLead = true, $returnSettings = false)
     {
         $socialCache     = $lead->getSocialCache();
         $featureSettings = [];
@@ -479,7 +479,7 @@ class IntegrationHelper
      *
      * @return array
      */
-    public function clearIntegrationCache($lead, $integration = false)
+    public function clearIntegrationCache(object $lead, $integration = false)
     {
         $socialCache = $lead->getSocialCache();
         if (!empty($integration)) {

--- a/app/bundles/PluginBundle/Integration/AbstractIntegration.php
+++ b/app/bundles/PluginBundle/Integration/AbstractIntegration.php
@@ -354,7 +354,7 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
      *
      * @return void|array
      */
-    public function mergeApiKeys($mergeKeys, $withKeys = [], $return = false)
+    public function mergeApiKeys(array $mergeKeys, $withKeys = [], $return = false)
     {
         if (empty($withKeys)) {
             $withKeys = $this->keys;
@@ -654,7 +654,7 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
      *
      * @return mixed|string|ResponseInterface
      */
-    public function makeRequest($url, $parameters = [], $method = 'GET', $settings = [])
+    public function makeRequest($url, $parameters = [], $method = 'GET', array $settings = [])
     {
         // If not authorizing the session itself, check isAuthorized which will refresh tokens if applicable
         if (empty($settings['authorize_session'])) {
@@ -875,7 +875,7 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
      *
      * @return array
      */
-    public function prepareRequest($url, $parameters, $method, $settings, $authType)
+    public function prepareRequest(string $url, $parameters, string $method, array $settings, $authType)
     {
         $clientIdKey     = $this->getClientIdKey();
         $clientSecretKey = $this->getClientSecretKey();
@@ -1074,7 +1074,7 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
      *
      * @throws ApiErrorException if OAuth2 state does not match
      */
-    public function authCallback($settings = [], $parameters = [])
+    public function authCallback(array $settings = [], $parameters = [])
     {
         $authType = $this->getAuthenticationType();
 
@@ -1779,11 +1779,9 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
     /**
      * Merges a config from integration_list with feature settings.
      *
-     * @param array $config
-     *
      * @return array|mixed
      */
-    public function mergeConfigToFeatureSettings($config = [])
+    public function mergeConfigToFeatureSettings(array $config = [])
     {
         $featureSettings = $this->settings->getFeatureSettings();
 
@@ -2123,11 +2121,9 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
     /**
      * Get available company fields for choices in the config UI.
      *
-     * @param array $settings
-     *
      * @return array
      */
-    public function getFormCompanyFields($settings = [])
+    public function getFormCompanyFields(array $settings = [])
     {
         $settings['feature_settings']['objects']['company'] = 'company';
 
@@ -2309,12 +2305,11 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
 
     /**
      * @param CommonEntity|null $entity
-     * @param array             $params
      * @param bool              $ignoreEntityChanges
      *
      * @return bool|\DateTime|null
      */
-    protected function getLastSyncDate($entity = null, $params = [], $ignoreEntityChanges = true)
+    protected function getLastSyncDate($entity = null, array $params = [], $ignoreEntityChanges = true)
     {
         $isNew = ($entity instanceof FormEntity) && $entity->isNew();
         if (!$isNew && !$ignoreEntityChanges && isset($params['start']) && $entity && method_exists($entity, 'getChanges')) {
@@ -2358,7 +2353,7 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
      *
      * @return array
      */
-    public function formatMatchedFields($fields)
+    public function formatMatchedFields(array $fields)
     {
         $formattedFields = [];
 
@@ -2403,7 +2398,7 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
      *
      * @return mixed
      */
-    public function getCompoundMauticFields($lead)
+    public function getCompoundMauticFields(array $lead)
     {
         if ($lead['internal_entity_id']) {
             $lead['mauticContactId']                   = $lead['internal_entity_id'];

--- a/app/bundles/PluginBundle/Integration/AbstractIntegration.php
+++ b/app/bundles/PluginBundle/Integration/AbstractIntegration.php
@@ -2260,9 +2260,8 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
 
     /**
      * @param array $mapping array of [$mauticId => ['entity' => FormEntity, 'integration_entity_id' => $integrationId]]
-     * @param array $params
      */
-    protected function buildIntegrationEntities(array $mapping, $integrationEntity, $internalEntity, $params = [])
+    protected function buildIntegrationEntities(array $mapping, $integrationEntity, $internalEntity, array $params = [])
     {
         $integrationEntities = $this->integrationEntityRepository->getIntegrationEntities(
             $this->getName(),

--- a/app/bundles/PluginBundle/Integration/AbstractSsoServiceIntegration.php
+++ b/app/bundles/PluginBundle/Integration/AbstractSsoServiceIntegration.php
@@ -66,12 +66,11 @@ abstract class AbstractSsoServiceIntegration extends AbstractIntegration
     }
 
     /**
-     * @param array $settings
      * @param array $parameters
      *
      * @return bool|string
      */
-    public function ssoAuthCallback($settings = [], $parameters = [])
+    public function ssoAuthCallback(array $settings = [], $parameters = [])
     {
         $response = $this->authCallback($settings, $parameters);
 

--- a/composer.lock
+++ b/composer.lock
@@ -17839,12 +17839,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "a4e8661d7dac2405e96349f2cf059c774effe1cf"
+                "reference": "2cffa98f89d37b2ba27ee88349bbaf74f96207ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/a4e8661d7dac2405e96349f2cf059c774effe1cf",
-                "reference": "a4e8661d7dac2405e96349f2cf059c774effe1cf",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/2cffa98f89d37b2ba27ee88349bbaf74f96207ca",
+                "reference": "2cffa98f89d37b2ba27ee88349bbaf74f96207ca",
                 "shasum": ""
             },
             "require": {
@@ -17892,7 +17892,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-08-09T16:25:44+00:00"
+            "time": "2026-08-09T22:24:38+00:00"
         },
         {
             "name": "rector/type-perfect",

--- a/composer.lock
+++ b/composer.lock
@@ -17839,12 +17839,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "4bb2c5c7a04b80fbb86a7991f0ce4666578021f1"
+                "reference": "a4e8661d7dac2405e96349f2cf059c774effe1cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/4bb2c5c7a04b80fbb86a7991f0ce4666578021f1",
-                "reference": "4bb2c5c7a04b80fbb86a7991f0ce4666578021f1",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/a4e8661d7dac2405e96349f2cf059c774effe1cf",
+                "reference": "a4e8661d7dac2405e96349f2cf059c774effe1cf",
                 "shasum": ""
             },
             "require": {
@@ -17892,7 +17892,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-08-08T21:25:50+00:00"
+            "time": "2026-08-09T16:25:44+00:00"
         },
         {
             "name": "rector/type-perfect",

--- a/plugins/GrapesJsBuilderBundle/Tests/Unit/Controller/GrapesJsControllerTest.php
+++ b/plugins/GrapesJsBuilderBundle/Tests/Unit/Controller/GrapesJsControllerTest.php
@@ -102,7 +102,7 @@ final class GrapesJsControllerTest extends TestCase
             /**
              * @return AbstractCommonModel<object>
              */
-            protected function getModel($modelNameKey): MauticModelInterface
+            protected function getModel(string $modelNameKey): MauticModelInterface
             {
                 return new class($this->testEntity) extends AbstractCommonModel {
                     public function __construct(

--- a/plugins/GrapesJsBuilderBundle/Tests/Unit/Model/GrapesJsBuilderModelTest.php
+++ b/plugins/GrapesJsBuilderBundle/Tests/Unit/Model/GrapesJsBuilderModelTest.php
@@ -45,10 +45,9 @@ final class GrapesJsBuilderModelTest extends \PHPUnit\Framework\TestCase
             }
 
             /**
-             * @param object $entity
-             * @param bool   $flush
+             * @param bool $flush
              */
-            public function saveEntity($entity, $flush = true): void
+            public function saveEntity(object $entity, $flush = true): void
             {
                 ++$this->saveEntityCallCount;
             }
@@ -69,10 +68,9 @@ final class GrapesJsBuilderModelTest extends \PHPUnit\Framework\TestCase
             }
 
             /**
-             * @param object $entity
-             * @param bool   $flush
+             * @param bool $flush
              */
-            public function saveEntity($entity, $flush = true): void
+            public function saveEntity(object $entity, $flush = true): void
             {
                 ++$this->saveEntityCallCount;
             }
@@ -152,7 +150,7 @@ final class GrapesJsBuilderModelTest extends \PHPUnit\Framework\TestCase
             /**
              * @param Email $entity
              */
-            public function saveEntity($entity, $flush = true): void
+            public function saveEntity(object $entity, $flush = true): void
             {
                 ++$this->saveEntityCallCount;
 
@@ -177,7 +175,7 @@ final class GrapesJsBuilderModelTest extends \PHPUnit\Framework\TestCase
             /**
              * @param GrapesJsBuilder $entity
              */
-            public function saveEntity($entity, $flush = true): void
+            public function saveEntity(object $entity, $flush = true): void
             {
                 ++$this->saveEntityCallCount;
 

--- a/plugins/MauticCrmBundle/Integration/ConnectwiseIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/ConnectwiseIntegration.php
@@ -100,7 +100,7 @@ class ConnectwiseIntegration extends CrmAbstractIntegration
         return $this->router->generate('mautic_integration_auth_callback', ['integration' => $this->getName()]);
     }
 
-    public function authCallback($settings = [], $parameters = []): string|false
+    public function authCallback(array $settings = [], $parameters = []): string|false
     {
         $url   = $this->getApiUrl();
         $error = false;
@@ -132,15 +132,13 @@ class ConnectwiseIntegration extends CrmAbstractIntegration
     /**
      * Append ClientID into header to enable authentication.
      *
-     * @param string       $url
      * @param array<mixed> $parameters
-     * @param string       $method
      * @param array<mixed> $settings
      * @param string       $authType
      *
      * @return array<mixed>
      */
-    public function prepareRequest($url, $parameters, $method, $settings, $authType): array
+    public function prepareRequest(string $url, $parameters, string $method, array $settings, $authType): array
     {
         [$parameters,$headers] = parent::prepareRequest($url, $parameters, $method, $settings, $authType);
 
@@ -162,11 +160,9 @@ class ConnectwiseIntegration extends CrmAbstractIntegration
     /**
      * Get available company fields for choices in the config UI.
      *
-     * @param array $settings
-     *
      * @return array
      */
-    public function getFormCompanyFields($settings = [])
+    public function getFormCompanyFields(array $settings = [])
     {
         return $this->getFormFieldsByObject('company', $settings);
     }
@@ -765,7 +761,7 @@ class ConnectwiseIntegration extends CrmAbstractIntegration
      *
      * @return array
      */
-    protected function cleanPriorityFields($fieldsToUpdate, $objects = null)
+    protected function cleanPriorityFields(array $fieldsToUpdate, $objects = null)
     {
         if (null === $objects) {
             $objects = ['Leads', 'Contacts'];
@@ -785,7 +781,7 @@ class ConnectwiseIntegration extends CrmAbstractIntegration
      *
      * @return mixed
      */
-    protected function getPriorityFieldsForMautic($config, $object = null, $priorityObject = 'mautic')
+    protected function getPriorityFieldsForMautic(array $config, $object = null, $priorityObject = 'mautic')
     {
         if ('company' == $object) {
             $priority = parent::getPriorityFieldsForMautic($config, $object, 'mautic_company');

--- a/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
@@ -459,7 +459,7 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
     /**
      * @return array|mixed
      */
-    protected function getFormFieldsByObject($object, $settings = [])
+    protected function getFormFieldsByObject($object, array $settings = [])
     {
         $settings['feature_settings']['objects'] = [$object => $object];
 
@@ -473,7 +473,7 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
      *
      * @return array
      */
-    protected function getPriorityFieldsForMautic($config, $entityObject = null, $priorityObject = 'mautic')
+    protected function getPriorityFieldsForMautic(array $config, $entityObject = null, $priorityObject = 'mautic')
     {
         return $this->cleanPriorityFields(
             $this->getFieldsByPriority($config, $priorityObject, 1),
@@ -486,7 +486,7 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
      *
      * @return array
      */
-    protected function getPriorityFieldsForIntegration($config, $entityObject = null, $priorityObject = 'mautic')
+    protected function getPriorityFieldsForIntegration(array $config, $entityObject = null, $priorityObject = 'mautic')
     {
         return $this->cleanPriorityFields(
             $this->getFieldsByPriority($config, $priorityObject, 0),
@@ -509,7 +509,7 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
      *
      * @return array
      */
-    protected function cleanPriorityFields($fieldsToUpdate, $objects = null)
+    protected function cleanPriorityFields(array $fieldsToUpdate, $objects = null)
     {
         if (!isset($fieldsToUpdate['leadFields'])) {
             return $fieldsToUpdate;
@@ -535,7 +535,7 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
         return [$fromDate, $toDate];
     }
 
-    public function getBlankFieldsToUpdateInMautic($matchedFields, $leadFieldValues, $objectFields, $integrationData, $object = 'Lead')
+    public function getBlankFieldsToUpdateInMautic(array $matchedFields, array $leadFieldValues, $objectFields, array $integrationData, $object = 'Lead')
     {
         foreach ($objectFields as $integrationField => $mauticField) {
             if (isset($leadFieldValues[$mauticField]) && empty($leadFieldValues[$mauticField]['value']) && !empty($integrationData[$integrationField.'__'.$object]) && $this->translator->trans('mautic.integration.form.lead.unknown') !== $integrationData[$integrationField.'__'.$object]) {
@@ -546,7 +546,7 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
         return $matchedFields;
     }
 
-    public function getBlankFieldsToUpdate($fields, $sfRecord, $objectFields, $config)
+    public function getBlankFieldsToUpdate(array $fields, $sfRecord, array $objectFields, array $config)
     {
         // check if update blank fields is selected
         if (isset($config['updateBlanks']) && isset($config['updateBlanks'][0])

--- a/plugins/MauticCrmBundle/Integration/DynamicsIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/DynamicsIntegration.php
@@ -195,11 +195,9 @@ final class DynamicsIntegration extends CrmAbstractIntegration
     /**
      * Get available company fields for choices in the config UI.
      *
-     * @param array $settings
-     *
      * @return array
      */
-    public function getFormCompanyFields($settings = [])
+    public function getFormCompanyFields(array $settings = [])
     {
         return $this->getFormFieldsByObject('accounts', $settings);
     }

--- a/plugins/MauticCrmBundle/Integration/HubspotIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/HubspotIntegration.php
@@ -112,11 +112,9 @@ class HubspotIntegration extends CrmAbstractIntegration
     /**
      * Get available company fields for choices in the config UI.
      *
-     * @param array $settings
-     *
      * @return array
      */
-    public function getFormCompanyFields($settings = [])
+    public function getFormCompanyFields(array $settings = [])
     {
         return $this->getFormFieldsByObject('company', $settings);
     }
@@ -197,7 +195,7 @@ class HubspotIntegration extends CrmAbstractIntegration
      *
      * @return array
      */
-    protected function cleanPriorityFields($fieldsToUpdate, $objects = null)
+    protected function cleanPriorityFields(array $fieldsToUpdate, $objects = null)
     {
         if (null === $objects) {
             $objects = ['Leads', 'Contacts'];

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -195,11 +195,9 @@ class SalesforceIntegration extends CrmAbstractIntegration
     /**
      * Get available company fields for choices in the config UI.
      *
-     * @param array $settings
-     *
      * @return array
      */
-    public function getFormCompanyFields($settings = [])
+    public function getFormCompanyFields(array $settings = [])
     {
         return $this->getFormFieldsByObject('company', $settings);
     }
@@ -1902,7 +1900,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
      *
      * @return mixed
      */
-    protected function getPriorityFieldsForMautic($config, $object = null, $priorityObject = 'mautic')
+    protected function getPriorityFieldsForMautic(array $config, $object = null, $priorityObject = 'mautic')
     {
         $fields = parent::getPriorityFieldsForMautic($config, $object, $priorityObject);
 
@@ -1914,7 +1912,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
      *
      * @return mixed
      */
-    protected function getPriorityFieldsForIntegration($config, $object = null, $priorityObject = 'mautic')
+    protected function getPriorityFieldsForIntegration(array $config, $object = null, $priorityObject = 'mautic')
     {
         $fields = parent::getPriorityFieldsForIntegration($config, $object, $priorityObject);
         unset($fields['Contact']['Id'], $fields['Lead']['Id']);
@@ -2350,7 +2348,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
      *
      * @return array
      */
-    protected function cleanPriorityFields($fieldsToUpdate, $objects = null)
+    protected function cleanPriorityFields(array $fieldsToUpdate, $objects = null)
     {
         if (null === $objects) {
             $objects = ['Lead', 'Contact'];

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -2358,7 +2358,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
             // Pass in the whole config
             $fields = $fieldsToUpdate;
         } else {
-            $fields = array_flip($fieldsToUpdate ?? []);
+            $fields = array_flip($fieldsToUpdate);
         }
 
         return $this->prepareFieldsForSync($fields, $fieldsToUpdate, $objects);

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -1599,7 +1599,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
     }
 
     protected function getMauticContactsToUpdate(
-        &$checkEmailsInSF,
+        array &$checkEmailsInSF,
         $mauticLeadFieldString,
         &$sfObject,
         array &$trackedContacts,

--- a/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
@@ -132,7 +132,7 @@ final class SugarcrmIntegration extends CrmAbstractIntegration
      *
      * @return array
      */
-    public function authCallback($settings = [], $parameters = [])
+    public function authCallback(array $settings = [], $parameters = [])
     {
         if (isset($this->keys['version']) && '6' == $this->keys['version']) {
             $success = $this->isAuthorized();
@@ -172,11 +172,9 @@ final class SugarcrmIntegration extends CrmAbstractIntegration
     /**
      * Get available company fields for choices in the config UI.
      *
-     * @param array $settings
-     *
      * @return array
      */
-    public function getFormCompanyFields($settings = [])
+    public function getFormCompanyFields(array $settings = [])
     {
         return $this->getFormFieldsByObject('company', $settings);
     }
@@ -577,7 +575,7 @@ final class SugarcrmIntegration extends CrmAbstractIntegration
     /**
      * @return array
      */
-    public function prepareRequest($url, $parameters, $method, $settings, $authType)
+    public function prepareRequest(string $url, $parameters, string $method, array $settings, $authType)
     {
         if ('oauth2' == $authType && empty($settings['authorize_session']) && isset($this->keys['access_token'])) {
             // Append the access token as the oauth-token header
@@ -1569,7 +1567,7 @@ final class SugarcrmIntegration extends CrmAbstractIntegration
      *
      * @return array
      */
-    protected function cleanPriorityFields($fieldsToUpdate, $objects = null)
+    protected function cleanPriorityFields(array $fieldsToUpdate, $objects = null)
     {
         if (null === $objects) {
             $objects = ['Leads', 'Contacts'];
@@ -1635,7 +1633,7 @@ final class SugarcrmIntegration extends CrmAbstractIntegration
      *
      * @return mixed
      */
-    protected function getPriorityFieldsForMautic($config, $object = null, $priorityObject = 'mautic')
+    protected function getPriorityFieldsForMautic(array $config, $object = null, $priorityObject = 'mautic')
     {
         $fields = parent::getPriorityFieldsForMautic($config, $object, $priorityObject);
 

--- a/plugins/MauticCrmBundle/Integration/VtigerIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/VtigerIntegration.php
@@ -118,10 +118,9 @@ class VtigerIntegration extends CrmAbstractIntegration
     /**
      * Retrieves and stores tokens returned from oAuthLogin.
      *
-     * @param array $settings
      * @param array $parameters
      */
-    public function authCallback($settings = [], $parameters = []): string|bool
+    public function authCallback(array $settings = [], $parameters = []): string|bool
     {
         $success = $this->isAuthorized();
         if (!$success) {
@@ -250,10 +249,8 @@ class VtigerIntegration extends CrmAbstractIntegration
 
     /**
      * Get available company fields for choices in the config UI.
-     *
-     * @param array $settings
      */
-    public function getFormCompanyFields($settings = []): array
+    public function getFormCompanyFields(array $settings = []): array
     {
         return parent::getAvailableLeadFields(['cache_suffix' => '.company']);
     }

--- a/plugins/MauticCrmBundle/Integration/ZohoIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/ZohoIntegration.php
@@ -671,11 +671,9 @@ final class ZohoIntegration extends CrmAbstractIntegration
     /**
      * Get available company fields for choices in the config UI.
      *
-     * @param array $settings
-     *
      * @return array
      */
-    public function getFormCompanyFields($settings = [])
+    public function getFormCompanyFields(array $settings = [])
     {
         return $this->getFormFieldsByObject('Accounts', $settings);
     }
@@ -1062,7 +1060,7 @@ final class ZohoIntegration extends CrmAbstractIntegration
         return false;
     }
 
-    public function getBlankFieldsToUpdate($fields, $sfRecord, $objectFields, $config)
+    public function getBlankFieldsToUpdate(array $fields, $sfRecord, array $objectFields, array $config): array
     {
         // check if update blank fields is selected
         if (isset($config['updateBlanks']) && isset($config['updateBlanks'][0]) && 'updateBlanks' == $config['updateBlanks'][0]) {
@@ -1203,7 +1201,7 @@ final class ZohoIntegration extends CrmAbstractIntegration
      *
      * @return array
      */
-    protected function cleanPriorityFields($fieldsToUpdate, $objects = null)
+    protected function cleanPriorityFields(array $fieldsToUpdate, $objects = null)
     {
         if (null === $objects) {
             $objects = ['Leads', 'Contacts'];

--- a/plugins/MauticCrmBundle/Tests/Api/SalesforceApiTest.php
+++ b/plugins/MauticCrmBundle/Tests/Api/SalesforceApiTest.php
@@ -224,7 +224,7 @@ final class SalesforceApiTest extends \PHPUnit\Framework\TestCase
         $integration->expects($this->once())
             ->method('makeRequest')
             ->willReturnCallback(
-                function ($url, $parameters = [], $method = 'GET', $settings = []): void {
+                function ($url, $parameters = [], $method = 'GET', array $settings = []): void {
                     $this->assertEquals(
                         [
                             'q' => 'select Id from Account where Name = \'Some\\\\thing E\\\'lse\' and BillingCountry =  \'Some\\\\Where E\\\'lse\' and BillingCity =  \'Some\\\\Where E\\\'lse\' and BillingState =  \'Some\\\\Where E\\\'lse\'',
@@ -269,7 +269,7 @@ final class SalesforceApiTest extends \PHPUnit\Framework\TestCase
         $integration->expects($this->once())
             ->method('makeRequest')
             ->willReturnCallback(
-                function ($url, $parameters = [], $method = 'GET', $settings = []): void {
+                function ($url, $parameters = [], $method = 'GET', array $settings = []): void {
                     $this->assertEquals(
                         [
                             'q' => 'select Id from Account where Name = \'Some\\\\thing\\\' E\\\'lse\' and BillingCountry =  \'Some\\\\Where\\\' E\\\'lse\' and BillingCity =  \'Some\\\\Where\\\' E\\\'lse\' and BillingState =  \'Some\\\\Where\\\' E\\\'lse\'',
@@ -318,7 +318,7 @@ final class SalesforceApiTest extends \PHPUnit\Framework\TestCase
         $integration->expects($this->once())
             ->method('makeRequest')
             ->willReturnCallback(
-                function ($url, $parameters = [], $method = 'GET', $settings = []): void {
+                function ($url, $parameters = [], $method = 'GET', array $settings = []): void {
                     $this->assertEquals(
                         [
                             'q' => 'select Id from Contact where email = \'con\\\\tact\\\'email@email.com\'',
@@ -365,7 +365,7 @@ final class SalesforceApiTest extends \PHPUnit\Framework\TestCase
         $integration->expects($this->once())
             ->method('makeRequest')
             ->willReturnCallback(
-                function ($url, $parameters = [], $method = 'GET', $settings = []): void {
+                function ($url, $parameters = [], $method = 'GET', array $settings = []): void {
                     $this->assertEquals(
                         [
                             'q' => 'select Id from Lead where email = \'con\\\\tact\\\'email@email.com\' and ConvertedContactId = NULL',

--- a/plugins/MauticEmailMarketingBundle/Integration/ConstantContactIntegration.php
+++ b/plugins/MauticEmailMarketingBundle/Integration/ConstantContactIntegration.php
@@ -44,7 +44,7 @@ final class ConstantContactIntegration extends EmailAbstractIntegration
      *
      * @return bool|string false if no error; otherwise the error string
      */
-    public function authCallback($settings = [], $parameters = [])
+    public function authCallback(array $settings = [], $parameters = [])
     {
         // Constanct Contact doesn't like POST
         $settings['method'] = 'GET';

--- a/plugins/MauticEmailMarketingBundle/Integration/EmailAbstractIntegration.php
+++ b/plugins/MauticEmailMarketingBundle/Integration/EmailAbstractIntegration.php
@@ -74,11 +74,9 @@ abstract class EmailAbstractIntegration extends AbstractIntegration
     /**
      * Merges a config from integration_list with feature settings.
      *
-     * @param array $config
-     *
      * @return array|mixed
      */
-    public function mergeConfigToFeatureSettings($config = [])
+    public function mergeConfigToFeatureSettings(array $config = [])
     {
         $featureSettings = $this->settings->getFeatureSettings();
 

--- a/plugins/MauticEmailMarketingBundle/Integration/IcontactIntegration.php
+++ b/plugins/MauticEmailMarketingBundle/Integration/IcontactIntegration.php
@@ -50,7 +50,7 @@ final class IcontactIntegration extends EmailAbstractIntegration
     /**
      * Get account ID and client folder ID.
      */
-    public function authCallback($settings = [], $parameters = [])
+    public function authCallback(array $settings = [], $parameters = [])
     {
         $url = $this->getApiUrl();
 
@@ -89,7 +89,7 @@ final class IcontactIntegration extends EmailAbstractIntegration
      *
      * @return mixed|string
      */
-    public function makeRequest($url, $parameters = [], $method = 'GET', $settings = [])
+    public function makeRequest($url, $parameters = [], $method = 'GET', array $settings = [])
     {
         $settings['headers'] = [
             'Except:',

--- a/plugins/MauticEmailMarketingBundle/Integration/MailchimpIntegration.php
+++ b/plugins/MauticEmailMarketingBundle/Integration/MailchimpIntegration.php
@@ -55,7 +55,7 @@ final class MailchimpIntegration extends EmailAbstractIntegration
      *
      * @return bool|string
      */
-    public function authCallback($settings = [], $parameters = [])
+    public function authCallback(array $settings = [], $parameters = [])
     {
         $error = parent::authCallback($settings, $parameters);
 

--- a/plugins/MauticSocialBundle/Integration/FoursquareIntegration.php
+++ b/plugins/MauticSocialBundle/Integration/FoursquareIntegration.php
@@ -55,7 +55,7 @@ final class FoursquareIntegration extends SocialIntegration
      *
      * @return mixed|string
      */
-    public function makeRequest($url, $parameters = [], $method = 'GET', $settings = [])
+    public function makeRequest($url, $parameters = [], $method = 'GET', array $settings = [])
     {
         $settings[$this->getAuthTokenKey()] = 'oauth_token';
 

--- a/plugins/MauticSocialBundle/Integration/SocialIntegration.php
+++ b/plugins/MauticSocialBundle/Integration/SocialIntegration.php
@@ -125,7 +125,7 @@ abstract class SocialIntegration extends AbstractIntegration
         return $fields;
     }
 
-    public function getFormCompanyFields($settings = [])
+    public function getFormCompanyFields(array $settings = [])
     {
         $settings['feature_settings']['objects'] = ['Company'];
 

--- a/plugins/MauticSocialBundle/Integration/TwitterIntegration.php
+++ b/plugins/MauticSocialBundle/Integration/TwitterIntegration.php
@@ -62,7 +62,7 @@ final class TwitterIntegration extends SocialIntegration
         return 'oauth1a';
     }
 
-    public function prepareRequest($url, $parameters, $method, $settings, $authType)
+    public function prepareRequest(string $url, $parameters, string $method, array $settings, $authType)
     {
         // Prevent SSL issues
         $settings['ssl_verifypeer'] = false;

--- a/rector.php
+++ b/rector.php
@@ -25,21 +25,6 @@ return RectorConfig::configure()
     )
     ->withPhpSets(php84: true)
     ->withCache(__DIR__.'/var/cache/rector')
-    ->withTypeGuardedClasses([
-        // common controllers
-        Mautic\CoreBundle\Controller\AbstractStandardFormController::class,
-        Mautic\CoreBundle\Controller\CommonController::class,
-        Mautic\CoreBundle\Controller\AbstractFormController::class,
-        Mautic\ApiBundle\Controller\CommonApiController::class,
-        Mautic\ApiBundle\Controller\FetchCommonApiController::class,
-        Mautic\PluginBundle\Integration\AbstractIntegration::class,
-        Mautic\LeadBundle\Controller\Api\CustomFieldsApiControllerTrait::class,
-        // other objects
-        CommonRepository::class,
-        Mautic\CoreBundle\Security\Permissions\AbstractPermissions::class,
-        MauticPlugin\MauticCrmBundle\Integration\CrmAbstractIntegration::class,
-        Mautic\PluginBundle\Integration\AbstractIntegration::class,
-    ])
     ->withRules([
         Rector\PHPUnit\CodeQuality\Rector\ClassMethod\AssertClassToThisAssertRector::class,
         Rector\TypeDeclarationDocblocks\Rector\Property\MergePhpstanDocTagIntoNativeRector::class,

--- a/rector.php
+++ b/rector.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use Mautic\CoreBundle\Entity\CommonRepository;
 use Rector\Config\RectorConfig;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnNewRector;
 use Utils\Rector\UnserializeToSerializerDecodeRector;

--- a/rector.php
+++ b/rector.php
@@ -41,16 +41,15 @@ return RectorConfig::configure()
         // handle later
         Rector\PHPUnit\PHPUnit120\Rector\Class_\AllowMockObjectsForDataProviderRector::class,
 
+<<<<<<< HEAD
         // this would escalate to runtime report, not what we want
         Rector\Php84\Rector\Class_\DeprecatedAnnotationToDeprecatedAttributeRector::class,
 
+=======
+>>>>>>> 4fca68c722 (cleanup rector.php config)
         // @todo move to "twig" group
         Rector\Symfony\Symfony73\Rector\Class_\GetFiltersToAsTwigFilterAttributeRector::class,
         Rector\Symfony\Symfony73\Rector\Class_\GetFunctionsToAsTwigFunctionAttributeRector::class,
-
-        Rector\EarlyReturn\Rector\If_\ChangeIfElseValueAssignToEarlyReturnRector::class,
-        Rector\EarlyReturn\Rector\If_\RemoveAlwaysElseRector::class,
-        Rector\PHPUnit\PHPUnit60\Rector\ClassMethod\AddDoesNotPerformAssertionToNonAssertingTestRector::class,
 
         // handle next
         Rector\PHPUnit\PHPUnit120\Rector\Class_\AllowMockObjectsWithoutExpectationsAttributeRector::class,

--- a/rector.php
+++ b/rector.php
@@ -43,6 +43,7 @@ return RectorConfig::configure()
         // @todo move to "twig" group
         Rector\Symfony\Symfony73\Rector\Class_\GetFiltersToAsTwigFilterAttributeRector::class,
         Rector\Symfony\Symfony73\Rector\Class_\GetFunctionsToAsTwigFunctionAttributeRector::class,
+        Rector\Php84\Rector\Class_\DeprecatedAnnotationToDeprecatedAttributeRector::class,
 
         // handle next
         Rector\PHPUnit\PHPUnit120\Rector\Class_\AllowMockObjectsWithoutExpectationsAttributeRector::class,

--- a/rector.php
+++ b/rector.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnNewRector;
 use Utils\Rector\UnserializeToSerializerDecodeRector;
 
 return RectorConfig::configure()
@@ -41,12 +40,6 @@ return RectorConfig::configure()
         // handle later
         Rector\PHPUnit\PHPUnit120\Rector\Class_\AllowMockObjectsForDataProviderRector::class,
 
-<<<<<<< HEAD
-        // this would escalate to runtime report, not what we want
-        Rector\Php84\Rector\Class_\DeprecatedAnnotationToDeprecatedAttributeRector::class,
-
-=======
->>>>>>> 4fca68c722 (cleanup rector.php config)
         // @todo move to "twig" group
         Rector\Symfony\Symfony73\Rector\Class_\GetFiltersToAsTwigFilterAttributeRector::class,
         Rector\Symfony\Symfony73\Rector\Class_\GetFunctionsToAsTwigFunctionAttributeRector::class,
@@ -54,8 +47,6 @@ return RectorConfig::configure()
         // handle next
         Rector\PHPUnit\PHPUnit120\Rector\Class_\AllowMockObjectsWithoutExpectationsAttributeRector::class,
 
-        Rector\EarlyReturn\Rector\Return_\PreparedValueToEarlyReturnRector::class,
-        Rector\EarlyReturn\Rector\StmtsAwareInterface\ReturnEarlyIfVariableRector::class,
         Rector\Symfony\CodeQuality\Rector\Class_\LoadValidatorMetadataToAttributeRector::class,
         Utils\Rector\ModelGetRepositoryToRepositoryServiceRector::class => [
             __DIR__.'/app/bundles/PageBundle/Form/Type/PreferenceCenterListType.php',
@@ -93,12 +84,6 @@ return RectorConfig::configure()
             __DIR__.'/app/bundles/EmailBundle/Entity/EmailDraft.php',
             __DIR__.'/app/bundles/EmailBundle/Helper/MailHelper.php',
             __DIR__.'/app/bundles/CoreBundle/Twig/Helper/DateHelper.php',
-        ],
-
-        // Avoiding breaking BC breaks with forced return types in public methods
-        ReturnTypeFromReturnNewRector::class => [
-            __DIR__.'/app/bundles/IntegrationsBundle/Sync/SyncProcess/Direction/Integration/ObjectChangeGenerator.php',
-            __DIR__.'/app/bundles/IntegrationsBundle/Sync/SyncProcess/Direction/Internal/ObjectChangeGenerator.php',
         ],
 
         Rector\DeadCode\Rector\Property\RemoveUnusedPrivatePropertyRector::class => [


### PR DESCRIPTION
Adds native param/return/property types to `*Common` and abstract classes: controllers, repositories, permissions and integrations.

Types are only made explicit — no behaviour change.

```diff
-    protected function getDefaultOrderDirection()
+    protected function getDefaultOrderDirection(): string
     {
         return 'ASC';
     }
```

## BC breaks

There are 4 kinds of breaks here. All of them hit **classes that extend ours**, not classes that only call us:

1. **Param type added** — child override without the same type is a fatal error
2. **Return type added** — child override must declare the same return type; an override returning `null` or nothing now throws a `TypeError`
3. **Property type added** — a child redeclaring the property untyped is a fatal error
4. **Property removed** — `FetchCommonApiController::$parametersContainer` (it was never assigned, so any read already failed)

Rule of thumb when upgrading: **copy the parent signature exactly**.

Below only the methods that are commonly overridden.

### `Mautic\CoreBundle\Entity\CommonRepository`

Widest impact — every repository that overrides these:

```diff
-    public function saveEntity($entity, $flush = true): void
+    public function saveEntity(object $entity, $flush = true): void

-    public function deleteEntity($entity, $flush = true): void
+    public function deleteEntity(object $entity, $flush = true): void

-    protected function validateOrderByClause($clause)
+    protected function validateOrderByClause(array $clause): array
```

### `Mautic\PluginBundle\Integration\AbstractIntegration`

Every third-party integration extends this:

```diff
-    public function makeRequest($url, $parameters = [], $method = 'GET', $settings = [])
+    public function makeRequest($url, $parameters = [], $method = 'GET', array $settings = [])

-    public function prepareRequest($url, $parameters, $method, $settings, $authType)
+    public function prepareRequest(string $url, $parameters, string $method, array $settings, $authType)

-    public function authCallback($settings = [], $parameters = [])
+    public function authCallback(array $settings = [], $parameters = [])

-    public function mergeConfigToFeatureSettings($config = [])
+    public function mergeConfigToFeatureSettings(array $config = [])

-    public function getFormCompanyFields($settings = [])
+    public function getFormCompanyFields(array $settings = [])
```

`MauticCrmBundle\Integration\CrmAbstractIntegration` follows the same pattern for `getFormFieldsByObject()`, `cleanPriorityFields()`, `getPriorityFieldsForMautic()`, `getPriorityFieldsForIntegration()` and `getBlankFieldsToUpdate()` — `$config`, `$fields` and `$fieldsToUpdate` are now `array`.

### `Mautic\ApiBundle\Controller\CommonApiController`

```diff
-    protected function prepareParametersForBinding(Request $request, $parameters, $entity, $action)
+    protected function prepareParametersForBinding(Request $request, array $parameters, object $entity, string $action): array|Response
```

Watch out: the old doc type was `@return mixed|void`, so an override that ended without a `return` now throws a `TypeError`. Return `$parameters`.

The batch actions return `Response` now, so an override may no longer return an array:

```diff
-    public function newEntitiesAction(Request $request)
+    public function newEntitiesAction(Request $request): Response
```

Same for `editEntitiesAction()` and `deleteEntitiesAction()`.

### `Mautic\ApiBundle\Controller\FetchCommonApiController`

Properties are typed now. A child that redeclares any of them must use the same type:

```diff
-    protected $entityClass;
+    protected string $entityClass = '';

-    protected $entityNameOne;
+    protected string $entityNameOne;

-    protected $entityNameMulti;
+    protected string $entityNameMulti;

-    protected $permissionBase;
+    protected ?string $permissionBase = null;

-    protected $serializerGroups = [];
+    protected array $serializerGroups = [];
```

Also `$listFilters`, `$exclusionStrategies`, `$extraGetEntitiesArguments` (`array`), `$inBatchMode`, `$customSelectRequested` (`bool`), `$parentChildrenLevelDepth` (`int`).

`$entityClass` defaults to `''` instead of `null`, and `getEntitiesAction()` / `getEntityAction()` return `Response`.

### `Mautic\CoreBundle\Controller\CommonController`

```diff
-    protected function getModel($modelNameKey): MauticModelInterface
+    protected function getModel(string $modelNameKey): MauticModelInterface

-    public function ajaxAction(Request $request, $args = []): Response
+    public function ajaxAction(Request $request, array $args = []): Response

-    protected function getDataForExport(AbstractCommonModel $model, array $args, ?callable $resultsCallback = null, ?int $start = 0)
+    protected function getDataForExport(AbstractCommonModel $model, array $args, ?callable $resultsCallback = null, ?int $start = 0): ?array

-    protected function getDefaultOrderDirection()
+    protected function getDefaultOrderDirection(): string
```

`executeAction()`, `renderException()` and `forwardWithPost()` return `Response`; `notFound()`, `accessDenied()` and `modalAccessDenied()` take `string $msg`.

`AbstractFormController::isLocked()` takes `string $model`, `refererPostActionVars()` takes `array $vars`, `unlockAction()` returns `RedirectResponse`.

`FormController::getRouteBase()`, `getTemplateBase()`, `getTranslationBase()`, `getPermissionBase()` and `getJsLoadMethodPrefix()` return `?string`.

### `Mautic\CoreBundle\Security\Permissions\AbstractPermissions`

Every bundle `*Permissions` class overrides at least one of these:

```diff
-    public function isGranted($userPermissions, $name, $level): bool
+    public function isGranted(array $userPermissions, $name, $level): bool

-    protected function addStandardFormFields($bundle, $level, &$builder, $data, $includePublish = true)
+    protected function addStandardFormFields($bundle, $level, &$builder, array $data, $includePublish = true)
```

Same `array $data` change in `addManageFormFields()` and `addExtendedFormFields()`.
