### PR TITLE
[ConfigBundle] remove deprecated mautic.config.model.sysinfo alias

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -58,3 +58,4 @@
 - `Mautic\DashboardBundle\Event\WidgetDetailEvent`: the legacy filesystem widget cache is gone. `setCacheDir()` and `setCacheTimeout()` were removed, the `$cacheProvider` constructor argument is now required, and `setTemplateData()` lost its 2nd `$skipCache` parameter. Widget data is cached only through `Mautic\CacheBundle\Cache\CacheProviderTagAwareInterface`, with the lifetime taken from `Widget::getCacheTimeout()`.
 - `Mautic\DashboardBundle\Factory\WidgetDetailEventFactory` no longer takes `UserHelper`, `CoreParametersHelper` and `PathsHelper` constructor arguments.
 - Deprecated class `Mautic\CoreBundle\Session\Storage\Handler\RedisSentinelSessionHandler` removed with no replacement. It was deprecated since Mautic 5.0, slated for removal in 6.0, and had no references left in the codebase.
+- Deprecated service alias `mautic.config.model.sysinfo` removed. Use the FQCN service id `Mautic\ConfigBundle\Model\SysinfoModel` instead.

--- a/app/bundles/ConfigBundle/Config/services.php
+++ b/app/bundles/ConfigBundle/Config/services.php
@@ -22,7 +22,4 @@ return function (ContainerConfigurator $configurator): void {
     $services->get(Mautic\ConfigBundle\Form\Type\EscapeTransformer::class)->arg('$allowedParameters', '%mautic.config_allowed_parameters%');
     $services->get(Mautic\ConfigBundle\Form\Helper\RestrictionHelper::class)->arg('$restrictedFields', '%mautic.security.restrictedConfigFields%');
     $services->get(Mautic\ConfigBundle\Form\Helper\RestrictionHelper::class)->arg('$displayMode', '%mautic.security.restrictedConfigFields.displayMode%');
-
-    // @deprecated Remove all aliases in Mautic 6. Use FQCN instead.
-    $services->alias('mautic.config.model.sysinfo', Mautic\ConfigBundle\Model\SysinfoModel::class);
 };


### PR DESCRIPTION
The `mautic.config.model.sysinfo` alias was marked for removal in Mautic 6 in favour of the FQCN service id, and has zero remaining usages. Continues the ongoing service-alias cleanup.