### PR TITLE
[symfony] Validator attributes: UniqueEntity

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadField.php
+++ b/app/bundles/LeadBundle/Entity/LeadField.php
@@ -44,11 +44,8 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
         'swagger_definition_name' => 'Write',
     ]
 )]
-<<<<<<< HEAD
 #[LeadFieldMinimumLength]
-=======
 #[UniqueEntity(fields: ['alias'], message: 'mautic.lead.field.alias.unique')]
->>>>>>> 84755710cc ([symfony] Validator attributes: UniqueEntity on Stage, User and LeadField entities)
 class LeadField extends FormEntity implements CacheInvalidateInterface, UuidInterface
 {
     use UuidTrait;

--- a/app/bundles/LeadBundle/Entity/LeadField.php
+++ b/app/bundles/LeadBundle/Entity/LeadField.php
@@ -44,7 +44,11 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
         'swagger_definition_name' => 'Write',
     ]
 )]
+<<<<<<< HEAD
 #[LeadFieldMinimumLength]
+=======
+#[UniqueEntity(fields: ['alias'], message: 'mautic.lead.field.alias.unique')]
+>>>>>>> 84755710cc ([symfony] Validator attributes: UniqueEntity on Stage, User and LeadField entities)
 class LeadField extends FormEntity implements CacheInvalidateInterface, UuidInterface
 {
     use UuidTrait;
@@ -316,8 +320,6 @@ class LeadField extends FormEntity implements CacheInvalidateInterface, UuidInte
         ));
 
         $metadata->addPropertyConstraint('label', new Assert\Length(max: 191, maxMessage: 'mautic.lead.field.label.maxlength'));
-
-        $metadata->addConstraint(new UniqueEntity(fields: ['alias'], message: 'mautic.lead.field.alias.unique'));
 
         $metadata->addConstraint(new Assert\Callback(
             function (LeadField $field, ExecutionContextInterface $context): void {

--- a/app/bundles/StageBundle/Entity/Stage.php
+++ b/app/bundles/StageBundle/Entity/Stage.php
@@ -42,6 +42,7 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
         'swagger_definition_name' => 'Write',
     ]
 )]
+#[UniqueEntity(fields: ['weight'], message: 'mautic.stage.weight.unique')]
 class Stage extends FormEntity implements UuidInterface
 {
     use UuidTrait;
@@ -136,8 +137,6 @@ class Stage extends FormEntity implements UuidInterface
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
         $metadata->addPropertyConstraint('name', new Assert\NotBlank(message: 'mautic.core.name.required'));
-
-        $metadata->addConstraint(new UniqueEntity(fields: ['weight'], message: 'mautic.stage.weight.unique'));
     }
 
     /**

--- a/app/bundles/UserBundle/Entity/User.php
+++ b/app/bundles/UserBundle/Entity/User.php
@@ -44,6 +44,8 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
         'swagger_definition_name' => 'Write',
     ]
 )]
+#[UniqueEntity(fields: ['username'], message: 'mautic.user.user.username.unique', repositoryMethod: 'checkUniqueUsernameEmail')]
+#[UniqueEntity(fields: ['email'], message: 'mautic.user.user.email.unique', repositoryMethod: 'checkUniqueUsernameEmail', groups: ['User', 'SecondPass'])]
 class User extends FormEntity implements UserInterface, EquatableInterface, PasswordAuthenticatedUserInterface, CacheInvalidateInterface
 {
     public const CACHE_NAMESPACE = 'User';
@@ -233,8 +235,6 @@ class User extends FormEntity implements UserInterface, EquatableInterface, Pass
             message: 'mautic.user.user.username.notblank'
         ));
 
-        $metadata->addConstraint(new UniqueEntity(fields: ['username'], message: 'mautic.user.user.username.unique', repositoryMethod: 'checkUniqueUsernameEmail'));
-
         $metadata->addPropertyConstraint('firstName', new Assert\NotBlank(
             message: 'mautic.user.user.firstname.notblank'
         ));
@@ -248,8 +248,6 @@ class User extends FormEntity implements UserInterface, EquatableInterface, Pass
         ));
 
         $metadata->addPropertyConstraint('email', new Assert\Email(message: 'mautic.user.user.email.valid', groups: ['SecondPass']));
-
-        $metadata->addConstraint(new UniqueEntity(fields: ['email'], message: 'mautic.user.user.email.unique', repositoryMethod: 'checkUniqueUsernameEmail', groups: ['User', 'SecondPass']));
 
         $metadata->addPropertyConstraint('position', new Assert\Length(max: 191, maxMessage: 'mautic.user.user.position.toolong'));
 


### PR DESCRIPTION
`UniqueEntity` has been an attribute since Symfony 5.2, but 3 entities still registered it through `loadValidatorMetadata()`.

```diff
+#[UniqueEntity(fields: ['weight'], message: 'mautic.stage.weight.unique')]
 class Stage extends FormEntity implements UuidInterface
 {
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
         $metadata->addPropertyConstraint('name', new Assert\NotBlank(message: 'mautic.core.name.required'));
-
-        $metadata->addConstraint(new UniqueEntity(fields: ['weight'], message: 'mautic.stage.weight.unique'));
     }
 }
```

Entities: Stage, User (username + email), LeadField.

Verified by dumping the resolved `ClassMetadata` before and after - the output is identical.
