### PR TITLE
[7.x] [deprecation] Deprecate EmojiHelper

### DIFF
--- a/app/bundles/CoreBundle/Helper/EmojiHelper.php
+++ b/app/bundles/CoreBundle/Helper/EmojiHelper.php
@@ -6,6 +6,8 @@ namespace Mautic\CoreBundle\Helper;
  * Helper class for Emoji unicodes.
  *
  * Build from modified https://github.com/iamcal/php-emoji
+ *
+ * @deprecated since Mautic 7.2, to be removed in 8.0 with no replacement. Emoji are stored and rendered as UTF-8 (utf8mb4) directly, so no conversion is needed.
  */
 final class EmojiHelper
 {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -120,6 +120,10 @@ parameters:
 		-
 			identifier: class.extendsDeprecatedClass
 			path: app/bundles/IntegrationsBundle/Tests/Unit/AbstractIntegrationTest.php
+		# EmojiHelper is deprecated and removed in 8.0; its call sites are removed there too
+		-
+			identifier: staticMethod.deprecatedClass
+			message: '#Call to method (toHtml|toShort|toEmoji)\(\) of deprecated class Mautic\\CoreBundle\\Helper\\EmojiHelper#'
 		-
 			identifier: classConstant.deprecatedClass
 			paths:


### PR DESCRIPTION
Marks `Mautic\CoreBundle\Helper\EmojiHelper` as deprecated, to be removed in 8.0.

Removal in 8.0: https://github.com/mautic/mautic/pull/17026
