### PR TITLE
[NotificationBundle] remove deprecated unused NotificationHelper::unsubscribe()

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -61,3 +61,4 @@
 - Deprecated constants `Mautic\LeadBundle\Segment\OperatorOptions::IN` and `::NOT_IN` removed. Use `OperatorOptions::INCLUDING_ANY` and `OperatorOptions::EXCLUDING_ANY` instead — they carry the identical values `in` and `!in`.
 - Deprecated method `Mautic\CoreBundle\Entity\UuidTrait::isValidUuid()` removed. Use `Mautic\CoreBundle\Helper\UuidHelper::isValidUuid()` instead — calling static trait methods directly is deprecated in PHP 8.4+.
 - Deprecated service alias `mautic.config.model.sysinfo` removed. Use the FQCN service id `Mautic\ConfigBundle\Model\SysinfoModel` instead.
+- Deprecated method `Mautic\NotificationBundle\Helper\NotificationHelper::unsubscribe()` removed with no replacement; it was unused. With it, the `LeadRepository` and `DoNotContact` constructor arguments of `NotificationHelper` were removed as well.

--- a/app/bundles/NotificationBundle/Helper/NotificationHelper.php
+++ b/app/bundles/NotificationBundle/Helper/NotificationHelper.php
@@ -4,9 +4,6 @@ namespace Mautic\NotificationBundle\Helper;
 
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Twig\Helper\AssetsHelper;
-use Mautic\LeadBundle\Entity\DoNotContact;
-use Mautic\LeadBundle\Entity\LeadRepository;
-use Mautic\LeadBundle\Model\DoNotContact as DoNotContactModel;
 use Mautic\PluginBundle\Helper\IntegrationHelper;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -15,32 +12,12 @@ use Symfony\Component\Routing\RouterInterface;
 class NotificationHelper
 {
     public function __construct(
-        protected LeadRepository $leadRepository,
         protected AssetsHelper $assetsHelper,
         protected CoreParametersHelper $coreParametersHelper,
         protected IntegrationHelper $integrationHelper,
         protected RouterInterface $router,
         protected RequestStack $requestStack,
-        private readonly DoNotContactModel $doNotContact,
     ) {
-    }
-
-    /**
-     * @param string $notification
-     *
-     * @return bool|DoNotContact
-     *
-     * @deprecated as unused. To be removed in 8.0
-     */
-    public function unsubscribe($notification)
-    {
-        $lead = $this->leadRepository->getLeadByEmail($notification);
-
-        if (!is_array($lead) || !isset($lead['id'])) {
-            return false;
-        }
-
-        return $this->doNotContact->addDncForContact((int) $lead['id'], 'notification', DoNotContact::UNSUBSCRIBED);
     }
 
     public function getHeaderScript(): ?string


### PR DESCRIPTION
The method was marked \`@deprecated as unused. To be removed in 8.0\` and has zero callers.