### PR TITLE
[removal] Remove deprecated on-the-fly permission object instantiation

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -6,6 +6,7 @@
 ## Removed code
 
 - Deprecated method `Mautic\LeadBundle\Model\LeadModel::isContactable()` removed. Use `Mautic\LeadBundle\Model\DoNotContact::isContactable()` instead.
+- Deprecated on-the-fly instantiation of permission objects in `Mautic\CoreBundle\Security\Permissions\CorePermissions` removed. Permission objects must be registered as services tagged with `mautic.permissions`; `getPermissionObject()` now throws `\InvalidArgumentException` (or returns `false` when `$throwException` is `false`) for a permission class that is not registered.
 
 ## Changed code
 

--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -6,3 +6,25 @@
 ## Removed code
 
 - Deprecated method `Mautic\LeadBundle\Model\LeadModel::isContactable()` removed. Use `Mautic\LeadBundle\Model\DoNotContact::isContactable()` instead.
+
+## Changed code
+
+- All permission classes are now registered as services instead of being instantiated on the fly by `Mautic\CoreBundle\Security\Permissions\CorePermissions`. `Mautic\CoreBundle\Security\Permissions\AbstractPermissions` takes `Mautic\CoreBundle\Helper\CoreParametersHelper` in the constructor instead of an array of parameters, so permission classes need no constructor at all. Define the permissions in `definePermissions()` instead of the constructor:
+
+    ```diff
+    -public function __construct(array $params)
+    -{
+    -    parent::__construct($params);
+    -    $this->addStandardPermissions('categories');
+    -}
+    +public function definePermissions(): void
+    +{
+    +    $this->addStandardPermissions('categories');
+    +}
+    ```
+
+    Third party permission classes must be registered in the bundle's `Config/services.php`. The `mautic.permissions` tag is added automatically to every `AbstractPermissions` child registered with autoconfiguration enabled:
+
+    ```php
+    $services->set(MauticPlugin\AcmeBundle\Security\Permissions\AcmePermissions::class);
+    ```

--- a/app/bundles/ApiBundle/Config/services.php
+++ b/app/bundles/ApiBundle/Config/services.php
@@ -50,4 +50,5 @@ return function (ContainerConfigurator $configurator): void {
             service('.inner'),
             service('doctrine.orm.entity_manager'),
         ]);
+    $services->set(Mautic\ApiBundle\Security\Permissions\ApiPermissions::class);
 };

--- a/app/bundles/ApiBundle/Security/Permissions/ApiPermissions.php
+++ b/app/bundles/ApiBundle/Security/Permissions/ApiPermissions.php
@@ -8,13 +8,8 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 final class ApiPermissions extends AbstractPermissions
 {
-    /**
-     * @param mixed[] $params
-     */
-    public function __construct(array $params)
+    public function definePermissions(): void
     {
-        parent::__construct($params);
-
         $this->permissions = [
             'access' => [
                 'full' => 1024,

--- a/app/bundles/AssetBundle/Config/services.php
+++ b/app/bundles/AssetBundle/Config/services.php
@@ -27,7 +27,7 @@ return function (ContainerConfigurator $configurator): void {
 
     $services->set('mautic.asset.fixture.asset', Mautic\AssetBundle\DataFixtures\ORM\LoadAssetData::class)->tag(Doctrine\Bundle\FixturesBundle\DependencyInjection\CompilerPass\FixturesCompilerPass::FIXTURE_TAG);
     $services->alias(Mautic\AssetBundle\DataFixtures\ORM\LoadAssetData::class, 'mautic.asset.fixture.asset');
-    $services->set('mautic.asset.permissions', Mautic\AssetBundle\Security\Permissions\AssetPermissions::class)->tag('mautic.permissions');
+    $services->set('mautic.asset.permissions', Mautic\AssetBundle\Security\Permissions\AssetPermissions::class);
     $services->alias(Mautic\AssetBundle\Security\Permissions\AssetPermissions::class, 'mautic.asset.permissions');
     $services->set('mautic.asset.upload.error.handler', Mautic\AssetBundle\ErrorHandler\DropzoneErrorHandler::class);
     $services->alias(Mautic\AssetBundle\ErrorHandler\DropzoneErrorHandler::class, 'mautic.asset.upload.error.handler');

--- a/app/bundles/AssetBundle/Security/Permissions/AssetPermissions.php
+++ b/app/bundles/AssetBundle/Security/Permissions/AssetPermissions.php
@@ -2,17 +2,11 @@
 
 namespace Mautic\AssetBundle\Security\Permissions;
 
-use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Security\Permissions\AbstractPermissions;
 use Symfony\Component\Form\FormBuilderInterface;
 
 final class AssetPermissions extends AbstractPermissions
 {
-    public function __construct(CoreParametersHelper $coreParametersHelper)
-    {
-        parent::__construct($coreParametersHelper->all());
-    }
-
     public function definePermissions(): void
     {
         $this->addExtendedPermissions('assets');

--- a/app/bundles/CampaignBundle/Config/services.php
+++ b/app/bundles/CampaignBundle/Config/services.php
@@ -77,4 +77,5 @@ return function (ContainerConfigurator $configurator): void {
             ->decorate(Mautic\CampaignBundle\Executioner\ScheduledExecutioner::class)
             ->tag('kernel.reset', ['method' => 'reset']);
     }
+    $services->set(Mautic\CampaignBundle\Security\Permissions\CampaignPermissions::class);
 };

--- a/app/bundles/CampaignBundle/Security/Permissions/CampaignPermissions.php
+++ b/app/bundles/CampaignBundle/Security/Permissions/CampaignPermissions.php
@@ -9,12 +9,8 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 final class CampaignPermissions extends AbstractPermissions
 {
-    /**
-     * @param mixed[] $params
-     */
-    public function __construct(array $params)
+    public function definePermissions(): void
     {
-        parent::__construct($params);
         $this->addExtendedPermissions('campaigns');
         $this->addStandardPermissions(['categories']);
         $this->addStandardPermissions(['imports']);

--- a/app/bundles/CategoryBundle/Config/services.php
+++ b/app/bundles/CategoryBundle/Config/services.php
@@ -22,4 +22,5 @@ return function (ContainerConfigurator $configurator): void {
     $services->alias('mautic.category.repository.category', Mautic\CategoryBundle\Entity\CategoryRepository::class);
     $services->alias('mautic.category.model.category', Mautic\CategoryBundle\Model\CategoryModel::class);
     $services->alias('mautic.category.model.contact.action', Mautic\CategoryBundle\Model\ContactActionModel::class);
+    $services->set(Mautic\CategoryBundle\Security\Permissions\CategoryPermissions::class);
 };

--- a/app/bundles/CategoryBundle/Security/Permissions/CategoryPermissions.php
+++ b/app/bundles/CategoryBundle/Security/Permissions/CategoryPermissions.php
@@ -7,13 +7,8 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 final class CategoryPermissions extends AbstractPermissions
 {
-    /**
-     * @param mixed[] $params
-     */
-    public function __construct(array $params)
+    public function definePermissions(): void
     {
-        parent::__construct($params);
-
         $this->addStandardPermissions('categories');
     }
 

--- a/app/bundles/ChannelBundle/Config/services.php
+++ b/app/bundles/ChannelBundle/Config/services.php
@@ -30,4 +30,5 @@ return function (ContainerConfigurator $configurator): void {
 
     $services->set(Mautic\ChannelBundle\Helper\ChannelListHelper::class)
         ->tag('twig.helper', ['alias' => 'channel']);
+    $services->set(Mautic\ChannelBundle\Security\Permissions\ChannelPermissions::class);
 };

--- a/app/bundles/ChannelBundle/Security/Permissions/ChannelPermissions.php
+++ b/app/bundles/ChannelBundle/Security/Permissions/ChannelPermissions.php
@@ -7,13 +7,8 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 final class ChannelPermissions extends AbstractPermissions
 {
-    /**
-     * @param mixed[] $params
-     */
-    public function __construct(array $params)
+    public function definePermissions(): void
     {
-        parent::__construct($params);
-
         $this->addStandardPermissions('categories');
         $this->addExtendedPermissions('messages');
     }

--- a/app/bundles/CoreBundle/Config/services.php
+++ b/app/bundles/CoreBundle/Config/services.php
@@ -336,4 +336,5 @@ return function (ContainerConfigurator $configurator): void {
     $services->alias('mautic.core.model.auditlog', Mautic\CoreBundle\Model\AuditLogModel::class);
     $services->alias('mautic.core.model.notification', Mautic\CoreBundle\Model\NotificationModel::class);
     $services->alias('mautic.core.model.form', Mautic\CoreBundle\Model\FormModel::class);
+    $services->set(Mautic\CoreBundle\Security\Permissions\SystemPermissions::class);
 };

--- a/app/bundles/CoreBundle/DependencyInjection/MauticCoreExtension.php
+++ b/app/bundles/CoreBundle/DependencyInjection/MauticCoreExtension.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\DependencyInjection;
 
+use Mautic\CoreBundle\Security\Permissions\AbstractPermissions;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
@@ -33,6 +34,9 @@ final class MauticCoreExtension extends Extension
      */
     public function load(array $configs, ContainerBuilder $container): void
     {
+        $container->registerForAutoconfiguration(AbstractPermissions::class)
+            ->addTag('mautic.permissions');
+
         // For the project:
         $loader = new PhpFileLoader($container, new FileLocator(__DIR__.'/../../../config'));
         $loader->load('services.php');

--- a/app/bundles/CoreBundle/Security/Permissions/AbstractPermissions.php
+++ b/app/bundles/CoreBundle/Security/Permissions/AbstractPermissions.php
@@ -2,6 +2,7 @@
 
 namespace Mautic\CoreBundle\Security\Permissions;
 
+use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\UserBundle\Form\Type\PermissionListType;
 use Symfony\Component\Form\FormBuilderInterface;
 
@@ -12,9 +13,14 @@ abstract class AbstractPermissions
      */
     protected $permissions = [];
 
-    public function __construct(
-        protected array $params,
-    ) {
+    /**
+     * @var mixed[]
+     */
+    protected array $params;
+
+    public function __construct(CoreParametersHelper $coreParametersHelper)
+    {
+        $this->params = $coreParametersHelper->all();
     }
 
     /**

--- a/app/bundles/CoreBundle/Security/Permissions/CorePermissions.php
+++ b/app/bundles/CoreBundle/Security/Permissions/CorePermissions.php
@@ -84,17 +84,12 @@ class CorePermissions implements ResetInterface
 
         try {
             $permissionObject = $this->findPermissionObject($bundle);
-        } catch (\UnexpectedValueException $e) {
-            try {
-                $permissionObject = $this->instantiatePermissionObject($bundle); // @phpstan-ignore method.deprecated
-                $this->setPermissionObject($permissionObject);
-            } catch (\InvalidArgumentException $e) {
-                if ($throwException) {
-                    throw $e;
-                }
-
-                return false;
+        } catch (\UnexpectedValueException) {
+            if ($throwException) {
+                throw new \InvalidArgumentException("Permission class not found for {$bundle} in permissions classes");
             }
+
+            return false;
         }
 
         if ($permissionObject->isEnabled()) {
@@ -440,25 +435,6 @@ class CorePermissions implements ResetInterface
         }
 
         return $this->permissionClasses;
-    }
-
-    /**
-     * @deprecated To be removed in 4.0.
-     *
-     * It is recommended to define permission objects via DI with tag 'mautic.permissions'.
-     * This is fallback for keeping BC where the permission object is instantiated on the fly.
-     *
-     * @throws \InvalidArgumentException
-     */
-    private function instantiatePermissionObject(string $class): AbstractPermissions
-    {
-        if (empty($this->getPermissionClasses()[$class])) {
-            throw new \InvalidArgumentException("Permission class not found for {$class} in permissions classes");
-        }
-
-        $permissionClass = $this->getPermissionClasses()[$class];
-
-        return new $permissionClass($this->getParams());
     }
 
     /**

--- a/app/bundles/CoreBundle/Security/Permissions/SystemPermissions.php
+++ b/app/bundles/CoreBundle/Security/Permissions/SystemPermissions.php
@@ -6,12 +6,8 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 final class SystemPermissions extends AbstractPermissions
 {
-    /**
-     * @param mixed[] $params
-     */
-    public function __construct(array $params)
+    public function definePermissions(): void
     {
-        parent::__construct($params);
         $this->addStandardPermissions('themes');
     }
 

--- a/app/bundles/CoreBundle/Tests/Unit/Security/Permissions/CorePermissionsTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Security/Permissions/CorePermissionsTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\Tests\Unit\Security\Permissions;
 
-use Mautic\ApiBundle\Security\Permissions\ApiPermissions;
 use Mautic\AssetBundle\Security\Permissions\AssetPermissions;
 use Mautic\CampaignBundle\Security\Permissions\CampaignPermissions;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
@@ -32,7 +31,6 @@ final class CorePermissionsTest extends \PHPUnit\Framework\TestCase
             $this->createStub(TranslatorInterface::class),
             $this->coreParametersHelper,
             [
-                $this->mockBundleArray(ApiPermissions::class),
                 $this->mockBundleArray(AssetPermissions::class),
                 $this->mockBundleArray(CampaignPermissions::class),
             ],
@@ -47,18 +45,22 @@ final class CorePermissionsTest extends \PHPUnit\Framework\TestCase
         $this->coreParametersHelper->method('all')
             ->willReturn(['parameter_a' => 'value_a']);
 
-        $assetPermissions = new AssetPermissions($this->coreParametersHelper);
-        $this->corePermissions->setPermissionObject($assetPermissions);
-        $permissionObjects = $this->corePermissions->getPermissionObjects();
+        $assetPermissions    = new AssetPermissions($this->coreParametersHelper);
+        $campaignPermissions = new CampaignPermissions($this->coreParametersHelper);
+        $focusPermissions    = new FocusPermissions($this->coreParametersHelper);
 
-        // Even though the AssetPermissions object was set upfront there are
-        // still 4 objects available.
-        // The other three were instantiated to keep BC.
-        $this->assertCount(4, $permissionObjects);
+        $this->corePermissions->setPermissionObject($assetPermissions);
+        $this->corePermissions->setPermissionObject($campaignPermissions);
+        $this->corePermissions->setPermissionObject($focusPermissions);
+
+        // Only the permission objects registered as services are available.
+        $permissionObjects = $this->corePermissions->getPermissionObjects();
+        $this->assertCount(3, $permissionObjects);
 
         $this->assertSame($assetPermissions, $this->corePermissions->getPermissionObject('asset'));
         $this->assertSame($assetPermissions, $this->corePermissions->getPermissionObject(AssetPermissions::class));
-        $this->assertSame($permissionObjects['campaign'], $this->corePermissions->getPermissionObject(CampaignPermissions::class));
+        $this->assertSame($campaignPermissions, $this->corePermissions->getPermissionObject(CampaignPermissions::class));
+        $this->assertSame($focusPermissions, $this->corePermissions->getPermissionObject(FocusPermissions::class));
     }
 
     /**

--- a/app/bundles/CoreBundle/Tests/Unit/Security/Permissions/CorePermissionsTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Security/Permissions/CorePermissionsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\Tests\Unit\Security\Permissions;
 
+use Mautic\ApiBundle\Security\Permissions\ApiPermissions;
 use Mautic\AssetBundle\Security\Permissions\AssetPermissions;
 use Mautic\CampaignBundle\Security\Permissions\CampaignPermissions;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
@@ -61,6 +62,19 @@ final class CorePermissionsTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($assetPermissions, $this->corePermissions->getPermissionObject(AssetPermissions::class));
         $this->assertSame($campaignPermissions, $this->corePermissions->getPermissionObject(CampaignPermissions::class));
         $this->assertSame($focusPermissions, $this->corePermissions->getPermissionObject(FocusPermissions::class));
+    }
+
+    public function testGetPermissionObjectThrowsForUnregisteredPermissionClass(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Permission class not found for '.ApiPermissions::class.' in permissions classes');
+
+        $this->corePermissions->getPermissionObject(ApiPermissions::class);
+    }
+
+    public function testGetPermissionObjectReturnsFalseForUnregisteredPermissionClass(): void
+    {
+        $this->assertFalse($this->corePermissions->getPermissionObject(ApiPermissions::class, false));
     }
 
     /**

--- a/app/bundles/DynamicContentBundle/Config/services.php
+++ b/app/bundles/DynamicContentBundle/Config/services.php
@@ -26,4 +26,5 @@ return function (ContainerConfigurator $configurator): void {
     $services->alias(Mautic\DynamicContentBundle\Helper\DynamicContentHelper::class, 'mautic.helper.dynamicContent');
     $services->alias('mautic.dynamicContent.model.dynamicContent', Mautic\DynamicContentBundle\Model\DynamicContentModel::class);
     $services->alias('mautic.dynamicContent.repository.stat', Mautic\DynamicContentBundle\Entity\StatRepository::class);
+    $services->set(Mautic\DynamicContentBundle\Security\Permissions\DynamicContentPermissions::class);
 };

--- a/app/bundles/DynamicContentBundle/Security/Permissions/DynamicContentPermissions.php
+++ b/app/bundles/DynamicContentBundle/Security/Permissions/DynamicContentPermissions.php
@@ -7,13 +7,8 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 final class DynamicContentPermissions extends AbstractPermissions
 {
-    /**
-     * @param mixed[] $params
-     */
-    public function __construct(array $params)
+    public function definePermissions(): void
     {
-        parent::__construct($params);
-
         $this->addStandardPermissions('categories');
         $this->addExtendedPermissions('dynamiccontents');
     }

--- a/app/bundles/EmailBundle/Config/services.php
+++ b/app/bundles/EmailBundle/Config/services.php
@@ -81,4 +81,5 @@ return function (ContainerConfigurator $configurator): void {
 
     $services->get(Mautic\EmailBundle\EventListener\WebhookSubscriber::class)
         ->arg('$includeDetails', '%mautic.webhook_email_details%');
+    $services->set(Mautic\EmailBundle\Security\Permissions\EmailPermissions::class);
 };

--- a/app/bundles/EmailBundle/Security/Permissions/EmailPermissions.php
+++ b/app/bundles/EmailBundle/Security/Permissions/EmailPermissions.php
@@ -8,13 +8,8 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 final class EmailPermissions extends AbstractPermissions
 {
-    /**
-     * @param mixed[] $params
-     */
-    public function __construct(array $params)
+    public function definePermissions(): void
     {
-        parent::__construct($params);
-
         $this->addStandardPermissions('categories');
         $this->addExtendedPermissions('emails');
         $this->permissions['emails']['sendtodnc'] = 1;

--- a/app/bundles/FormBundle/Config/services.php
+++ b/app/bundles/FormBundle/Config/services.php
@@ -77,4 +77,5 @@ return function (ContainerConfigurator $configurator): void {
     $services->alias('mautic.form.model.submission_result_loader', Mautic\FormBundle\Model\SubmissionResultLoader::class);
     $services->alias('mautic.form.repository.form', Mautic\FormBundle\Entity\FormRepository::class);
     $services->alias('mautic.form.repository.submission', Mautic\FormBundle\Entity\SubmissionRepository::class);
+    $services->set(Mautic\FormBundle\Security\Permissions\FormPermissions::class);
 };

--- a/app/bundles/FormBundle/Security/Permissions/FormPermissions.php
+++ b/app/bundles/FormBundle/Security/Permissions/FormPermissions.php
@@ -7,12 +7,8 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 final class FormPermissions extends AbstractPermissions
 {
-    /**
-     * @param mixed[] $params
-     */
-    public function __construct(array $params)
+    public function definePermissions(): void
     {
-        parent::__construct($params);
         $this->addCustomPermission('export', ['enable' => 1024]);
         $this->addExtendedPermissions('forms');
         $this->addStandardPermissions('categories');

--- a/app/bundles/LeadBundle/Config/services.php
+++ b/app/bundles/LeadBundle/Config/services.php
@@ -237,4 +237,5 @@ return function (ContainerConfigurator $configurator): void {
     $services->alias('mautic.lead.report.dnc_report_service', Mautic\LeadBundle\Report\DncReportService::class);
     $services->alias('mautic.helper.segment.count.cache', Mautic\LeadBundle\Helper\SegmentCountCacheHelper::class);
     $services->get(Mautic\LeadBundle\Validator\Constraints\SegmentDateValidator::class)->tag('validator.constraint_validator');
+    $services->set(Mautic\LeadBundle\Security\Permissions\LeadPermissions::class);
 };

--- a/app/bundles/LeadBundle/Security/Permissions/LeadPermissions.php
+++ b/app/bundles/LeadBundle/Security/Permissions/LeadPermissions.php
@@ -26,13 +26,8 @@ final class LeadPermissions extends AbstractPermissions
 
     public const string LISTS_FULL         = 'lead:lists:full';
 
-    /**
-     * @param mixed[] $params
-     */
-    public function __construct(array $params)
+    public function definePermissions(): void
     {
-        parent::__construct($params);
-
         $this->permissions = [
             'fields' => [
                 'full' => 1024,

--- a/app/bundles/MarketplaceBundle/Config/services.php
+++ b/app/bundles/MarketplaceBundle/Config/services.php
@@ -17,7 +17,7 @@ return function (ContainerConfigurator $configurator): void {
     $services->load('Mautic\\MarketplaceBundle\\', '../')
         ->exclude('../{'.implode(',', array_merge(MauticCoreExtension::DEFAULT_EXCLUDES, $excludes)).'}');
 
-    $services->set('marketplace.permissions', Mautic\MarketplaceBundle\Security\Permissions\MarketplacePermissions::class)->tag('mautic.permissions');
+    $services->set('marketplace.permissions', Mautic\MarketplaceBundle\Security\Permissions\MarketplacePermissions::class);
 
     $services->alias(Mautic\MarketplaceBundle\Security\Permissions\MarketplacePermissions::class, 'marketplace.permissions');
 

--- a/app/bundles/MarketplaceBundle/Security/Permissions/MarketplacePermissions.php
+++ b/app/bundles/MarketplaceBundle/Security/Permissions/MarketplacePermissions.php
@@ -25,7 +25,7 @@ final class MarketplacePermissions extends AbstractPermissions
         CoreParametersHelper $coreParametersHelper,
         private readonly Config $config,
     ) {
-        parent::__construct($coreParametersHelper->all());
+        parent::__construct($coreParametersHelper);
     }
 
     public function definePermissions(): void

--- a/app/bundles/NotificationBundle/Config/services.php
+++ b/app/bundles/NotificationBundle/Config/services.php
@@ -33,4 +33,5 @@ return function (ContainerConfigurator $configurator): void {
     $services->alias('notification_helper', Mautic\NotificationBundle\Helper\NotificationHelper::class);
 
     $services->alias('mautic.notification.api', Mautic\NotificationBundle\Api\OneSignalApi::class);
+    $services->set(Mautic\NotificationBundle\Security\Permissions\NotificationPermissions::class);
 };

--- a/app/bundles/NotificationBundle/Security/Permissions/NotificationPermissions.php
+++ b/app/bundles/NotificationBundle/Security/Permissions/NotificationPermissions.php
@@ -7,12 +7,8 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 final class NotificationPermissions extends AbstractPermissions
 {
-    /**
-     * @param mixed[] $params
-     */
-    public function __construct(array $params)
+    public function definePermissions(): void
     {
-        parent::__construct($params);
         $this->addStandardPermissions('categories');
         $this->addExtendedPermissions('notifications');
         $this->addExtendedPermissions('mobile_notifications');

--- a/app/bundles/PageBundle/Config/services.php
+++ b/app/bundles/PageBundle/Config/services.php
@@ -39,4 +39,5 @@ return function (ContainerConfigurator $configurator): void {
     $services->alias('mautic.page.repository.hit', Mautic\PageBundle\Entity\HitRepository::class);
     $services->alias('mautic.page.repository.page', Mautic\PageBundle\Entity\PageRepository::class);
     $services->alias('mautic.page.repository.redirect', Mautic\PageBundle\Entity\RedirectRepository::class);
+    $services->set(Mautic\PageBundle\Security\Permissions\PagePermissions::class);
 };

--- a/app/bundles/PageBundle/Security/Permissions/PagePermissions.php
+++ b/app/bundles/PageBundle/Security/Permissions/PagePermissions.php
@@ -7,12 +7,8 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 final class PagePermissions extends AbstractPermissions
 {
-    /**
-     * @param mixed[] $params
-     */
-    public function __construct(array $params)
+    public function definePermissions(): void
     {
-        parent::__construct($params);
         $this->addExtendedPermissions('pages');
         $this->addStandardPermissions('categories');
         $this->addExtendedPermissions('preference_center');

--- a/app/bundles/PluginBundle/Config/services.php
+++ b/app/bundles/PluginBundle/Config/services.php
@@ -41,4 +41,5 @@ return function (ContainerConfigurator $configurator): void {
         ->call('setIntegrationHelper', [service('mautic.helper.integration')]);
     $services->set(CampaignSubscriber::class)
         ->call('setIntegrationHelper', [service('mautic.helper.integration')]);
+    $services->set(Mautic\PluginBundle\Security\Permissions\PluginPermissions::class);
 };

--- a/app/bundles/PluginBundle/Security/Permissions/PluginPermissions.php
+++ b/app/bundles/PluginBundle/Security/Permissions/PluginPermissions.php
@@ -7,12 +7,8 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 final class PluginPermissions extends AbstractPermissions
 {
-    /**
-     * @param mixed[] $params
-     */
-    public function __construct(array $params)
+    public function definePermissions(): void
     {
-        parent::__construct($params);
         $this->addManagePermission('plugins');
     }
 

--- a/app/bundles/PointBundle/Config/services.php
+++ b/app/bundles/PointBundle/Config/services.php
@@ -28,4 +28,5 @@ return function (ContainerConfigurator $configurator): void {
     $services->alias('mautic.point.repository.lead_point_log', Mautic\PointBundle\Entity\LeadPointLogRepository::class);
     $services->alias('mautic.point.repository.lead_trigger_log', Mautic\PointBundle\Entity\LeadTriggerLogRepository::class);
     $services->alias('mautic.point.model.insight', Mautic\PointBundle\Model\InsightModel::class);
+    $services->set(Mautic\PointBundle\Security\Permissions\PointPermissions::class);
 };

--- a/app/bundles/PointBundle/Security/Permissions/PointPermissions.php
+++ b/app/bundles/PointBundle/Security/Permissions/PointPermissions.php
@@ -9,13 +9,8 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 final class PointPermissions extends AbstractPermissions
 {
-    /**
-     * @param mixed[] $params
-     */
-    public function __construct(array $params)
+    public function definePermissions(): void
     {
-        parent::__construct($params);
-
         $this->addStandardPermissions(['points', 'triggers', 'groups', 'categories', 'insights']);
     }
 

--- a/app/bundles/ProjectBundle/Config/services.php
+++ b/app/bundles/ProjectBundle/Config/services.php
@@ -21,4 +21,5 @@ return function (ContainerConfigurator $configurator): void {
         ->tag(Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass::REPOSITORY_SERVICE_TAG);
 
     $services->alias('mautic.project.model.project', Mautic\ProjectBundle\Model\ProjectModel::class);
+    $services->set(Mautic\ProjectBundle\Security\Permissions\ProjectPermissions::class);
 };

--- a/app/bundles/ProjectBundle/Security/Permissions/ProjectPermissions.php
+++ b/app/bundles/ProjectBundle/Security/Permissions/ProjectPermissions.php
@@ -22,13 +22,8 @@ final class ProjectPermissions extends AbstractPermissions
 
     public const string CAN_ASSOCIATE    = self::PERMISSION_BASE.':associate';
 
-    /**
-     * @param mixed[] $params
-     */
-    public function __construct(array $params)
+    public function definePermissions(): void
     {
-        parent::__construct($params);
-
         $this->addStandardPermissions([$this->getName()], false);
 
         // Add the associate permission directly to the permissions array

--- a/app/bundles/ReportBundle/Config/services.php
+++ b/app/bundles/ReportBundle/Config/services.php
@@ -47,4 +47,5 @@ return function (ContainerConfigurator $configurator): void {
 
     $services->set(Mautic\ReportBundle\Helper\ReportHelper::class)
         ->tag('twig.helper', ['alias' => 'report']);
+    $services->set(Mautic\ReportBundle\Security\Permissions\ReportPermissions::class);
 };

--- a/app/bundles/ReportBundle/Security/Permissions/ReportPermissions.php
+++ b/app/bundles/ReportBundle/Security/Permissions/ReportPermissions.php
@@ -9,12 +9,8 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 final class ReportPermissions extends AbstractPermissions
 {
-    /**
-     * @param mixed[] $params
-     */
-    public function __construct(array $params)
+    public function definePermissions(): void
     {
-        parent::__construct($params);
         $this->addExtendedPermissions('reports');
         $this->addCustomPermission('export', ['enable' => 1024]);
     }

--- a/app/bundles/SmsBundle/Config/services.php
+++ b/app/bundles/SmsBundle/Config/services.php
@@ -46,4 +46,5 @@ return function (ContainerConfigurator $configurator): void {
     $services->alias('mautic.sms.model.sms', Mautic\SmsBundle\Model\SmsModel::class);
     $services->alias('mautic.sms.repository.stat', Mautic\SmsBundle\Entity\StatRepository::class);
     $services->alias('mautic.sms.callback_handler_container', Mautic\SmsBundle\Callback\HandlerContainer::class);
+    $services->set(Mautic\SmsBundle\Security\Permissions\SmsPermissions::class);
 };

--- a/app/bundles/SmsBundle/Security/Permissions/SmsPermissions.php
+++ b/app/bundles/SmsBundle/Security/Permissions/SmsPermissions.php
@@ -7,12 +7,8 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 final class SmsPermissions extends AbstractPermissions
 {
-    /**
-     * @param mixed[] $params
-     */
-    public function __construct(array $params)
+    public function definePermissions(): void
     {
-        parent::__construct($params);
         $this->addStandardPermissions('categories');
         $this->addExtendedPermissions('smses');
     }

--- a/app/bundles/StageBundle/Config/services.php
+++ b/app/bundles/StageBundle/Config/services.php
@@ -24,4 +24,5 @@ return function (ContainerConfigurator $configurator): void {
     $services->alias('mautic.stage.model.stage', Mautic\StageBundle\Model\StageModel::class);
     $services->alias('mautic.stage.repository.lead_stage_log', Mautic\StageBundle\Entity\LeadStageLogRepository::class);
     $services->alias('mautic.stage.repository.stage', Mautic\StageBundle\Entity\StageRepository::class);
+    $services->set(Mautic\StageBundle\Security\Permissions\StagePermissions::class);
 };

--- a/app/bundles/StageBundle/Security/Permissions/StagePermissions.php
+++ b/app/bundles/StageBundle/Security/Permissions/StagePermissions.php
@@ -17,13 +17,8 @@ final class StagePermissions extends AbstractPermissions
 
     public const string PERMISSION_PUBLISH = 'stage:stages:publish';
 
-    /**
-     * @param mixed[] $params
-     */
-    public function __construct(array $params)
+    public function definePermissions(): void
     {
-        parent::__construct($params);
-
         $this->addStandardPermissions('stages');
         $this->addStandardPermissions('categories');
     }

--- a/app/bundles/UserBundle/Config/services.php
+++ b/app/bundles/UserBundle/Config/services.php
@@ -140,4 +140,5 @@ return function (ContainerConfigurator $configurator): void {
             service('security.password_hasher_factory'),
             [], // This will be replaced by the compiler pass
         ]);
+    $services->set(Mautic\UserBundle\Security\Permissions\UserPermissions::class);
 };

--- a/app/bundles/UserBundle/Security/Permissions/UserPermissions.php
+++ b/app/bundles/UserBundle/Security/Permissions/UserPermissions.php
@@ -8,12 +8,8 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 final class UserPermissions extends AbstractPermissions
 {
-    /**
-     * @param mixed[] $params
-     */
-    public function __construct(array $params)
+    public function definePermissions(): void
     {
-        parent::__construct($params);
         $this->permissions = [
             'profile' => [
                 'editusername' => 1,

--- a/app/bundles/WebhookBundle/Config/services.php
+++ b/app/bundles/WebhookBundle/Config/services.php
@@ -29,4 +29,5 @@ return function (ContainerConfigurator $configurator): void {
 
     $services->alias('mautic.webhook.model.webhook', Mautic\WebhookBundle\Model\WebhookModel::class);
     $services->alias('mautic.webhook.repository.queue', Mautic\WebhookBundle\Entity\WebhookQueueRepository::class);
+    $services->set(Mautic\WebhookBundle\Security\Permissions\WebhookPermissions::class);
 };

--- a/app/bundles/WebhookBundle/Security/Permissions/WebhookPermissions.php
+++ b/app/bundles/WebhookBundle/Security/Permissions/WebhookPermissions.php
@@ -7,12 +7,8 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 final class WebhookPermissions extends AbstractPermissions
 {
-    /**
-     * @param mixed[] $params
-     */
-    public function __construct(array $params)
+    public function definePermissions(): void
     {
-        parent::__construct($params);
         $this->addExtendedPermissions('webhooks');
         $this->addStandardPermissions('categories');
     }

--- a/plugins/MauticFocusBundle/Config/services.php
+++ b/plugins/MauticFocusBundle/Config/services.php
@@ -24,4 +24,5 @@ return function (ContainerConfigurator $configurator): void {
     $services->alias(MauticPlugin\MauticFocusBundle\Helper\TokenHelper::class, 'mautic.focus.helper.token');
 
     $services->alias('mautic.focus.model.focus', MauticPlugin\MauticFocusBundle\Model\FocusModel::class);
+    $services->set(MauticPlugin\MauticFocusBundle\Security\Permissions\FocusPermissions::class);
 };

--- a/plugins/MauticFocusBundle/Security/Permissions/FocusPermissions.php
+++ b/plugins/MauticFocusBundle/Security/Permissions/FocusPermissions.php
@@ -7,12 +7,8 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 final class FocusPermissions extends AbstractPermissions
 {
-    /**
-     * @param mixed[] $params
-     */
-    public function __construct(array $params)
+    public function definePermissions(): void
     {
-        parent::__construct($params);
         $this->addStandardPermissions('categories');
         $this->addExtendedPermissions('items');
     }

--- a/plugins/MauticSocialBundle/Config/services.php
+++ b/plugins/MauticSocialBundle/Config/services.php
@@ -30,4 +30,5 @@ return function (ContainerConfigurator $configurator): void {
     $services->alias('mautic.social.model.monitoring', MauticPlugin\MauticSocialBundle\Model\MonitoringModel::class);
     $services->alias('mautic.social.model.postcount', MauticPlugin\MauticSocialBundle\Model\PostCountModel::class);
     $services->alias('mautic.social.model.tweet', MauticPlugin\MauticSocialBundle\Model\TweetModel::class);
+    $services->set(MauticPlugin\MauticSocialBundle\Security\Permissions\MauticSocialPermissions::class);
 };

--- a/plugins/MauticSocialBundle/Security/Permissions/MauticSocialPermissions.php
+++ b/plugins/MauticSocialBundle/Security/Permissions/MauticSocialPermissions.php
@@ -7,12 +7,8 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 final class MauticSocialPermissions extends AbstractPermissions
 {
-    /**
-     * @param mixed[] $params
-     */
-    public function __construct(array $params)
+    public function definePermissions(): void
     {
-        parent::__construct($params);
         $this->addStandardPermissions('categories');
         $this->addStandardPermissions('monitoring');
         $this->addExtendedPermissions('tweets');

--- a/plugins/MauticTagManagerBundle/Config/services.php
+++ b/plugins/MauticTagManagerBundle/Config/services.php
@@ -26,4 +26,5 @@ return function (ContainerConfigurator $configurator): void {
     $services->alias('mautic.tagmanager.repository.tag', MauticPlugin\MauticTagManagerBundle\Entity\TagRepository::class);
     $services->alias('mautic.integration.tagmanager', MauticPlugin\MauticTagManagerBundle\Integration\TagManagerIntegration::class);
     $services->alias('mautic.integration.tagmanager.config', MauticPlugin\MauticTagManagerBundle\Integration\Support\ConfigSupport::class);
+    $services->set(MauticPlugin\MauticTagManagerBundle\Security\Permissions\TagManagerPermissions::class);
 };

--- a/plugins/MauticTagManagerBundle/Security/Permissions/TagManagerPermissions.php
+++ b/plugins/MauticTagManagerBundle/Security/Permissions/TagManagerPermissions.php
@@ -9,13 +9,8 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class TagManagerPermissions extends AbstractPermissions
 {
-    /**
-     * @param mixed[] $params
-     */
-    public function __construct(array $params)
+    public function definePermissions(): void
     {
-        parent::__construct($params);
-
         $this->addStandardPermissions(['tagManager'], false);
     }
 


### PR DESCRIPTION
> **Stacked on #17035** — that PR converts every permission class to a DI service. Until it is merged, the diff here also contains its commit. Merge #17035 first; this one then reduces to the single commit below.

Removes `CorePermissions::instantiatePermissionObject()`, marked `@deprecated To be removed in 4.0.`. With #17035 merged, every permission class is resolved through `findPermissionObject()`, so the fallback is unreachable.

## Changes

```diff
         try {
             $permissionObject = $this->findPermissionObject($bundle);
-        } catch (\UnexpectedValueException $e) {
-            try {
-                $permissionObject = $this->instantiatePermissionObject($bundle); // @phpstan-ignore method.deprecated
-                $this->setPermissionObject($permissionObject);
-            } catch (\InvalidArgumentException $e) {
-                if ($throwException) {
-                    throw $e;
-                }
-
-                return false;
-            }
+        } catch (\UnexpectedValueException) {
+            if ($throwException) {
+                throw new \InvalidArgumentException("Permission class not found for {$bundle} in permissions classes");
+            }
+
+            return false;
         }
```

```diff
-    /**
-     * @deprecated To be removed in 4.0.
-     *
-     * It is recommended to define permission objects via DI with tag 'mautic.permissions'.
-     * This is fallback for keeping BC where the permission object is instantiated on the fly.
-     *
-     * @throws \InvalidArgumentException
-     */
-    private function instantiatePermissionObject(string $class): AbstractPermissions
-    {
-        if (empty($this->getPermissionClasses()[$class])) {
-            throw new \InvalidArgumentException("Permission class not found for {$class} in permissions classes");
-        }
-
-        $permissionClass = $this->getPermissionClasses()[$class];
-
-        return new $permissionClass($this->getParams());
-    }
```

The exception type and message for an unresolvable permission class are unchanged — `\InvalidArgumentException` with `Permission class not found for {$bundle} in permissions classes` — so callers such as `getPermissionObjects()`, which catches `\InvalidArgumentException`, keep working. Covered by two new cases in `CorePermissionsTest`.

BC break documented in `UPGRADE-8.0.md`.
