### PR TITLE
[symfony] move Mautic constraints from loadValidatorMetadata() to property attributes

### DIFF
--- a/app/bundles/ApiBundle/Form/Validator/Constraints/OAuthCallback.php
+++ b/app/bundles/ApiBundle/Form/Validator/Constraints/OAuthCallback.php
@@ -5,7 +5,7 @@ namespace Mautic\ApiBundle\Form\Validator\Constraints;
 use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
-#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class OAuthCallback extends Constraint
 {
     /**

--- a/app/bundles/CampaignBundle/Form/Validator/Constraints/InfiniteLoop.php
+++ b/app/bundles/CampaignBundle/Form/Validator/Constraints/InfiniteLoop.php
@@ -6,7 +6,7 @@ namespace Mautic\CampaignBundle\Form\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
-#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class InfiniteLoop extends Constraint
 {
 }

--- a/app/bundles/CoreBundle/Form/Validator/Constraints/CircularDependency.php
+++ b/app/bundles/CoreBundle/Form/Validator/Constraints/CircularDependency.php
@@ -5,7 +5,7 @@ namespace Mautic\CoreBundle\Form\Validator\Constraints;
 use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
-#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class CircularDependency extends Constraint
 {
     /**

--- a/app/bundles/CoreBundle/Form/Validator/Constraints/FileEncoding.php
+++ b/app/bundles/CoreBundle/Form/Validator/Constraints/FileEncoding.php
@@ -5,7 +5,7 @@ namespace Mautic\CoreBundle\Form\Validator\Constraints;
 use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
-#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class FileEncoding extends Constraint
 {
     /**

--- a/app/bundles/CoreBundle/Validator/SafeRemoteUrl.php
+++ b/app/bundles/CoreBundle/Validator/SafeRemoteUrl.php
@@ -7,7 +7,7 @@ namespace Mautic\CoreBundle\Validator;
 use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
-#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class SafeRemoteUrl extends Constraint
 {
     /**

--- a/app/bundles/DynamicContentBundle/Validator/Constraints/NoNesting.php
+++ b/app/bundles/DynamicContentBundle/Validator/Constraints/NoNesting.php
@@ -10,7 +10,7 @@ use Symfony\Component\Validator\Constraint;
 /**
  * This constraint checks if the content does not include another DWC token.
  */
-#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class NoNesting extends Constraint
 {
     /**

--- a/app/bundles/EmailBundle/Validator/Dsn.php
+++ b/app/bundles/EmailBundle/Validator/Dsn.php
@@ -6,7 +6,7 @@ namespace Mautic\EmailBundle\Validator;
 
 use Symfony\Component\Validator\Constraint;
 
-#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class Dsn extends Constraint
 {
 }

--- a/app/bundles/EmailBundle/Validator/EmailOrEmailTokenList.php
+++ b/app/bundles/EmailBundle/Validator/EmailOrEmailTokenList.php
@@ -7,7 +7,7 @@ namespace Mautic\EmailBundle\Validator;
 use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
-#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class EmailOrEmailTokenList extends Constraint
 {
     /**

--- a/app/bundles/EmailBundle/Validator/MultipleEmailsValid.php
+++ b/app/bundles/EmailBundle/Validator/MultipleEmailsValid.php
@@ -6,7 +6,7 @@ namespace Mautic\EmailBundle\Validator;
 
 use Symfony\Component\Validator\Constraint;
 
-#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class MultipleEmailsValid extends Constraint
 {
     public function getTargets(): string

--- a/app/bundles/EmailBundle/Validator/TextOnlyDynamicContent.php
+++ b/app/bundles/EmailBundle/Validator/TextOnlyDynamicContent.php
@@ -7,7 +7,7 @@ namespace Mautic\EmailBundle\Validator;
 use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
-#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class TextOnlyDynamicContent extends Constraint
 {
     /**

--- a/app/bundles/FormBundle/Entity/Form.php
+++ b/app/bundles/FormBundle/Entity/Form.php
@@ -24,7 +24,6 @@ use Mautic\FormBundle\Validator\Constraint\IsPostActionRedirectUrl;
 use Mautic\ProjectBundle\Entity\ProjectTrait;
 use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 #[ApiResource(
     operations: [
@@ -114,6 +113,7 @@ class Form extends FormEntity implements UuidInterface
     #[Assert\NotBlank(message: 'mautic.form.form.postactionproperty_message.notblank', groups: ['messageRequired'])]
     #[Assert\NotBlank(message: 'mautic.form.form.postactionproperty_redirect.notblank', groups: ['urlRequired'])]
     #[Assert\NotBlank(message: 'mautic.form.form.postactionproperty_hideform.notblank', groups: ['hideformRequired'])]
+    #[IsPostActionRedirectUrl(groups: ['urlRequired'])]
     private $postActionProperty;
 
     /**
@@ -311,11 +311,6 @@ class Form extends FormEntity implements UuidInterface
 
         static::addUuidField($builder);
         self::addProjectsField($builder, 'form_projects_xref', 'form_id');
-    }
-
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addPropertyConstraint('postActionProperty', new IsPostActionRedirectUrl(groups: ['urlRequired']));
     }
 
     public static function determineValidationGroups(\Symfony\Component\Form\Form $form): array

--- a/app/bundles/FormBundle/Validator/Constraint/FileExtensionConstraint.php
+++ b/app/bundles/FormBundle/Validator/Constraint/FileExtensionConstraint.php
@@ -5,7 +5,7 @@ namespace Mautic\FormBundle\Validator\Constraint;
 use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
-#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class FileExtensionConstraint extends Constraint
 {
     /**

--- a/app/bundles/FormBundle/Validator/Constraint/IsPostActionRedirectUrl.php
+++ b/app/bundles/FormBundle/Validator/Constraint/IsPostActionRedirectUrl.php
@@ -7,7 +7,7 @@ namespace Mautic\FormBundle\Validator\Constraint;
 use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
-#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class IsPostActionRedirectUrl extends Constraint
 {
     /**

--- a/app/bundles/FormBundle/Validator/Constraint/PhoneNumberConstraint.php
+++ b/app/bundles/FormBundle/Validator/Constraint/PhoneNumberConstraint.php
@@ -8,7 +8,7 @@ use Symfony\Component\Validator\Constraint;
 /**
  * Phone number constraint.
  */
-#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class PhoneNumberConstraint extends Constraint
 {
     /**

--- a/app/bundles/FormBundle/Validator/Constraint/SliderMaxGreaterThanMin.php
+++ b/app/bundles/FormBundle/Validator/Constraint/SliderMaxGreaterThanMin.php
@@ -7,7 +7,7 @@ namespace Mautic\FormBundle\Validator\Constraint;
 use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
-#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class SliderMaxGreaterThanMin extends Constraint
 {
     /**

--- a/app/bundles/FormBundle/Validator/Constraint/SliderStepLessThanMax.php
+++ b/app/bundles/FormBundle/Validator/Constraint/SliderStepLessThanMax.php
@@ -7,7 +7,7 @@ namespace Mautic\FormBundle\Validator\Constraint;
 use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
-#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class SliderStepLessThanMax extends Constraint
 {
     /**

--- a/app/bundles/LeadBundle/Form/Validator/Constraints/DbRegex.php
+++ b/app/bundles/LeadBundle/Form/Validator/Constraints/DbRegex.php
@@ -6,7 +6,7 @@ namespace Mautic\LeadBundle\Form\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
-#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class DbRegex extends Constraint
 {
 }

--- a/app/bundles/LeadBundle/Form/Validator/Constraints/FieldAliasKeyword.php
+++ b/app/bundles/LeadBundle/Form/Validator/Constraints/FieldAliasKeyword.php
@@ -5,7 +5,7 @@ namespace Mautic\LeadBundle\Form\Validator\Constraints;
 use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
-#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class FieldAliasKeyword extends Constraint
 {
     /**

--- a/app/bundles/LeadBundle/Validator/Constraints/SafeUrl.php
+++ b/app/bundles/LeadBundle/Validator/Constraints/SafeUrl.php
@@ -7,7 +7,7 @@ namespace Mautic\LeadBundle\Validator\Constraints;
 use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
-#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class SafeUrl extends Constraint
 {
     /**

--- a/app/bundles/LeadBundle/Validator/Constraints/SegmentDate.php
+++ b/app/bundles/LeadBundle/Validator/Constraints/SegmentDate.php
@@ -7,7 +7,7 @@ namespace Mautic\LeadBundle\Validator\Constraints;
 use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
-#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class SegmentDate extends Constraint
 {
     /**

--- a/app/bundles/MessengerBundle/Validator/Dsn.php
+++ b/app/bundles/MessengerBundle/Validator/Dsn.php
@@ -6,7 +6,7 @@ namespace Mautic\MessengerBundle\Validator;
 
 use Symfony\Component\Validator\Constraint;
 
-#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class Dsn extends Constraint
 {
 }

--- a/app/bundles/PluginBundle/Form/Constraint/CanPublish.php
+++ b/app/bundles/PluginBundle/Form/Constraint/CanPublish.php
@@ -7,7 +7,7 @@ namespace Mautic\PluginBundle\Form\Constraint;
 use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
-#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class CanPublish extends Constraint
 {
     /**

--- a/app/bundles/ReportBundle/Entity/Report.php
+++ b/app/bundles/ReportBundle/Entity/Report.php
@@ -23,7 +23,6 @@ use Mautic\ReportBundle\Scheduler\SchedulerInterface;
 use Mautic\ReportBundle\Scheduler\Validator as ReportAssert;
 use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Validator\Constraints\NotBlank;
-use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 #[ApiResource(
     operations: [
@@ -133,6 +132,7 @@ class Report extends FormEntity implements SchedulerInterface, UuidInterface
      * @var string|null
      */
     #[Groups(['report:read', 'report:write'])]
+    #[EmailAssert\MultipleEmailsValid]
     private $toAddress;
 
     /**
@@ -217,11 +217,6 @@ class Report extends FormEntity implements SchedulerInterface, UuidInterface
         $builder->addNullableField('scheduleMonthFrequency', Types::STRING, 'schedule_month_frequency');
 
         static::addUuidField($builder);
-    }
-
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addPropertyConstraint('toAddress', new EmailAssert\MultipleEmailsValid());
     }
 
     /**

--- a/app/bundles/UserBundle/Entity/User.php
+++ b/app/bundles/UserBundle/Entity/User.php
@@ -23,6 +23,7 @@ use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 #[ApiResource(
     shortName: 'User',
@@ -73,7 +74,6 @@ class User extends FormEntity implements UserInterface, EquatableInterface, Pass
     #[Groups(['user:write'])]
     #[Assert\NotBlank(message: 'mautic.user.user.password.notblank', groups: ['CheckPasswordNotBlank'])]
     #[Assert\Length(min: 6, minMessage: 'mautic.user.user.password.minlength', groups: ['CheckPassword'])]
-    #[NotWeak(message: 'mautic.user.user.password.weak', groups: ['CheckPassword'])]
     private $plainPassword;
 
     /**
@@ -237,6 +237,11 @@ class User extends FormEntity implements UserInterface, EquatableInterface, Pass
         $builder->createField('signature', 'text')
             ->nullable()
             ->build();
+    }
+
+    public static function loadValidatorMetadata(ClassMetadata $metadata): void
+    {
+        $metadata->addPropertyConstraint('plainPassword', new NotWeak(message: 'mautic.user.user.password.weak', groups: ['CheckPassword']));
     }
 
     public static function determineValidationGroups(Form $form): array

--- a/app/bundles/UserBundle/Entity/User.php
+++ b/app/bundles/UserBundle/Entity/User.php
@@ -23,7 +23,6 @@ use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 #[ApiResource(
     shortName: 'User',
@@ -74,6 +73,7 @@ class User extends FormEntity implements UserInterface, EquatableInterface, Pass
     #[Groups(['user:write'])]
     #[Assert\NotBlank(message: 'mautic.user.user.password.notblank', groups: ['CheckPasswordNotBlank'])]
     #[Assert\Length(min: 6, minMessage: 'mautic.user.user.password.minlength', groups: ['CheckPassword'])]
+    #[NotWeak(message: 'mautic.user.user.password.weak', groups: ['CheckPassword'])]
     private $plainPassword;
 
     /**
@@ -237,11 +237,6 @@ class User extends FormEntity implements UserInterface, EquatableInterface, Pass
         $builder->createField('signature', 'text')
             ->nullable()
             ->build();
-    }
-
-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addPropertyConstraint('plainPassword', new NotWeak(message: 'mautic.user.user.password.weak', groups: ['CheckPassword']));
     }
 
     public static function determineValidationGroups(Form $form): array

--- a/app/bundles/UserBundle/Form/Validator/Constraints/NotWeak.php
+++ b/app/bundles/UserBundle/Form/Validator/Constraints/NotWeak.php
@@ -8,7 +8,7 @@ use Mautic\UserBundle\Model\PasswordStrengthEstimatorModel;
 use Symfony\Component\Validator\Attribute\HasNamedArguments;
 use Symfony\Component\Validator\Constraint;
 
-#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class NotWeak extends Constraint
 {
     public const string TOO_WEAK = 'f61e730a-284e-11eb-adc1-0242ac120002';


### PR DESCRIPTION
Moves the remaining Mautic-owned constraints from `loadValidatorMetadata()` to property attributes. All three constraint classes are already attribute-ready (`#[\Attribute(...)]` + `#[HasNamedArguments]`), so this is a 1:1 move.

Entities that still register constraints via `new Callback()` (Email, Notification, Page, Sms, LeadField) are intentionally left untouched.

```diff
 class User extends FormEntity implements UserInterface, ...
 {
     #[Assert\Length(min: 6, minMessage: 'mautic.user.user.password.minlength', groups: ['CheckPassword'])]
+    #[NotWeak(message: 'mautic.user.user.password.weak', groups: ['CheckPassword'])]
     private $plainPassword;

-    public static function loadValidatorMetadata(ClassMetadata $metadata): void
-    {
-        $metadata->addPropertyConstraint('plainPassword', new NotWeak(message: 'mautic.user.user.password.weak', groups: ['CheckPassword']));
-    }
```

Same shape for:

* `Mautic\FormBundle\Entity\Form::$postActionProperty` — `IsPostActionRedirectUrl(groups: ['urlRequired'])`
* `Mautic\ReportBundle\Entity\Report::$toAddress` — `MultipleEmailsValid`

With `loadValidatorMetadata()` gone in all three, the now-unused `Symfony\Component\Validator\Mapping\ClassMetadata` imports are dropped as well.

## Verification

The resolved `ClassMetadata` was dumped for all three entities before and after the change (attribute loader + static method loader chain) — constraint classes, messages, groups and payloads are byte-identical.
