### PR TITLE
[CoreBundle] register Filesystem by class name, drop deprecated symfony.filesystem id

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -62,3 +62,4 @@
 - Deprecated method `Mautic\CoreBundle\Entity\UuidTrait::isValidUuid()` removed. Use `Mautic\CoreBundle\Helper\UuidHelper::isValidUuid()` instead — calling static trait methods directly is deprecated in PHP 8.4+.
 - Deprecated service alias `mautic.config.model.sysinfo` removed. Use the FQCN service id `Mautic\ConfigBundle\Model\SysinfoModel` instead.
 - Deprecated method `Mautic\NotificationBundle\Helper\NotificationHelper::unsubscribe()` removed with no replacement; it was unused. With it, the `LeadRepository` and `DoNotContact` constructor arguments of `NotificationHelper` were removed as well.
+- Deprecated service id `symfony.filesystem` removed. `Symfony\Component\Filesystem\Filesystem` is now registered under its class name, so autowired and FQCN-based usages are unaffected; only container lookups by the `symfony.filesystem` string need updating.

--- a/app/bundles/CoreBundle/Config/services.php
+++ b/app/bundles/CoreBundle/Config/services.php
@@ -147,9 +147,7 @@ return function (ContainerConfigurator $configurator): void {
             service('mautic.cipher.openssl'),
         ]);
 
-    /* @deprecated to be removed in Mautic 4. Use 'mautic.filesystem' instead. */
-    $services->set('symfony.filesystem', Symfony\Component\Filesystem\Filesystem::class);
-    $services->alias(Symfony\Component\Filesystem\Filesystem::class, 'symfony.filesystem');
+    $services->set(Symfony\Component\Filesystem\Filesystem::class);
 
     $services->set('symfony.finder', Symfony\Component\Finder\Finder::class);
     $services->alias(Symfony\Component\Finder\Finder::class, 'symfony.finder');


### PR DESCRIPTION
The `symfony.filesystem` string service id was deprecated for removal in Mautic 4 and has zero usages across `app`, `plugins`, `themes`, or `config`. This collapses the deprecated id + alias pair into a single class-named registration.

```diff
-    /* @deprecated to be removed in Mautic 4. Use 'mautic.filesystem' instead. */
-    $services->set('symfony.filesystem', Symfony\Component\Filesystem\Filesystem::class);
-    $services->alias(Symfony\Component\Filesystem\Filesystem::class, 'symfony.filesystem');
+    $services->set(Symfony\Component\Filesystem\Filesystem::class);
```

`Symfony\Component\Filesystem\Filesystem` was only autowirable through the alias before; registering it directly by class name keeps autowiring working while dropping the deprecated string id.