### PR TITLE
[symfony] Register all permission classes as DI services tagged mautic.permissions

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -57,3 +57,35 @@
 - `Mautic\PluginBundle\Integration\AbstractIntegration::getCache()` returns `Psr\SimpleCache\CacheInterface` instead of `CacheStorageHelper`, and its 2nd constructor argument is now `Mautic\CacheBundle\Cache\CacheProviderInterface`. Keys stay namespaced per integration, so `$this->cache->set('leadFields', $fields)` in an integration keeps working unchanged.
 - `Mautic\DashboardBundle\Event\WidgetDetailEvent`: the legacy filesystem widget cache is gone. `setCacheDir()` and `setCacheTimeout()` were removed, the `$cacheProvider` constructor argument is now required, and `setTemplateData()` lost its 2nd `$skipCache` parameter. Widget data is cached only through `Mautic\CacheBundle\Cache\CacheProviderTagAwareInterface`, with the lifetime taken from `Widget::getCacheTimeout()`.
 - `Mautic\DashboardBundle\Factory\WidgetDetailEventFactory` no longer takes `UserHelper`, `CoreParametersHelper` and `PathsHelper` constructor arguments.
+
+## Changed code
+
+- `Mautic\CoreBundle\Security\Permissions\AbstractPermissions::definePermissions()` was removed. Define the permissions in the constructor instead:
+
+    ```diff
+    -public function definePermissions(): void
+    +public function __construct()
+     {
+         $this->addStandardPermissions('categories');
+     }
+    ```
+
+    Permission classes that already define their permissions in the constructor need no change.
+
+- The resolved Mautic parameters are injected into `AbstractPermissions` by the autowired `setCoreParametersHelper()` method, so `$this->params` is available in every method except the constructor. The `array $params` constructor argument is deprecated and defaults to an empty array; drop it from your permission class:
+
+    ```diff
+    -public function __construct(array $params)
+    +public function __construct()
+     {
+    -    parent::__construct($params);
+    -
+         $this->addStandardPermissions('categories');
+     }
+    ```
+
+- All permission classes are now registered as services and tagged with `mautic.permissions`, instead of being instantiated on the fly by `Mautic\CoreBundle\Security\Permissions\CorePermissions`. A permission class that is not registered as a service is still instantiated on the fly. Register it in the bundle's `Config/services.php` to have it managed by the container and to autowire other services into it; the `mautic.permissions` tag is added automatically to every `AbstractPermissions` child registered with autoconfiguration enabled:
+
+    ```php
+    $services->set(MauticPlugin\AcmeBundle\Security\Permissions\AcmePermissions::class);
+    ```

--- a/app/bundles/ApiBundle/Config/services.php
+++ b/app/bundles/ApiBundle/Config/services.php
@@ -50,4 +50,5 @@ return function (ContainerConfigurator $configurator): void {
             service('.inner'),
             service('doctrine.orm.entity_manager'),
         ]);
+    $services->set(Mautic\ApiBundle\Security\Permissions\ApiPermissions::class);
 };

--- a/app/bundles/ApiBundle/Security/Permissions/ApiPermissions.php
+++ b/app/bundles/ApiBundle/Security/Permissions/ApiPermissions.php
@@ -8,13 +8,8 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 final class ApiPermissions extends AbstractPermissions
 {
-    /**
-     * @param mixed[] $params
-     */
-    public function __construct(array $params)
+    public function __construct()
     {
-        parent::__construct($params);
-
         $this->permissions = [
             'access' => [
                 'full' => 1024,

--- a/app/bundles/AssetBundle/Security/Permissions/AssetPermissions.php
+++ b/app/bundles/AssetBundle/Security/Permissions/AssetPermissions.php
@@ -2,18 +2,12 @@
 
 namespace Mautic\AssetBundle\Security\Permissions;
 
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Security\Permissions\AbstractPermissions;
 use Symfony\Component\Form\FormBuilderInterface;
 
 final class AssetPermissions extends AbstractPermissions
 {
-    public function __construct(CoreParametersHelper $coreParametersHelper)
-    {
-        parent::__construct($coreParametersHelper->all());
-    }
-
-    public function definePermissions(): void
+    public function __construct()
     {
         $this->addExtendedPermissions('assets');
         $this->addStandardPermissions('categories');

--- a/app/bundles/CampaignBundle/Config/services.php
+++ b/app/bundles/CampaignBundle/Config/services.php
@@ -64,4 +64,5 @@ return function (ContainerConfigurator $configurator): void {
             ->decorate(Mautic\CampaignBundle\Executioner\ScheduledExecutioner::class)
             ->tag('kernel.reset', ['method' => 'reset']);
     }
+    $services->set(Mautic\CampaignBundle\Security\Permissions\CampaignPermissions::class);
 };

--- a/app/bundles/CampaignBundle/Security/Permissions/CampaignPermissions.php
+++ b/app/bundles/CampaignBundle/Security/Permissions/CampaignPermissions.php
@@ -9,12 +9,8 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 final class CampaignPermissions extends AbstractPermissions
 {
-    /**
-     * @param mixed[] $params
-     */
-    public function __construct(array $params)
+    public function __construct()
     {
-        parent::__construct($params);
         $this->addExtendedPermissions('campaigns');
         $this->addStandardPermissions(['categories']);
         $this->addStandardPermissions(['imports']);

--- a/app/bundles/CategoryBundle/Config/services.php
+++ b/app/bundles/CategoryBundle/Config/services.php
@@ -20,4 +20,5 @@ return function (ContainerConfigurator $configurator): void {
 
     $services->load('Mautic\\CategoryBundle\\Entity\\', '../Entity/*Repository.php');
     $services->alias('mautic.category.model.category', Mautic\CategoryBundle\Model\CategoryModel::class);
+    $services->set(Mautic\CategoryBundle\Security\Permissions\CategoryPermissions::class);
 };

--- a/app/bundles/CategoryBundle/Security/Permissions/CategoryPermissions.php
+++ b/app/bundles/CategoryBundle/Security/Permissions/CategoryPermissions.php
@@ -7,13 +7,8 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 final class CategoryPermissions extends AbstractPermissions
 {
-    /**
-     * @param mixed[] $params
-     */
-    public function __construct(array $params)
+    public function __construct()
     {
-        parent::__construct($params);
-
         $this->addStandardPermissions('categories');
     }
 

--- a/app/bundles/ChannelBundle/Config/services.php
+++ b/app/bundles/ChannelBundle/Config/services.php
@@ -27,4 +27,5 @@ return function (ContainerConfigurator $configurator): void {
 
     $services->set(Mautic\ChannelBundle\Helper\ChannelListHelper::class)
         ->tag('twig.helper', ['alias' => 'channel']);
+    $services->set(Mautic\ChannelBundle\Security\Permissions\ChannelPermissions::class);
 };

--- a/app/bundles/ChannelBundle/Security/Permissions/ChannelPermissions.php
+++ b/app/bundles/ChannelBundle/Security/Permissions/ChannelPermissions.php
@@ -7,13 +7,8 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 final class ChannelPermissions extends AbstractPermissions
 {
-    /**
-     * @param mixed[] $params
-     */
-    public function __construct(array $params)
+    public function __construct()
     {
-        parent::__construct($params);
-
         $this->addStandardPermissions('categories');
         $this->addExtendedPermissions('messages');
     }

--- a/app/bundles/CoreBundle/Config/services.php
+++ b/app/bundles/CoreBundle/Config/services.php
@@ -256,4 +256,5 @@ return function (ContainerConfigurator $configurator): void {
     $services->alias('mautic.core.model.auditlog', Mautic\CoreBundle\Model\AuditLogModel::class);
     $services->alias('mautic.core.model.notification', Mautic\CoreBundle\Model\NotificationModel::class);
     $services->alias('mautic.core.model.form', Mautic\CoreBundle\Model\FormModel::class);
+    $services->set(Mautic\CoreBundle\Security\Permissions\SystemPermissions::class);
 };

--- a/app/bundles/CoreBundle/DependencyInjection/MauticCoreExtension.php
+++ b/app/bundles/CoreBundle/DependencyInjection/MauticCoreExtension.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\DependencyInjection;
 
+use Mautic\CoreBundle\Security\Permissions\AbstractPermissions;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
@@ -33,6 +34,9 @@ final class MauticCoreExtension extends Extension
      */
     public function load(array $configs, ContainerBuilder $container): void
     {
+        $container->registerForAutoconfiguration(AbstractPermissions::class)
+            ->addTag('mautic.permissions');
+
         // For the project:
         $loader = new PhpFileLoader($container, new FileLocator(__DIR__.'/../../../config'));
         $loader->load('services.php');

--- a/app/bundles/CoreBundle/Security/Permissions/AbstractPermissions.php
+++ b/app/bundles/CoreBundle/Security/Permissions/AbstractPermissions.php
@@ -2,8 +2,10 @@
 
 namespace Mautic\CoreBundle\Security\Permissions;
 
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\UserBundle\Form\Type\PermissionListType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Contracts\Service\Attribute\Required;
 
 abstract class AbstractPermissions
 {
@@ -12,18 +14,27 @@ abstract class AbstractPermissions
      */
     protected $permissions = [];
 
-    public function __construct(
-        protected array $params,
-    ) {
-    }
+    /**
+     * @var mixed[]
+     */
+    protected array $params = [];
 
     /**
-     * This method is called before the permissions object is used.
-     * Define permissions with `addExtendedPermissions` here instead of constructor.
+     * @param mixed[] $params
+     *
+     * @deprecated since Mautic 8.0, the parameters are injected by setCoreParametersHelper(); to be removed in Mautic 9.0
      */
-    public function definePermissions(): void
+    public function __construct(array $params = [])
     {
-        // Override this method in the final class
+        $this->params = $params;
+    }
+
+    #[Required]
+    public function setCoreParametersHelper(
+        CoreParametersHelper $coreParametersHelper
+    ): void
+    {
+        $this->params = $coreParametersHelper->all();
     }
 
     /**

--- a/app/bundles/CoreBundle/Security/Permissions/CorePermissions.php
+++ b/app/bundles/CoreBundle/Security/Permissions/CorePermissions.php
@@ -97,10 +97,6 @@ class CorePermissions implements ResetInterface
             }
         }
 
-        if ($permissionObject->isEnabled()) {
-            $permissionObject->definePermissions();
-        }
-
         return $permissionObject;
     }
 
@@ -458,7 +454,10 @@ class CorePermissions implements ResetInterface
 
         $permissionClass = $this->getPermissionClasses()[$class];
 
-        return new $permissionClass($this->getParams());
+        $permissionObject = new $permissionClass($this->getParams());
+        $permissionObject->setCoreParametersHelper($this->coreParametersHelper);
+
+        return $permissionObject;
     }
 
     /**

--- a/app/bundles/CoreBundle/Security/Permissions/SystemPermissions.php
+++ b/app/bundles/CoreBundle/Security/Permissions/SystemPermissions.php
@@ -6,12 +6,8 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 final class SystemPermissions extends AbstractPermissions
 {
-    /**
-     * @param mixed[] $params
-     */
-    public function __construct(array $params)
+    public function __construct()
     {
-        parent::__construct($params);
         $this->addStandardPermissions('themes');
     }
 

--- a/app/bundles/CoreBundle/Tests/Unit/Security/Permissions/CorePermissionsTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Security/Permissions/CorePermissionsTest.php
@@ -47,7 +47,7 @@ final class CorePermissionsTest extends \PHPUnit\Framework\TestCase
         $this->coreParametersHelper->method('all')
             ->willReturn(['parameter_a' => 'value_a']);
 
-        $assetPermissions = new AssetPermissions($this->coreParametersHelper);
+        $assetPermissions = new AssetPermissions();
         $this->corePermissions->setPermissionObject($assetPermissions);
         $permissionObjects = $this->corePermissions->getPermissionObjects();
 

--- a/app/bundles/DynamicContentBundle/Config/services.php
+++ b/app/bundles/DynamicContentBundle/Config/services.php
@@ -24,4 +24,5 @@ return function (ContainerConfigurator $configurator): void {
         ->tag(Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass::REPOSITORY_SERVICE_TAG);
     $services->set(Mautic\DynamicContentBundle\Helper\DynamicContentHelper::class);
     $services->alias('mautic.dynamicContent.model.dynamicContent', Mautic\DynamicContentBundle\Model\DynamicContentModel::class);
+    $services->set(Mautic\DynamicContentBundle\Security\Permissions\DynamicContentPermissions::class);
 };

--- a/app/bundles/DynamicContentBundle/Security/Permissions/DynamicContentPermissions.php
+++ b/app/bundles/DynamicContentBundle/Security/Permissions/DynamicContentPermissions.php
@@ -7,13 +7,8 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 final class DynamicContentPermissions extends AbstractPermissions
 {
-    /**
-     * @param mixed[] $params
-     */
-    public function __construct(array $params)
+    public function __construct()
     {
-        parent::__construct($params);
-
         $this->addStandardPermissions('categories');
         $this->addExtendedPermissions('dynamiccontents');
     }

--- a/app/bundles/EmailBundle/Config/services.php
+++ b/app/bundles/EmailBundle/Config/services.php
@@ -70,4 +70,5 @@ return function (ContainerConfigurator $configurator): void {
 
     $services->get(Mautic\EmailBundle\EventListener\WebhookSubscriber::class)
         ->arg('$includeDetails', '%mautic.webhook_email_details%');
+    $services->set(Mautic\EmailBundle\Security\Permissions\EmailPermissions::class);
 };

--- a/app/bundles/EmailBundle/Security/Permissions/EmailPermissions.php
+++ b/app/bundles/EmailBundle/Security/Permissions/EmailPermissions.php
@@ -8,13 +8,8 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 final class EmailPermissions extends AbstractPermissions
 {
-    /**
-     * @param mixed[] $params
-     */
-    public function __construct(array $params)
+    public function __construct()
     {
-        parent::__construct($params);
-
         $this->addStandardPermissions('categories');
         $this->addExtendedPermissions('emails');
         $this->permissions['emails']['sendtodnc'] = 1;

--- a/app/bundles/FormBundle/Config/services.php
+++ b/app/bundles/FormBundle/Config/services.php
@@ -59,4 +59,5 @@ return function (ContainerConfigurator $configurator): void {
     $services->alias('mautic.form.model.form', Mautic\FormBundle\Model\FormModel::class);
     $services->alias('mautic.form.model.submission', Mautic\FormBundle\Model\SubmissionModel::class);
     $services->alias('mautic.form.model.submission_result_loader', Mautic\FormBundle\Model\SubmissionResultLoader::class);
+    $services->set(Mautic\FormBundle\Security\Permissions\FormPermissions::class);
 };

--- a/app/bundles/FormBundle/Security/Permissions/FormPermissions.php
+++ b/app/bundles/FormBundle/Security/Permissions/FormPermissions.php
@@ -7,12 +7,8 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 final class FormPermissions extends AbstractPermissions
 {
-    /**
-     * @param mixed[] $params
-     */
-    public function __construct(array $params)
+    public function __construct()
     {
-        parent::__construct($params);
         $this->addCustomPermission('export', ['enable' => 1024]);
         $this->addExtendedPermissions('forms');
         $this->addStandardPermissions('categories');

--- a/app/bundles/LeadBundle/Config/services.php
+++ b/app/bundles/LeadBundle/Config/services.php
@@ -148,4 +148,5 @@ return function (ContainerConfigurator $configurator): void {
     $services->alias('mautic.lead.model.export_scheduler', Mautic\LeadBundle\Model\ContactExportSchedulerModel::class);
     $services->alias('mautic.lead.repository.list_lead', Mautic\LeadBundle\Entity\ListLeadRepository::class);
     $services->get(Mautic\LeadBundle\Validator\Constraints\SegmentDateValidator::class)->tag('validator.constraint_validator');
+    $services->set(Mautic\LeadBundle\Security\Permissions\LeadPermissions::class);
 };

--- a/app/bundles/LeadBundle/Security/Permissions/LeadPermissions.php
+++ b/app/bundles/LeadBundle/Security/Permissions/LeadPermissions.php
@@ -26,13 +26,8 @@ final class LeadPermissions extends AbstractPermissions
 
     public const string LISTS_FULL         = 'lead:lists:full';
 
-    /**
-     * @param mixed[] $params
-     */
-    public function __construct(array $params)
+    public function __construct()
     {
-        parent::__construct($params);
-
         $this->permissions = [
             'fields' => [
                 'full' => 1024,

--- a/app/bundles/MarketplaceBundle/Security/Permissions/MarketplacePermissions.php
+++ b/app/bundles/MarketplaceBundle/Security/Permissions/MarketplacePermissions.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\MarketplaceBundle\Security\Permissions;
 
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Security\Permissions\AbstractPermissions;
 use Mautic\MarketplaceBundle\Service\Config;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -22,14 +21,8 @@ final class MarketplacePermissions extends AbstractPermissions
     public const string CAN_REMOVE_PACKAGES  = self::BASE.':'.self::PACKAGES.':remove';
 
     public function __construct(
-        CoreParametersHelper $coreParametersHelper,
         private readonly Config $config,
     ) {
-        parent::__construct($coreParametersHelper->all());
-    }
-
-    public function definePermissions(): void
-    {
         $this->addStandardPermissions(self::PACKAGES, false);
     }
 

--- a/app/bundles/NotificationBundle/Config/services.php
+++ b/app/bundles/NotificationBundle/Config/services.php
@@ -29,4 +29,5 @@ return function (ContainerConfigurator $configurator): void {
     $services->alias('mautic.notification.model.notification', Mautic\NotificationBundle\Model\NotificationModel::class);
 
     $services->alias('mautic.notification.api', Mautic\NotificationBundle\Api\OneSignalApi::class);
+    $services->set(Mautic\NotificationBundle\Security\Permissions\NotificationPermissions::class);
 };

--- a/app/bundles/NotificationBundle/Security/Permissions/NotificationPermissions.php
+++ b/app/bundles/NotificationBundle/Security/Permissions/NotificationPermissions.php
@@ -7,12 +7,8 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 final class NotificationPermissions extends AbstractPermissions
 {
-    /**
-     * @param mixed[] $params
-     */
-    public function __construct(array $params)
+    public function __construct()
     {
-        parent::__construct($params);
         $this->addStandardPermissions('categories');
         $this->addExtendedPermissions('notifications');
         $this->addExtendedPermissions('mobile_notifications');

--- a/app/bundles/PageBundle/Config/services.php
+++ b/app/bundles/PageBundle/Config/services.php
@@ -32,4 +32,5 @@ return function (ContainerConfigurator $configurator): void {
     $services->alias('mautic.page.model.redirect', Mautic\PageBundle\Model\RedirectModel::class);
     $services->alias('mautic.page.model.trackable', Mautic\PageBundle\Model\TrackableModel::class);
     $services->alias('mautic.page.model.video', Mautic\PageBundle\Model\VideoModel::class);
+    $services->set(Mautic\PageBundle\Security\Permissions\PagePermissions::class);
 };

--- a/app/bundles/PageBundle/Security/Permissions/PagePermissions.php
+++ b/app/bundles/PageBundle/Security/Permissions/PagePermissions.php
@@ -7,12 +7,8 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 final class PagePermissions extends AbstractPermissions
 {
-    /**
-     * @param mixed[] $params
-     */
-    public function __construct(array $params)
+    public function __construct()
     {
-        parent::__construct($params);
         $this->addExtendedPermissions('pages');
         $this->addStandardPermissions('categories');
         $this->addExtendedPermissions('preference_center');

--- a/app/bundles/PluginBundle/Config/services.php
+++ b/app/bundles/PluginBundle/Config/services.php
@@ -38,4 +38,5 @@ return function (ContainerConfigurator $configurator): void {
         ->call('setIntegrationHelper', [service('mautic.helper.integration')]);
     $services->set(CampaignSubscriber::class)
         ->call('setIntegrationHelper', [service('mautic.helper.integration')]);
+    $services->set(Mautic\PluginBundle\Security\Permissions\PluginPermissions::class);
 };

--- a/app/bundles/PluginBundle/Security/Permissions/PluginPermissions.php
+++ b/app/bundles/PluginBundle/Security/Permissions/PluginPermissions.php
@@ -7,12 +7,8 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 final class PluginPermissions extends AbstractPermissions
 {
-    /**
-     * @param mixed[] $params
-     */
-    public function __construct(array $params)
+    public function __construct()
     {
-        parent::__construct($params);
         $this->addManagePermission('plugins');
     }
 

--- a/app/bundles/PointBundle/Config/services.php
+++ b/app/bundles/PointBundle/Config/services.php
@@ -26,4 +26,5 @@ return function (ContainerConfigurator $configurator): void {
     $services->alias('mautic.point.model.trigger', Mautic\PointBundle\Model\TriggerModel::class);
     $services->alias('mautic.point.model.group', Mautic\PointBundle\Model\PointGroupModel::class);
     $services->alias('mautic.point.model.insight', Mautic\PointBundle\Model\InsightModel::class);
+    $services->set(Mautic\PointBundle\Security\Permissions\PointPermissions::class);
 };

--- a/app/bundles/PointBundle/Security/Permissions/PointPermissions.php
+++ b/app/bundles/PointBundle/Security/Permissions/PointPermissions.php
@@ -9,13 +9,8 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 final class PointPermissions extends AbstractPermissions
 {
-    /**
-     * @param mixed[] $params
-     */
-    public function __construct(array $params)
+    public function __construct()
     {
-        parent::__construct($params);
-
         $this->addStandardPermissions(['points', 'triggers', 'groups', 'categories', 'insights']);
     }
 

--- a/app/bundles/ProjectBundle/Config/services.php
+++ b/app/bundles/ProjectBundle/Config/services.php
@@ -21,4 +21,5 @@ return function (ContainerConfigurator $configurator): void {
         ->tag(Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass::REPOSITORY_SERVICE_TAG);
 
     $services->alias('mautic.project.model.project', Mautic\ProjectBundle\Model\ProjectModel::class);
+    $services->set(Mautic\ProjectBundle\Security\Permissions\ProjectPermissions::class);
 };

--- a/app/bundles/ProjectBundle/Security/Permissions/ProjectPermissions.php
+++ b/app/bundles/ProjectBundle/Security/Permissions/ProjectPermissions.php
@@ -22,13 +22,8 @@ final class ProjectPermissions extends AbstractPermissions
 
     public const string CAN_ASSOCIATE    = self::PERMISSION_BASE.':associate';
 
-    /**
-     * @param mixed[] $params
-     */
-    public function __construct(array $params)
+    public function __construct()
     {
-        parent::__construct($params);
-
         $this->addStandardPermissions([$this->getName()], false);
 
         // Add the associate permission directly to the permissions array

--- a/app/bundles/ReportBundle/Config/services.php
+++ b/app/bundles/ReportBundle/Config/services.php
@@ -45,4 +45,5 @@ return function (ContainerConfigurator $configurator): void {
 
     $services->set(Mautic\ReportBundle\Helper\ReportHelper::class)
         ->tag('twig.helper', ['alias' => 'report']);
+    $services->set(Mautic\ReportBundle\Security\Permissions\ReportPermissions::class);
 };

--- a/app/bundles/ReportBundle/Security/Permissions/ReportPermissions.php
+++ b/app/bundles/ReportBundle/Security/Permissions/ReportPermissions.php
@@ -9,12 +9,8 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 final class ReportPermissions extends AbstractPermissions
 {
-    /**
-     * @param mixed[] $params
-     */
-    public function __construct(array $params)
+    public function __construct()
     {
-        parent::__construct($params);
         $this->addExtendedPermissions('reports');
         $this->addCustomPermission('export', ['enable' => 1024]);
     }

--- a/app/bundles/SmsBundle/Config/services.php
+++ b/app/bundles/SmsBundle/Config/services.php
@@ -42,4 +42,5 @@ return function (ContainerConfigurator $configurator): void {
 
     $services->alias('mautic.sms.model.sms', Mautic\SmsBundle\Model\SmsModel::class);
     $services->alias('mautic.sms.callback_handler_container', Mautic\SmsBundle\Callback\HandlerContainer::class);
+    $services->set(Mautic\SmsBundle\Security\Permissions\SmsPermissions::class);
 };

--- a/app/bundles/SmsBundle/Security/Permissions/SmsPermissions.php
+++ b/app/bundles/SmsBundle/Security/Permissions/SmsPermissions.php
@@ -7,12 +7,8 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 final class SmsPermissions extends AbstractPermissions
 {
-    /**
-     * @param mixed[] $params
-     */
-    public function __construct(array $params)
+    public function __construct()
     {
-        parent::__construct($params);
         $this->addStandardPermissions('categories');
         $this->addExtendedPermissions('smses');
     }

--- a/app/bundles/StageBundle/Config/services.php
+++ b/app/bundles/StageBundle/Config/services.php
@@ -22,4 +22,5 @@ return function (ContainerConfigurator $configurator): void {
         ->tag(Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass::REPOSITORY_SERVICE_TAG);
 
     $services->alias('mautic.stage.model.stage', Mautic\StageBundle\Model\StageModel::class);
+    $services->set(Mautic\StageBundle\Security\Permissions\StagePermissions::class);
 };

--- a/app/bundles/StageBundle/Security/Permissions/StagePermissions.php
+++ b/app/bundles/StageBundle/Security/Permissions/StagePermissions.php
@@ -17,13 +17,8 @@ final class StagePermissions extends AbstractPermissions
 
     public const string PERMISSION_PUBLISH = 'stage:stages:publish';
 
-    /**
-     * @param mixed[] $params
-     */
-    public function __construct(array $params)
+    public function __construct()
     {
-        parent::__construct($params);
-
         $this->addStandardPermissions('stages');
         $this->addStandardPermissions('categories');
     }

--- a/app/bundles/UserBundle/Config/services.php
+++ b/app/bundles/UserBundle/Config/services.php
@@ -130,4 +130,5 @@ return function (ContainerConfigurator $configurator): void {
             service('security.password_hasher_factory'),
             [], // This will be replaced by the compiler pass
         ]);
+    $services->set(Mautic\UserBundle\Security\Permissions\UserPermissions::class);
 };

--- a/app/bundles/UserBundle/Security/Permissions/UserPermissions.php
+++ b/app/bundles/UserBundle/Security/Permissions/UserPermissions.php
@@ -8,12 +8,8 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 final class UserPermissions extends AbstractPermissions
 {
-    /**
-     * @param mixed[] $params
-     */
-    public function __construct(array $params)
+    public function __construct()
     {
-        parent::__construct($params);
         $this->permissions = [
             'profile' => [
                 'editusername' => 1,

--- a/app/bundles/WebhookBundle/Config/services.php
+++ b/app/bundles/WebhookBundle/Config/services.php
@@ -27,4 +27,5 @@ return function (ContainerConfigurator $configurator): void {
         ->arg('$client', service('mautic.http.client'));
 
     $services->alias('mautic.webhook.model.webhook', Mautic\WebhookBundle\Model\WebhookModel::class);
+    $services->set(Mautic\WebhookBundle\Security\Permissions\WebhookPermissions::class);
 };

--- a/app/bundles/WebhookBundle/Security/Permissions/WebhookPermissions.php
+++ b/app/bundles/WebhookBundle/Security/Permissions/WebhookPermissions.php
@@ -7,12 +7,8 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 final class WebhookPermissions extends AbstractPermissions
 {
-    /**
-     * @param mixed[] $params
-     */
-    public function __construct(array $params)
+    public function __construct()
     {
-        parent::__construct($params);
         $this->addExtendedPermissions('webhooks');
         $this->addStandardPermissions('categories');
     }

--- a/plugins/MauticFocusBundle/Config/services.php
+++ b/plugins/MauticFocusBundle/Config/services.php
@@ -23,4 +23,5 @@ return function (ContainerConfigurator $configurator): void {
     $services->set(MauticPlugin\MauticFocusBundle\Helper\TokenHelper::class);
 
     $services->alias('mautic.focus.model.focus', MauticPlugin\MauticFocusBundle\Model\FocusModel::class);
+    $services->set(MauticPlugin\MauticFocusBundle\Security\Permissions\FocusPermissions::class);
 };

--- a/plugins/MauticFocusBundle/Security/Permissions/FocusPermissions.php
+++ b/plugins/MauticFocusBundle/Security/Permissions/FocusPermissions.php
@@ -7,12 +7,8 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 final class FocusPermissions extends AbstractPermissions
 {
-    /**
-     * @param mixed[] $params
-     */
-    public function __construct(array $params)
+    public function __construct()
     {
-        parent::__construct($params);
         $this->addStandardPermissions('categories');
         $this->addExtendedPermissions('items');
     }

--- a/plugins/MauticSocialBundle/Config/services.php
+++ b/plugins/MauticSocialBundle/Config/services.php
@@ -29,4 +29,5 @@ return function (ContainerConfigurator $configurator): void {
     $services->alias('mautic.social.model.monitoring', MauticPlugin\MauticSocialBundle\Model\MonitoringModel::class);
     $services->alias('mautic.social.model.postcount', MauticPlugin\MauticSocialBundle\Model\PostCountModel::class);
     $services->alias('mautic.social.model.tweet', MauticPlugin\MauticSocialBundle\Model\TweetModel::class);
+    $services->set(MauticPlugin\MauticSocialBundle\Security\Permissions\MauticSocialPermissions::class);
 };

--- a/plugins/MauticSocialBundle/Security/Permissions/MauticSocialPermissions.php
+++ b/plugins/MauticSocialBundle/Security/Permissions/MauticSocialPermissions.php
@@ -7,12 +7,8 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 final class MauticSocialPermissions extends AbstractPermissions
 {
-    /**
-     * @param mixed[] $params
-     */
-    public function __construct(array $params)
+    public function __construct()
     {
-        parent::__construct($params);
         $this->addStandardPermissions('categories');
         $this->addStandardPermissions('monitoring');
         $this->addExtendedPermissions('tweets');

--- a/plugins/MauticTagManagerBundle/Config/services.php
+++ b/plugins/MauticTagManagerBundle/Config/services.php
@@ -25,4 +25,5 @@ return function (ContainerConfigurator $configurator): void {
     $services->alias('mautic.tagmanager.model.tag', MauticPlugin\MauticTagManagerBundle\Model\TagModel::class);
     $services->alias('mautic.integration.tagmanager', MauticPlugin\MauticTagManagerBundle\Integration\TagManagerIntegration::class);
     $services->alias('mautic.integration.tagmanager.config', MauticPlugin\MauticTagManagerBundle\Integration\Support\ConfigSupport::class);
+    $services->set(MauticPlugin\MauticTagManagerBundle\Security\Permissions\TagManagerPermissions::class);
 };

--- a/plugins/MauticTagManagerBundle/Security/Permissions/TagManagerPermissions.php
+++ b/plugins/MauticTagManagerBundle/Security/Permissions/TagManagerPermissions.php
@@ -9,13 +9,8 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class TagManagerPermissions extends AbstractPermissions
 {
-    /**
-     * @param mixed[] $params
-     */
-    public function __construct(array $params)
+    public function __construct()
     {
-        parent::__construct($params);
-
         $this->addStandardPermissions(['tagManager'], false);
     }
 


### PR DESCRIPTION
`CorePermissions::instantiatePermissionObject()` is marked `@deprecated To be removed in 4.0.` and instantiates permission objects on the fly as a BC fallback. It is still the only code path for 22 of the 24 permission classes — `Security` is in `MauticCoreExtension::DEFAULT_EXCLUDES`, so permission classes are never picked up by the bundle service loaders, and only `AssetPermissions` and `MarketplacePermissions` were registered explicitly.

This PR registers all of them as services, so the fallback becomes unreachable. Removing the deprecated method itself is a follow-up PR.

## Changes

### Permissions are defined in the constructor, `definePermissions()` is gone

`AbstractPermissions::definePermissions()` existed only because the constructor had to take the resolved Mautic parameters, which cannot be autowired. The parameters are now injected by an autowired `#[Required]` setter, so the constructor is free again and no permission class needs a constructor argument:

```diff
 abstract class AbstractPermissions
 {
-    public function __construct(
-        protected array $params,
-    ) {
-    }
+    protected array $params = [];
 
-    public function definePermissions(): void
-    {
-        // Override this method in the final class
-    }
+    /**
+     * @deprecated since Mautic 8.0, the parameters are injected by setCoreParametersHelper(); to be removed in Mautic 9.0
+     */
+    public function __construct(array $params = [])
+    {
+        $this->params = $params;
+    }
+
+    #[Required]
+    public function setCoreParametersHelper(
+        CoreParametersHelper $coreParametersHelper
+    ): void {
+        $this->params = $coreParametersHelper->all();
+    }
 }
```

Every permission class shrinks to a plain constructor:

```diff
 final class EmailPermissions extends AbstractPermissions
 {
-    /**
-     * @param mixed[] $params
-     */
-    public function __construct(array $params)
+    public function __construct()
     {
-        parent::__construct($params);
-
         $this->addStandardPermissions('categories');
         $this->addExtendedPermissions('emails');
         $this->permissions['emails']['sendtodnc'] = 1;
     }
```

`AssetPermissions` and `MarketplacePermissions`, which already used `definePermissions()`, move back to the constructor as well. `MarketplacePermissions` keeps autowiring `Config`:

```diff
 public function __construct(
-    CoreParametersHelper $coreParametersHelper,
     private readonly Config $config,
 ) {
-    parent::__construct($coreParametersHelper->all());
-}
-
-public function definePermissions(): void
-{
     $this->addStandardPermissions(self::PACKAGES, false);
 }
```

The `array $params` constructor argument is kept with an empty default, so a third party class still calling `parent::__construct($params)` keeps working.

### Registration

Each class is registered in its bundle's `Config/services.php`:

```diff
+    $services->set(Mautic\EmailBundle\Security\Permissions\EmailPermissions::class);
```

`MauticCoreExtension` autoconfigures the `mautic.permissions` tag for every `AbstractPermissions` child, `PermissionsPass` picks the tag up and adds a `setPermissionObject()` call to `mautic.security`, so `CorePermissions::findPermissionObject()` resolves every class and the deprecated fallback is never reached. A class that is not registered as a service is still instantiated on the fly, and now also gets its parameters injected.

Converted: Api, Asset, Campaign, Category, Channel, DynamicContent, Email, Form, Lead, Marketplace, Notification, Page, Plugin, Point, Project, Report, Sms, Stage, System, User, Webhook + the Focus, MauticSocial and TagManager plugins.

## Behaviour note

`getPermissionObject()` used to call `definePermissions()` only when `isEnabled()` returned `true`, so a disabled bundle had an empty permission set. Permissions are now always defined, which is the behaviour from before `definePermissions()` was introduced. Disabled bundles stay inaccessible through the paths that matter: `RoleController` skips `buildForm()` for them, `AbstractPermissions::convertBitsToPermissionNames()` guards on `isEnabled()`, `ApiPermissions::getValue()` returns `0` when the API is disabled, and every Marketplace controller and its menu subscriber guard on `Config::marketplaceIsEnabled()`.

`$this->params` is available in every method except the constructor, because the setter runs after instantiation. No permission class used it in the constructor.

## Follow-up

`CorePermissions::instantiatePermissionObject()` and its `@deprecated` annotation are removed in a separate PR.
