### PR TITLE
[symfony] Validator attributes: UniqueEntity

### DIFF
--- a/app/bundles/LeadBundle/Entity/LeadField.php
+++ b/app/bundles/LeadBundle/Entity/LeadField.php
@@ -45,6 +45,7 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
     ]
 )]
 #[LeadFieldMinimumLength]
+#[UniqueEntity(fields: ['alias'], message: 'mautic.lead.field.alias.unique')]
 class LeadField extends FormEntity implements CacheInvalidateInterface, UuidInterface
 {
     use UuidTrait;
@@ -313,8 +314,6 @@ class LeadField extends FormEntity implements CacheInvalidateInterface, UuidInte
 
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
-        $metadata->addConstraint(new UniqueEntity(fields: ['alias'], message: 'mautic.lead.field.alias.unique'));
-
         $metadata->addConstraint(new Assert\Callback(
             function (LeadField $field, ExecutionContextInterface $context): void {
                 $violations = $context->getValidator()->validate($field, [new FieldAliasKeyword()]);

--- a/app/bundles/StageBundle/Entity/Stage.php
+++ b/app/bundles/StageBundle/Entity/Stage.php
@@ -21,7 +21,6 @@ use Mautic\ProjectBundle\Entity\ProjectTrait;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 #[ApiResource(
     operations: [
@@ -42,6 +41,7 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
         'swagger_definition_name' => 'Write',
     ]
 )]
+#[UniqueEntity(fields: ['weight'], message: 'mautic.stage.weight.unique')]
 class Stage extends FormEntity implements UuidInterface
 {
     use UuidTrait;
@@ -132,11 +132,6 @@ class Stage extends FormEntity implements UuidInterface
 
         static::addUuidField($builder);
         self::addProjectsField($builder, 'stage_projects_xref', 'stage_id');
-    }
-
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addConstraint(new UniqueEntity(fields: ['weight'], message: 'mautic.stage.weight.unique'));
     }
 
     /**

--- a/app/bundles/UserBundle/Entity/User.php
+++ b/app/bundles/UserBundle/Entity/User.php
@@ -45,6 +45,8 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
     ]
 )]
 #[Assert\GroupSequence(['User', 'SecondPass', 'CheckPassword'])]
+#[UniqueEntity(fields: ['username'], message: 'mautic.user.user.username.unique', repositoryMethod: 'checkUniqueUsernameEmail')]
+#[UniqueEntity(fields: ['email'], message: 'mautic.user.user.email.unique', repositoryMethod: 'checkUniqueUsernameEmail', groups: ['User', 'SecondPass'])]
 class User extends FormEntity implements UserInterface, EquatableInterface, PasswordAuthenticatedUserInterface, CacheInvalidateInterface
 {
     public const CACHE_NAMESPACE = 'User';
@@ -239,10 +241,6 @@ class User extends FormEntity implements UserInterface, EquatableInterface, Pass
 
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
-        $metadata->addConstraint(new UniqueEntity(fields: ['username'], message: 'mautic.user.user.username.unique', repositoryMethod: 'checkUniqueUsernameEmail'));
-
-        $metadata->addConstraint(new UniqueEntity(fields: ['email'], message: 'mautic.user.user.email.unique', repositoryMethod: 'checkUniqueUsernameEmail', groups: ['User', 'SecondPass']));
-
         $metadata->addPropertyConstraint('plainPassword', new NotWeak(message: 'mautic.user.user.password.weak', groups: ['CheckPassword']));
     }
 


### PR DESCRIPTION
Continues the migration of validator metadata from `loadValidatorMetadata()` to native PHP attributes.

This one covers the class-level `UniqueEntity` constraints on `Stage`, `User` and `LeadField`.

```diff
 )]
+#[UniqueEntity(fields: ['weight'], message: 'mautic.stage.weight.unique')]
 class Stage extends FormEntity implements UuidInterface
 {
...
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addConstraint(new UniqueEntity(fields: ['weight'], message: 'mautic.stage.weight.unique'));
-    }
```

Where the method body becomes empty (`Stage`), the method and its now-unused `ClassMetadata` import are removed.

Behavior is unchanged - the resolved `ClassMetadata` is identical, only the declaration site moves.

Note: the `NotBlank` work this branch originally carried landed already via #17017, so the branch was rebased onto current `8.x` and now carries the `UniqueEntity` change from #17011 instead. #17011 is closed as superseded.
