### PR TITLE
[symfony] Validator attributes: GroupSequence on User

### DIFF
--- a/app/bundles/UserBundle/Entity/User.php
+++ b/app/bundles/UserBundle/Entity/User.php
@@ -44,6 +44,7 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
         'swagger_definition_name' => 'Write',
     ]
 )]
+#[Assert\GroupSequence(['User', 'SecondPass', 'CheckPassword'])]
 class User extends FormEntity implements UserInterface, EquatableInterface, PasswordAuthenticatedUserInterface, CacheInvalidateInterface
 {
     public const CACHE_NAMESPACE = 'User';
@@ -262,8 +263,6 @@ class User extends FormEntity implements UserInterface, EquatableInterface, Pass
         $metadata->addPropertyConstraint('plainPassword', new Assert\Length(min: 6, minMessage: 'mautic.user.user.password.minlength', groups: ['CheckPassword']));
 
         $metadata->addPropertyConstraint('plainPassword', new NotWeak(message: 'mautic.user.user.password.weak', groups: ['CheckPassword']));
-
-        $metadata->setGroupSequence(['User', 'SecondPass', 'CheckPassword']);
     }
 
     public static function determineValidationGroups(Form $form): array


### PR DESCRIPTION
The last piece of `User` validation that was still imperative: the group sequence.

```diff
+#[Assert\GroupSequence(['User', 'SecondPass', 'CheckPassword'])]
 class User extends FormEntity implements UserInterface, ...
 {
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
         // ...
-
-        $metadata->setGroupSequence(['User', 'SecondPass', 'CheckPassword']);
     }
 }
```

Verified by dumping the resolved `ClassMetadata` before and after - the group sequence and all constraints are identical.
