### PR TITLE
[symfony] Validator attributes: property-level custom constraints

### DIFF
--- a/app/bundles/EmailBundle/Entity/Email.php
+++ b/app/bundles/EmailBundle/Entity/Email.php
@@ -108,6 +108,7 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
      * @var string|null
      */
     #[Groups(['email:read', 'email:write', 'download:read'])]
+    #[TextOnlyDynamicContent]
     private $subject;
 
     /**
@@ -126,6 +127,7 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
      * @var string|null
      */
     #[Groups(['email:read', 'email:write', 'download:read'])]
+    #[EmailOrEmailTokenList(allowMultiple: false)]
     private $fromAddress;
 
     /**
@@ -497,11 +499,6 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
         );
 
         $metadata->addPropertyConstraint(
-            'fromAddress',
-            new EmailOrEmailTokenList(allowMultiple: false),
-        );
-
-        $metadata->addPropertyConstraint(
             'replyToAddress',
             new \Symfony\Component\Validator\Constraints\Email(
                 message: 'mautic.core.email.required'
@@ -514,8 +511,6 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
                 message: 'mautic.core.email.required'
             )
         );
-
-        $metadata->addPropertyConstraint('subject', new TextOnlyDynamicContent());
 
         $metadata->addConstraint(new EmailLists());
         $metadata->addConstraint(new EntityEvent());

--- a/app/bundles/FormBundle/Entity/Form.php
+++ b/app/bundles/FormBundle/Entity/Form.php
@@ -110,6 +110,7 @@ class Form extends FormEntity implements UuidInterface
      * @var string|null
      */
     #[Groups(['form:read', 'form:write', 'download:read', 'campaign:read', 'email:read'])]
+    #[IsPostActionRedirectUrl(groups: ['urlRequired'])]
     private $postActionProperty;
 
     /**
@@ -315,8 +316,6 @@ class Form extends FormEntity implements UuidInterface
         $metadata->addPropertyConstraint('postActionProperty', new Assert\NotBlank(message: 'mautic.form.form.postactionproperty_message.notblank', groups: ['messageRequired']));
 
         $metadata->addPropertyConstraint('postActionProperty', new Assert\NotBlank(message: 'mautic.form.form.postactionproperty_redirect.notblank', groups: ['urlRequired']));
-
-        $metadata->addPropertyConstraint('postActionProperty', new IsPostActionRedirectUrl(groups: ['urlRequired']));
 
         $metadata->addPropertyConstraint('postActionProperty', new Assert\NotBlank(message: 'mautic.form.form.postactionproperty_hideform.notblank', groups: ['hideformRequired']));
 

--- a/app/bundles/ReportBundle/Entity/Report.php
+++ b/app/bundles/ReportBundle/Entity/Report.php
@@ -131,6 +131,7 @@ class Report extends FormEntity implements SchedulerInterface, UuidInterface
      * @var string|null
      */
     #[Groups(['report:read', 'report:write'])]
+    #[EmailAssert\MultipleEmailsValid]
     private $toAddress;
 
     /**
@@ -220,8 +221,6 @@ class Report extends FormEntity implements SchedulerInterface, UuidInterface
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
         $metadata->addPropertyConstraint('name', new NotBlank(message: 'mautic.core.name.required'));
-
-        $metadata->addPropertyConstraint('toAddress', new EmailAssert\MultipleEmailsValid());
 
         $metadata->addConstraint(new ReportAssert\ScheduleIsValid());
     }

--- a/app/bundles/UserBundle/Entity/User.php
+++ b/app/bundles/UserBundle/Entity/User.php
@@ -68,6 +68,7 @@ class User extends FormEntity implements UserInterface, EquatableInterface, Pass
      * @var ?string
      */
     #[Groups(['user:write'])]
+    #[NotWeak(message: 'mautic.user.user.password.weak', groups: ['CheckPassword'])]
     private $plainPassword;
 
     /**
@@ -260,8 +261,6 @@ class User extends FormEntity implements UserInterface, EquatableInterface, Pass
         $metadata->addPropertyConstraint('plainPassword', new Assert\NotBlank(message: 'mautic.user.user.password.notblank', groups: ['CheckPasswordNotBlank']));
 
         $metadata->addPropertyConstraint('plainPassword', new Assert\Length(min: 6, minMessage: 'mautic.user.user.password.minlength', groups: ['CheckPassword']));
-
-        $metadata->addPropertyConstraint('plainPassword', new NotWeak(message: 'mautic.user.user.password.weak', groups: ['CheckPassword']));
 
         $metadata->setGroupSequence(['User', 'SecondPass', 'CheckPassword']);
     }


### PR DESCRIPTION
Property-level custom constraints move next to the property they validate, so the rule is visible where the data is defined.

```diff
 #[Groups(['user:write'])]
+#[NotWeak(message: 'mautic.user.user.password.weak', groups: ['CheckPassword'])]
 private $plainPassword;

 public static function loadValidatorMetadata(ClassMetadata $metadata): void
 {
     // ...
-
-    $metadata->addPropertyConstraint('plainPassword', new NotWeak(message: 'mautic.user.user.password.weak', groups: ['CheckPassword']));
 }
```

Covered:

* `Email::$subject` - `#[TextOnlyDynamicContent]`
* `Email::$fromAddress` - `#[EmailOrEmailTokenList(allowMultiple: false)]`
* `Form::$postActionProperty` - `#[IsPostActionRedirectUrl(groups: ['urlRequired'])]`
* `Report::$toAddress` - `#[MultipleEmailsValid]`
* `User::$plainPassword` - `#[NotWeak(...)]`

`Report::loadValidatorMetadata()` keeps only a single `NotBlank` after this.

Verified by dumping the resolved `ClassMetadata` before and after - the output is identical.
