### PR TITLE
[removal] Remove deprecated LeadModel::isContactable()

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -2,3 +2,7 @@
 
 ## Platform requirements
 - The minimum required PHP version has been increased from **8.2** to **8.4**.
+
+## Removed code
+
+- Deprecated method `Mautic\LeadBundle\Model\LeadModel::isContactable()` removed. Use `Mautic\LeadBundle\Model\DoNotContact::isContactable()` instead.

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -35,7 +35,6 @@ use Mautic\LeadBundle\Entity\CompanyLead;
 use Mautic\LeadBundle\Entity\CompanyLeadRepository;
 use Mautic\LeadBundle\Entity\CompanyRepository;
 use Mautic\LeadBundle\Entity\DoNotContact as DNC;
-use Mautic\LeadBundle\Entity\DoNotContactRepository;
 use Mautic\LeadBundle\Entity\FrequencyRule;
 use Mautic\LeadBundle\Entity\FrequencyRuleRepository;
 use Mautic\LeadBundle\Entity\Lead;
@@ -88,6 +87,7 @@ use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Component\Intl\Countries;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\EventDispatcher\Event;
+use Symfony\Contracts\Service\Attribute\Required;
 
 /**
  * @extends FormModel<Lead>
@@ -122,6 +122,8 @@ class LeadModel extends FormModel
     private array $flattenedFields = [];
 
     private array $fieldsByGroup = [];
+
+    private DoNotContact $doNotContact;
 
     public function __construct(
         protected RequestStack $requestStack,
@@ -163,11 +165,20 @@ class LeadModel extends FormModel
         private readonly StageRepository $stageRepository,
         private readonly UserRepository $userRepository,
         private readonly CompanyLeadRepository $companyLeadRepository,
-        private readonly DoNotContactRepository $doNotContactRepository,
         private readonly StatRepository $statRepository,
         private readonly CompanyRepository $companyRepository,
     ) {
         parent::__construct($em, $security, $dispatcher, $router, $translator, $userHelper, $mauticLogger, $coreParametersHelper);
+    }
+
+    /**
+     * Use to avoid circular dependency.
+     */
+    #[Required]
+    public function autowireLeadModel(
+        DoNotContact $doNotContact,
+    ): void {
+        $this->doNotContact = $doNotContact;
     }
 
     public function getRepository(): LeadRepository
@@ -2187,7 +2198,7 @@ class LeadModel extends FormModel
 
         $channels = [];
         foreach ($allChannels as $channel) {
-            if (DNC::IS_CONTACTABLE === $this->isContactable($lead, $channel)) {
+            if (DNC::IS_CONTACTABLE === $this->doNotContact->isContactable($lead, $channel)) {
                 $channels[$channel] = $channel;
             }
         }
@@ -2204,7 +2215,7 @@ class LeadModel extends FormModel
 
         $channels = [];
         foreach ($allChannels as $channel) {
-            if (DNC::IS_CONTACTABLE !== $this->isContactable($lead, $channel)) {
+            if (DNC::IS_CONTACTABLE !== $this->doNotContact->isContactable($lead, $channel)) {
                 $channels[$channel] = $channel;
             }
         }
@@ -2361,39 +2372,6 @@ class LeadModel extends FormModel
         }
 
         return $lead;
-    }
-
-    /**
-     * @deprecated 2.12.0 to be removed in 3.0; use Mautic\LeadBundle\Model\DoNotContact instead
-     *
-     * @param string $channel
-     *
-     * @return int
-     *
-     * @see DNC This method can return boolean false, so be
-     *                                             sure to always compare the return value against
-     *                                             the class constants of DoNotContact
-     */
-    public function isContactable(Lead $lead, $channel)
-    {
-        if (is_array($channel)) {
-            $channel = key($channel);
-        }
-
-        $dncEntries = $this->doNotContactRepository->getEntriesByLeadAndChannel($lead, $channel);
-
-        // If the lead has no entries in the DNC table, we're good to go
-        if (empty($dncEntries)) {
-            return DNC::IS_CONTACTABLE;
-        }
-
-        foreach ($dncEntries as $dnc) {
-            if (DNC::IS_CONTACTABLE !== $dnc->getReason()) {
-                return $dnc->getReason();
-            }
-        }
-
-        return DNC::IS_CONTACTABLE;
     }
 
     public function getAvailableLeadFields(): array

--- a/app/bundles/LeadBundle/Tests/Model/LeadModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/LeadModelTest.php
@@ -21,7 +21,6 @@ use Mautic\EmailBundle\Helper\EmailValidator;
 use Mautic\LeadBundle\DataObject\LeadManipulator;
 use Mautic\LeadBundle\Entity\CompanyLeadRepository;
 use Mautic\LeadBundle\Entity\CompanyRepository;
-use Mautic\LeadBundle\Entity\DoNotContactRepository;
 use Mautic\LeadBundle\Entity\FrequencyRuleRepository;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadCategoryRepository;
@@ -184,23 +183,22 @@ final class LeadModelTest extends \PHPUnit\Framework\TestCase
             $this->userHelperMock,
             $this->createStub(LoggerInterface::class),
             $this->leadRepositoryMock,
-            $this->createStub(TagRepository::class), // $tagRepository
-            $this->createStub(PointsChangeLogRepository::class), // $pointsChangeLogRepository
-            $this->createStub(UtmTagRepository::class), // $utmTagRepository
-            $this->createStub(LeadDeviceRepository::class), // $leadDeviceRepository
-            $this->createStub(LeadEventLogRepository::class), // $leadEventLogRepository
-            $this->createStub(FrequencyRuleRepository::class), // $frequencyRuleRepository
+            $this->createStub(TagRepository::class),
+            $this->createStub(PointsChangeLogRepository::class),
+            $this->createStub(UtmTagRepository::class),
+            $this->createStub(LeadDeviceRepository::class),
+            $this->createStub(LeadEventLogRepository::class),
+            $this->createStub(FrequencyRuleRepository::class),
             $this->stagesChangeLogRepositoryMock,
-            $this->createStub(LeadCategoryRepository::class), // $leadCategoryRepository
-            $this->createStub(MergeRecordRepository::class), // $mergeRecordRepository
-            $this->createStub(LeadListRepository::class), // $leadListRepository
-            $this->createStub(GroupContactScoreRepository::class), // $groupContactScoreRepository
+            $this->createStub(LeadCategoryRepository::class),
+            $this->createStub(MergeRecordRepository::class),
+            $this->createStub(LeadListRepository::class),
+            $this->createStub(GroupContactScoreRepository::class),
             $this->stageRepositoryMock,
-            $this->createStub(UserRepository::class), // $userRepository
+            $this->createStub(UserRepository::class),
             $this->companyLeadRepositoryMock,
-            $this->createStub(DoNotContactRepository::class), // $doNotContactRepository
-            $this->createStub(StatRepository::class), // $statRepository
-            $this->createStub(CompanyRepository::class), // $companyRepository
+            $this->createStub(StatRepository::class),
+            $this->createStub(CompanyRepository::class),
         );
 
         $this->setSecurity($this->leadModel);
@@ -656,7 +654,7 @@ final class LeadModelTest extends \PHPUnit\Framework\TestCase
         $action = 'post_batch_save';
 
         // Lead Model that provides access to dispatchBatchEvent
-        $leadModel = new class($this->requestStack, $this->createStub(IpLookupHelper::class), $this->createStub(PathsHelper::class), $this->createStub(IntegrationHelper::class), $this->fieldModelMock, $this->fieldsWithUniqueIdentifier, $this->createStub(ListModel::class), $this->createStub(FormFactory::class), $this->companyModelMock, $this->createStub(CategoryModel::class), $this->channelListHelperMock, $this->coreParametersHelperMock, $this->emailValidatorMock, $this->createStub(UserProvider::class), $this->createStub(ContactTracker::class), $this->createStub(DeviceTracker::class), $this->createStub(IpAddressModel::class), $this->entityManagerMock, $this->createStub(CorePermissions::class), $this->dispatcherMock, $this->createStub(UrlGeneratorInterface::class), $this->translator, $this->userHelperMock, $this->createStub(LoggerInterface::class), $this->leadRepositoryMock, $this->createStub(TagRepository::class), $this->createStub(PointsChangeLogRepository::class), $this->createStub(UtmTagRepository::class), $this->createStub(LeadDeviceRepository::class), $this->createStub(LeadEventLogRepository::class), $this->createStub(FrequencyRuleRepository::class), $this->stagesChangeLogRepositoryMock, $this->createStub(LeadCategoryRepository::class), $this->createStub(MergeRecordRepository::class), $this->createStub(LeadListRepository::class), $this->createStub(GroupContactScoreRepository::class), $this->stageRepositoryMock, $this->createStub(UserRepository::class), $this->companyLeadRepositoryMock, $this->createStub(DoNotContactRepository::class), $this->createStub(StatRepository::class), $this->createStub(CompanyRepository::class)) extends LeadModel {
+        $leadModel = new class($this->requestStack, $this->createStub(IpLookupHelper::class), $this->createStub(PathsHelper::class), $this->createStub(IntegrationHelper::class), $this->fieldModelMock, $this->fieldsWithUniqueIdentifier, $this->createStub(ListModel::class), $this->createStub(FormFactory::class), $this->companyModelMock, $this->createStub(CategoryModel::class), $this->channelListHelperMock, $this->coreParametersHelperMock, $this->emailValidatorMock, $this->createStub(UserProvider::class), $this->createStub(ContactTracker::class), $this->createStub(DeviceTracker::class), $this->createStub(IpAddressModel::class), $this->entityManagerMock, $this->createStub(CorePermissions::class), $this->dispatcherMock, $this->createStub(UrlGeneratorInterface::class), $this->translator, $this->userHelperMock, $this->createStub(LoggerInterface::class), $this->leadRepositoryMock, $this->createStub(TagRepository::class), $this->createStub(PointsChangeLogRepository::class), $this->createStub(UtmTagRepository::class), $this->createStub(LeadDeviceRepository::class), $this->createStub(LeadEventLogRepository::class), $this->createStub(FrequencyRuleRepository::class), $this->stagesChangeLogRepositoryMock, $this->createStub(LeadCategoryRepository::class), $this->createStub(MergeRecordRepository::class), $this->createStub(LeadListRepository::class), $this->createStub(GroupContactScoreRepository::class), $this->stageRepositoryMock, $this->createStub(UserRepository::class), $this->companyLeadRepositoryMock, $this->createStub(StatRepository::class), $this->createStub(CompanyRepository::class)) extends LeadModel {
             /**
              * @param array<mixed> $leads
              */


### PR DESCRIPTION
## Description

`LeadModel::isContactable()` has been `@deprecated 2.12.0 to be removed in 3.0` in favour of `Mautic\LeadBundle\Model\DoNotContact::isContactable()`, which carries a byte-for-byte identical implementation.
