### PR TITLE
[types] Add void return types and class constant references

### DIFF
--- a/app/bundles/CoreBundle/IpLookup/AbstractMaxmindLookup.php
+++ b/app/bundles/CoreBundle/IpLookup/AbstractMaxmindLookup.php
@@ -45,7 +45,7 @@ abstract class AbstractMaxmindLookup extends AbstractRemoteDataLookup
         return $url."/{$this->ip}";
     }
 
-    protected function parseResponse($response)
+    protected function parseResponse($response): void
     {
         $data = json_decode($response);
 

--- a/app/bundles/CoreBundle/IpLookup/AbstractRemoteDataLookup.php
+++ b/app/bundles/CoreBundle/IpLookup/AbstractRemoteDataLookup.php
@@ -45,7 +45,7 @@ abstract class AbstractRemoteDataLookup extends AbstractLookup
     /**
      * Fetch data from lookup service.
      */
-    protected function lookup()
+    protected function lookup(): void
     {
         $url = $this->getUrl();
 

--- a/app/bundles/EmailBundle/Stats/Helper/AbstractHelper.php
+++ b/app/bundles/EmailBundle/Stats/Helper/AbstractHelper.php
@@ -71,7 +71,7 @@ abstract class AbstractHelper implements StatHelperInterface
      *
      * @param string $emailIdColumn
      */
-    protected function limitQueryToCreator(QueryBuilder $q, $emailIdColumn = 't.email_id')
+    protected function limitQueryToCreator(QueryBuilder $q, $emailIdColumn = 't.email_id'): void
     {
         $q->join('t', MAUTIC_TABLE_PREFIX.'emails', 'e', 'e.id = '.$emailIdColumn)
             ->andWhere('e.created_by = :userId')
@@ -82,7 +82,7 @@ abstract class AbstractHelper implements StatHelperInterface
      * @param string $column
      * @param string $prefix
      */
-    protected function limitQueryToEmailIds(QueryBuilder $q, array $ids, $column, $prefix)
+    protected function limitQueryToEmailIds(QueryBuilder $q, array $ids, $column, $prefix): void
     {
         if (0 === count($ids)) {
             return;
@@ -102,7 +102,7 @@ abstract class AbstractHelper implements StatHelperInterface
     /**
      * @throws \Exception
      */
-    protected function fetchAndBindToCollection(QueryBuilder $q, StatCollection $statCollection)
+    protected function fetchAndBindToCollection(QueryBuilder $q, StatCollection $statCollection): void
     {
         $results = $q->executeQuery()->fetchAllAssociative();
         foreach ($results as $result) {

--- a/app/config/config.php
+++ b/app/config/config.php
@@ -252,7 +252,7 @@ $container->loadFromExtension('oneup_uploader', [
             'error_handler'   => 'mautic.asset.upload.error.handler',
             'frontend'        => 'custom',
             'custom_frontend' => [
-                'class' => 'Mautic\AssetBundle\Controller\UploadController',
+                'class' => Mautic\AssetBundle\Controller\UploadController::class,
                 'name'  => 'mautic',
             ],
             // 'max_size' => ($maxSize * 1000000),

--- a/app/config/security_api.php
+++ b/app/config/security_api.php
@@ -2,10 +2,10 @@
 
 $container->loadFromExtension('fos_oauth_server', [
     'db_driver'           => 'orm',
-    'client_class'        => 'Mautic\ApiBundle\Entity\oAuth2\Client',
-    'access_token_class'  => 'Mautic\ApiBundle\Entity\oAuth2\AccessToken',
-    'refresh_token_class' => 'Mautic\ApiBundle\Entity\oAuth2\RefreshToken',
-    'auth_code_class'     => 'Mautic\ApiBundle\Entity\oAuth2\AuthCode',
+    'client_class'        => Mautic\ApiBundle\Entity\oAuth2\Client::class,
+    'access_token_class'  => Mautic\ApiBundle\Entity\oAuth2\AccessToken::class,
+    'refresh_token_class' => Mautic\ApiBundle\Entity\oAuth2\RefreshToken::class,
+    'auth_code_class'     => Mautic\ApiBundle\Entity\oAuth2\AuthCode::class,
     'service'             => [
         'user_provider' => 'mautic.user.provider',
         'options'       => [


### PR DESCRIPTION
**Void return types** on methods whose every path returns nothing:

```diff
-    protected function lookup()
+    protected function lookup(): void
     {
         $url = $this->getUrl();
```

**Class constant instead of a class-name string**, so the reference is checked and refactorable:

```diff
-    'client_class'        => 'Mautic\ApiBundle\Entity\oAuth2\Client',
-    'access_token_class'  => 'Mautic\ApiBundle\Entity\oAuth2\AccessToken',
+    'client_class'        => Mautic\ApiBundle\Entity\oAuth2\Client::class,
+    'access_token_class'  => Mautic\ApiBundle\Entity\oAuth2\AccessToken::class,
```
