### PR TITLE
[symfony] Validator attributes: class-level constraints

### DIFF
--- a/app/bundles/AssetBundle/Entity/Asset.php
+++ b/app/bundles/AssetBundle/Entity/Asset.php
@@ -27,7 +27,6 @@ use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Constraints\Sequentially;
-use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 #[ApiResource(
     operations: [
@@ -48,6 +47,7 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
         'swagger_definition_name' => 'Write',
     ]
 )]
+#[Upload]
 class Asset extends FormEntity implements UuidInterface
 {
     use UuidTrait;
@@ -291,11 +291,6 @@ class Asset extends FormEntity implements UuidInterface
 
         static::addUuidField($builder);
         self::addProjectsField($builder, 'asset_projects_xref', 'asset_id');
-    }
-
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addConstraint(new Upload());
     }
 
     /**

--- a/app/bundles/CampaignBundle/Entity/Campaign.php
+++ b/app/bundles/CampaignBundle/Entity/Campaign.php
@@ -31,7 +31,6 @@ use Mautic\ProjectBundle\Entity\Project;
 use Mautic\ProjectBundle\Entity\ProjectTrait;
 use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 #[ApiResource(
     operations: [
@@ -52,6 +51,7 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
         'swagger_definition_name' => 'Write',
     ]
 )]
+#[NoOrphanEvents]
 class Campaign extends FormEntity implements OptimisticLockInterface, UuidInterface
 {
     use UuidTrait;
@@ -215,11 +215,6 @@ class Campaign extends FormEntity implements OptimisticLockInterface, UuidInterf
         self::addVersionField($builder);
         static::addUuidField($builder);
         self::addProjectsField($builder, 'campaign_projects_xref', 'campaign_id');
-    }
-
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addConstraint(new NoOrphanEvents());
     }
 
     /**

--- a/app/bundles/CampaignBundle/Entity/Event.php
+++ b/app/bundles/CampaignBundle/Entity/Event.php
@@ -22,7 +22,6 @@ use Mautic\CoreBundle\Entity\UuidTrait;
 use Mautic\CoreBundle\Validator\EntityEvent;
 use Mautic\LeadBundle\Entity\Lead as Contact;
 use Symfony\Component\Serializer\Attribute\Groups;
-use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 #[ApiResource(
     operations: [
@@ -42,6 +41,7 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
         'swagger_definition_name' => 'Write',
     ]
 )]
+#[EntityEvent]
 class Event implements ChannelInterface, UuidInterface
 {
     use UuidTrait;
@@ -511,11 +511,6 @@ class Event implements ChannelInterface, UuidInterface
                 ]
             )
              ->build();
-    }
-
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addConstraint(new EntityEvent());
     }
 
     /**

--- a/app/bundles/EmailBundle/Entity/Email.php
+++ b/app/bundles/EmailBundle/Entity/Email.php
@@ -69,6 +69,10 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
  * @use VariantEntityTrait<Email>
  * @use TranslationEntityTrait<Email>
  */
+#[EmailLists]
+#[EntityEvent]
+#[ScheduleDateRange]
+#[ValidEmailLinks]
 class Email extends FormEntity implements VariantEntityInterface, TranslationEntityInterface, UuidInterface, OptimisticLockInterface
 {
     use VariantEntityTrait;
@@ -516,11 +520,6 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
         );
 
         $metadata->addPropertyConstraint('subject', new TextOnlyDynamicContent());
-
-        $metadata->addConstraint(new EmailLists());
-        $metadata->addConstraint(new EntityEvent());
-        $metadata->addConstraint(new ScheduleDateRange());
-        $metadata->addConstraint(new ValidEmailLinks());
 
         $metadata->addConstraint(new Callback(
             function (Email $email, ExecutionContextInterface $context): void {

--- a/app/bundles/LeadBundle/Entity/Company.php
+++ b/app/bundles/LeadBundle/Entity/Company.php
@@ -41,6 +41,7 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
         'swagger_definition_name' => 'Write',
     ]
 )]
+#[UniqueCustomField(object: 'company')]
 class Company extends FormEntity implements CustomFieldEntityInterface, IdentifierFieldEntityInterface
 {
     use CustomFieldEntityTrait;
@@ -262,7 +263,6 @@ class Company extends FormEntity implements CustomFieldEntityInterface, Identifi
 
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
-        $metadata->addConstraint(new UniqueCustomField(object: 'company'));
         $metadata->addPropertyConstraint('score', new Assert\Range(min: 0, max: 2147483647));
     }
 

--- a/app/bundles/LeadBundle/Entity/Lead.php
+++ b/app/bundles/LeadBundle/Entity/Lead.php
@@ -28,7 +28,6 @@ use Mautic\PointBundle\Entity\GroupContactScore;
 use Mautic\StageBundle\Entity\Stage;
 use Mautic\UserBundle\Entity\User;
 use Symfony\Component\Serializer\Attribute\Groups;
-use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 #[ApiResource(
     shortName: 'Contacts',
@@ -50,6 +49,7 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
         'swagger_definition_name' => 'Write',
     ]
 )]
+#[UniqueCustomField(object: 'lead')]
 class Lead extends FormEntity implements CustomFieldEntityInterface, IdentifierFieldEntityInterface, SkipModifiedInterface
 {
     use CustomFieldEntityTrait;
@@ -524,11 +524,6 @@ class Lead extends FormEntity implements CustomFieldEntityInterface, IdentifierF
                 ]
             )
             ->build();
-    }
-
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addConstraint(new UniqueCustomField(object: 'lead'));
     }
 
     public static function getDefaultIdentifierFields(): array

--- a/app/bundles/LeadBundle/Entity/LeadField.php
+++ b/app/bundles/LeadBundle/Entity/LeadField.php
@@ -44,6 +44,7 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
         'swagger_definition_name' => 'Write',
     ]
 )]
+#[LeadFieldMinimumLength]
 class LeadField extends FormEntity implements CacheInvalidateInterface, UuidInterface
 {
     use UuidTrait;
@@ -329,8 +330,6 @@ class LeadField extends FormEntity implements CacheInvalidateInterface, UuidInte
                 }
             },
         ));
-
-        $metadata->addConstraint(new LeadFieldMinimumLength());
     }
 
     /**

--- a/app/bundles/LeadBundle/Entity/LeadList.php
+++ b/app/bundles/LeadBundle/Entity/LeadList.php
@@ -46,6 +46,9 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
         'swagger_definition_name' => 'Write',
     ]
 )]
+#[UniqueUserAlias(field: 'alias', message: 'mautic.lead.list.alias.unique')]
+#[SegmentUsedInCampaigns]
+#[SegmentInUse]
 class LeadList extends FormEntity implements UuidInterface
 {
     use UuidTrait;
@@ -185,14 +188,6 @@ class LeadList extends FormEntity implements UuidInterface
         $metadata->addPropertyConstraint('name', new Assert\NotBlank(
             message: 'mautic.core.name.required'
         ));
-
-        $metadata->addConstraint(new UniqueUserAlias([
-            'field'   => 'alias',
-            'message' => 'mautic.lead.list.alias.unique',
-        ]));
-
-        $metadata->addConstraint(new SegmentUsedInCampaigns());
-        $metadata->addConstraint(new SegmentInUse());
     }
 
     /**

--- a/app/bundles/LeadBundle/Form/Validator/Constraints/UniqueUserAlias.php
+++ b/app/bundles/LeadBundle/Form/Validator/Constraints/UniqueUserAlias.php
@@ -4,14 +4,24 @@ declare(strict_types=1);
 
 namespace Mautic\LeadBundle\Form\Validator\Constraints;
 
+use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
-#[\Attribute]
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final class UniqueUserAlias extends Constraint
 {
-    public $message = 'This alias is already in use.';
-
-    public $field   = '';
+    /**
+     * @param string[]|null $groups
+     */
+    #[HasNamedArguments]
+    public function __construct(
+        public string $field,
+        public string $message = 'This alias is already in use.',
+        ?array $groups = null,
+        mixed $payload = null,
+    ) {
+        parent::__construct(null, $groups, $payload);
+    }
 
     public function validatedBy(): string
     {
@@ -21,15 +31,5 @@ final class UniqueUserAlias extends Constraint
     public function getTargets(): string
     {
         return self::CLASS_CONSTRAINT;
-    }
-
-    public function getRequiredOptions(): array
-    {
-        return ['field'];
-    }
-
-    public function getDefaultOption(): string
-    {
-        return 'field';
     }
 }

--- a/app/bundles/PageBundle/Entity/Hit.php
+++ b/app/bundles/PageBundle/Entity/Hit.php
@@ -10,8 +10,8 @@ use Mautic\EmailBundle\Entity\Email;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadDevice;
 use Mautic\PageBundle\Validator\PageHit;
-use Symfony\Component\Validator\Mapping\ClassMetadata;
 
+#[PageHit]
 class Hit
 {
     public const TABLE_NAME = 'page_hits';
@@ -285,11 +285,6 @@ class Hit
                 ]
             )
             ->build();
-    }
-
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addConstraint(new PageHit());
     }
 
     public function getId(): int

--- a/app/bundles/PageBundle/Entity/Page.php
+++ b/app/bundles/PageBundle/Entity/Page.php
@@ -56,6 +56,7 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
  * @use TranslationEntityTrait<Page>
  * @use VariantEntityTrait<Page>
  */
+#[EntityEvent]
 class Page extends FormEntity implements TranslationEntityInterface, VariantEntityInterface, UuidInterface, OptimisticLockInterface
 {
     use TranslationEntityTrait;
@@ -361,8 +362,6 @@ class Page extends FormEntity implements TranslationEntityInterface, VariantEnti
                 }
             },
         ));
-
-        $metadata->addConstraint(new EntityEvent());
     }
 
     /**

--- a/app/bundles/ProjectBundle/Entity/Project.php
+++ b/app/bundles/ProjectBundle/Entity/Project.php
@@ -21,7 +21,6 @@ use Mautic\CoreBundle\Entity\UuidTrait;
 use Mautic\ProjectBundle\Validator\Constraints\UniqueName;
 use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Validator\Constraints\NotBlank;
-use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 #[ApiResource(
     operations: [
@@ -41,6 +40,7 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
         'swagger_definition_name' => 'Write',
     ]
 )]
+#[UniqueName]
 class Project extends FormEntity implements UuidInterface
 {
     use UuidTrait;
@@ -107,11 +107,6 @@ class Project extends FormEntity implements UuidInterface
                 ]
             )
             ->build();
-    }
-
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addConstraint(new UniqueName());
     }
 
     public function getId(): ?int

--- a/app/bundles/ReportBundle/Entity/Report.php
+++ b/app/bundles/ReportBundle/Entity/Report.php
@@ -43,6 +43,7 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
         'swagger_definition_name' => 'Write',
     ]
 )]
+#[ReportAssert\ScheduleIsValid]
 class Report extends FormEntity implements SchedulerInterface, UuidInterface
 {
     use UuidTrait;
@@ -222,8 +223,6 @@ class Report extends FormEntity implements SchedulerInterface, UuidInterface
         $metadata->addPropertyConstraint('name', new NotBlank(message: 'mautic.core.name.required'));
 
         $metadata->addPropertyConstraint('toAddress', new EmailAssert\MultipleEmailsValid());
-
-        $metadata->addConstraint(new ReportAssert\ScheduleIsValid());
     }
 
     /**

--- a/app/bundles/SmsBundle/Entity/Sms.php
+++ b/app/bundles/SmsBundle/Entity/Sms.php
@@ -57,6 +57,8 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
  * @use TranslationEntityTrait<Sms>
  * @use VariantEntityTrait<Sms>
  */
+#[EntityEvent]
+#[MediaMaxAllowedSize]
 class Sms extends FormEntity implements UuidInterface, TranslationEntityInterface, VariantEntityInterface
 {
     use UuidTrait;
@@ -255,9 +257,6 @@ class Sms extends FormEntity implements UuidInterface, TranslationEntityInterfac
                 }
             },
         ));
-
-        $metadata->addConstraint(new EntityEvent());
-        $metadata->addConstraint(new MediaMaxAllowedSize());
     }
 
     /**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6517,18 +6517,6 @@ parameters:
 			path: app/bundles/LeadBundle/Form/Validator/Constraints/FieldAliasKeywordValidator.php
 
 		-
-			message: '#^Property Mautic\\LeadBundle\\Form\\Validator\\Constraints\\UniqueUserAlias\:\:\$field has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/bundles/LeadBundle/Form/Validator/Constraints/UniqueUserAlias.php
-
-		-
-			message: '#^Property Mautic\\LeadBundle\\Form\\Validator\\Constraints\\UniqueUserAlias\:\:\$message has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/bundles/LeadBundle/Form/Validator/Constraints/UniqueUserAlias.php
-
-		-
 			message: '#^Access to an undefined property Symfony\\Component\\Validator\\Constraint\:\:\$field\.$#'
 			identifier: property.notFound
 			count: 1


### PR DESCRIPTION
Follow-up on #16974, which made every constraint usable as an attribute with named arguments.

Class-level constraints were still registered in `loadValidatorMetadata()`. This PR moves them to class attributes, where they are visible right at the entity declaration.

```diff
+#[Upload]
 class Asset extends FormEntity implements UuidInterface
 {
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addConstraint(new Upload());
-    }
 }
```

`loadValidatorMetadata()` is dropped completely from `Asset`, `Campaign`, `Event`, `Hit` and `Lead`; the rest keep it for property constraints and `Callback` closures.

Entities: Asset, Campaign, Event, Hit, Lead, Company, Project, LeadList, LeadField, Email, Sms, Page, Report.

`UniqueUserAlias` was still on the legacy options-array API, so it got the same named-arguments constructor as the other constraints in #16974:

```diff
-$metadata->addConstraint(new UniqueUserAlias([
-    'field'   => 'alias',
-    'message' => 'mautic.lead.list.alias.unique',
-]));
+#[UniqueUserAlias(field: 'alias', message: 'mautic.lead.list.alias.unique')]
```

Verified by dumping the resolved `ClassMetadata` (class constraints, property constraints, options and groups) for all touched entities before and after - the output is identical.
