### PR TITLE
[phpunit 12] Add Rector rule for missing ->expects() call that are required for mocks

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -30,6 +30,7 @@ return RectorConfig::configure()
         Rector\Instanceof_\Rector\Ternary\FlipNegatedTernaryInstanceofRector::class,
         Rector\TypeDeclarationDocblocks\Rector\ClassMethod\NarrowArrayCollectionUnionReturnDocblockRector::class,
         UnserializeToSerializerDecodeRector::class,
+        Utils\Rector\AddExpectsOnceToMockMethodCallRector::class,
 
         // DI
         Utils\Rector\ModelGetRepositoryToRepositoryServiceRector::class,
@@ -45,6 +46,9 @@ return RectorConfig::configure()
 
         // handle next
         Rector\PHPUnit\PHPUnit120\Rector\Class_\AllowMockObjectsWithoutExpectationsAttributeRector::class,
+
+        // applied in a follow-up pull request
+        Utils\Rector\AddExpectsOnceToMockMethodCallRector::class,
 
         Rector\Symfony\CodeQuality\Rector\Class_\LoadValidatorMetadataToAttributeRector::class,
         Utils\Rector\ModelGetRepositoryToRepositoryServiceRector::class => [

--- a/utils/rector/src/AddExpectsOnceToMockMethodCallRector.php
+++ b/utils/rector/src/AddExpectsOnceToMockMethodCallRector.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\Rector;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\Variable;
+use PHPStan\Type\ObjectType;
+use Rector\Rector\AbstractRector;
+
+/**
+ * Makes an expectation-less mock method configuration explicit about how often it is called.
+ *
+ *   $queueMock->method('getPayload')->willReturn('...')
+ *   ->
+ *   $queueMock->expects($this->once())->method('getPayload')->willReturn('...')
+ *
+ * A bare method() only stubs a return value and never fails, so a test keeps passing after the
+ * production code stops calling the method - or starts calling it in a loop. Adding expects()
+ * turns the stub into a verified expectation.
+ *
+ * Left alone:
+ *   - calls that already carry an expects(), e.g. $mock->expects($this->never())->method('run')
+ *   - method() on anything that is not a MockObject
+ */
+final class AddExpectsOnceToMockMethodCallRector extends AbstractRector
+{
+    private const MOCK_OBJECT = 'PHPUnit\Framework\MockObject\MockObject';
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        if (!$node instanceof MethodCall) {
+            return null;
+        }
+
+        if (!$this->isName($node->name, 'method')) {
+            return null;
+        }
+
+        // $mock->expects(...)->method(...) is already explicit
+        if ($node->var instanceof MethodCall && $this->isName($node->var->name, 'expects')) {
+            return null;
+        }
+
+        // method() is also defined on the InvocationMocker returned by expects(), so the mock type
+        // check is what separates a bare stub from an already configured expectation
+        if (!$this->isObjectType($node->var, new ObjectType(self::MOCK_OBJECT))) {
+            return null;
+        }
+
+        $onceCall = new MethodCall(new Variable('this'), 'once');
+
+        $node->var = new MethodCall($node->var, 'expects', [new Arg($onceCall)]);
+
+        return $node;
+    }
+}

--- a/utils/rector/tests/AddExpectsOnceToMockMethodCallRector/AddExpectsOnceToMockMethodCallRectorTest.php
+++ b/utils/rector/tests/AddExpectsOnceToMockMethodCallRector/AddExpectsOnceToMockMethodCallRectorTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\Rector\Tests\AddExpectsOnceToMockMethodCallRector;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AddExpectsOnceToMockMethodCallRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__.'/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__.'/config/configured_rule.php';
+    }
+}

--- a/utils/rector/tests/AddExpectsOnceToMockMethodCallRector/Fixture/mock_method_without_expects.php.inc
+++ b/utils/rector/tests/AddExpectsOnceToMockMethodCallRector/Fixture/mock_method_without_expects.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Utils\Rector\Tests\AddExpectsOnceToMockMethodCallRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+class MockMethodWithoutExpects extends TestCase
+{
+    public function testPayload()
+    {
+        $queueMock = $this->createMock(\stdClass::class);
+        $queueMock->method('getPayload')->willReturn('{"the": "payload"}');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Utils\Rector\Tests\AddExpectsOnceToMockMethodCallRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+class MockMethodWithoutExpects extends TestCase
+{
+    public function testPayload()
+    {
+        $queueMock = $this->createMock(\stdClass::class);
+        $queueMock->expects($this->once())->method('getPayload')->willReturn('{"the": "payload"}');
+    }
+}
+
+?>

--- a/utils/rector/tests/AddExpectsOnceToMockMethodCallRector/Fixture/skip_existing_expects.php.inc
+++ b/utils/rector/tests/AddExpectsOnceToMockMethodCallRector/Fixture/skip_existing_expects.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Utils\Rector\Tests\AddExpectsOnceToMockMethodCallRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+class SkipExistingExpects extends TestCase
+{
+    public function testPayload()
+    {
+        $queueMock = $this->createMock(\stdClass::class);
+        $queueMock->expects($this->never())->method('getPayload');
+    }
+}

--- a/utils/rector/tests/AddExpectsOnceToMockMethodCallRector/Fixture/skip_non_mock_object.php.inc
+++ b/utils/rector/tests/AddExpectsOnceToMockMethodCallRector/Fixture/skip_non_mock_object.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Utils\Rector\Tests\AddExpectsOnceToMockMethodCallRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+class SomeReflectionLikeClass
+{
+    public function method(string $name)
+    {
+    }
+}
+
+class SkipNonMockObject extends TestCase
+{
+    public function testPayload()
+    {
+        $someObject = new SomeReflectionLikeClass();
+        $someObject->method('getPayload');
+    }
+}

--- a/utils/rector/tests/AddExpectsOnceToMockMethodCallRector/config/configured_rule.php
+++ b/utils/rector/tests/AddExpectsOnceToMockMethodCallRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Utils\Rector\AddExpectsOnceToMockMethodCallRector;
+
+return RectorConfig::configure()
+    ->withRules([AddExpectsOnceToMockMethodCallRector::class]);


### PR DESCRIPTION
A bare `$mock->method('x')` only stubs a return value - it never fails. A test keeps passing after the production code stops calling the method, or starts calling it in a loop.

This rule turns such a stub into a verified expectation:

```diff
-$queueMock->method('getPayload')
+$queueMock->expects($this->once())->method('getPayload')
     ->willReturn('...');
```

Left alone:

* calls that already carry an `expects()`, e.g. `$mock->expects($this->never())->method('run')`
* `method()` on anything that is not a `MockObject` (e.g. the `InvocationMocker` returned by `expects()`)

The rule is registered in `rector.php`, but skipped there for now, so this pull request adds only the rule + tests. The code changes it produces land in a follow-up pull request.
