### PR TITLE
[symfony] Validator attributes: Notification

### DIFF
--- a/app/bundles/NotificationBundle/Entity/Notification.php
+++ b/app/bundles/NotificationBundle/Entity/Notification.php
@@ -60,6 +60,7 @@ class Notification extends FormEntity implements UuidInterface, TranslationEntit
      * @var string
      */
     #[Groups(['notification:read', 'notification:write'])]
+    #[NotBlank(message: 'mautic.core.name.required')]
     private $name;
 
     /**
@@ -78,12 +79,14 @@ class Notification extends FormEntity implements UuidInterface, TranslationEntit
      * @var string
      */
     #[Groups(['notification:read', 'notification:write'])]
+    #[NotBlank(message: 'mautic.core.heading.required')]
     private $heading;
 
     /**
      * @var string
      */
     #[Groups(['notification:read', 'notification:write'])]
+    #[NotBlank(message: 'mautic.core.message.required')]
     private $message;
 
     /**
@@ -250,27 +253,6 @@ class Notification extends FormEntity implements UuidInterface, TranslationEntit
 
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
-        $metadata->addPropertyConstraint(
-            'name',
-            new NotBlank(
-                message: 'mautic.core.name.required'
-            )
-        );
-
-        $metadata->addPropertyConstraint(
-            'heading',
-            new NotBlank(
-                message: 'mautic.core.heading.required'
-            )
-        );
-
-        $metadata->addPropertyConstraint(
-            'message',
-            new NotBlank(
-                message: 'mautic.core.message.required'
-            )
-        );
-
         $metadata->addConstraint(new Callback(
             function (Notification $notification, ExecutionContextInterface $context): void {
                 $type = $notification->getNotificationType();


### PR DESCRIPTION
Same change as #17016, for the `Notification` entity, targeted at 8.x.

```diff
     #[Groups(['notification:read', 'notification:write'])]
+    #[NotBlank(message: 'mautic.core.heading.required')]
     private $heading;

     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
-        $metadata->addPropertyConstraint(
-            'heading',
-            new NotBlank(
-                message: 'mautic.core.heading.required'
-            )
-        );
-
         $metadata->addConstraint(new Callback(
```

Three property constraints – `name`, `heading`, `message`. The `NotBlank` used inside the `Callback` closure for list validation stays where it is, it is not a property constraint.

## Behavior is identical

The resolved `ClassMetadata` was dumped before and after – property constraints, class constraints, and every constraint option including groups – and the two dumps are identical.
