### PR TITLE
[phpstan] remove 18 redundant service tags autoconfigure() already adds

### DIFF
--- a/app/bundles/ApiBundle/Config/services.php
+++ b/app/bundles/ApiBundle/Config/services.php
@@ -25,8 +25,7 @@ return function (ContainerConfigurator $configurator): void {
 
     $services->load('Mautic\\ApiBundle\\Entity\\oAuth2\\', '../Entity/oAuth2/*Repository.php');
 
-    $services->set(Mautic\ApiBundle\Form\Validator\Constraints\OAuthCallbackValidator::class)->tag('validator.constraint_validator');
-    $services->set(Mautic\ApiBundle\Security\Voter\ApiPermissionVoter::class)->tag('security.voter');
+    $services->set(Mautic\ApiBundle\Security\Voter\ApiPermissionVoter::class);
 
     $services->alias(AuthorizeFormHandler::class, 'fos_oauth_server.authorize.form.handler.default');
 

--- a/app/bundles/CoreBundle/Config/services.php
+++ b/app/bundles/CoreBundle/Config/services.php
@@ -52,8 +52,6 @@ return function (ContainerConfigurator $configurator): void {
 
     $services->load('Mautic\\CoreBundle\\Entity\\', '../Entity/*Repository.php');
 
-    $services->set(Mautic\CoreBundle\Helper\CoreParametersHelper::class)->tag('twig.helper');
-
     $services->alias('mautic.helper.core_parameters', Mautic\CoreBundle\Helper\CoreParametersHelper::class);
 
     $services->set(Mautic\CoreBundle\IpLookup\AbstractLookup::class)
@@ -141,16 +139,13 @@ return function (ContainerConfigurator $configurator): void {
         ->arg('$path', param('mautic.cookie_path'))
         ->arg('$domain', param('mautic.cookie_domain'))
         ->arg('$secure', param('mautic.cookie_secure'))
-        ->arg('$httponly', param('mautic.cookie_httponly'))
-        ->tag('kernel.event_subscriber');
+        ->arg('$httponly', param('mautic.cookie_httponly'));
 
     $services->set(Mautic\CoreBundle\Helper\EncryptionHelper::class)
         ->args([
             service('mautic.helper.core_parameters'),
             service('mautic.cipher.openssl'),
         ]);
-
-    $services->set(Mautic\CoreBundle\Form\Validator\Constraints\CircularDependencyValidator::class)->tag('validator.constraint_validator');
 
     /* @deprecated to be removed in Mautic 4. Use 'mautic.filesystem' instead. */
     $services->set('symfony.filesystem', Symfony\Component\Filesystem\Filesystem::class);
@@ -233,8 +228,7 @@ return function (ContainerConfigurator $configurator): void {
     $services->set('mautic.http.client', GuzzleHttp\Client::class)->autowire();
     $services->set(Mautic\CoreBundle\Doctrine\MigrationFactoryDecorator::class)->autowire();
 
-    $services->set(StringExtension::class)
-        ->tag('twig.extension');
+    $services->set(StringExtension::class);
 
     $services->alias(GuzzleHttp\Client::class, 'mautic.http.client');
     $services->alias(Psr\Http\Client\ClientInterface::class, 'mautic.http.client');

--- a/app/bundles/EmailBundle/Config/services.php
+++ b/app/bundles/EmailBundle/Config/services.php
@@ -48,9 +48,6 @@ return function (ContainerConfigurator $configurator): void {
     $services->set(Mautic\EmailBundle\Stats\Helper\UnsubscribedHelper::class)
         ->tag('mautic.email_stat_helper');
 
-    $services->set(Mautic\EmailBundle\Validator\MultipleEmailsValidValidator::class)->tag('validator.constraint_validator');
-    $services->set(Mautic\EmailBundle\Validator\EmailOrEmailTokenListValidator::class)->tag('validator.constraint_validator');
-
     $services->alias(Mautic\CoreBundle\Doctrine\Provider\GeneratedColumnsProviderInterface::class, Mautic\CoreBundle\Doctrine\Provider\GeneratedColumnsProvider::class);
     $services->set(Mautic\EmailBundle\Mailer\Transport\TransportFactory::class)->decorate('mailer.transport_factory');
 

--- a/app/bundles/FormBundle/Config/services.php
+++ b/app/bundles/FormBundle/Config/services.php
@@ -39,9 +39,6 @@ return function (ContainerConfigurator $configurator): void {
     $services->set(Mautic\FormBundle\Validator\Constraint\FileExtensionConstraintValidator::class)
         ->tag('validator.constraint_validator', ['alias' => 'file_extension_constraint_validator']);
 
-    $services->set(Mautic\FormBundle\Command\DeleteOrphanSubmissionRecordsFromFormResultsTableCommand::class)->tag('console.command');
-    $services->set(Mautic\FormBundle\Command\DeleteOrphanFormResultsTableCommand::class)->tag('console.command');
-
     $services->alias('mautic.form.model.action', Mautic\FormBundle\Model\ActionModel::class);
     $services->alias('mautic.form.model.field', Mautic\FormBundle\Model\FieldModel::class);
     $services->alias('mautic.form.model.form', Mautic\FormBundle\Model\FormModel::class);

--- a/app/bundles/LeadBundle/Config/services.php
+++ b/app/bundles/LeadBundle/Config/services.php
@@ -33,8 +33,6 @@ return function (ContainerConfigurator $configurator): void {
     $services->load('Mautic\\LeadBundle\\Entity\\', '../Entity/*Repository.php')
         ->tag(Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass::REPOSITORY_SERVICE_TAG);
     $services->set(Mautic\LeadBundle\EventListener\SerializerSubscriber::class)->tag('jms_serializer.event_subscriber', ['event' => JMS\Serializer\EventDispatcher\Events::POST_SERIALIZE]);
-    $services->set(Mautic\LeadBundle\Form\Validator\Constraints\FieldAliasKeywordValidator::class)->tag('validator.constraint_validator');
-    $services->set(Mautic\CoreBundle\Form\Validator\Constraints\FileEncodingValidator::class)->tag('validator.constraint_validator');
     $services->set(Mautic\LeadBundle\Form\Validator\Constraints\LeadListAccessValidator::class)->tag('validator.constraint_validator', ['alias' => 'leadlist_access']);
     $services->set(Mautic\LeadBundle\Form\Validator\Constraints\UniqueUserAliasValidator::class)->tag('validator.constraint_validator', ['alias' => 'uniqueleadlist']);
     $services->set(Mautic\LeadBundle\Form\Validator\Constraints\SegmentInUseValidator::class)->tag('validator.constraint_validator', ['alias' => 'segment_in_use']);
@@ -46,9 +44,6 @@ return function (ContainerConfigurator $configurator): void {
     $services->set(Mautic\LeadBundle\Tests\DataFixtures\ORM\LoadTagData::class);
     $services->set(Mautic\LeadBundle\Tests\DataFixtures\ORM\LoadPageHitData::class);
     $services->set(Mautic\LeadBundle\Tests\DataFixtures\ORM\LoadSegmentsData::class);
-    $services->set(Mautic\LeadBundle\Form\Validator\Constraints\EmailAddressValidator::class)->tag('validator.constraint_validator');
-    $services->set(Mautic\LeadBundle\Validator\Constraints\SegmentUsedInCampaignsValidator::class)->tag('validator.constraint_validator');
-    $services->set(Mautic\LeadBundle\Validator\Constraints\LengthValidator::class)->tag('validator.constraint_validator');
     $services->set(Mautic\LeadBundle\Segment\Stat\SegmentDependencies::class);
 
     $services->set(Mautic\LeadBundle\Segment\Stat\SegmentChartQueryFactory::class);
@@ -100,5 +95,4 @@ return function (ContainerConfigurator $configurator): void {
     $services->alias('mautic.lead.model.ipaddress', Mautic\LeadBundle\Model\IpAddressModel::class);
     $services->alias('mautic.lead.model.export_scheduler', Mautic\LeadBundle\Model\ContactExportSchedulerModel::class);
     $services->alias('mautic.lead.repository.list_lead', Mautic\LeadBundle\Entity\ListLeadRepository::class);
-    $services->get(Mautic\LeadBundle\Validator\Constraints\SegmentDateValidator::class)->tag('validator.constraint_validator');
 };

--- a/app/bundles/ReportBundle/Config/services.php
+++ b/app/bundles/ReportBundle/Config/services.php
@@ -24,7 +24,6 @@ return function (ContainerConfigurator $configurator): void {
         ->exclude('../{'.implode(',', array_merge(MauticCoreExtension::DEFAULT_EXCLUDES, $excludes)).'}');
 
     $services->load('Mautic\\ReportBundle\\Entity\\', '../Entity/*Repository.php');
-    $services->set(Mautic\ReportBundle\Scheduler\Validator\ScheduleIsValidValidator::class)->tag('validator.constraint_validator');
     $services->set('mautic.report.model.scheduler_builder', Mautic\ReportBundle\Scheduler\Builder\SchedulerBuilder::class);
     $services->set('mautic.report.model.scheduler_template_factory', Mautic\ReportBundle\Scheduler\Factory\SchedulerTemplateFactory::class);
     $services->set('mautic.report.model.scheduler_date_builder', Mautic\ReportBundle\Scheduler\Date\DateBuilder::class);

--- a/app/bundles/UserBundle/Config/services.php
+++ b/app/bundles/UserBundle/Config/services.php
@@ -70,7 +70,6 @@ return function (ContainerConfigurator $configurator): void {
     $services->alias('mautic.user.model.role', Mautic\UserBundle\Model\RoleModel::class);
     $services->alias('mautic.user.model.user', Mautic\UserBundle\Model\UserModel::class);
     $services->alias('mautic.user.model.password_strength_estimator', Mautic\UserBundle\Model\PasswordStrengthEstimatorModel::class);
-    $services->get(Mautic\UserBundle\Form\Validator\Constraints\NotWeakValidator::class)->tag('validator.constraint_validator');
 
     $services->load('Mautic\\UserBundle\\Security\\SAML\Store\\Request\\', '../Security/SAML/Store/Request/*.php');
     $services->get(Mautic\UserBundle\Security\SAML\Store\Request\RequestStateStore::class)

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -268,6 +268,7 @@ rules:
 	- Utils\PHPStan\Rule\NoUnusedServiceNameRule
 	- Utils\PHPStan\Rule\NoClassNameServiceAliasRule
 	- Utils\PHPStan\Rule\NoAlreadyLoadedServiceSetRule
+	- Utils\PHPStan\Rule\NoAutoconfiguredServiceTagRule
 
 services:
 	- Utils\PHPStan\ServiceNameUsageResolver

--- a/utils/phpstan/src/Rule/NoAutoconfiguredServiceTagRule.php
+++ b/utils/phpstan/src/Rule/NoAutoconfiguredServiceTagRule.php
@@ -1,0 +1,212 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Rule;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\NodeFinder;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\FileNode;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Reports the tags of Config/services.php that autoconfigure() adds by itself,
+ * e.g. $services->set(OAuthCallbackValidator::class)->tag('validator.constraint_validator').
+ *
+ * Every bundle config opens with $services->defaults()->autoconfigure(), so a service implementing
+ * ConstraintValidatorInterface is tagged "validator.constraint_validator" either way - the tag repeats
+ * what the interface already says.
+ *
+ * Only a tag with no attributes of its own is reported. An attribute says more than autoconfigure() does
+ * and so keeps the tag, e.g. ->tag('twig.extension', ['priority' => 100]) or a validator alias:
+ *
+ *     $services->set(FileExtensionConstraintValidator::class)
+ *         ->tag('validator.constraint_validator', ['alias' => 'file_extension_constraint_validator']);
+ *
+ * A file with no autoconfigure() in its defaults is left alone, there the tag is the only thing that
+ * registers the service.
+ *
+ * @implements Rule<FileNode>
+ */
+final class NoAutoconfiguredServiceTagRule implements Rule
+{
+    /**
+     * @var string
+     */
+    private const SERVICES_FILE_NAME = 'services.php';
+
+    /**
+     * @var string
+     */
+    private const SERVICES_VARIABLE_NAME = 'services';
+
+    /**
+     * The tags Symfony adds on its own to a service of the given type.
+     *
+     * @see \Symfony\Bundle\FrameworkBundle\DependencyInjection\FrameworkExtension::load()
+     * @see \Symfony\Bundle\TwigBundle\DependencyInjection\TwigExtension::load()
+     *
+     * @var array<string, string>
+     */
+    private const AUTOCONFIGURED_TAGS = [
+        'console.command'                => \Symfony\Component\Console\Command\Command::class,
+        'form.type'                      => \Symfony\Component\Form\FormTypeInterface::class,
+        'kernel.event_subscriber'        => \Symfony\Component\EventDispatcher\EventSubscriberInterface::class,
+        'security.voter'                 => \Symfony\Component\Security\Core\Authorization\Voter\VoterInterface::class,
+        'twig.extension'                 => \Twig\Extension\ExtensionInterface::class,
+        'validator.constraint_validator' => \Symfony\Component\Validator\ConstraintValidatorInterface::class,
+    ];
+
+    public function __construct(
+        private readonly ReflectionProvider $reflectionProvider,
+    ) {
+    }
+
+    public function getNodeType(): string
+    {
+        return FileNode::class;
+    }
+
+    /**
+     * @param FileNode $node
+     *
+     * @return list<\PHPStan\Rules\IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (self::SERVICES_FILE_NAME !== basename($scope->getFile())) {
+            return [];
+        }
+
+        $nodeFinder = new NodeFinder();
+
+        /** @var MethodCall[] $methodCalls */
+        $methodCalls = $nodeFinder->findInstanceOf($node->getNodes(), MethodCall::class);
+
+        if (!$this->hasAutoconfigureCall($methodCalls)) {
+            return [];
+        }
+
+        $ruleErrors = [];
+
+        foreach ($methodCalls as $methodCall) {
+            $tagName = $this->matchTagNameWithoutAttributes($methodCall);
+            if (null === $tagName) {
+                continue;
+            }
+
+            $autoconfiguredType = self::AUTOCONFIGURED_TAGS[$tagName] ?? null;
+            if (null === $autoconfiguredType) {
+                continue;
+            }
+
+            $className = $this->resolveTaggedClassName($methodCall);
+            if (null === $className) {
+                continue;
+            }
+
+            if (!$this->isSubclassOf($className, $autoconfiguredType)) {
+                continue;
+            }
+
+            $ruleErrors[] = RuleErrorBuilder::message(sprintf(
+                'Tag "%s" is added by autoconfigure() on its own, as "%s" is a %s - remove the ->tag() call.',
+                $tagName,
+                $className,
+                $autoconfiguredType
+            ))
+                ->identifier('mautic.noAutoconfiguredServiceTag')
+                // the name, not the call - a chained call starts on the line of the $services->set() above it
+                ->line($methodCall->name->getStartLine())
+                ->build();
+        }
+
+        return $ruleErrors;
+    }
+
+    /**
+     * @param MethodCall[] $methodCalls
+     */
+    private function hasAutoconfigureCall(array $methodCalls): bool
+    {
+        foreach ($methodCalls as $methodCall) {
+            if ($methodCall->name instanceof Identifier && 'autoconfigure' === $methodCall->name->toString()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return string|null the tag name of a ->tag() call that adds no attributes of its own
+     */
+    private function matchTagNameWithoutAttributes(MethodCall $methodCall): ?string
+    {
+        if (!$methodCall->name instanceof Identifier || 'tag' !== $methodCall->name->toString()) {
+            return null;
+        }
+
+        $args = $methodCall->getArgs();
+        if (1 !== count($args)) {
+            return null;
+        }
+
+        return $args[0]->value instanceof String_ ? $args[0]->value->value : null;
+    }
+
+    /**
+     * Walks the call chain down to the $services->set() or $services->get() call the tag belongs to.
+     */
+    private function resolveTaggedClassName(MethodCall $methodCall): ?string
+    {
+        $currentCall = $methodCall->var;
+
+        while ($currentCall instanceof MethodCall) {
+            if ($currentCall->var instanceof Variable && self::SERVICES_VARIABLE_NAME === $currentCall->var->name) {
+                if (!$currentCall->name instanceof Identifier || !in_array($currentCall->name->toString(), ['set', 'get'], true)) {
+                    return null;
+                }
+
+                $args = $currentCall->getArgs();
+
+                return [] === $args ? null : $this->matchClassName($args[0]->value);
+            }
+
+            $currentCall = $currentCall->var;
+        }
+
+        return null;
+    }
+
+    private function matchClassName(Node $classValue): ?string
+    {
+        if (!$classValue instanceof ClassConstFetch || !$classValue->class instanceof Name) {
+            return null;
+        }
+
+        if (!$classValue->name instanceof Identifier || 'class' !== $classValue->name->toLowerString()) {
+            return null;
+        }
+
+        return $classValue->class->toString();
+    }
+
+    private function isSubclassOf(string $className, string $parentClassName): bool
+    {
+        if (!$this->reflectionProvider->hasClass($className)) {
+            return false;
+        }
+
+        return $this->reflectionProvider->getClass($className)->is($parentClassName);
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/AutoconfiguredTagBundle/AliasedValidator.php
+++ b/utils/phpstan/tests/Rule/Fixture/AutoconfiguredTagBundle/AliasedValidator.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture\AutoconfiguredTagBundle;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+final class AliasedValidator extends ConstraintValidator
+{
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/AutoconfiguredTagBundle/Config/services.php
+++ b/utils/phpstan/tests/Rule/Fixture/AutoconfiguredTagBundle/Config/services.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Utils\PHPStan\Tests\Rule\Fixture\AutoconfiguredTagBundle\AliasedValidator;
+use Utils\PHPStan\Tests\Rule\Fixture\AutoconfiguredTagBundle\PlainService;
+use Utils\PHPStan\Tests\Rule\Fixture\AutoconfiguredTagBundle\SomeSubscriber;
+use Utils\PHPStan\Tests\Rule\Fixture\AutoconfiguredTagBundle\SomeValidator;
+
+return function (ContainerConfigurator $configurator): void {
+    $services = $configurator->services()
+        ->defaults()
+        ->autowire()
+        ->autoconfigure()
+        ->public();
+
+    $services->set(SomeSubscriber::class)->tag('kernel.event_subscriber');
+    $services->set(SomeValidator::class)->tag('validator.constraint_validator');
+    $services->set(AliasedValidator::class)->tag('validator.constraint_validator', ['alias' => 'aliased_validator']);
+    $services->set(PlainService::class)->tag('mautic.custom_tag');
+    $services->get(SomeValidator::class)->tag('validator.constraint_validator');
+
+    $services->set(SomeSubscriber::class)
+        ->arg('$name', 'value')
+        ->tag('kernel.event_subscriber');
+};

--- a/utils/phpstan/tests/Rule/Fixture/AutoconfiguredTagBundle/PlainService.php
+++ b/utils/phpstan/tests/Rule/Fixture/AutoconfiguredTagBundle/PlainService.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture\AutoconfiguredTagBundle;
+
+final class PlainService
+{
+}

--- a/utils/phpstan/tests/Rule/Fixture/AutoconfiguredTagBundle/SomeSubscriber.php
+++ b/utils/phpstan/tests/Rule/Fixture/AutoconfiguredTagBundle/SomeSubscriber.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture\AutoconfiguredTagBundle;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+final class SomeSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @return array<string, string>
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [];
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/AutoconfiguredTagBundle/SomeValidator.php
+++ b/utils/phpstan/tests/Rule/Fixture/AutoconfiguredTagBundle/SomeValidator.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture\AutoconfiguredTagBundle;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+final class SomeValidator extends ConstraintValidator
+{
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/NoAutoconfigureBundle/Config/services.php
+++ b/utils/phpstan/tests/Rule/Fixture/NoAutoconfigureBundle/Config/services.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Utils\PHPStan\Tests\Rule\Fixture\AutoconfiguredTagBundle\SomeSubscriber;
+
+return function (ContainerConfigurator $configurator): void {
+    $services = $configurator->services()
+        ->defaults()
+        ->autowire()
+        ->public();
+
+    $services->set(SomeSubscriber::class)->tag('kernel.event_subscriber');
+};

--- a/utils/phpstan/tests/Rule/NoAutoconfiguredServiceTagRuleTest.php
+++ b/utils/phpstan/tests/Rule/NoAutoconfiguredServiceTagRuleTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use Utils\PHPStan\Rule\NoAutoconfiguredServiceTagRule;
+
+/**
+ * @extends RuleTestCase<NoAutoconfiguredServiceTagRule>
+ */
+final class NoAutoconfiguredServiceTagRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new NoAutoconfiguredServiceTagRule($this->createReflectionProvider());
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse([
+            __DIR__.'/Fixture/AutoconfiguredTagBundle/Config/services.php',
+        ], [
+            [
+                'Tag "kernel.event_subscriber" is added by autoconfigure() on its own, as "Utils\PHPStan\Tests\Rule\Fixture\AutoconfiguredTagBundle\SomeSubscriber" is a Symfony\Component\EventDispatcher\EventSubscriberInterface - remove the ->tag() call.',
+                18,
+            ],
+            [
+                'Tag "validator.constraint_validator" is added by autoconfigure() on its own, as "Utils\PHPStan\Tests\Rule\Fixture\AutoconfiguredTagBundle\SomeValidator" is a Symfony\Component\Validator\ConstraintValidatorInterface - remove the ->tag() call.',
+                19,
+            ],
+            [
+                'Tag "validator.constraint_validator" is added by autoconfigure() on its own, as "Utils\PHPStan\Tests\Rule\Fixture\AutoconfiguredTagBundle\SomeValidator" is a Symfony\Component\Validator\ConstraintValidatorInterface - remove the ->tag() call.',
+                22,
+            ],
+            [
+                'Tag "kernel.event_subscriber" is added by autoconfigure() on its own, as "Utils\PHPStan\Tests\Rule\Fixture\AutoconfiguredTagBundle\SomeSubscriber" is a Symfony\Component\EventDispatcher\EventSubscriberInterface - remove the ->tag() call.',
+                26,
+            ],
+        ]);
+    }
+
+    public function testSkipConfigWithoutAutoconfigure(): void
+    {
+        $this->analyse([
+            __DIR__.'/Fixture/NoAutoconfigureBundle/Config/services.php',
+        ], []);
+    }
+}


### PR DESCRIPTION
Bundle `Config/services.php` files hand-write 18 tags the container does not need, plus the registration lines those tags were holding up.

## The rule

Every bundle config opens with `$services->defaults()->autoconfigure()`, so a service implementing `ConstraintValidatorInterface` is tagged `validator.constraint_validator` whether the tag is written out or not.

```diff
-    $services->set(Mautic\EmailBundle\Validator\MultipleEmailsValidValidator::class)->tag('validator.constraint_validator');
```

`Utils\PHPStan\Rule\NoAutoconfiguredServiceTagRule` reports these:

```
app/bundles/EmailBundle/Config/services.php:56:
Tag "validator.constraint_validator" is added by autoconfigure() on its own, as
"Mautic\EmailBundle\Validator\MultipleEmailsValidValidator" is a
Symfony\Component\Validator\ConstraintValidatorInterface - remove the ->tag() call.
```

The tags it knows, with the type Symfony autoconfigures them for:

| Tag | Type |
| --- | --- |
| `console.command` | `Symfony\Component\Console\Command\Command` |
| `form.type` | `Symfony\Component\Form\FormTypeInterface` |
| `kernel.event_subscriber` | `Symfony\Component\EventDispatcher\EventSubscriberInterface` |
| `security.voter` | `Symfony\Component\Security\Core\Authorization\Voter\VoterInterface` |
| `twig.extension` | `Twig\Extension\ExtensionInterface` |
| `validator.constraint_validator` | `Symfony\Component\Validator\ConstraintValidatorInterface` |

### What it keeps

A tag carrying attributes of its own says more than `autoconfigure()` does, so it stays:

```php
// kept - the alias is not what autoconfigure() gives
$services->set(FileExtensionConstraintValidator::class)
    ->tag('validator.constraint_validator', ['alias' => 'file_extension_constraint_validator']);

// kept - the priority is not what autoconfigure() gives
$services->set(Mautic\CoreBundle\Twig\Extension\OverrideIncludeExtension::class)
    ->tag('twig.extension', ['priority' => 100]);
```

A `services.php` whose defaults have no `autoconfigure()` is left alone - there the tag is the only thing registering the service.

That covers 17 of the 18 tags. The 18th is a lone `->tag('twig.helper')` on `CoreParametersHelper`: no compiler pass, in Mautic or in any vendor package, ever calls `findTaggedServiceIds('twig.helper')`, and this one carries no alias to keep it around.
