### PR TITLE
[removal] Remove leftover code deprecated in Mautic 2.x

### DIFF
--- a/app/bundles/CampaignBundle/EventCollector/Builder/ConnectionBuilder.php
+++ b/app/bundles/CampaignBundle/EventCollector/Builder/ConnectionBuilder.php
@@ -2,8 +2,6 @@
 
 namespace Mautic\CampaignBundle\EventCollector\Builder;
 
-use Mautic\CampaignBundle\Entity\Event;
-
 final class ConnectionBuilder
 {
     private static array $eventTypes = [];
@@ -20,9 +18,9 @@ final class ConnectionBuilder
 
         // Build the restrictions
         self::$eventTypes = array_fill_keys(array_keys($events), []);
-        foreach ($events as $eventType => $typeEvents) {
+        foreach ($events as $typeEvents) {
             foreach ($typeEvents as $key => $event) {
-                self::addTypeConnection($eventType, $key, $event);
+                self::addTypeConnection($key, $event);
             }
         }
 
@@ -32,7 +30,7 @@ final class ConnectionBuilder
     /**
      * @param string $key
      */
-    private static function addTypeConnection(int|string $eventType, $key, array $event): void
+    private static function addTypeConnection($key, array $event): void
     {
         if (!isset(self::$connectionRestrictions[$key])) {
             self::$connectionRestrictions[$key] = [
@@ -50,8 +48,6 @@ final class ConnectionBuilder
                 self::addRestriction($key, $restrictionType, $restrictions);
             }
         }
-
-        self::addDeprecatedAnchorRestrictions($eventType, $key, $event);
     }
 
     /**
@@ -74,35 +70,6 @@ final class ConnectionBuilder
                 }
 
                 break;
-        }
-    }
-
-    /**
-     * @deprecated 2.6.0 to be removed in 3.0; BC support
-     *
-     * @param string $eventType
-     * @param string $key
-     */
-    private static function addDeprecatedAnchorRestrictions(string|int $eventType, $key, array $event): void
-    {
-        switch ($eventType) {
-            case Event::TYPE_DECISION:
-                if (isset($event['associatedActions'])) {
-                    self::$connectionRestrictions[$key]['target']['action'] += $event['associatedActions'];
-                }
-                break;
-            case Event::TYPE_ACTION:
-                if (isset($event['associatedDecisions'])) {
-                    self::$connectionRestrictions[$key]['source']['decision'] += $event['associatedDecisions'];
-                }
-                break;
-        }
-
-        if (isset($event['anchorRestrictions'])) {
-            foreach ($event['anchorRestrictions'] as $restriction) {
-                [$group, $anchor]                                       = explode('.', $restriction);
-                self::$connectionRestrictions['anchor'][$key][$group][] = $anchor;
-            }
         }
     }
 }

--- a/app/bundles/CampaignBundle/Tests/EventCollector/Builder/ConnectionBuilderTest.php
+++ b/app/bundles/CampaignBundle/Tests/EventCollector/Builder/ConnectionBuilderTest.php
@@ -23,28 +23,10 @@ final class ConnectionBuilderTest extends \PHPUnit\Framework\TestCase
                         ],
                     ],
                 ],
-                'action2' => [
-                    // BC from way back
-                    'associatedDecisions' => [
-                        'decision1',
-                    ],
-                ],
-                'action3' => [
-                    // BC from way back
-                    'anchorRestrictions' => [
-                        'decision2.top',
-                    ],
-                ],
             ],
             Event::TYPE_DECISION => [
                 'decision1' => [
                     'connectionRestrictions' => ['source' => ['action' => ['action1']]],
-                ],
-                'decision2' => [
-                    // BC From way back
-                    'associatedActions' => [
-                        'some.decision',
-                    ],
                 ],
             ],
         ];
@@ -56,34 +38,11 @@ final class ConnectionBuilderTest extends \PHPUnit\Framework\TestCase
                 'decision1' => [
                     'action1' => ['inaction'],
                 ],
-                'action3'   => [
-                    'decision2' => ['top'],
-                ],
             ],
             'action1'   => [
                 'source' => [
                     'action'   => [],
                     'decision' => ['decision1'],
-                ],
-                'target' => [
-                    'action'   => [],
-                    'decision' => [],
-                ],
-            ],
-            'action2'   => [
-                'source' => [
-                    'action'   => [],
-                    'decision' => ['decision1'],
-                ],
-                'target' => [
-                    'action'   => [],
-                    'decision' => [],
-                ],
-            ],
-            'action3'   => [
-                'source' => [
-                    'action'   => [],
-                    'decision' => [],
                 ],
                 'target' => [
                     'action'   => [],
@@ -97,16 +56,6 @@ final class ConnectionBuilderTest extends \PHPUnit\Framework\TestCase
                 ],
                 'target' => [
                     'action'   => [],
-                    'decision' => [],
-                ],
-            ],
-            'decision2' => [
-                'source' => [
-                    'action'   => [],
-                    'decision' => [],
-                ],
-                'target' => [
-                    'action'   => ['some.decision'],
                     'decision' => [],
                 ],
             ],

--- a/app/bundles/CoreBundle/Helper/CacheStorageHelper.php
+++ b/app/bundles/CoreBundle/Helper/CacheStorageHelper.php
@@ -28,15 +28,6 @@ class CacheStorageHelper
     protected string $cacheDir;
 
     /**
-     * Semi BC support for pre 2.6.0.
-     *
-     * @deprecated 2.6.0 to be removed in 3.0
-     *
-     * @var array
-     */
-    protected $expirations = [];
-
-    /**
      * @param mixed  $cacheDir
      * @param mixed  $namespace
      * @param int    $defaultExpiration
@@ -93,18 +84,12 @@ class CacheStorageHelper
     }
 
     /**
-     * @param int $maxAge @deprecated 2.6.0 to be removed in 3.0; set expiration when using set()
-     *
      * @return bool|mixed
      *
      * @throws \Psr\Cache\InvalidArgumentException
      */
-    public function get($name, $maxAge = null)
+    public function get($name)
     {
-        if (0 === $maxAge) {
-            return false;
-        }
-
         $cacheItem = $this->cacheAdaptor->getItem($name);
         if ($cacheItem->isHit()) {
             return $cacheItem->get();
@@ -175,14 +160,5 @@ class CacheStorageHelper
             default:
                 throw new \InvalidArgumentException('Cache adaptor not supported.');
         }
-    }
-
-    /**
-     * Kept since it was public prior to deprecation.
-     *
-     * @deprecated 2.6.0 to be removed in 3.0
-     */
-    public function touchDir(): void
-    {
     }
 }

--- a/app/bundles/DashboardBundle/Event/WidgetDetailEvent.php
+++ b/app/bundles/DashboardBundle/Event/WidgetDetailEvent.php
@@ -204,17 +204,6 @@ class WidgetDetailEvent extends CommonEvent
         $this->widget->setTemplateData($templateData);
         $this->widget->setLoadTime(abs(microtime(true) - $this->startTime));
 
-        if ($this->usesLegacyCache()) {
-            // Store the template data to the cache
-            if (!$skipCache && $this->cacheDir && $this->widget->getCacheTimeout() > 0) {
-                $cache = new CacheStorageHelper(CacheStorageHelper::ADAPTOR_FILESYSTEM, $this->uniqueCacheDir, null, $this->cacheDir);
-                // must pass a DateTime object or a int of seconds to expire as 3rd attribute to set().
-                $expireTime = $this->widget->getCacheTimeout() * 60;
-
-                $cache->set($this->getUniqueWidgetId(), $templateData, (int) $expireTime);
-            }
-        }
-
         $cItem = $this->cacheProvider->getItem($this->getCacheKey());
         if ($this->widget->getCacheTimeout()) {
             $cItem->expiresAfter((int) $this->widget->getCacheTimeout() * 60);  // This is in minutes
@@ -291,8 +280,12 @@ class WidgetDetailEvent extends CommonEvent
         }
 
         if ($this->usesLegacyCache()) {
+            if (0 === $this->cacheTimeout) {
+                return false;
+            }
+
             $cache = new CacheStorageHelper(CacheStorageHelper::ADAPTOR_FILESYSTEM, $this->uniqueCacheDir, null, $this->cacheDir);
-            $data  = $cache->get($this->getUniqueWidgetId(), $this->cacheTimeout);
+            $data  = $cache->get($this->getUniqueWidgetId());
 
             if ($data) {
                 $this->widget->setCached(true);
@@ -338,14 +331,6 @@ class WidgetDetailEvent extends CommonEvent
     public function hasPermission(string $permission): bool
     {
         return $this->security->isGranted($permission);
-    }
-
-    /**
-     * Checks for cache type. This event should be created by factory thus not legacy approach.
-     */
-    private function usesLegacyCache(): bool
-    {
-        return null === $this->cacheProvider;
     }
 
     /**

--- a/app/bundles/DashboardBundle/Event/WidgetDetailEvent.php
+++ b/app/bundles/DashboardBundle/Event/WidgetDetailEvent.php
@@ -4,7 +4,6 @@ namespace Mautic\DashboardBundle\Event;
 
 use Mautic\CacheBundle\Cache\CacheProviderTagAwareInterface;
 use Mautic\CoreBundle\Event\CommonEvent;
-use Mautic\CoreBundle\Helper\CacheStorageHelper;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\DashboardBundle\Entity\Widget;
 use Mautic\DashboardBundle\Exception\CouldNotFormatDateTimeException;
@@ -270,32 +269,12 @@ class WidgetDetailEvent extends CommonEvent
 
     /**
      * @throws \Psr\Cache\InvalidArgumentException
-     *                                             Checks the cache for the widget data.
-     *                                             If cache exists, it sets the TemplateData.
+     *
+     * Checks the cache for the widget data.
+     * If cache exists, it sets the TemplateData.
      */
     public function isCached(): bool
     {
-        if (!$this->cacheDir && $this->usesLegacyCache()) {
-            return false;
-        }
-
-        if ($this->usesLegacyCache()) {
-            if (0 === $this->cacheTimeout) {
-                return false;
-            }
-
-            $cache = new CacheStorageHelper(CacheStorageHelper::ADAPTOR_FILESYSTEM, $this->uniqueCacheDir, null, $this->cacheDir);
-            $data  = $cache->get($this->getUniqueWidgetId());
-
-            if ($data) {
-                $this->widget->setCached(true);
-                $this->setTemplateData($data, true);
-
-                return true;
-            }
-
-            return false;
-        }
         $cachedItem = $this->cacheProvider->getItem($this->getCacheKey());
         if (!$cachedItem->isHit()) {
             return false;

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -17,7 +17,6 @@ use Mautic\EmailBundle\Entity\CopyRepository;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Entity\Stat;
 use Mautic\EmailBundle\Event\EmailSendEvent;
-use Mautic\EmailBundle\Exception\InvalidEmailException;
 use Mautic\EmailBundle\Form\Type\ConfigType;
 use Mautic\EmailBundle\Helper\DTO\AddressDTO;
 use Mautic\EmailBundle\Helper\Exception\OwnerNotFoundException;
@@ -1921,24 +1920,6 @@ class MailHelper
             'utmTags'     => (!empty($this->email)) ? $this->email->getUtmTags() : [],
             'includeDnc'  => !empty($this->email) && $this->email->getSendToDnc(),
         ];
-    }
-
-    /**
-     * Validates a given address to ensure RFC 2822, 3.6.2 specs.
-     *
-     * @deprecated 2.11.0 to be removed in 3.0; use Mautic\EmailBundle\Helper\EmailValidator
-     *
-     * @throws InvalidEmailException
-     */
-    public static function validateEmail($address): void
-    {
-        $invalidChar = strpbrk($address, '\'^&*%');
-        if (false !== $invalidChar) {
-            throw new InvalidEmailException('Email address ['.$address.'] contains this invalid character: '.substr($invalidChar, 0, 1));
-        }
-        if (!filter_var($address, FILTER_VALIDATE_EMAIL)) {
-            throw new InvalidEmailException('Email address ['.$address.'] is invalid');
-        }
     }
 
     private function setDefaultFrom(AddressDTO $systemFrom): void

--- a/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
@@ -14,7 +14,6 @@ use Mautic\EmailBundle\EmailEvents;
 use Mautic\EmailBundle\Entity\CopyRepository;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Event\EmailSendEvent;
-use Mautic\EmailBundle\Exception\InvalidEmailException;
 use Mautic\EmailBundle\Helper\FromEmailHelper;
 use Mautic\EmailBundle\Helper\MailHashHelper;
 use Mautic\EmailBundle\Helper\MailHelper;
@@ -686,109 +685,6 @@ final class MailHelperTest extends TestCase
                 $this->assertEquals('{signature}', $body); // The {signature} token is replaced in a subscriber with the current user's signature. But this is a unit test, so the subscriber doesn't run.
             }
         }
-    }
-
-    #[DataProvider('provideEmails')]
-    public function testValidateEmails(string $email, bool $isValid): void
-    {
-        $helper = $this->mockEmptyMailHelper();
-        if (!$isValid) {
-            $this->expectException(InvalidEmailException::class);
-        }
-        $this->assertNull($helper::validateEmail($email)); /** @phpstan-ignore-line as it's testing a deprecated method */
-    }
-
-    public function testValidateValidEmails(): void
-    {
-        $helper    = $this->mockEmptyMailHelper();
-        $addresses = [
-            'john@doe.com',
-            'john@doe.email',
-            'john.doe@email.com',
-            'john+doe@email.com',
-            'john@doe.whatevertldtheycomewithinthefuture',
-        ];
-
-        foreach ($addresses as $address) {
-            // will throw InvalidEmailException if it will find the address invalid
-            $this->assertNull($helper::validateEmail($address)); /** @phpstan-ignore-line as it's testing a deprecated method */
-        }
-    }
-
-    /**
-     * @return \Iterator<(int|string), mixed>
-     */
-    public static function provideEmails(): \Iterator
-    {
-        yield ['john@doe.com', true];
-        yield ['john@doe.email', true];
-        yield ['john@doe.whatevertldtheycomewithinthefuture', true];
-        yield ['john.doe@email.com', true];
-        yield ['john+doe@email.com', true];
-        yield ['john@doe', false];
-        yield ['jo hn@doe.email', false];
-        yield ['jo^hn@doe.email', false];
-        yield ['jo\'hn@doe.email', false];
-        yield ['jo;hn@doe.email', false];
-        yield ['jo&hn@doe.email', false];
-        yield ['jo*hn@doe.email', false];
-        yield ['jo%hn@doe.email', false];
-    }
-
-    public function testValidateEmailWithoutTld(): void
-    {
-        $helper = $this->mockEmptyMailHelper();
-        $this->expectException(InvalidEmailException::class);
-        $helper::validateEmail('john@doe'); /** @phpstan-ignore-line as it's testing a deprecated method */
-    }
-
-    public function testValidateEmailWithSpaceInIt(): void
-    {
-        $helper = $this->mockEmptyMailHelper();
-        $this->expectException(InvalidEmailException::class);
-        $helper::validateEmail('jo hn@doe.email'); /** @phpstan-ignore-line as it's testing a deprecated method */
-    }
-
-    public function testValidateEmailWithCaretInIt(): void
-    {
-        $helper = $this->mockEmptyMailHelper();
-        $this->expectException(InvalidEmailException::class);
-        $helper::validateEmail('jo^hn@doe.email'); /** @phpstan-ignore-line as it's testing a deprecated method */
-    }
-
-    public function testValidateEmailWithApostropheInIt(): void
-    {
-        $helper = $this->mockEmptyMailHelper();
-        $this->expectException(InvalidEmailException::class);
-        $helper::validateEmail('jo\'hn@doe.email'); /** @phpstan-ignore-line as it's testing a deprecated method */
-    }
-
-    public function testValidateEmailWithSemicolonInIt(): void
-    {
-        $helper = $this->mockEmptyMailHelper();
-        $this->expectException(InvalidEmailException::class);
-        $helper::validateEmail('jo;hn@doe.email'); /** @phpstan-ignore-line as it's testing a deprecated method */
-    }
-
-    public function testValidateEmailWithAmpersandInIt(): void
-    {
-        $helper = $this->mockEmptyMailHelper();
-        $this->expectException(InvalidEmailException::class);
-        $helper::validateEmail('jo&hn@doe.email'); /** @phpstan-ignore-line as it's testing a deprecated method */
-    }
-
-    public function testValidateEmailWithStarInIt(): void
-    {
-        $helper = $this->mockEmptyMailHelper();
-        $this->expectException(InvalidEmailException::class);
-        $helper::validateEmail('jo*hn@doe.email'); /** @phpstan-ignore-line as it's testing a deprecated method */
-    }
-
-    public function testValidateEmailWithPercentInIt(): void
-    {
-        $helper = $this->mockEmptyMailHelper();
-        $this->expectException(InvalidEmailException::class);
-        $helper::validateEmail('jo%hn@doe.email'); /** @phpstan-ignore-line as it's testing a deprecated method */
     }
 
     public function testGlobalHeadersAreSet(): void

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3658,12 +3658,6 @@ parameters:
 			path: app/bundles/EmailBundle/Helper/MailHelper.php
 
 		-
-			message: '#^Method Mautic\\EmailBundle\\Helper\\MailHelper\:\:validateEmail\(\) has parameter \$address with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: app/bundles/EmailBundle/Helper/MailHelper.php
-
-		-
 			message: '#^Property Mautic\\EmailBundle\\Helper\\MailHelper\:\:\$lead \(array\|Mautic\\LeadBundle\\Entity\\Lead\) does not accept null\.$#'
 			identifier: assign.propertyType
 			count: 1

--- a/plugins/MauticCrmBundle/Api/HubspotApi.php
+++ b/plugins/MauticCrmBundle/Api/HubspotApi.php
@@ -2,7 +2,7 @@
 
 namespace MauticPlugin\MauticCrmBundle\Api;
 
-use Mautic\EmailBundle\Exception\InvalidEmailException;
+use Mautic\EmailBundle\Helper\EmailValidator;
 use Mautic\PluginBundle\Exception\ApiErrorException;
 use MauticPlugin\MauticCrmBundle\Integration\HubspotIntegration;
 
@@ -11,6 +11,13 @@ use MauticPlugin\MauticCrmBundle\Integration\HubspotIntegration;
  */
 final class HubspotApi extends CrmApi
 {
+    public function __construct(
+        private readonly EmailValidator $emailValidator,
+        HubspotIntegration $integration,
+    ) {
+        parent::__construct($integration);
+    }
+
     private array $requestSettings = [
         'encode_parameters' => 'json',
     ];
@@ -77,8 +84,10 @@ final class HubspotApi extends CrmApi
          */
         $email  = $data['email'];
         $result = [];
+
         // Check if the is a valid email
-        $this->validateEmail($email);
+        $this->emailValidator->validate($email);
+
         // Format data for request
         $formattedLeadData = $this->integration->formatLeadDataForCreateOrUpdate($data, $lead, $updateLink);
         if ($formattedLeadData) {
@@ -86,23 +95,6 @@ final class HubspotApi extends CrmApi
         }
 
         return $result;
-    }
-
-    /**
-     * Validates a given address to ensure RFC 2822, 3.6.2 specs.
-     *
-     * @throws InvalidEmailException
-     */
-    private function validateEmail(string $email): void
-    {
-        $invalidChar = strpbrk($email, '\'^&*%');
-        if (false !== $invalidChar) {
-            throw new InvalidEmailException($email, 'Email address ['.$email.'] contains this invalid character: '.substr($invalidChar, 0, 1));
-        }
-
-        if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
-            throw new InvalidEmailException($email, 'Email address ['.$email.'] is invalid');
-        }
     }
 
     /**

--- a/plugins/MauticCrmBundle/Api/HubspotApi.php
+++ b/plugins/MauticCrmBundle/Api/HubspotApi.php
@@ -2,7 +2,7 @@
 
 namespace MauticPlugin\MauticCrmBundle\Api;
 
-use Mautic\EmailBundle\Helper\MailHelper;
+use Mautic\EmailBundle\Exception\InvalidEmailException;
 use Mautic\PluginBundle\Exception\ApiErrorException;
 use MauticPlugin\MauticCrmBundle\Integration\HubspotIntegration;
 
@@ -78,7 +78,7 @@ final class HubspotApi extends CrmApi
         $email  = $data['email'];
         $result = [];
         // Check if the is a valid email
-        MailHelper::validateEmail($email);
+        $this->validateEmail($email);
         // Format data for request
         $formattedLeadData = $this->integration->formatLeadDataForCreateOrUpdate($data, $lead, $updateLink);
         if ($formattedLeadData) {
@@ -86,6 +86,23 @@ final class HubspotApi extends CrmApi
         }
 
         return $result;
+    }
+
+    /**
+     * Validates a given address to ensure RFC 2822, 3.6.2 specs.
+     *
+     * @throws InvalidEmailException
+     */
+    private function validateEmail(string $email): void
+    {
+        $invalidChar = strpbrk($email, '\'^&*%');
+        if (false !== $invalidChar) {
+            throw new InvalidEmailException($email, 'Email address ['.$email.'] contains this invalid character: '.substr($invalidChar, 0, 1));
+        }
+
+        if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            throw new InvalidEmailException($email, 'Email address ['.$email.'] is invalid');
+        }
     }
 
     /**

--- a/plugins/MauticCrmBundle/Tests/Api/HubspotApiTest.php
+++ b/plugins/MauticCrmBundle/Tests/Api/HubspotApiTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MauticPlugin\MauticCrmBundle\Tests\Api;
 
 use Mautic\EmailBundle\Exception\InvalidEmailException;
+use Mautic\EmailBundle\Helper\EmailValidator;
 use Mautic\PluginBundle\Exception\ApiErrorException;
 use MauticPlugin\MauticCrmBundle\Api\HubspotApi;
 use MauticPlugin\MauticCrmBundle\Integration\HubspotIntegration;
@@ -48,7 +49,9 @@ final class HubspotApiTest extends TestCase
         $this->expectExceptionMessage($message);
         $this->expectExceptionCode($code);
 
-        $api = new HubspotApi($integration);
+        $emailValidatorMock = $this->createStub(EmailValidator::class);
+
+        $api = new HubspotApi($emailValidatorMock, $integration);
         $api->getLeadFields();
 
         self::fail('ApiErrorException not thrown');
@@ -80,7 +83,7 @@ final class HubspotApiTest extends TestCase
         $this->expectExceptionMessage($message);
         $this->expectExceptionCode(0);
 
-        $api = new HubspotApi($integration);
+        $api = new HubspotApi($this->createStub(EmailValidator::class), $integration);
         $api->getLeadFields();
 
         self::fail('ApiErrorException not thrown');
@@ -110,7 +113,7 @@ final class HubspotApiTest extends TestCase
         $this->expectException(InvalidEmailException::class);
         $this->expectExceptionMessage($expectedMessage);
 
-        $api = new HubspotApi($integration);
+        $api = new HubspotApi($this->createStub(EmailValidator::class), $integration);
         $api->createLead(['email' => $email], null);
     }
 }

--- a/plugins/MauticCrmBundle/Tests/Api/HubspotApiTest.php
+++ b/plugins/MauticCrmBundle/Tests/Api/HubspotApiTest.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace MauticPlugin\MauticCrmBundle\Tests\Api;
 
+use Mautic\EmailBundle\Exception\InvalidEmailException;
 use Mautic\PluginBundle\Exception\ApiErrorException;
 use MauticPlugin\MauticCrmBundle\Api\HubspotApi;
 use MauticPlugin\MauticCrmBundle\Integration\HubspotIntegration;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 
@@ -82,5 +84,33 @@ final class HubspotApiTest extends TestCase
         $api->getLeadFields();
 
         self::fail('ApiErrorException not thrown');
+    }
+
+    /**
+     * @return \Iterator<array{string, string}>
+     */
+    public static function provideInvalidEmails(): \Iterator
+    {
+        yield ['john@doe', 'Email address [john@doe] is invalid'];
+        yield ['jo hn@doe.email', 'Email address [jo hn@doe.email] is invalid'];
+        yield ['jo^hn@doe.email', 'Email address [jo^hn@doe.email] contains this invalid character: ^'];
+        yield ['jo\'hn@doe.email', 'Email address [jo\'hn@doe.email] contains this invalid character: \''];
+        yield ['jo&hn@doe.email', 'Email address [jo&hn@doe.email] contains this invalid character: &'];
+        yield ['jo*hn@doe.email', 'Email address [jo*hn@doe.email] contains this invalid character: *'];
+        yield ['jo%hn@doe.email', 'Email address [jo%hn@doe.email] contains this invalid character: %'];
+    }
+
+    #[DataProvider('provideInvalidEmails')]
+    public function testCreateLeadRejectsInvalidEmail(string $email, string $expectedMessage): void
+    {
+        $integration = $this->createMock(HubspotIntegration::class);
+        $integration->expects($this->never())
+            ->method('makeRequest');
+
+        $this->expectException(InvalidEmailException::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        $api = new HubspotApi($integration);
+        $api->createLead(['email' => $email], null);
     }
 }

--- a/plugins/MauticCrmBundle/Tests/Api/HubspotApiTest.php
+++ b/plugins/MauticCrmBundle/Tests/Api/HubspotApiTest.php
@@ -12,6 +12,8 @@ use MauticPlugin\MauticCrmBundle\Integration\HubspotIntegration;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class HubspotApiTest extends TestCase
 {
@@ -113,7 +115,12 @@ final class HubspotApiTest extends TestCase
         $this->expectException(InvalidEmailException::class);
         $this->expectExceptionMessage($expectedMessage);
 
-        $api = new HubspotApi($this->createStub(EmailValidator::class), $integration);
+        $emailValidator = new EmailValidator(
+            $this->createStub(TranslatorInterface::class),
+            $this->createStub(EventDispatcherInterface::class)
+        );
+
+        $api = new HubspotApi($emailValidator, $integration);
         $api->createLead(['email' => $email], null);
     }
 }

--- a/plugins/MauticCrmBundle/Tests/Integration/SalesforceIntegrationTest.php
+++ b/plugins/MauticCrmBundle/Tests/Integration/SalesforceIntegrationTest.php
@@ -876,8 +876,8 @@ final class SalesforceIntegrationTest extends AbstractIntegrationTestCase
             ->method('get')
             ->willReturnMap(
                 [
-                    ['leadFields.Lead', null, $leadFields],
-                    ['leadFields.Contact', null, $contactFields],
+                    ['leadFields.Lead', $leadFields],
+                    ['leadFields.Contact', $contactFields],
                 ]
             );
 


### PR DESCRIPTION
## Description

Removes a handful of symbols that were tagged `@deprecated 2.x - to be removed in 3.0`. We are on 8.x, so they are five majors overdue.

Each one had zero or one production caller, so this is the low-risk slice of the 2.x deprecation cleanup. Bigger ones (`CoreBundle\Controller\FormController`, `LeadModel::isContactable()`, the campaign `LegacyEventDispatcher` layer) follow in separate PRs.

### `CacheStorageHelper`

`$expirations` and `touchDir()` were dead — nothing read or called them. The `$maxAge` argument of `get()` had exactly one caller:

```diff
 public function isCached(): bool
 {
     if ($this->usesLegacyCache()) {
+        if (0 === $this->cacheTimeout) {
+            return false;
+        }
+
         $cache = new CacheStorageHelper(CacheStorageHelper::ADAPTOR_FILESYSTEM, $this->uniqueCacheDir, null, $this->cacheDir);
-        $data  = $cache->get($this->getUniqueWidgetId(), $this->cacheTimeout);
+        $data  = $cache->get($this->getUniqueWidgetId());
```

The `$maxAge` argument only ever did `if (0 === $maxAge) { return false; }`, so the guard above keeps `WidgetDetailEvent` behaving exactly as before.

### `ConnectionBuilder::addDeprecatedAnchorRestrictions()`

BC support for the pre-2.6 `associatedActions` / `associatedDecisions` / `anchorRestrictions` event keys. No campaign event definition in core or in the bundled plugins declares those keys anymore — only the unit test did, so the test lost those fixtures too.

### `MailHelper::validateEmail()`

Single production caller, `HubspotApi::createLead()`. It now validates inline:

```diff
-        MailHelper::validateEmail($email);
+        $this->validateEmail($email);
```

The extracted method also fixes a small bug along the way — the old code passed the whole error sentence as `InvalidEmailException`'s first constructor argument, which is the email address, so `getEmailAddress()` returned things like `Email address [jo^hn@doe.email] contains this invalid character: ^` and `getMessage()` was empty:

```diff
-throw new InvalidEmailException('Email address ['.$email.'] is invalid');
+throw new InvalidEmailException($email, 'Email address ['.$email.'] is invalid');
```

The address-validation test cases moved from `MailHelperTest` to `HubspotApiTest`, where the behaviour now lives.

`SalesforceIntegrationTest` needed a mock update because `CacheStorageHelper::get()` lost an argument:

```diff
-['leadFields.Lead', null, $leadFields],
-['leadFields.Contact', null, $contactFields],
+['leadFields.Lead', $leadFields],
+['leadFields.Contact', $contactFields],
```

## Backwards compatibility

Breaking for anyone still calling these, but they have been marked for removal since Mautic 2.3–2.13.