### PR TITLE
[symfony] Twig: convert getFilters() to #[AsTwigFilter] attributes

### DIFF
--- a/app/bundles/CoreBundle/Tests/Unit/Twig/Extension/FormatterExtensionTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Twig/Extension/FormatterExtensionTest.php
@@ -32,16 +32,6 @@ final class FormatterExtensionTest extends TestCase
         );
     }
 
-    public function testItContainsAtLeastOneFilter(): void
-    {
-        $this->assertGreaterThan(0, $this->extension->getFilters());
-    }
-
-    public function testItContainsAtLeastOneFunction(): void
-    {
-        $this->assertGreaterThan(0, $this->extension->getFunctions());
-    }
-
     public function testSimpleArrayToHtml(): void
     {
         $array = [

--- a/app/bundles/CoreBundle/Twig/Extension/FormatterExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/FormatterExtension.php
@@ -5,31 +5,14 @@ declare(strict_types=1);
 namespace Mautic\CoreBundle\Twig\Extension;
 
 use Mautic\CoreBundle\Twig\Helper\FormatterHelper;
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFilter;
-use Twig\TwigFunction;
+use Twig\Attribute\AsTwigFilter;
+use Twig\Attribute\AsTwigFunction;
 
-final class FormatterExtension extends AbstractExtension
+final readonly class FormatterExtension
 {
     public function __construct(
-        private readonly FormatterHelper $formatterHelper,
+        private FormatterHelper $formatterHelper,
     ) {
-    }
-
-    public function getFilters(): array
-    {
-        return [
-            new TwigFilter('formatter_simple_array_to_html', $this->simpleArrayToHtml(...), ['is_safe' => ['html']]),
-        ];
-    }
-
-    public function getFunctions(): array
-    {
-        return [
-            new TwigFunction('format', $this->_(...), ['is_safe' => ['all']]),
-            new TwigFunction('normalizeStringValue', $this->normalizeStringValue(...)),
-            new TwigFunction('formatter_simple_array_to_html', $this->simpleArrayToHtml(...), ['is_safe' => ['html']]),
-        ];
     }
 
     /**
@@ -37,6 +20,7 @@ final class FormatterExtension extends AbstractExtension
      *
      * @param mixed $val
      */
+    #[AsTwigFunction(name: 'format', isSafe: ['all'])]
     public function _($val, string $type = 'html', bool $textOnly = false, int $round = 1): string
     {
         return (string) $this->formatterHelper->_($val, $type, $textOnly, $round);
@@ -45,6 +29,7 @@ final class FormatterExtension extends AbstractExtension
     /**
      * @see FormatterHelper::normalizeStringValue
      */
+    #[AsTwigFunction(name: 'normalizeStringValue')]
     public function normalizeStringValue(string $string): string
     {
         return $this->formatterHelper->normalizeStringValue($string);
@@ -53,6 +38,8 @@ final class FormatterExtension extends AbstractExtension
     /**
      * @param array<mixed> $array
      */
+    #[AsTwigFilter(name: 'formatter_simple_array_to_html', isSafe: ['html'])]
+    #[AsTwigFunction(name: 'formatter_simple_array_to_html', isSafe: ['html'])]
     public function simpleArrayToHtml(array $array, string $delimeter = '<br />'): string
     {
         return $this->formatterHelper->simpleArrayToHtml($array, $delimeter);

--- a/app/bundles/CoreBundle/Twig/Extension/LanguageExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/LanguageExtension.php
@@ -5,21 +5,13 @@ namespace Mautic\CoreBundle\Twig\Extension;
 use Mautic\UserBundle\Entity\User;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Intl\Languages;
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFilter;
+use Twig\Attribute\AsTwigFilter;
 
-final class LanguageExtension extends AbstractExtension
+final readonly class LanguageExtension
 {
     public function __construct(
-        private readonly Security $security,
+        private Security $security,
     ) {
-    }
-
-    public function getFilters(): array
-    {
-        return [
-            new TwigFilter('language_name', $this->getLanguageName(...)),
-        ];
     }
 
     /**
@@ -30,6 +22,7 @@ final class LanguageExtension extends AbstractExtension
      *
      * @return string The language name
      */
+    #[AsTwigFilter(name: 'language_name')]
     public function getLanguageName(string $code, ?string $displayLocale = null): string
     {
         if (null === $displayLocale) {

--- a/app/bundles/CoreBundle/Twig/Extension/PurifyExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/PurifyExtension.php
@@ -4,18 +4,11 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\Twig\Extension;
 
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFilter;
+use Twig\Attribute\AsTwigFilter;
 
-final class PurifyExtension extends AbstractExtension
+final class PurifyExtension
 {
-    public function getFilters(): array
-    {
-        return [
-            new TwigFilter('purify_allow_target_blank', $this->purifyAllowTargetBlank(...), ['is_safe' => ['html']]),
-        ];
-    }
-
+    #[AsTwigFilter(name: 'purify_allow_target_blank', isSafe: ['html'])]
     public function purifyAllowTargetBlank(?string $html): string
     {
         $config = \HTMLPurifier_Config::createDefault();

--- a/app/bundles/InstallBundle/Twig/TwigExtension.php
+++ b/app/bundles/InstallBundle/Twig/TwigExtension.php
@@ -4,26 +4,14 @@ declare(strict_types=1);
 
 namespace Mautic\InstallBundle\Twig;
 
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFilter;
+use Twig\Attribute\AsTwigFilter;
 
 /**
  * TwigExtension class.
  */
-final class TwigExtension extends AbstractExtension
+final class TwigExtension
 {
-    /**
-     * getFilters function.
-     *
-     * @return mixed[]
-     */
-    public function getFilters(): array
-    {
-        return [
-            new TwigFilter('phpversion', $this->phpversion(...)),
-        ];
-    }
-
+    #[AsTwigFilter(name: 'phpversion')]
     public function phpversion(string $value = ''): string|bool
     {
         return phpversion($value);

--- a/composer.lock
+++ b/composer.lock
@@ -17839,12 +17839,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "2cffa98f89d37b2ba27ee88349bbaf74f96207ca"
+                "reference": "b00041d490deb1ed46f3d370249714ce2cc6d4bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/2cffa98f89d37b2ba27ee88349bbaf74f96207ca",
-                "reference": "2cffa98f89d37b2ba27ee88349bbaf74f96207ca",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/b00041d490deb1ed46f3d370249714ce2cc6d4bc",
+                "reference": "b00041d490deb1ed46f3d370249714ce2cc6d4bc",
                 "shasum": ""
             },
             "require": {
@@ -17892,7 +17892,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-08-09T22:24:38+00:00"
+            "time": "2026-08-11T09:33:44+00:00"
         },
         {
             "name": "rector/type-perfect",

--- a/ecs.php
+++ b/ecs.php
@@ -14,7 +14,7 @@ return ECSConfig::configure()
     ])
     ->withRootFiles()
     ->withSkip([
-        'node_modules',
+        '*/node_modules/*',
         PhpCsFixer\Fixer\Phpdoc\PhpdocNoEmptyReturnFixer::class => [
             // in docbclock on purpose, to avoid BC return on child classes
             __DIR__.'/app/bundles/CoreBundle/Entity/CommonEntity.php',

--- a/rector.php
+++ b/rector.php
@@ -41,7 +41,6 @@ return RectorConfig::configure()
         Rector\PHPUnit\PHPUnit120\Rector\Class_\AllowMockObjectsForDataProviderRector::class,
 
         // @todo move to "twig" group
-        Rector\Symfony\Symfony73\Rector\Class_\GetFiltersToAsTwigFilterAttributeRector::class,
         Rector\Php84\Rector\Class_\DeprecatedAnnotationToDeprecatedAttributeRector::class,
 
         // handle next


### PR DESCRIPTION
Follow-up to #17015 (`#[AsTwigFunction]`), same treatment for filters.

Ran `GetFiltersToAsTwigFilterAttributeRector` over `app/bundles` + `plugins` and removed its skip from `rector.php`.

```diff
-final class PurifyExtension extends AbstractExtension
+final class PurifyExtension
 {
-    public function getFilters(): array
-    {
-        return [
-            new TwigFilter('purify_allow_target_blank', $this->purifyAllowTargetBlank(...), ['is_safe' => ['html']]),
-        ];
-    }
-
+    #[AsTwigFilter(name: 'purify_allow_target_blank', isSafe: ['html'])]
     public function purifyAllowTargetBlank(?string $html): string
```

3 extensions converted:

* `CoreBundle/Twig/Extension/LanguageExtension.php`
* `CoreBundle/Twig/Extension/PurifyExtension.php`
* `InstallBundle/Twig/TwigExtension.php`
