### PR TITLE
[symfony] Validator attributes: built-in property constraints

### DIFF
--- a/app/bundles/ChannelBundle/Entity/Message.php
+++ b/app/bundles/ChannelBundle/Entity/Message.php
@@ -22,7 +22,6 @@ use Mautic\CoreBundle\Entity\UuidTrait;
 use Mautic\ProjectBundle\Entity\ProjectTrait;
 use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Validator\Constraints\NotBlank;
-use Symfony\Component\Validator\Mapping\ClassMetadata as ValidationClassMetadata;
 
 #[ApiResource(
     operations: [
@@ -58,6 +57,7 @@ class Message extends FormEntity implements UuidInterface
      * @var string
      */
     #[Groups(['message:read', 'message:write', 'channel:read'])]
+    #[NotBlank(message: 'mautic.core.name.required')]
     private $name;
 
     /**
@@ -119,11 +119,6 @@ class Message extends FormEntity implements UuidInterface
 
         static::addUuidField($builder);
         self::addProjectsField($builder, 'message_projects_xref', 'message_id');
-    }
-
-    public static function loadValidatorMetadata(ValidationClassMetadata $metadata): void
-    {
-        $metadata->addPropertyConstraint('name', new NotBlank(message: 'mautic.core.name.required'));
     }
 
     public static function loadApiMetadata(ApiMetadataDriver $metadata): void

--- a/app/bundles/CoreBundle/Helper/EmojiMap/HtmlToUnicodeEmojiMap.php
+++ b/app/bundles/CoreBundle/Helper/EmojiMap/HtmlToUnicodeEmojiMap.php
@@ -9,7 +9,9 @@ namespace Mautic\CoreBundle\Helper\EmojiMap;
  */
 final class HtmlToUnicodeEmojiMap
 {
-    /** @var array<string, string> */
+    /**
+     * @var array<string, string>
+     */
     public static array $map = [
         "<span class=\x22emoji-outer emoji-sizer\x22><span class=\x22emoji-inner emojia9\x22></span></span>"                                  => "\xc2\xa9",
         "<span class=\x22emoji-outer emoji-sizer\x22><span class=\x22emoji-inner emojiae\x22></span></span>"                                  => "\xc2\xae",

--- a/app/bundles/CoreBundle/Helper/EmojiMap/HtmlToUnicodeEmojiMap.php
+++ b/app/bundles/CoreBundle/Helper/EmojiMap/HtmlToUnicodeEmojiMap.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\Helper\EmojiMap;
 
+/**
+ * @deprecated as unused. No replacement.
+ */
 final class HtmlToUnicodeEmojiMap
 {
-    public static $map = [
+    /** @var array<string, string> */
+    public static array $map = [
         "<span class=\x22emoji-outer emoji-sizer\x22><span class=\x22emoji-inner emojia9\x22></span></span>"                                  => "\xc2\xa9",
         "<span class=\x22emoji-outer emoji-sizer\x22><span class=\x22emoji-inner emojiae\x22></span></span>"                                  => "\xc2\xae",
         "<span class=\x22emoji-outer emoji-sizer\x22><span class=\x22emoji-inner emoji203c\x22></span></span>"                                => "\xe2\x80\xbc",

--- a/app/bundles/CoreBundle/Helper/EmojiMap/ShortToUnicodeEmojiMap.php
+++ b/app/bundles/CoreBundle/Helper/EmojiMap/ShortToUnicodeEmojiMap.php
@@ -9,7 +9,9 @@ namespace Mautic\CoreBundle\Helper\EmojiMap;
  */
 final class ShortToUnicodeEmojiMap
 {
-    /** @var array<string, string> */
+    /**
+     * @var array<string, string>
+     */
     public static array $map = [
         ':copyright:'                                              => "\xc2\xa9",
         ':registered:'                                             => "\xc2\xae",
@@ -1355,7 +1357,9 @@ final class ShortToUnicodeEmojiMap
         ':woman-kiss-woman:'                                       => "\xf0\x9f\x91\xa9\xe2\x80\x8d\xe2\x9d\xa4\xef\xb8\x8f\xe2\x80\x8d\xf0\x9f\x92\x8b\xe2\x80\x8d\xf0\x9f\x91\xa9",
     ];
 
-    /** @var array<string, string> */
+    /**
+     * @var array<string, string>
+     */
     public static array $exceptions = [
         // Outlook email rendering
         "microsoft-com\xf0\x9f\x8f\xa2office" => 'microsoft-com:office:office',

--- a/app/bundles/CoreBundle/Helper/EmojiMap/ShortToUnicodeEmojiMap.php
+++ b/app/bundles/CoreBundle/Helper/EmojiMap/ShortToUnicodeEmojiMap.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\Helper\EmojiMap;
 
+/**
+ * @deprecated as unused. No replacement.
+ */
 final class ShortToUnicodeEmojiMap
 {
-    public static $map = [
+    /** @var array<string, string> */
+    public static array $map = [
         ':copyright:'                                              => "\xc2\xa9",
         ':registered:'                                             => "\xc2\xae",
         ':bangbang:'                                               => "\xe2\x80\xbc",
@@ -1351,7 +1355,8 @@ final class ShortToUnicodeEmojiMap
         ':woman-kiss-woman:'                                       => "\xf0\x9f\x91\xa9\xe2\x80\x8d\xe2\x9d\xa4\xef\xb8\x8f\xe2\x80\x8d\xf0\x9f\x92\x8b\xe2\x80\x8d\xf0\x9f\x91\xa9",
     ];
 
-    public static $exceptions = [
+    /** @var array<string, string> */
+    public static array $exceptions = [
         // Outlook email rendering
         "microsoft-com\xf0\x9f\x8f\xa2office" => 'microsoft-com:office:office',
     ];

--- a/app/bundles/CoreBundle/Helper/EmojiMap/UnicodeToHtmlEmojiMap.php
+++ b/app/bundles/CoreBundle/Helper/EmojiMap/UnicodeToHtmlEmojiMap.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\Helper\EmojiMap;
 
+/**
+ * @deprecated as unused. No replacement.
+ */
 final class UnicodeToHtmlEmojiMap
 {
-    public static $map = [
+    /** @var array<string, string> */
+    public static array $map = [
         "\xc2\xa9"                                                                                                       => "<span class=\x22emoji-outer emoji-sizer\x22><span class=\x22emoji-inner emojia9\x22></span></span>",
         "\xf3\xbe\xac\xa9"                                                                                               => "<span class=\x22emoji-outer emoji-sizer\x22><span class=\x22emoji-inner emojia9\x22></span></span>",
         "\xee\x9c\xb1"                                                                                                   => "<span class=\x22emoji-outer emoji-sizer\x22><span class=\x22emoji-inner emojia9\x22></span></span>",

--- a/app/bundles/CoreBundle/Helper/EmojiMap/UnicodeToHtmlEmojiMap.php
+++ b/app/bundles/CoreBundle/Helper/EmojiMap/UnicodeToHtmlEmojiMap.php
@@ -9,7 +9,9 @@ namespace Mautic\CoreBundle\Helper\EmojiMap;
  */
 final class UnicodeToHtmlEmojiMap
 {
-    /** @var array<string, string> */
+    /**
+     * @var array<string, string>
+     */
     public static array $map = [
         "\xc2\xa9"                                                                                                       => "<span class=\x22emoji-outer emoji-sizer\x22><span class=\x22emoji-inner emojia9\x22></span></span>",
         "\xf3\xbe\xac\xa9"                                                                                               => "<span class=\x22emoji-outer emoji-sizer\x22><span class=\x22emoji-inner emojia9\x22></span></span>",

--- a/app/bundles/CoreBundle/Helper/EmojiMap/UnicodeToShortEmojiMap.php
+++ b/app/bundles/CoreBundle/Helper/EmojiMap/UnicodeToShortEmojiMap.php
@@ -9,7 +9,9 @@ namespace Mautic\CoreBundle\Helper\EmojiMap;
  */
 final class UnicodeToShortEmojiMap
 {
-    /** @var array<string, string> */
+    /**
+     * @var array<string, string>
+     */
     public static array $map = [
         "\xc2\xa9"                                                                                                     => ':copyright:',
         "\xf3\xbe\xac\xa9"                                                                                             => ':copyright:',

--- a/app/bundles/CoreBundle/Helper/EmojiMap/UnicodeToShortEmojiMap.php
+++ b/app/bundles/CoreBundle/Helper/EmojiMap/UnicodeToShortEmojiMap.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\Helper\EmojiMap;
 
+/**
+ * @deprecated as unused. No replacement.
+ */
 final class UnicodeToShortEmojiMap
 {
-    public static $map = [
+    /** @var array<string, string> */
+    public static array $map = [
         "\xc2\xa9"                                                                                                     => ':copyright:',
         "\xf3\xbe\xac\xa9"                                                                                             => ':copyright:',
         "\xee\x9c\xb1"                                                                                                 => ':copyright:',

--- a/app/bundles/DashboardBundle/Entity/Widget.php
+++ b/app/bundles/DashboardBundle/Entity/Widget.php
@@ -8,7 +8,6 @@ use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
 use Mautic\CoreBundle\Entity\FormEntity;
 use Mautic\CoreBundle\Helper\InputHelper;
 use Symfony\Component\Validator\Constraints\NotBlank;
-use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 class Widget extends FormEntity
 {
@@ -40,6 +39,7 @@ class Widget extends FormEntity
     /**
      * @var string
      */
+    #[NotBlank(message: 'mautic.core.type.required')]
     private $type;
 
     /**
@@ -96,11 +96,6 @@ class Widget extends FormEntity
         $builder->addNullableField('cacheTimeout', Types::INTEGER, 'cache_timeout');
         $builder->addNullableField('ordering', Types::INTEGER);
         $builder->addNullableField('params', Types::ARRAY);
-    }
-
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addPropertyConstraint('type', new NotBlank(message: 'mautic.core.type.required'));
     }
 
     /**

--- a/app/bundles/EmailBundle/Entity/Email.php
+++ b/app/bundles/EmailBundle/Entity/Email.php
@@ -147,12 +147,14 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
      * @var string|null
      */
     #[Groups(['email:read', 'email:write', 'download:read'])]
+    #[\Symfony\Component\Validator\Constraints\Email(message: 'mautic.core.email.required')]
     private $replyToAddress;
 
     /**
      * @var string|null
      */
     #[Groups(['email:read', 'email:write', 'download:read'])]
+    #[\Symfony\Component\Validator\Constraints\Email(message: 'mautic.core.email.required')]
     private $bccAddress;
 
     /**
@@ -479,20 +481,6 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
         $metadata->addPropertyConstraint(
             'fromAddress',
             new EmailOrEmailTokenList(allowMultiple: false),
-        );
-
-        $metadata->addPropertyConstraint(
-            'replyToAddress',
-            new \Symfony\Component\Validator\Constraints\Email(
-                message: 'mautic.core.email.required'
-            )
-        );
-
-        $metadata->addPropertyConstraint(
-            'bccAddress',
-            new \Symfony\Component\Validator\Constraints\Email(
-                message: 'mautic.core.email.required'
-            )
         );
 
         $metadata->addPropertyConstraint('subject', new TextOnlyDynamicContent());

--- a/app/bundles/EmailBundle/Entity/Email.php
+++ b/app/bundles/EmailBundle/Entity/Email.php
@@ -101,6 +101,7 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
      */
     #[Groups(['email:read', 'email:write', 'download:read'])]
     #[NotBlank(message: 'mautic.core.name.required')]
+    #[Length(max: self::MAX_NAME_SUBJECT_LENGTH, maxMessage: 'mautic.email.name.length')]
     private $name;
 
     /**
@@ -114,6 +115,7 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
      */
     #[Groups(['email:read', 'email:write', 'download:read'])]
     #[NotBlank(message: 'mautic.core.subject.required')]
+    #[Length(max: self::MAX_NAME_SUBJECT_LENGTH, maxMessage: 'mautic.email.subject.length')]
     private $subject;
 
     /**
@@ -126,6 +128,7 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
     private bool $sendToDnc = false;
 
     #[Groups(['email:read', 'email:write', 'download:read'])]
+    #[Length(max: 130, maxMessage: 'mautic.email.preheader_text.length')]
     private ?string $preheaderText = null;
 
     /**
@@ -473,21 +476,6 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
 
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
-        $metadata->addPropertyConstraint(
-            'name',
-            new Length(max: self::MAX_NAME_SUBJECT_LENGTH, maxMessage: 'mautic.email.name.length')
-        );
-
-        $metadata->addPropertyConstraint(
-            'subject',
-            new Length(max: self::MAX_NAME_SUBJECT_LENGTH, maxMessage: 'mautic.email.subject.length')
-        );
-
-        $metadata->addPropertyConstraint(
-            'preheaderText',
-            new Length(max: 130, maxMessage: 'mautic.email.preheader_text.length')
-        );
-
         $metadata->addPropertyConstraint(
             'fromAddress',
             new EmailOrEmailTokenList(allowMultiple: false),

--- a/app/bundles/EmailBundle/Entity/Email.php
+++ b/app/bundles/EmailBundle/Entity/Email.php
@@ -100,6 +100,7 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
      * @var string
      */
     #[Groups(['email:read', 'email:write', 'download:read'])]
+    #[NotBlank(message: 'mautic.core.name.required')]
     private $name;
 
     /**
@@ -112,6 +113,7 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
      * @var string|null
      */
     #[Groups(['email:read', 'email:write', 'download:read'])]
+    #[NotBlank(message: 'mautic.core.subject.required')]
     private $subject;
 
     /**
@@ -473,21 +475,7 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
     {
         $metadata->addPropertyConstraint(
             'name',
-            new NotBlank(
-                message: 'mautic.core.name.required'
-            )
-        );
-
-        $metadata->addPropertyConstraint(
-            'name',
             new Length(max: self::MAX_NAME_SUBJECT_LENGTH, maxMessage: 'mautic.email.name.length')
-        );
-
-        $metadata->addPropertyConstraint(
-            'subject',
-            new NotBlank(
-                message: 'mautic.core.subject.required'
-            )
         );
 
         $metadata->addPropertyConstraint(

--- a/app/bundles/FormBundle/Entity/Action.php
+++ b/app/bundles/FormBundle/Entity/Action.php
@@ -16,7 +16,6 @@ use Mautic\CoreBundle\Entity\UuidInterface;
 use Mautic\CoreBundle\Entity\UuidTrait;
 use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 #[ApiResource(
     operations: [
@@ -64,6 +63,7 @@ class Action implements UuidInterface
      * @var string
      */
     #[Groups(['action:read', 'action:write', 'form:read'])]
+    #[Assert\NotBlank(message: 'mautic.core.name.required', groups: ['action'])]
     private $type;
 
     /**
@@ -141,11 +141,6 @@ class Action implements UuidInterface
                 ]
             )
             ->build();
-    }
-
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addPropertyConstraint('type', new Assert\NotBlank(message: 'mautic.core.name.required', groups: ['action']));
     }
 
     private function isChanged(string $prop, mixed $val): void

--- a/app/bundles/FormBundle/Entity/Form.php
+++ b/app/bundles/FormBundle/Entity/Form.php
@@ -185,6 +185,7 @@ class Form extends FormEntity implements UuidInterface
      * @var int|null
      */
     #[Groups(['form:read', 'form:write', 'download:read', 'campaign:read', 'email:read'])]
+    #[Assert\GreaterThan(value: 0, message: 'mautic.form.form.progressive_profiling_limit.error', groups: ['progressiveProfilingLimit'])]
     private $progressiveProfilingLimit;
 
     #[Groups(['form:read', 'form:write', 'download:read', 'campaign:read', 'email:read'])]
@@ -315,8 +316,6 @@ class Form extends FormEntity implements UuidInterface
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
         $metadata->addPropertyConstraint('postActionProperty', new IsPostActionRedirectUrl(groups: ['urlRequired']));
-
-        $metadata->addPropertyConstraint('progressiveProfilingLimit', new Assert\GreaterThan(value: 0, message: 'mautic.form.form.progressive_profiling_limit.error', groups: ['progressiveProfilingLimit']));
     }
 
     public static function determineValidationGroups(\Symfony\Component\Form\Form $form): array

--- a/app/bundles/FormBundle/Entity/Form.php
+++ b/app/bundles/FormBundle/Entity/Form.php
@@ -68,6 +68,7 @@ class Form extends FormEntity implements UuidInterface
      * @var string
      */
     #[Groups(['form:read', 'form:write', 'download:read', 'campaign:read', 'email:read'])]
+    #[Assert\NotBlank(message: 'mautic.core.name.required', groups: ['form'])]
     private $name;
 
     /**
@@ -110,6 +111,9 @@ class Form extends FormEntity implements UuidInterface
      * @var string|null
      */
     #[Groups(['form:read', 'form:write', 'download:read', 'campaign:read', 'email:read'])]
+    #[Assert\NotBlank(message: 'mautic.form.form.postactionproperty_message.notblank', groups: ['messageRequired'])]
+    #[Assert\NotBlank(message: 'mautic.form.form.postactionproperty_redirect.notblank', groups: ['urlRequired'])]
+    #[Assert\NotBlank(message: 'mautic.form.form.postactionproperty_hideform.notblank', groups: ['hideformRequired'])]
     private $postActionProperty;
 
     /**
@@ -310,15 +314,7 @@ class Form extends FormEntity implements UuidInterface
 
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
-        $metadata->addPropertyConstraint('name', new Assert\NotBlank(message: 'mautic.core.name.required', groups: ['form']));
-
-        $metadata->addPropertyConstraint('postActionProperty', new Assert\NotBlank(message: 'mautic.form.form.postactionproperty_message.notblank', groups: ['messageRequired']));
-
-        $metadata->addPropertyConstraint('postActionProperty', new Assert\NotBlank(message: 'mautic.form.form.postactionproperty_redirect.notblank', groups: ['urlRequired']));
-
         $metadata->addPropertyConstraint('postActionProperty', new IsPostActionRedirectUrl(groups: ['urlRequired']));
-
-        $metadata->addPropertyConstraint('postActionProperty', new Assert\NotBlank(message: 'mautic.form.form.postactionproperty_hideform.notblank', groups: ['hideformRequired']));
 
         $metadata->addPropertyConstraint('progressiveProfilingLimit', new Assert\GreaterThan(value: 0, message: 'mautic.form.form.progressive_profiling_limit.error', groups: ['progressiveProfilingLimit']));
     }

--- a/app/bundles/LeadBundle/Entity/Company.php
+++ b/app/bundles/LeadBundle/Entity/Company.php
@@ -61,6 +61,7 @@ class Company extends FormEntity implements CustomFieldEntityInterface, Identifi
      * @var int|null
      */
     #[Groups(['company:read', 'company:write'])]
+    #[Assert\Range(min: 0, max: 2147483647)]
     private $score = 0;
 
     #[Groups(['company:read', 'company:write'])]
@@ -263,7 +264,11 @@ class Company extends FormEntity implements CustomFieldEntityInterface, Identifi
 
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
+<<<<<<< HEAD
         $metadata->addPropertyConstraint('score', new Assert\Range(min: 0, max: 2147483647));
+=======
+        $metadata->addConstraint(new UniqueCustomField(object: 'company'));
+>>>>>>> dbe46ece6a ([symfony] move Range property constraints to attributes)
     }
 
     public static function getDefaultIdentifierFields(): array

--- a/app/bundles/LeadBundle/Entity/Company.php
+++ b/app/bundles/LeadBundle/Entity/Company.php
@@ -20,7 +20,6 @@ use Mautic\ProjectBundle\Entity\ProjectTrait;
 use Mautic\UserBundle\Entity\User;
 use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 #[ApiResource(
     shortName: 'Companies',
@@ -260,15 +259,6 @@ class Company extends FormEntity implements CustomFieldEntityInterface, Identifi
             ->build();
 
         self::addProjectsInLoadApiMetadata($metadata, 'company');
-    }
-
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-<<<<<<< HEAD
-        $metadata->addPropertyConstraint('score', new Assert\Range(min: 0, max: 2147483647));
-=======
-        $metadata->addConstraint(new UniqueCustomField(object: 'company'));
->>>>>>> dbe46ece6a ([symfony] move Range property constraints to attributes)
     }
 
     public static function getDefaultIdentifierFields(): array

--- a/app/bundles/LeadBundle/Entity/Import.php
+++ b/app/bundles/LeadBundle/Entity/Import.php
@@ -10,7 +10,6 @@ use Mautic\CoreBundle\Entity\FormEntity;
 use Mautic\CoreBundle\Helper\Chart\PieChart;
 use Mautic\CoreBundle\Translation\Translator;
 use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 class Import extends FormEntity
 {
@@ -69,6 +68,7 @@ class Import extends FormEntity
      *
      * @var string
      */
+    #[Assert\NotBlank(message: 'mautic.lead.import.dir.notblank')]
     private $dir;
 
     /**
@@ -76,6 +76,7 @@ class Import extends FormEntity
      *
      * @var string
      */
+    #[Assert\NotBlank(message: 'mautic.lead.import.file.notblank')]
     private $file = 'import.csv';
 
     /**
@@ -155,17 +156,6 @@ class Import extends FormEntity
             ->addNullableField('dateEnded', Types::DATETIME_MUTABLE, 'date_ended')
             ->addField('object', Types::STRING)
             ->addNullableField('properties', Types::JSON);
-    }
-
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addPropertyConstraint('dir', new Assert\NotBlank(
-            message: 'mautic.lead.import.dir.notblank'
-        ));
-
-        $metadata->addPropertyConstraint('file', new Assert\NotBlank(
-            message: 'mautic.lead.import.file.notblank'
-        ));
     }
 
     /**

--- a/app/bundles/LeadBundle/Entity/LeadField.php
+++ b/app/bundles/LeadBundle/Entity/LeadField.php
@@ -75,6 +75,7 @@ class LeadField extends FormEntity implements CacheInvalidateInterface, UuidInte
      * @var string
      */
     #[Groups(['leadfield:read', 'leadfield:write'])]
+    #[Assert\NotBlank(message: 'mautic.lead.field.label.notblank')]
     private $label;
 
     /**
@@ -311,10 +312,6 @@ class LeadField extends FormEntity implements CacheInvalidateInterface, UuidInte
 
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
-        $metadata->addPropertyConstraint('label', new Assert\NotBlank(
-            message: 'mautic.lead.field.label.notblank'
-        ));
-
         $metadata->addPropertyConstraint('label', new Assert\Length(max: 191, maxMessage: 'mautic.lead.field.label.maxlength'));
 
         $metadata->addConstraint(new UniqueEntity(fields: ['alias'], message: 'mautic.lead.field.alias.unique'));

--- a/app/bundles/LeadBundle/Entity/LeadField.php
+++ b/app/bundles/LeadBundle/Entity/LeadField.php
@@ -76,6 +76,7 @@ class LeadField extends FormEntity implements CacheInvalidateInterface, UuidInte
      */
     #[Groups(['leadfield:read', 'leadfield:write'])]
     #[Assert\NotBlank(message: 'mautic.lead.field.label.notblank')]
+    #[Assert\Length(max: 191, maxMessage: 'mautic.lead.field.label.maxlength')]
     private $label;
 
     /**
@@ -312,8 +313,6 @@ class LeadField extends FormEntity implements CacheInvalidateInterface, UuidInte
 
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
-        $metadata->addPropertyConstraint('label', new Assert\Length(max: 191, maxMessage: 'mautic.lead.field.label.maxlength'));
-
         $metadata->addConstraint(new UniqueEntity(fields: ['alias'], message: 'mautic.lead.field.alias.unique'));
 
         $metadata->addConstraint(new Assert\Callback(

--- a/app/bundles/LeadBundle/Entity/LeadList.php
+++ b/app/bundles/LeadBundle/Entity/LeadList.php
@@ -24,7 +24,6 @@ use Mautic\LeadBundle\Validator\Constraints\SegmentUsedInCampaigns;
 use Mautic\ProjectBundle\Entity\ProjectTrait;
 use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 #[ApiResource(
     shortName: 'Segments',
@@ -182,23 +181,6 @@ class LeadList extends FormEntity implements UuidInterface
         $builder->addNullableField('deleted', 'datetime');
 
         static::addUuidField($builder);
-    }
-
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-<<<<<<< HEAD
-        $metadata->addPropertyConstraint('name', new Assert\NotBlank(
-            message: 'mautic.core.name.required'
-        ));
-=======
-        $metadata->addConstraint(new UniqueUserAlias([
-            'field'   => 'alias',
-            'message' => 'mautic.lead.list.alias.unique',
-        ]));
-
-        $metadata->addConstraint(new SegmentUsedInCampaigns());
-        $metadata->addConstraint(new SegmentInUse());
->>>>>>> 81c5c7b1d1 ([symfony] move NotBlank property constraints from loadValidatorMetadata() to property attributes)
     }
 
     /**

--- a/app/bundles/LeadBundle/Entity/LeadList.php
+++ b/app/bundles/LeadBundle/Entity/LeadList.php
@@ -69,6 +69,7 @@ class LeadList extends FormEntity implements UuidInterface
      * @var string
      */
     #[Groups(['segment:read', 'segment:write', 'campaign:read', 'email:read', 'sms:read'])]
+    #[Assert\NotBlank(message: 'mautic.core.name.required')]
     private $name;
 
     /**
@@ -185,9 +186,19 @@ class LeadList extends FormEntity implements UuidInterface
 
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
+<<<<<<< HEAD
         $metadata->addPropertyConstraint('name', new Assert\NotBlank(
             message: 'mautic.core.name.required'
         ));
+=======
+        $metadata->addConstraint(new UniqueUserAlias([
+            'field'   => 'alias',
+            'message' => 'mautic.lead.list.alias.unique',
+        ]));
+
+        $metadata->addConstraint(new SegmentUsedInCampaigns());
+        $metadata->addConstraint(new SegmentInUse());
+>>>>>>> 81c5c7b1d1 ([symfony] move NotBlank property constraints from loadValidatorMetadata() to property attributes)
     }
 
     /**

--- a/app/bundles/LeadBundle/Entity/LeadNote.php
+++ b/app/bundles/LeadBundle/Entity/LeadNote.php
@@ -9,7 +9,6 @@ use Mautic\ApiBundle\Serializer\Driver\ApiMetadataDriver;
 use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
 use Mautic\CoreBundle\Entity\FormEntity;
 use Symfony\Component\Validator\Constraints\NotBlank;
-use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 class LeadNote extends FormEntity
 {
@@ -26,6 +25,7 @@ class LeadNote extends FormEntity
     /**
      * @var string
      */
+    #[NotBlank(message: 'mautic.lead.note.text.notblank')]
     private $text;
 
     /**
@@ -129,13 +129,6 @@ class LeadNote extends FormEntity
     /**
      * Form validation rules.
      */
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addPropertyConstraint('text', new NotBlank(
-            message: 'mautic.lead.note.text.notblank'
-        ));
-    }
-
     /**
      * @return Lead
      */

--- a/app/bundles/NotificationBundle/Entity/Notification.php
+++ b/app/bundles/NotificationBundle/Entity/Notification.php
@@ -60,6 +60,7 @@ class Notification extends FormEntity implements UuidInterface, TranslationEntit
      * @var string
      */
     #[Groups(['notification:read', 'notification:write'])]
+    #[NotBlank(message: 'mautic.core.name.required')]
     private $name;
 
     /**
@@ -78,12 +79,14 @@ class Notification extends FormEntity implements UuidInterface, TranslationEntit
      * @var string
      */
     #[Groups(['notification:read', 'notification:write'])]
+    #[NotBlank(message: 'mautic.core.heading.required')]
     private $heading;
 
     /**
      * @var string
      */
     #[Groups(['notification:read', 'notification:write'])]
+    #[NotBlank(message: 'mautic.core.message.required')]
     private $message;
 
     /**
@@ -250,27 +253,6 @@ class Notification extends FormEntity implements UuidInterface, TranslationEntit
 
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
-        $metadata->addPropertyConstraint(
-            'name',
-            new NotBlank(
-                message: 'mautic.core.name.required'
-            )
-        );
-
-        $metadata->addPropertyConstraint(
-            'heading',
-            new NotBlank(
-                message: 'mautic.core.heading.required'
-            )
-        );
-
-        $metadata->addPropertyConstraint(
-            'message',
-            new NotBlank(
-                message: 'mautic.core.message.required'
-            )
-        );
-
         $metadata->addConstraint(new Callback(
             function (Notification $notification, ExecutionContextInterface $context): void {
                 $type = $notification->getNotificationType();

--- a/app/bundles/NotificationBundle/Entity/Notification.php
+++ b/app/bundles/NotificationBundle/Entity/Notification.php
@@ -60,7 +60,6 @@ class Notification extends FormEntity implements UuidInterface, TranslationEntit
      * @var string
      */
     #[Groups(['notification:read', 'notification:write'])]
-    #[NotBlank(message: 'mautic.core.name.required')]
     private $name;
 
     /**
@@ -79,14 +78,12 @@ class Notification extends FormEntity implements UuidInterface, TranslationEntit
      * @var string
      */
     #[Groups(['notification:read', 'notification:write'])]
-    #[NotBlank(message: 'mautic.core.heading.required')]
     private $heading;
 
     /**
      * @var string
      */
     #[Groups(['notification:read', 'notification:write'])]
-    #[NotBlank(message: 'mautic.core.message.required')]
     private $message;
 
     /**
@@ -253,6 +250,27 @@ class Notification extends FormEntity implements UuidInterface, TranslationEntit
 
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
+        $metadata->addPropertyConstraint(
+            'name',
+            new NotBlank(
+                message: 'mautic.core.name.required'
+            )
+        );
+
+        $metadata->addPropertyConstraint(
+            'heading',
+            new NotBlank(
+                message: 'mautic.core.heading.required'
+            )
+        );
+
+        $metadata->addPropertyConstraint(
+            'message',
+            new NotBlank(
+                message: 'mautic.core.message.required'
+            )
+        );
+
         $metadata->addConstraint(new Callback(
             function (Notification $notification, ExecutionContextInterface $context): void {
                 $type = $notification->getNotificationType();

--- a/app/bundles/PageBundle/Entity/Page.php
+++ b/app/bundles/PageBundle/Entity/Page.php
@@ -79,6 +79,7 @@ class Page extends FormEntity implements TranslationEntityInterface, VariantEnti
      * @var string
      */
     #[Groups(['page:read', 'page:write', 'download:read', 'email:read'])]
+    #[NotBlank(message: 'mautic.core.title.required')]
     private $title;
 
     /**
@@ -321,8 +322,6 @@ class Page extends FormEntity implements TranslationEntityInterface, VariantEnti
 
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
-        $metadata->addPropertyConstraint('title', new NotBlank(message: 'mautic.core.title.required'));
-
         $metadata->addConstraint(new Callback(
             function (Page $page, ExecutionContextInterface $context): void {
                 $type = $page->getRedirectType();

--- a/app/bundles/PointBundle/Entity/Group.php
+++ b/app/bundles/PointBundle/Entity/Group.php
@@ -9,7 +9,6 @@ use Mautic\CoreBundle\Entity\FormEntity;
 use Mautic\CoreBundle\Entity\UuidInterface;
 use Mautic\CoreBundle\Entity\UuidTrait;
 use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 class Group extends FormEntity implements UuidInterface
 {
@@ -21,6 +20,7 @@ class Group extends FormEntity implements UuidInterface
 
     private ?int $id             = null;
 
+    #[Assert\NotBlank(message: 'mautic.core.name.required')]
     private ?string $name        = '';
 
     private ?string $description = '';
@@ -38,11 +38,6 @@ class Group extends FormEntity implements UuidInterface
         static::addUuidField($builder);
 
         $builder->addIdColumns();
-    }
-
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addPropertyConstraint('name', new Assert\NotBlank(message: 'mautic.core.name.required'));
     }
 
     public static function loadApiMetadata(ApiMetadataDriver $metadata): void

--- a/app/bundles/PointBundle/Entity/Point.php
+++ b/app/bundles/PointBundle/Entity/Point.php
@@ -61,6 +61,7 @@ class Point extends FormEntity implements UuidInterface
      * @var string
      */
     #[Groups(['point:read', 'point:write'])]
+    #[Assert\NotBlank(message: 'mautic.core.name.required')]
     private $name;
 
     /**
@@ -73,6 +74,7 @@ class Point extends FormEntity implements UuidInterface
      * @var string
      */
     #[Groups(['point:read', 'point:write'])]
+    #[Assert\NotBlank(message: 'mautic.point.type.notblank')]
     private $type;
 
     /**
@@ -97,6 +99,7 @@ class Point extends FormEntity implements UuidInterface
      * @var int
      */
     #[Groups(['point:read', 'point:write'])]
+    #[Assert\NotBlank(message: 'mautic.point.delta.notblank')]
     private $delta = 0;
 
     /**
@@ -174,12 +177,6 @@ class Point extends FormEntity implements UuidInterface
 
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
-        $metadata->addPropertyConstraint('name', new Assert\NotBlank(message: 'mautic.core.name.required'));
-
-        $metadata->addPropertyConstraint('type', new Assert\NotBlank(message: 'mautic.point.type.notblank'));
-
-        $metadata->addPropertyConstraint('delta', new Assert\NotBlank(message: 'mautic.point.delta.notblank'));
-
         $metadata->addPropertyConstraint('delta', new Assert\Range(min: IntHelper::MIN_INTEGER_VALUE, max: IntHelper::MAX_INTEGER_VALUE));
     }
 

--- a/app/bundles/PointBundle/Entity/Point.php
+++ b/app/bundles/PointBundle/Entity/Point.php
@@ -23,7 +23,6 @@ use Mautic\CoreBundle\Helper\IntHelper;
 use Mautic\ProjectBundle\Entity\ProjectTrait;
 use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 #[ApiResource(
     operations: [
@@ -100,6 +99,7 @@ class Point extends FormEntity implements UuidInterface
      */
     #[Groups(['point:read', 'point:write'])]
     #[Assert\NotBlank(message: 'mautic.point.delta.notblank')]
+    #[Assert\Range(min: IntHelper::MIN_INTEGER_VALUE, max: IntHelper::MAX_INTEGER_VALUE)]
     private $delta = 0;
 
     /**
@@ -173,11 +173,6 @@ class Point extends FormEntity implements UuidInterface
 
         static::addUuidField($builder);
         self::addProjectsField($builder, 'point_projects_xref', 'point_id');
-    }
-
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addPropertyConstraint('delta', new Assert\Range(min: IntHelper::MIN_INTEGER_VALUE, max: IntHelper::MAX_INTEGER_VALUE));
     }
 
     /**

--- a/app/bundles/PointBundle/Entity/PointInsight.php
+++ b/app/bundles/PointBundle/Entity/PointInsight.php
@@ -9,7 +9,6 @@ use Mautic\CategoryBundle\Entity\Category;
 use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
 use Mautic\CoreBundle\Entity\FormEntity;
 use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 class PointInsight extends FormEntity
 {
@@ -19,6 +18,7 @@ class PointInsight extends FormEntity
 
     private ?int $id = null;
 
+    #[Assert\NotBlank(message: 'mautic.core.name.required')]
     private string $name = '';
 
     /**
@@ -29,11 +29,13 @@ class PointInsight extends FormEntity
     /**
      * @var string
      */
+    #[Assert\NotBlank(message: 'mautic.point.insight.type.required')]
     private $insightType = self::INSIGHT_TYPE_COMPARE_POINT_GROUPS;
 
     /**
      * @var string
      */
+    #[Assert\NotBlank(message: 'mautic.point.insight.action.required')]
     private $insightAction = self::INSIGHT_ACTION_SET_CUSTOM_FIELD;
 
     /**
@@ -85,15 +87,6 @@ class PointInsight extends FormEntity
             ->build();
 
         $builder->addCategory();
-    }
-
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addPropertyConstraint('name', new Assert\NotBlank(message: 'mautic.core.name.required'));
-
-        $metadata->addPropertyConstraint('insightType', new Assert\NotBlank(message: 'mautic.point.insight.type.required'));
-
-        $metadata->addPropertyConstraint('insightAction', new Assert\NotBlank(message: 'mautic.point.insight.action.required'));
     }
 
     /**

--- a/app/bundles/PointBundle/Entity/Trigger.php
+++ b/app/bundles/PointBundle/Entity/Trigger.php
@@ -20,7 +20,6 @@ use Mautic\CoreBundle\Entity\UuidTrait;
 use Mautic\ProjectBundle\Entity\ProjectTrait;
 use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 #[ApiResource(
     operations: [
@@ -58,6 +57,7 @@ class Trigger extends FormEntity implements UuidInterface
      * @var string
      */
     #[Groups(['trigger:read', 'trigger:write'])]
+    #[Assert\NotBlank(message: 'mautic.core.name.required')]
     private $name;
 
     /**
@@ -161,11 +161,6 @@ class Trigger extends FormEntity implements UuidInterface
 
         static::addUuidField($builder);
         self::addProjectsField($builder, 'point_trigger_projects_xref', 'point_trigger_id');
-    }
-
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addPropertyConstraint('name', new Assert\NotBlank(message: 'mautic.core.name.required'));
     }
 
     /**

--- a/app/bundles/ReportBundle/Entity/Report.php
+++ b/app/bundles/ReportBundle/Entity/Report.php
@@ -58,6 +58,7 @@ class Report extends FormEntity implements SchedulerInterface, UuidInterface
      * @var string
      */
     #[Groups(['report:read', 'report:write'])]
+    #[NotBlank(message: 'mautic.core.name.required')]
     private $name;
 
     /**
@@ -220,8 +221,6 @@ class Report extends FormEntity implements SchedulerInterface, UuidInterface
 
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
-        $metadata->addPropertyConstraint('name', new NotBlank(message: 'mautic.core.name.required'));
-
         $metadata->addPropertyConstraint('toAddress', new EmailAssert\MultipleEmailsValid());
     }
 

--- a/app/bundles/SmsBundle/Entity/Sms.php
+++ b/app/bundles/SmsBundle/Entity/Sms.php
@@ -138,6 +138,7 @@ class Sms extends FormEntity implements UuidInterface, TranslationEntityInterfac
      * @var array<mixed>
      */
     #[Groups(['sms:read', 'sms:write'])]
+    #[Count(max: 10, maxMessage: 'mautic.sms.form.max.media.error')]
     private array $media = [];
 
     #[Groups(['sms:read', 'sms:write'])]
@@ -227,11 +228,6 @@ class Sms extends FormEntity implements UuidInterface, TranslationEntityInterfac
 
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
-        $metadata->addPropertyConstraint(
-            'media',
-            new Count(max: 10, maxMessage: 'mautic.sms.form.max.media.error')
-        );
-
         $metadata->addConstraint(new Callback(
             function (Sms $sms, ExecutionContextInterface $context): void {
                 $type      = $sms->getSmsType();

--- a/app/bundles/SmsBundle/Entity/Sms.php
+++ b/app/bundles/SmsBundle/Entity/Sms.php
@@ -78,6 +78,7 @@ class Sms extends FormEntity implements UuidInterface, TranslationEntityInterfac
      * @var string
      */
     #[Groups(['sms:read', 'sms:write'])]
+    #[NotBlank(message: 'mautic.core.name.required')]
     private $name;
 
     /**
@@ -226,11 +227,6 @@ class Sms extends FormEntity implements UuidInterface, TranslationEntityInterfac
 
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
-        $metadata->addPropertyConstraint(
-            'name',
-            new NotBlank(message: 'mautic.core.name.required')
-        );
-
         $metadata->addPropertyConstraint(
             'media',
             new Count(max: 10, maxMessage: 'mautic.sms.form.max.media.error')

--- a/app/bundles/StageBundle/Entity/Stage.php
+++ b/app/bundles/StageBundle/Entity/Stage.php
@@ -57,6 +57,7 @@ class Stage extends FormEntity implements UuidInterface
      * @var string
      */
     #[Groups(['stage:read', 'stage:write'])]
+    #[Assert\NotBlank(message: 'mautic.core.name.required')]
     private $name;
 
     /**
@@ -135,8 +136,6 @@ class Stage extends FormEntity implements UuidInterface
 
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
-        $metadata->addPropertyConstraint('name', new Assert\NotBlank(message: 'mautic.core.name.required'));
-
         $metadata->addConstraint(new UniqueEntity(fields: ['weight'], message: 'mautic.stage.weight.unique'));
     }
 

--- a/app/bundles/UserBundle/Entity/Role.php
+++ b/app/bundles/UserBundle/Entity/Role.php
@@ -21,7 +21,6 @@ use Mautic\CoreBundle\Entity\UuidInterface;
 use Mautic\CoreBundle\Entity\UuidTrait;
 use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 #[ApiResource(
     operations: [
@@ -58,6 +57,7 @@ class Role extends FormEntity implements CacheInvalidateInterface, UuidInterface
      * @var string
      */
     #[Groups(['role:read', 'role:write'])]
+    #[Assert\NotBlank(message: 'mautic.core.name.required')]
     private $name;
 
     /**
@@ -126,13 +126,6 @@ class Role extends FormEntity implements CacheInvalidateInterface, UuidInterface
             ->build();
 
         static::addUuidField($builder);
-    }
-
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addPropertyConstraint('name', new Assert\NotBlank(
-            message: 'mautic.core.name.required'
-        ));
     }
 
     /**

--- a/app/bundles/UserBundle/Entity/User.php
+++ b/app/bundles/UserBundle/Entity/User.php
@@ -70,6 +70,7 @@ class User extends FormEntity implements UserInterface, EquatableInterface, Pass
      */
     #[Groups(['user:write'])]
     #[Assert\NotBlank(message: 'mautic.user.user.password.notblank', groups: ['CheckPasswordNotBlank'])]
+    #[Assert\Length(min: 6, minMessage: 'mautic.user.user.password.minlength', groups: ['CheckPassword'])]
     private $plainPassword;
 
     /**
@@ -104,6 +105,7 @@ class User extends FormEntity implements UserInterface, EquatableInterface, Pass
      * @var string|null
      */
     #[Groups(['user:read', 'user:write'])]
+    #[Assert\Length(max: 191, maxMessage: 'mautic.user.user.position.toolong')]
     private $position;
 
     /**
@@ -240,10 +242,6 @@ class User extends FormEntity implements UserInterface, EquatableInterface, Pass
         $metadata->addPropertyConstraint('email', new Assert\Email(message: 'mautic.user.user.email.valid', groups: ['SecondPass']));
 
         $metadata->addConstraint(new UniqueEntity(fields: ['email'], message: 'mautic.user.user.email.unique', repositoryMethod: 'checkUniqueUsernameEmail', groups: ['User', 'SecondPass']));
-
-        $metadata->addPropertyConstraint('position', new Assert\Length(max: 191, maxMessage: 'mautic.user.user.position.toolong'));
-
-        $metadata->addPropertyConstraint('plainPassword', new Assert\Length(min: 6, minMessage: 'mautic.user.user.password.minlength', groups: ['CheckPassword']));
 
         $metadata->addPropertyConstraint('plainPassword', new NotWeak(message: 'mautic.user.user.password.weak', groups: ['CheckPassword']));
 

--- a/app/bundles/UserBundle/Entity/User.php
+++ b/app/bundles/UserBundle/Entity/User.php
@@ -99,6 +99,7 @@ class User extends FormEntity implements UserInterface, EquatableInterface, Pass
      */
     #[Groups(['user:read', 'user:write'])]
     #[Assert\NotBlank(message: 'mautic.user.user.email.valid')]
+    #[Assert\Email(message: 'mautic.user.user.email.valid', groups: ['SecondPass'])]
     private $email;
 
     /**
@@ -238,8 +239,6 @@ class User extends FormEntity implements UserInterface, EquatableInterface, Pass
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
         $metadata->addConstraint(new UniqueEntity(fields: ['username'], message: 'mautic.user.user.username.unique', repositoryMethod: 'checkUniqueUsernameEmail'));
-
-        $metadata->addPropertyConstraint('email', new Assert\Email(message: 'mautic.user.user.email.valid', groups: ['SecondPass']));
 
         $metadata->addConstraint(new UniqueEntity(fields: ['email'], message: 'mautic.user.user.email.unique', repositoryMethod: 'checkUniqueUsernameEmail', groups: ['User', 'SecondPass']));
 

--- a/app/bundles/UserBundle/Entity/User.php
+++ b/app/bundles/UserBundle/Entity/User.php
@@ -55,6 +55,7 @@ class User extends FormEntity implements UserInterface, EquatableInterface, Pass
     protected $id;
 
     #[Groups(['user:read', 'user:write'])]
+    #[Assert\NotBlank(message: 'mautic.user.user.username.notblank')]
     protected ?string $username = null;
 
     /**
@@ -68,6 +69,7 @@ class User extends FormEntity implements UserInterface, EquatableInterface, Pass
      * @var ?string
      */
     #[Groups(['user:write'])]
+    #[Assert\NotBlank(message: 'mautic.user.user.password.notblank', groups: ['CheckPasswordNotBlank'])]
     private $plainPassword;
 
     /**
@@ -81,18 +83,21 @@ class User extends FormEntity implements UserInterface, EquatableInterface, Pass
      * @var string
      */
     #[Groups(['user:read', 'user:write'])]
+    #[Assert\NotBlank(message: 'mautic.user.user.firstname.notblank')]
     private $firstName;
 
     /**
      * @var string
      */
     #[Groups(['user:read', 'user:write'])]
+    #[Assert\NotBlank(message: 'mautic.user.user.lastname.notblank')]
     private $lastName;
 
     /**
      * @var string
      */
     #[Groups(['user:read', 'user:write'])]
+    #[Assert\NotBlank(message: 'mautic.user.user.email.valid')]
     private $email;
 
     /**
@@ -105,6 +110,7 @@ class User extends FormEntity implements UserInterface, EquatableInterface, Pass
      * @var Role
      */
     #[Groups(['user:read', 'user:write'])]
+    #[Assert\NotBlank(message: 'mautic.user.user.role.notblank')]
     private $role;
 
     /**
@@ -229,35 +235,13 @@ class User extends FormEntity implements UserInterface, EquatableInterface, Pass
 
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
-        $metadata->addPropertyConstraint('username', new Assert\NotBlank(
-            message: 'mautic.user.user.username.notblank'
-        ));
-
         $metadata->addConstraint(new UniqueEntity(fields: ['username'], message: 'mautic.user.user.username.unique', repositoryMethod: 'checkUniqueUsernameEmail'));
-
-        $metadata->addPropertyConstraint('firstName', new Assert\NotBlank(
-            message: 'mautic.user.user.firstname.notblank'
-        ));
-
-        $metadata->addPropertyConstraint('lastName', new Assert\NotBlank(
-            message: 'mautic.user.user.lastname.notblank'
-        ));
-
-        $metadata->addPropertyConstraint('email', new Assert\NotBlank(
-            message: 'mautic.user.user.email.valid'
-        ));
 
         $metadata->addPropertyConstraint('email', new Assert\Email(message: 'mautic.user.user.email.valid', groups: ['SecondPass']));
 
         $metadata->addConstraint(new UniqueEntity(fields: ['email'], message: 'mautic.user.user.email.unique', repositoryMethod: 'checkUniqueUsernameEmail', groups: ['User', 'SecondPass']));
 
         $metadata->addPropertyConstraint('position', new Assert\Length(max: 191, maxMessage: 'mautic.user.user.position.toolong'));
-
-        $metadata->addPropertyConstraint('role', new Assert\NotBlank(
-            message: 'mautic.user.user.role.notblank'
-        ));
-
-        $metadata->addPropertyConstraint('plainPassword', new Assert\NotBlank(message: 'mautic.user.user.password.notblank', groups: ['CheckPasswordNotBlank']));
 
         $metadata->addPropertyConstraint('plainPassword', new Assert\Length(min: 6, minMessage: 'mautic.user.user.password.minlength', groups: ['CheckPassword']));
 

--- a/app/bundles/WebhookBundle/Entity/Webhook.php
+++ b/app/bundles/WebhookBundle/Entity/Webhook.php
@@ -73,6 +73,7 @@ class Webhook extends FormEntity implements SkipModifiedInterface
      */
     #[Groups(['webhook:read', 'webhook:write'])]
     #[NotBlank(message: 'mautic.core.valid_url_required')]
+    #[Assert\Url(message: 'mautic.core.valid_url_required')]
     private $webhookUrl;
 
     /**
@@ -192,13 +193,6 @@ class Webhook extends FormEntity implements SkipModifiedInterface
 
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
-        $metadata->addPropertyConstraint(
-            'webhookUrl',
-            new Assert\Url(
-                message: 'mautic.core.valid_url_required'
-            )
-        );
-
         $metadata->addPropertyConstraint(
             'eventsOrderbyDir',
             new Assert\Choice(

--- a/app/bundles/WebhookBundle/Entity/Webhook.php
+++ b/app/bundles/WebhookBundle/Entity/Webhook.php
@@ -23,7 +23,6 @@ use Mautic\CoreBundle\Entity\SkipModifiedInterface;
 use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Validator\Constraints\NotBlank;
-use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 #[ApiResource(
     shortName: 'Webhooks',
@@ -121,6 +120,11 @@ class Webhook extends FormEntity implements SkipModifiedInterface
      * @var string|null
      */
     #[Groups(['webhook:read', 'webhook:write'])]
+    #[Assert\Choice([
+        null,
+        Order::Ascending->value,
+        Order::Descending->value,
+    ])]
     private $eventsOrderbyDir;
 
     private ?\DateTimeImmutable $markedUnhealthyAt      = null;
@@ -189,20 +193,6 @@ class Webhook extends FormEntity implements SkipModifiedInterface
                 ]
             )
             ->build();
-    }
-
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addPropertyConstraint(
-            'eventsOrderbyDir',
-            new Assert\Choice(
-                [
-                    null,
-                    Order::Ascending->value,
-                    Order::Descending->value,
-                ]
-            )
-        );
     }
 
     /**

--- a/app/bundles/WebhookBundle/Entity/Webhook.php
+++ b/app/bundles/WebhookBundle/Entity/Webhook.php
@@ -59,6 +59,7 @@ class Webhook extends FormEntity implements SkipModifiedInterface
      * @var ?string
      */
     #[Groups(['webhook:read', 'webhook:write'])]
+    #[NotBlank(message: 'mautic.core.name.required')]
     private $name;
 
     /**
@@ -71,6 +72,7 @@ class Webhook extends FormEntity implements SkipModifiedInterface
      * @var ?string
      */
     #[Groups(['webhook:read', 'webhook:write'])]
+    #[NotBlank(message: 'mautic.core.valid_url_required')]
     private $webhookUrl;
 
     /**
@@ -191,22 +193,8 @@ class Webhook extends FormEntity implements SkipModifiedInterface
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
         $metadata->addPropertyConstraint(
-            'name',
-            new NotBlank(
-                message: 'mautic.core.name.required'
-            )
-        );
-
-        $metadata->addPropertyConstraint(
             'webhookUrl',
             new Assert\Url(
-                message: 'mautic.core.valid_url_required'
-            )
-        );
-
-        $metadata->addPropertyConstraint(
-            'webhookUrl',
-            new NotBlank(
                 message: 'mautic.core.valid_url_required'
             )
         );

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2380,36 +2380,6 @@ parameters:
 			path: app/bundles/CoreBundle/Helper/DateTimeHelper.php
 
 		-
-			message: '#^Property Mautic\\CoreBundle\\Helper\\EmojiMap\\HtmlToUnicodeEmojiMap\:\:\$map has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/bundles/CoreBundle/Helper/EmojiMap/HtmlToUnicodeEmojiMap.php
-
-		-
-			message: '#^Property Mautic\\CoreBundle\\Helper\\EmojiMap\\ShortToUnicodeEmojiMap\:\:\$exceptions has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/bundles/CoreBundle/Helper/EmojiMap/ShortToUnicodeEmojiMap.php
-
-		-
-			message: '#^Property Mautic\\CoreBundle\\Helper\\EmojiMap\\ShortToUnicodeEmojiMap\:\:\$map has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/bundles/CoreBundle/Helper/EmojiMap/ShortToUnicodeEmojiMap.php
-
-		-
-			message: '#^Property Mautic\\CoreBundle\\Helper\\EmojiMap\\UnicodeToHtmlEmojiMap\:\:\$map has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/bundles/CoreBundle/Helper/EmojiMap/UnicodeToHtmlEmojiMap.php
-
-		-
-			message: '#^Property Mautic\\CoreBundle\\Helper\\EmojiMap\\UnicodeToShortEmojiMap\:\:\$map has no type specified\.$#'
-			identifier: missingType.property
-			count: 1
-			path: app/bundles/CoreBundle/Helper/EmojiMap/UnicodeToShortEmojiMap.php
-
-		-
 			message: '#^Parameter \#1 \$prefix of function uniqid expects string, int\<0, max\> given\.$#'
 			identifier: argument.type
 			count: 1

--- a/plugins/MauticFocusBundle/Entity/Focus.php
+++ b/plugins/MauticFocusBundle/Entity/Focus.php
@@ -21,7 +21,6 @@ use Mautic\FormBundle\Entity\Form;
 use Mautic\ProjectBundle\Entity\ProjectTrait;
 use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Validator\Constraints\NotBlank;
-use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 #[ApiResource(
     operations: [
@@ -80,6 +79,7 @@ class Focus extends FormEntity implements UuidInterface
      * @var string
      */
     #[Groups(['focus:read', 'focus:write'])]
+    #[NotBlank(message: 'mautic.core.name.required')]
     private $name;
 
     #[Groups(['focus:read', 'focus:write'])]
@@ -89,6 +89,7 @@ class Focus extends FormEntity implements UuidInterface
      * @var string
      */
     #[Groups(['focus:read', 'focus:write'])]
+    #[NotBlank(message: 'mautic.focus.error.select_type')]
     private $type;
 
     /**
@@ -101,6 +102,7 @@ class Focus extends FormEntity implements UuidInterface
      * @var string
      */
     #[Groups(['focus:read', 'focus:write'])]
+    #[NotBlank(message: 'mautic.focus.error.select_style')]
     private $style;
 
     /**
@@ -140,30 +142,6 @@ class Focus extends FormEntity implements UuidInterface
     public function __construct()
     {
         $this->initializeProjects();
-    }
-
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addPropertyConstraint(
-            'name',
-            new NotBlank(
-                message: 'mautic.core.name.required'
-            )
-        );
-
-        $metadata->addPropertyConstraint(
-            'type',
-            new NotBlank(
-                message: 'mautic.focus.error.select_type'
-            )
-        );
-
-        $metadata->addPropertyConstraint(
-            'style',
-            new NotBlank(
-                message: 'mautic.focus.error.select_style'
-            )
-        );
     }
 
     public function __clone()

--- a/plugins/MauticSocialBundle/Entity/Monitoring.php
+++ b/plugins/MauticSocialBundle/Entity/Monitoring.php
@@ -16,7 +16,6 @@ use Mautic\CoreBundle\Entity\UuidInterface;
 use Mautic\CoreBundle\Entity\UuidTrait;
 use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 #[ApiResource(
     operations: [
@@ -51,6 +50,7 @@ class Monitoring extends FormEntity implements UuidInterface
      * @var string
      */
     #[Groups(['monitoring:read', 'monitoring:write'])]
+    #[Assert\NotBlank(message: 'mautic.core.title.required')]
     private $title;
 
     /**
@@ -75,6 +75,7 @@ class Monitoring extends FormEntity implements UuidInterface
      * @var string|null
      */
     #[Groups(['monitoring:read', 'monitoring:write'])]
+    #[Assert\NotBlank(message: 'mautic.social.network.type')]
     private $networkType;
 
     /**
@@ -138,17 +139,6 @@ class Monitoring extends FormEntity implements UuidInterface
     /**
      * Constraints for required fields.
      */
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addPropertyConstraint('title', new Assert\NotBlank(
-            message: 'mautic.core.title.required'
-        ));
-
-        $metadata->addPropertyConstraint('networkType', new Assert\NotBlank(
-            message: 'mautic.social.network.type'
-        ));
-    }
-
     /**
      * @return mixed
      */

--- a/plugins/MauticSocialBundle/Entity/Tweet.php
+++ b/plugins/MauticSocialBundle/Entity/Tweet.php
@@ -12,7 +12,6 @@ use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
 use Mautic\CoreBundle\Entity\FormEntity;
 use Mautic\PageBundle\Entity\Page;
 use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 #[ORM\Table(name: 'tweets')]
 #[ORM\Entity(repositoryClass: TweetRepository::class)]
@@ -51,6 +50,7 @@ class Tweet extends FormEntity
      *
      * @var string
      */
+    #[Assert\Length(max: 280)]
     private $text;
 
     /**
@@ -183,13 +183,6 @@ class Tweet extends FormEntity
     /**
      * Constraints for required fields.
      */
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addPropertyConstraint('text', new Assert\Length(
-            max: 280
-        ));
-    }
-
     /**
      * @return int|null
      */


### PR DESCRIPTION
Follow-up to #17016, same idea for the remaining built-in Symfony constraints: `Length`, `Email`, `Range`, `Url`, `Choice`, `GreaterThan` and `Count` move from `loadValidatorMetadata()` to the property they validate.

```diff
     #[Groups(['point:read', 'point:write'])]
     #[Assert\NotBlank(message: 'mautic.point.delta.notblank')]
+    #[Assert\Range(min: IntHelper::MIN_INTEGER_VALUE, max: IntHelper::MAX_INTEGER_VALUE)]
     private $delta = 0;

-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addPropertyConstraint('delta', new Assert\Range(min: IntHelper::MIN_INTEGER_VALUE, max: IntHelper::MAX_INTEGER_VALUE));
-    }
```

One commit per constraint type, 16 constraints over 9 entities. `Point`, `Webhook` and `Tweet` lose their `loadValidatorMetadata()` entirely, along with the now-unused `ClassMetadata` import.

Two spots keep their fully qualified name because the entity class shadows the constraint class – `Email::$replyToAddress` and `Email::$bccAddress` use `#[\Symfony\Component\Validator\Constraints\Email(...)]`, exactly as the old code did.

## Behavior is identical

The resolved `ClassMetadata` was dumped for all touched entities before and after – property constraints, class constraints, and every constraint option including groups – and the two dumps are identical.

Stacked on #17016; the diff shown here includes that PR until it is merged.
