### PR TITLE
[removal] Remove dead $cacheTimeout state from WidgetDetailEvent

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -27,8 +27,6 @@
 - Deprecated class `Mautic\CoreBundle\Helper\EmojiMap\UnicodeToShortEmojiMap` removed with no replacement.
 - Class `Mautic\CoreBundle\Helper\EmojiHelper` removed with no replacement. All emoji conversion calls were dropped; emoji are stored and rendered as UTF-8 (`utf8mb4`) directly.
 - Emoji sprite stylesheet `app/bundles/CoreBundle/Assets/css/libraries/emoji/` (`_emoji.scss` + `emoji.png`) removed together with its `@import` in `_libraries.scss`. It styled the `span.emoji-sizer`/`.emoji-outer`/`.emoji-inner` markup that `EmojiHelper::toHtml()` used to emit, which is no longer produced. Custom themes relying on those classes must ship their own CSS.
-<<<<<<< HEAD
-<<<<<<< HEAD
 - Deprecated class `Mautic\CoreBundle\Helper\CacheStorageHelper` removed together with the `mautic.helper.cache_storage` service. Use the CacheBundle instead: inject `Mautic\CacheBundle\Cache\CacheProviderInterface` and call `getSimpleCache()` for the PSR-16 API the helper mimicked.
 
 ```diff
@@ -52,17 +50,8 @@
   - Cached data moves from the `cache_items` database table to the adapter configured by the `cache_adapter` parameter (filesystem by default), so it is dropped by a cache clear. The `cache_items` table and `Mautic\CoreBundle\Entity\Cache` entity are kept, but are no longer written to by Mautic itself.
 - `Mautic\PluginBundle\Integration\AbstractIntegration::getCache()` returns `Psr\SimpleCache\CacheInterface` instead of `CacheStorageHelper`, and its 2nd constructor argument is now `Mautic\CacheBundle\Cache\CacheProviderInterface`. Keys stay namespaced per integration, so `$this->cache->set('leadFields', $fields)` in an integration keeps working unchanged.
 - `Mautic\DashboardBundle\Event\WidgetDetailEvent`: the legacy filesystem widget cache is gone. `setCacheDir()` was removed, the `$cacheProvider` constructor argument is now required, and `setTemplateData()` lost its 2nd `$skipCache` parameter. Widget data is cached only through `Mautic\CacheBundle\Cache\CacheProviderTagAwareInterface`.
-=======
-=======
-=======
->>>>>>> 7cfc9d56a2 (rebase)
 - Legacy filesystem cache fallback in `Mautic\DashboardBundle\Event\WidgetDetailEvent` removed. Widget data is always cached through the tag-aware cache provider:
     - The `$cacheProvider` constructor argument is now required and no longer nullable.
     - Methods `setCacheDir()` and `setCacheTimeout()` removed. The cache lifetime comes from `Widget::getCacheTimeout()`.
     - The second `$skipCache` argument of `setTemplateData()` removed.
 - `Mautic\DashboardBundle\Factory\WidgetDetailEventFactory` no longer takes `UserHelper`, `CoreParametersHelper` and `PathsHelper` constructor arguments.
-<<<<<<< HEAD
->>>>>>> 03592dfff7 ([removal] Remove legacy filesystem cache fallback from WidgetDetailEvent)
->>>>>>> 7e52bcc4c8 ([removal] Remove legacy filesystem cache fallback from WidgetDetailEvent)
-=======
->>>>>>> 7cfc9d56a2 (rebase)

--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -49,9 +49,5 @@
   - A cache miss now returns `null` instead of `false`, so `false === $value` checks must become `null === $value`.
   - Cached data moves from the `cache_items` database table to the adapter configured by the `cache_adapter` parameter (filesystem by default), so it is dropped by a cache clear. The `cache_items` table and `Mautic\CoreBundle\Entity\Cache` entity are kept, but are no longer written to by Mautic itself.
 - `Mautic\PluginBundle\Integration\AbstractIntegration::getCache()` returns `Psr\SimpleCache\CacheInterface` instead of `CacheStorageHelper`, and its 2nd constructor argument is now `Mautic\CacheBundle\Cache\CacheProviderInterface`. Keys stay namespaced per integration, so `$this->cache->set('leadFields', $fields)` in an integration keeps working unchanged.
-- `Mautic\DashboardBundle\Event\WidgetDetailEvent`: the legacy filesystem widget cache is gone. `setCacheDir()` was removed, the `$cacheProvider` constructor argument is now required, and `setTemplateData()` lost its 2nd `$skipCache` parameter. Widget data is cached only through `Mautic\CacheBundle\Cache\CacheProviderTagAwareInterface`.
-- Legacy filesystem cache fallback in `Mautic\DashboardBundle\Event\WidgetDetailEvent` removed. Widget data is always cached through the tag-aware cache provider:
-    - The `$cacheProvider` constructor argument is now required and no longer nullable.
-    - Methods `setCacheDir()` and `setCacheTimeout()` removed. The cache lifetime comes from `Widget::getCacheTimeout()`.
-    - The second `$skipCache` argument of `setTemplateData()` removed.
+- `Mautic\DashboardBundle\Event\WidgetDetailEvent`: the legacy filesystem widget cache is gone. `setCacheDir()` and `setCacheTimeout()` were removed, the `$cacheProvider` constructor argument is now required, and `setTemplateData()` lost its 2nd `$skipCache` parameter. Widget data is cached only through `Mautic\CacheBundle\Cache\CacheProviderTagAwareInterface`, with the lifetime taken from `Widget::getCacheTimeout()`.
 - `Mautic\DashboardBundle\Factory\WidgetDetailEventFactory` no longer takes `UserHelper`, `CoreParametersHelper` and `PathsHelper` constructor arguments.

--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -7,7 +7,6 @@
 ## Removed code
 
 - Deprecated method `Mautic\LeadBundle\Model\LeadModel::isContactable()` removed. Use `Mautic\LeadBundle\Model\DoNotContact::isContactable()` instead.
-<<<<<<< HEAD
 - Deprecated method `Mautic\CampaignBundle\EventCollector\Builder\ConnectionBuilder::addDeprecatedAnchorRestrictions()` removed. With it, the campaign event keys `associatedActions`, `associatedDecisions` and `anchorRestrictions` are no longer read. Use the `connectionRestrictions` key instead:
 
 ```diff
@@ -28,6 +27,7 @@
 - Deprecated class `Mautic\CoreBundle\Helper\EmojiMap\UnicodeToShortEmojiMap` removed with no replacement.
 - Class `Mautic\CoreBundle\Helper\EmojiHelper` removed with no replacement. All emoji conversion calls were dropped; emoji are stored and rendered as UTF-8 (`utf8mb4`) directly.
 - Emoji sprite stylesheet `app/bundles/CoreBundle/Assets/css/libraries/emoji/` (`_emoji.scss` + `emoji.png`) removed together with its `@import` in `_libraries.scss`. It styled the `span.emoji-sizer`/`.emoji-outer`/`.emoji-inner` markup that `EmojiHelper::toHtml()` used to emit, which is no longer produced. Custom themes relying on those classes must ship their own CSS.
+<<<<<<< HEAD
 <<<<<<< HEAD
 - Deprecated class `Mautic\CoreBundle\Helper\CacheStorageHelper` removed together with the `mautic.helper.cache_storage` service. Use the CacheBundle instead: inject `Mautic\CacheBundle\Cache\CacheProviderInterface` and call `getSimpleCache()` for the PSR-16 API the helper mimicked.
 
@@ -54,10 +54,15 @@
 - `Mautic\DashboardBundle\Event\WidgetDetailEvent`: the legacy filesystem widget cache is gone. `setCacheDir()` was removed, the `$cacheProvider` constructor argument is now required, and `setTemplateData()` lost its 2nd `$skipCache` parameter. Widget data is cached only through `Mautic\CacheBundle\Cache\CacheProviderTagAwareInterface`.
 =======
 =======
+=======
+>>>>>>> 7cfc9d56a2 (rebase)
 - Legacy filesystem cache fallback in `Mautic\DashboardBundle\Event\WidgetDetailEvent` removed. Widget data is always cached through the tag-aware cache provider:
     - The `$cacheProvider` constructor argument is now required and no longer nullable.
     - Methods `setCacheDir()` and `setCacheTimeout()` removed. The cache lifetime comes from `Widget::getCacheTimeout()`.
     - The second `$skipCache` argument of `setTemplateData()` removed.
 - `Mautic\DashboardBundle\Factory\WidgetDetailEventFactory` no longer takes `UserHelper`, `CoreParametersHelper` and `PathsHelper` constructor arguments.
+<<<<<<< HEAD
 >>>>>>> 03592dfff7 ([removal] Remove legacy filesystem cache fallback from WidgetDetailEvent)
 >>>>>>> 7e52bcc4c8 ([removal] Remove legacy filesystem cache fallback from WidgetDetailEvent)
+=======
+>>>>>>> 7cfc9d56a2 (rebase)

--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -7,6 +7,7 @@
 ## Removed code
 
 - Deprecated method `Mautic\LeadBundle\Model\LeadModel::isContactable()` removed. Use `Mautic\LeadBundle\Model\DoNotContact::isContactable()` instead.
+<<<<<<< HEAD
 - Deprecated method `Mautic\CampaignBundle\EventCollector\Builder\ConnectionBuilder::addDeprecatedAnchorRestrictions()` removed. With it, the campaign event keys `associatedActions`, `associatedDecisions` and `anchorRestrictions` are no longer read. Use the `connectionRestrictions` key instead:
 
 ```diff
@@ -27,6 +28,7 @@
 - Deprecated class `Mautic\CoreBundle\Helper\EmojiMap\UnicodeToShortEmojiMap` removed with no replacement.
 - Class `Mautic\CoreBundle\Helper\EmojiHelper` removed with no replacement. All emoji conversion calls were dropped; emoji are stored and rendered as UTF-8 (`utf8mb4`) directly.
 - Emoji sprite stylesheet `app/bundles/CoreBundle/Assets/css/libraries/emoji/` (`_emoji.scss` + `emoji.png`) removed together with its `@import` in `_libraries.scss`. It styled the `span.emoji-sizer`/`.emoji-outer`/`.emoji-inner` markup that `EmojiHelper::toHtml()` used to emit, which is no longer produced. Custom themes relying on those classes must ship their own CSS.
+<<<<<<< HEAD
 - Deprecated class `Mautic\CoreBundle\Helper\CacheStorageHelper` removed together with the `mautic.helper.cache_storage` service. Use the CacheBundle instead: inject `Mautic\CacheBundle\Cache\CacheProviderInterface` and call `getSimpleCache()` for the PSR-16 API the helper mimicked.
 
 ```diff
@@ -50,3 +52,12 @@
   - Cached data moves from the `cache_items` database table to the adapter configured by the `cache_adapter` parameter (filesystem by default), so it is dropped by a cache clear. The `cache_items` table and `Mautic\CoreBundle\Entity\Cache` entity are kept, but are no longer written to by Mautic itself.
 - `Mautic\PluginBundle\Integration\AbstractIntegration::getCache()` returns `Psr\SimpleCache\CacheInterface` instead of `CacheStorageHelper`, and its 2nd constructor argument is now `Mautic\CacheBundle\Cache\CacheProviderInterface`. Keys stay namespaced per integration, so `$this->cache->set('leadFields', $fields)` in an integration keeps working unchanged.
 - `Mautic\DashboardBundle\Event\WidgetDetailEvent`: the legacy filesystem widget cache is gone. `setCacheDir()` was removed, the `$cacheProvider` constructor argument is now required, and `setTemplateData()` lost its 2nd `$skipCache` parameter. Widget data is cached only through `Mautic\CacheBundle\Cache\CacheProviderTagAwareInterface`.
+=======
+=======
+- Legacy filesystem cache fallback in `Mautic\DashboardBundle\Event\WidgetDetailEvent` removed. Widget data is always cached through the tag-aware cache provider:
+    - The `$cacheProvider` constructor argument is now required and no longer nullable.
+    - Methods `setCacheDir()` and `setCacheTimeout()` removed. The cache lifetime comes from `Widget::getCacheTimeout()`.
+    - The second `$skipCache` argument of `setTemplateData()` removed.
+- `Mautic\DashboardBundle\Factory\WidgetDetailEventFactory` no longer takes `UserHelper`, `CoreParametersHelper` and `PathsHelper` constructor arguments.
+>>>>>>> 03592dfff7 ([removal] Remove legacy filesystem cache fallback from WidgetDetailEvent)
+>>>>>>> 7e52bcc4c8 ([removal] Remove legacy filesystem cache fallback from WidgetDetailEvent)

--- a/app/bundles/DashboardBundle/Event/WidgetDetailEvent.php
+++ b/app/bundles/DashboardBundle/Event/WidgetDetailEvent.php
@@ -23,8 +23,11 @@ class WidgetDetailEvent extends CommonEvent
 
     protected $uniqueId;
 
+<<<<<<< HEAD
     protected $cacheTimeout;
 
+=======
+>>>>>>> 7e52bcc4c8 ([removal] Remove legacy filesystem cache fallback from WidgetDetailEvent)
     protected float $startTime;
 
     protected $loadTime  = 0;
@@ -60,7 +63,7 @@ class WidgetDetailEvent extends CommonEvent
     }
 
     /**
-     * Return unique key, uses legacy methods for BC.
+     * Return unique cache key for the widget.
      */
     public function getCacheKey(): string
     {
@@ -88,6 +91,7 @@ class WidgetDetailEvent extends CommonEvent
     }
 
     /**
+<<<<<<< HEAD
      * @param int|null $cacheTimeout
      */
     public function setCacheTimeout($cacheTimeout): void
@@ -96,6 +100,8 @@ class WidgetDetailEvent extends CommonEvent
     }
 
     /**
+=======
+>>>>>>> 7e52bcc4c8 ([removal] Remove legacy filesystem cache fallback from WidgetDetailEvent)
      * Set the widget type.
      *
      * @param string $type
@@ -144,7 +150,6 @@ class WidgetDetailEvent extends CommonEvent
         $widget->setParams($params);
 
         $this->setType($widget->getType());
-        $this->setCacheTimeout($widget->getCacheTimeout());
     }
 
     /**
@@ -296,9 +301,12 @@ class WidgetDetailEvent extends CommonEvent
     }
 
     /**
+<<<<<<< HEAD
      * Checks for cache type. This event should be created by factory thus not legacy approach.
      */
     /**
+=======
+>>>>>>> 7e52bcc4c8 ([removal] Remove legacy filesystem cache fallback from WidgetDetailEvent)
      * We need to cast DateTime objects to strings to use them in the cache key.
      *
      * @param mixed|null $value

--- a/app/bundles/DashboardBundle/Event/WidgetDetailEvent.php
+++ b/app/bundles/DashboardBundle/Event/WidgetDetailEvent.php
@@ -23,11 +23,6 @@ class WidgetDetailEvent extends CommonEvent
 
     protected $uniqueId;
 
-<<<<<<< HEAD
-    protected $cacheTimeout;
-
-=======
->>>>>>> 7e52bcc4c8 ([removal] Remove legacy filesystem cache fallback from WidgetDetailEvent)
     protected float $startTime;
 
     protected $loadTime  = 0;
@@ -91,17 +86,6 @@ class WidgetDetailEvent extends CommonEvent
     }
 
     /**
-<<<<<<< HEAD
-     * @param int|null $cacheTimeout
-     */
-    public function setCacheTimeout($cacheTimeout): void
-    {
-        $this->cacheTimeout = (int) $cacheTimeout;
-    }
-
-    /**
-=======
->>>>>>> 7e52bcc4c8 ([removal] Remove legacy filesystem cache fallback from WidgetDetailEvent)
      * Set the widget type.
      *
      * @param string $type
@@ -301,12 +285,6 @@ class WidgetDetailEvent extends CommonEvent
     }
 
     /**
-<<<<<<< HEAD
-     * Checks for cache type. This event should be created by factory thus not legacy approach.
-     */
-    /**
-=======
->>>>>>> 7e52bcc4c8 ([removal] Remove legacy filesystem cache fallback from WidgetDetailEvent)
      * We need to cast DateTime objects to strings to use them in the cache key.
      *
      * @param mixed|null $value


### PR DESCRIPTION
Most of the legacy widget cache removal already landed with #17033. What is left is the dead `$cacheTimeout` state on the event: it is written by `setWidget()` and `setCacheTimeout()`, but never read — the cache lifetime comes from `Widget::getCacheTimeout()` in `setTemplateData()`.

```diff
-    protected $cacheTimeout;
-
-    /**
-     * @param int|null $cacheTimeout
-     */
-    public function setCacheTimeout($cacheTimeout): void
-    {
-        $this->cacheTimeout = (int) $cacheTimeout;
-    }
-
     public function setWidget(Widget $widget): void
     {
         ...
         $this->setType($widget->getType());
-        $this->setCacheTimeout($widget->getCacheTimeout());
     }
```

Behaviour is unchanged; caching still runs through `CacheProviderTagAwareInterface` with the lifetime from the `Widget` entity.

The `setCacheTimeout()` removal is folded into the existing `WidgetDetailEvent` entry in `UPGRADE-8.0.md`, and the `WidgetDetailEventFactory` constructor change from #17033 is documented there too.
