### PR TITLE
[code quality] use arrow functions for single-return closures

### DIFF
--- a/app/migrations/Version20190524124819.php
+++ b/app/migrations/Version20190524124819.php
@@ -13,9 +13,7 @@ final class Version20190524124819 extends PreUpAssertionMigration
 {
     protected function preUpAssertions(): void
     {
-        $this->skipAssertion(function (Schema $schema) {
-            return $schema->getTable("{$this->prefix}lead_fields")->hasColumn('is_index');
-        }, sprintf('Schema includes this migration'));
+        $this->skipAssertion(fn (Schema $schema) => $schema->getTable("{$this->prefix}lead_fields")->hasColumn('is_index'), sprintf('Schema includes this migration'));
     }
 
     public function up(Schema $schema): void

--- a/app/migrations/Version20210818090322.php
+++ b/app/migrations/Version20210818090322.php
@@ -11,9 +11,7 @@ final class Version20210818090322 extends PreUpAssertionMigration
 {
     public function preUpAssertions(): void
     {
-        $this->skipAssertion(function (Schema $schema) {
-            return $schema->getTable("{$this->prefix}roles")->hasColumn('uuid');
-        }, sprintf('Column %s already exists', 'uuid'));
+        $this->skipAssertion(fn (Schema $schema) => $schema->getTable("{$this->prefix}roles")->hasColumn('uuid'), sprintf('Column %s already exists', 'uuid'));
     }
 
     public function up(Schema $schema): void

--- a/app/migrations/Version20210819201726.php
+++ b/app/migrations/Version20210819201726.php
@@ -11,9 +11,7 @@ final class Version20210819201726 extends PreUpAssertionMigration
 {
     public function preUpAssertions(): void
     {
-        $this->skipAssertion(function (Schema $schema) {
-            return $schema->getTable("{$this->prefix}permissions")->hasColumn('uuid');
-        }, sprintf('Column %s already exists', 'uuid'));
+        $this->skipAssertion(fn (Schema $schema) => $schema->getTable("{$this->prefix}permissions")->hasColumn('uuid'), sprintf('Column %s already exists', 'uuid'));
     }
 
     public function up(Schema $schema): void

--- a/app/migrations/Version20211110070503.php
+++ b/app/migrations/Version20211110070503.php
@@ -12,9 +12,7 @@ final class Version20211110070503 extends PreUpAssertionMigration
 {
     public function preUpAssertions(): void
     {
-        $this->skipAssertion(function (Schema $schema) {
-            return $schema->getTable("{$this->prefix}campaigns")->getColumn('allow_restart')->getType() instanceof BooleanType;
-        }, 'Column already in BOOLEAN type');
+        $this->skipAssertion(fn (Schema $schema) => $schema->getTable("{$this->prefix}campaigns")->getColumn('allow_restart')->getType() instanceof BooleanType, 'Column already in BOOLEAN type');
     }
 
     public function up(Schema $schema): void

--- a/app/migrations/Version20220104115633.php
+++ b/app/migrations/Version20220104115633.php
@@ -13,9 +13,7 @@ final class Version20220104115633 extends PreUpAssertionMigration
 {
     protected function preUpAssertions(): void
     {
-        $this->skipAssertion(function (Schema $schema) {
-            return $schema->getTable($this->getPrefixedTableName(LeadList::TABLE_NAME))->hasColumn('deleted');
-        }, 'Deleted column already added in '.LeadList::TABLE_NAME);
+        $this->skipAssertion(fn (Schema $schema) => $schema->getTable($this->getPrefixedTableName(LeadList::TABLE_NAME))->hasColumn('deleted'), 'Deleted column already added in '.LeadList::TABLE_NAME);
     }
 
     public function up(Schema $schema): void

--- a/app/migrations/Version20220208032455.php
+++ b/app/migrations/Version20220208032455.php
@@ -35,9 +35,7 @@ final class Version20220208032455 extends PreUpAssertionMigration
             $fields       = $formField['fields'];
             $deleteFields = array_diff($columns, $fields);
 
-            $dropColumns   = array_map(function (string $column) {
-                return sprintf('DROP COLUMN %s', $column);
-            }, $deleteFields);
+            $dropColumns   = array_map(fn (string $column) => sprintf('DROP COLUMN %s', $column), $deleteFields);
 
             if ($dropColumns) {
                 $this->addSql(sprintf('ALTER TABLE %s %s', $tableName, implode(', ', $dropColumns)));

--- a/app/migrations/Version20220223072252.php
+++ b/app/migrations/Version20220223072252.php
@@ -14,9 +14,7 @@ final class Version20220223072252 extends PreUpAssertionMigration
 
     protected function preUpAssertions(): void
     {
-        $this->skipAssertion(function (Schema $schema) {
-            return $schema->getTable($this->getPrefixedTableName(self::TABLE))->getColumn('channel_id')->getType() instanceof StringType;
-        }, 'Column already in Varchar type');
+        $this->skipAssertion(fn (Schema $schema) => $schema->getTable($this->getPrefixedTableName(self::TABLE))->getColumn('channel_id')->getType() instanceof StringType, 'Column already in Varchar type');
     }
 
     public function up(Schema $schema): void

--- a/app/migrations/Version20220429091934.php
+++ b/app/migrations/Version20220429091934.php
@@ -16,9 +16,7 @@ final class Version20220429091934 extends PreUpAssertionMigration
 
     protected function preUpAssertions(): void
     {
-        $this->skipAssertion(function (Schema $schema) {
-            return $schema->hasTable("{$this->prefix}contact_export_scheduler");
-        }, sprintf('Table %s already exists', "{$this->prefix}contact_export_scheduler"));
+        $this->skipAssertion(fn (Schema $schema) => $schema->hasTable("{$this->prefix}contact_export_scheduler"), sprintf('Table %s already exists', "{$this->prefix}contact_export_scheduler"));
     }
 
     public function up(Schema $schema): void

--- a/app/migrations/Version20230301051300.php
+++ b/app/migrations/Version20230301051300.php
@@ -12,9 +12,7 @@ final class Version20230301051300 extends PreUpAssertionMigration
 {
     protected function preUpAssertions(): void
     {
-        $this->skipAssertion(function (Schema $schema) {
-            return $schema->getTable($this->getPrefixedTableName(Sms::TABLE_NAME))->hasColumn('media');
-        }, 'Column media already exists');
+        $this->skipAssertion(fn (Schema $schema) => $schema->getTable($this->getPrefixedTableName(Sms::TABLE_NAME))->hasColumn('media'), 'Column media already exists');
     }
 
     public function up(Schema $schema): void

--- a/app/migrations/Version20230313111424.php
+++ b/app/migrations/Version20230313111424.php
@@ -13,9 +13,7 @@ final class Version20230313111424 extends PreUpAssertionMigration
 {
     protected function preUpAssertions(): void
     {
-        $this->skipAssertion(function (Schema $schema) {
-            return $schema->getTable($this->getPrefixedTableName(Sms::TABLE_NAME))->hasColumn('is_mms');
-        }, 'Column is_mms already exists');
+        $this->skipAssertion(fn (Schema $schema) => $schema->getTable($this->getPrefixedTableName(Sms::TABLE_NAME))->hasColumn('is_mms'), 'Column is_mms already exists');
     }
 
     public function up(Schema $schema): void

--- a/app/migrations/Version20230506112314.php
+++ b/app/migrations/Version20230506112314.php
@@ -11,9 +11,7 @@ final class Version20230506112314 extends PreUpAssertionMigration
 {
     public function preUpAssertions(): void
     {
-        $this->skipAssertion(function (Schema $schema) {
-            return $schema->getTable($this->getTableName())->hasIndex($this->getIndexName());
-        }, sprintf('The index "%s" has already been added to the table "%s".', $this->getIndexName(), $this->getTableName()));
+        $this->skipAssertion(fn (Schema $schema) => $schema->getTable($this->getTableName())->hasIndex($this->getIndexName()), sprintf('The index "%s" has already been added to the table "%s".', $this->getIndexName(), $this->getTableName()));
     }
 
     public function up(Schema $schema): void

--- a/app/migrations/Version20230506113422.php
+++ b/app/migrations/Version20230506113422.php
@@ -11,9 +11,7 @@ final class Version20230506113422 extends PreUpAssertionMigration
 {
     public function preUpAssertions(): void
     {
-        $this->skipAssertion(function (Schema $schema) {
-            return $schema->getTable($this->getTableName())->hasIndex($this->getIndexName());
-        }, sprintf('The index "%s" has already been added to the table "%s".', $this->getIndexName(), $this->getTableName()));
+        $this->skipAssertion(fn (Schema $schema) => $schema->getTable($this->getTableName())->hasIndex($this->getIndexName()), sprintf('The index "%s" has already been added to the table "%s".', $this->getIndexName(), $this->getTableName()));
     }
 
     public function up(Schema $schema): void

--- a/app/migrations/Version20230506113627.php
+++ b/app/migrations/Version20230506113627.php
@@ -11,9 +11,7 @@ final class Version20230506113627 extends PreUpAssertionMigration
 {
     public function preUpAssertions(): void
     {
-        $this->skipAssertion(function (Schema $schema) {
-            return $schema->getTable($this->getTableName())->hasIndex($this->getIndexName());
-        }, sprintf('The index "%s" has already been added to the table "%s".', $this->getIndexName(), $this->getTableName()));
+        $this->skipAssertion(fn (Schema $schema) => $schema->getTable($this->getTableName())->hasIndex($this->getIndexName()), sprintf('The index "%s" has already been added to the table "%s".', $this->getIndexName(), $this->getTableName()));
     }
 
     public function up(Schema $schema): void

--- a/app/migrations/Version20230506113731.php
+++ b/app/migrations/Version20230506113731.php
@@ -11,9 +11,7 @@ final class Version20230506113731 extends PreUpAssertionMigration
 {
     public function preUpAssertions(): void
     {
-        $this->skipAssertion(function (Schema $schema) {
-            return $schema->getTable($this->getTableName())->hasIndex($this->getIndexName());
-        }, sprintf('The index "%s" has already been added to the table "%s".', $this->getIndexName(), $this->getTableName()));
+        $this->skipAssertion(fn (Schema $schema) => $schema->getTable($this->getTableName())->hasIndex($this->getIndexName()), sprintf('The index "%s" has already been added to the table "%s".', $this->getIndexName(), $this->getTableName()));
     }
 
     public function up(Schema $schema): void

--- a/app/migrations/Version20230506113812.php
+++ b/app/migrations/Version20230506113812.php
@@ -11,9 +11,7 @@ final class Version20230506113812 extends PreUpAssertionMigration
 {
     public function preUpAssertions(): void
     {
-        $this->skipAssertion(function (Schema $schema) {
-            return $schema->getTable($this->getTableName())->hasIndex($this->getIndexName());
-        }, sprintf('The index "%s" has already been added to the table "%s".', $this->getIndexName(), $this->getTableName()));
+        $this->skipAssertion(fn (Schema $schema) => $schema->getTable($this->getTableName())->hasIndex($this->getIndexName()), sprintf('The index "%s" has already been added to the table "%s".', $this->getIndexName(), $this->getTableName()));
     }
 
     public function up(Schema $schema): void

--- a/app/migrations/Version20231205094436.php
+++ b/app/migrations/Version20231205094436.php
@@ -12,9 +12,7 @@ final class Version20231205094436 extends PreUpAssertionMigration
 {
     protected function preUpAssertions(): void
     {
-        $this->skipAssertion(function (Schema $schema) {
-            return $schema->getTable($this->getTableName())->hasIndex($this->getIndexName());
-        }, sprintf('Index %s already exists', $this->getIndexName()));
+        $this->skipAssertion(fn (Schema $schema) => $schema->getTable($this->getTableName())->hasIndex($this->getIndexName()), sprintf('Index %s already exists', $this->getIndexName()));
     }
 
     public function up(Schema $schema): void

--- a/app/migrations/Version20231206152313.php
+++ b/app/migrations/Version20231206152313.php
@@ -11,13 +11,9 @@ final class Version20231206152313 extends PreUpAssertionMigration
 {
     protected function preUpAssertions(): void
     {
-        $this->skipAssertion(function (Schema $schema) {
-            return $schema->getTable($this->getTableName())->hasIndex($this->getSentIndexName());
-        }, sprintf('Index %s already exists', $this->getSentIndexName()));
+        $this->skipAssertion(fn (Schema $schema) => $schema->getTable($this->getTableName())->hasIndex($this->getSentIndexName()), sprintf('Index %s already exists', $this->getSentIndexName()));
 
-        $this->skipAssertion(function (Schema $schema) {
-            return $schema->getTable($this->getTableName())->hasIndex($this->getIsReadIndexName());
-        }, sprintf('Index %s already exists', $this->getIsReadIndexName()));
+        $this->skipAssertion(fn (Schema $schema) => $schema->getTable($this->getTableName())->hasIndex($this->getIsReadIndexName()), sprintf('Index %s already exists', $this->getIsReadIndexName()));
     }
 
     public function up(Schema $schema): void

--- a/app/migrations/Version20240226114528.php
+++ b/app/migrations/Version20240226114528.php
@@ -11,19 +11,13 @@ final class Version20240226114528 extends PreUpAssertionMigration
 {
     protected function preUpAssertions(): void
     {
-        $this->skipAssertion(function (Schema $schema) {
-            return $schema->hasTable($this->getTableName());
-        }, sprintf('Table %s already exists', $this->getTableName()));
+        $this->skipAssertion(fn (Schema $schema) => $schema->hasTable($this->getTableName()), sprintf('Table %s already exists', $this->getTableName()));
 
-        $this->skipAssertion(function (Schema $schema) {
-            return $schema->getTable($this->getTableName())
-                ->hasForeignKey($this->getForeignKeyName('email_id'));
-        }, sprintf('Foreign key %s already exists', $this->getForeignKeyName('email_id')));
+        $this->skipAssertion(fn (Schema $schema) => $schema->getTable($this->getTableName())
+                ->hasForeignKey($this->getForeignKeyName('email_id')), sprintf('Foreign key %s already exists', $this->getForeignKeyName('email_id')));
 
-        $this->skipAssertion(function (Schema $schema) {
-            return $schema->getTable($this->getTableName())
-                ->hasForeignKey($this->getForeignKeyName('leadlist_id'));
-        }, sprintf('Foreign key %s already exists', $this->getForeignKeyName('leadlist_id')));
+        $this->skipAssertion(fn (Schema $schema) => $schema->getTable($this->getTableName())
+                ->hasForeignKey($this->getForeignKeyName('leadlist_id')), sprintf('Foreign key %s already exists', $this->getForeignKeyName('leadlist_id')));
     }
 
     public function up(Schema $schema): void

--- a/app/migrations/Version20240229101323.php
+++ b/app/migrations/Version20240229101323.php
@@ -15,9 +15,7 @@ final class Version20240229101323 extends PreUpAssertionMigration
 
     protected function preUpAssertions(): void
     {
-        $this->skipAssertion(function (Schema $schema) {
-            return $schema->getTable($this->getPrefixedTableName(Email::TABLE_NAME))->hasColumn(self::COLUMN_NAME);
-        }, sprintf('Column %s already exists', self::COLUMN_NAME));
+        $this->skipAssertion(fn (Schema $schema) => $schema->getTable($this->getPrefixedTableName(Email::TABLE_NAME))->hasColumn(self::COLUMN_NAME), sprintf('Column %s already exists', self::COLUMN_NAME));
     }
 
     public function up(Schema $schema): void

--- a/app/migrations/Version20240416112112.php
+++ b/app/migrations/Version20240416112112.php
@@ -11,9 +11,7 @@ final class Version20240416112112 extends PreUpAssertionMigration
 {
     protected function preUpAssertions(): void
     {
-        $this->skipAssertion(function (Schema $schema) {
-            return $schema->getTable("{$this->prefix}campaigns")->hasColumn('version');
-        }, sprintf('Column %s already exists', 'version'));
+        $this->skipAssertion(fn (Schema $schema) => $schema->getTable("{$this->prefix}campaigns")->hasColumn('version'), sprintf('Column %s already exists', 'version'));
     }
 
     public function up(Schema $schema): void

--- a/app/migrations/Version20250909202247.php
+++ b/app/migrations/Version20250909202247.php
@@ -15,9 +15,7 @@ final class Version20250909202247 extends PreUpAssertionMigration
 
     protected function preUpAssertions(): void
     {
-        $this->skipAssertion(function (Schema $schema) {
-            return $schema->getTable($this->getPrefixedTableName(self::TABLE_NAME))->hasIndex($this->getIndexName());
-        }, sprintf('Index %s already exists', $this->getIndexName()));
+        $this->skipAssertion(fn (Schema $schema) => $schema->getTable($this->getPrefixedTableName(self::TABLE_NAME))->hasIndex($this->getIndexName()), sprintf('Index %s already exists', $this->getIndexName()));
     }
 
     public function up(Schema $schema): void

--- a/app/migrations/Version20260521114026.php
+++ b/app/migrations/Version20260521114026.php
@@ -15,9 +15,7 @@ final class Version20260521114026 extends PreUpAssertionMigration
 
     protected function preUpAssertions(): void
     {
-        $this->skipAssertion(function (Schema $schema) {
-            return $schema->getTable($this->getPrefixedTableName())->hasColumn('deleted');
-        }, 'Deleted column already added in '.self::TABLE_NAME);
+        $this->skipAssertion(fn (Schema $schema) => $schema->getTable($this->getPrefixedTableName())->hasColumn('deleted'), 'Deleted column already added in '.self::TABLE_NAME);
     }
 
     public function up(Schema $schema): void

--- a/build/package_release.php
+++ b/build/package_release.php
@@ -239,9 +239,7 @@ if (!isset($args['repackage'])) {
     if (0 === $result) {
         $deletedFiles = array_unique(array_merge(
             $deletedFiles,
-            array_filter($vendorDeletedFiles, function ($path) {
-                return str_starts_with($path, 'vendor/');
-            })
+            array_filter($vendorDeletedFiles, fn ($path) => str_starts_with($path, 'vendor/'))
         ));
         sort($deletedFiles);
     }

--- a/utils/rector/src/GetRepositoryToRepositoryServiceRector.php
+++ b/utils/rector/src/GetRepositoryToRepositoryServiceRector.php
@@ -345,8 +345,6 @@ final class GetRepositoryToRepositoryServiceRector extends AbstractRector
      */
     private function replaceNode(Class_ $class, MethodCall $oldNode, Node $newNode): void
     {
-        $this->traverseNodesWithCallable($class, static function (Node $node) use ($oldNode, $newNode): ?Node {
-            return $node === $oldNode ? $newNode : null;
-        });
+        $this->traverseNodesWithCallable($class, static fn (Node $node): ?Node => $node === $oldNode ? $newNode : null);
     }
 }

--- a/utils/rector/src/ModelGetRepositoryToRepositoryServiceRector.php
+++ b/utils/rector/src/ModelGetRepositoryToRepositoryServiceRector.php
@@ -318,8 +318,6 @@ final class ModelGetRepositoryToRepositoryServiceRector extends AbstractRector
      */
     private function replaceNode(Class_ $class, MethodCall $oldNode, Node $newNode): void
     {
-        $this->traverseNodesWithCallable($class, static function (Node $node) use ($oldNode, $newNode): ?Node {
-            return $node === $oldNode ? $newNode : null;
-        });
+        $this->traverseNodesWithCallable($class, static fn (Node $node): ?Node => $node === $oldNode ? $newNode : null);
     }
 }


### PR DESCRIPTION
Mechanical code-quality change: closures whose body is a single `return` are rewritten as arrow functions.

Touches 22 `PreUpAssertionMigration::preUpAssertions()` callbacks, `build/package_release.php` and the 2 Rector rules in `utils/rector/src`.

```diff
 protected function preUpAssertions(): void
 {
-    $this->skipAssertion(function (Schema $schema) {
-        return $schema->getTable("{$this->prefix}lead_fields")->hasColumn('is_index');
-    }, sprintf('Schema includes this migration'));
+    $this->skipAssertion(fn (Schema $schema) => $schema->getTable("{$this->prefix}lead_fields")->hasColumn('is_index'), sprintf('Schema includes this migration'));
 }
```

```diff
-        array_filter($vendorDeletedFiles, function ($path) {
-            return str_starts_with($path, 'vendor/');
-        })
+        array_filter($vendorDeletedFiles, fn ($path) => str_starts_with($path, 'vendor/'))
```

No behaviour change - none of these closures capture local variables, so the by-value auto-capture of arrow functions is equivalent.
