### PR TITLE
[phpunit] Verify how often mocked methods are called in unit tests

### DIFF
--- a/app/bundles/CoreBundle/Tests/Unit/Command/MaxMindDoNotSellPurgeCommandTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Command/MaxMindDoNotSellPurgeCommandTest.php
@@ -99,14 +99,14 @@ final class MaxMindDoNotSellPurgeCommandTest extends TestCase
     {
         $mockStatement = $this->createMock(Statement::class);
         $resultMock    = $this->createMock(Result::class);
-        $mockStatement->method('executeQuery')->withAnyParameters()->willReturn($resultMock);
-        $resultMock->method('fetchAllAssociative')->withAnyParameters()->willReturn($dataToReturn);
+        $mockStatement->expects($this->once())->method('executeQuery')->withAnyParameters()->willReturn($resultMock);
+        $resultMock->expects($this->once())->method('fetchAllAssociative')->withAnyParameters()->willReturn($dataToReturn);
 
         $mockConnection = $this->createMock(Connection::class);
-        $mockConnection->method('prepare')->withAnyParameters()->willReturn($mockStatement);
+        $mockConnection->expects($this->once())->method('prepare')->withAnyParameters()->willReturn($mockStatement);
 
         $mockEntityManager = $this->createMock(EntityManager::class);
-        $mockEntityManager->method('getConnection')->willReturn($mockConnection);
+        $mockEntityManager->expects($this->once())->method('getConnection')->willReturn($mockConnection);
 
         return $mockEntityManager;
     }

--- a/app/bundles/CoreBundle/Tests/Unit/Command/ModeratedCommandTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Command/ModeratedCommandTest.php
@@ -71,7 +71,7 @@ final class ModeratedCommandTest extends TestCase
             ->with('cache')
             ->willReturn('/does/not/exist');
 
-        $this->input->method('getOption')
+        $this->input->expects($this->exactly(4))->method('getOption')
             ->willReturnCallback(
                 fn (string $name): ?string => match ($name) {
                     'lock_mode' => ModeratedCommand::MODE_FLOCK,
@@ -87,7 +87,7 @@ final class ModeratedCommandTest extends TestCase
         $this->pathsHelper->expects($this->never())
             ->method('getSystemPath');
 
-        $this->input->method('getOption')
+        $this->input->expects($this->once())->method('getOption')
             ->willReturnCallback(
                 fn (string $name): string|true|null => match ($name) {
                     'lock_mode'      => ModeratedCommand::MODE_FLOCK,
@@ -104,7 +104,7 @@ final class ModeratedCommandTest extends TestCase
         $this->pathsHelper->expects($this->never())
             ->method('getSystemPath');
 
-        $this->input->method('getOption')
+        $this->input->expects($this->exactly(2))->method('getOption')
             ->willReturnCallback(
                 fn (string $name): bool|string|null => match ($name) {
                     'lock_mode'      => ModeratedCommand::MODE_FLOCK,
@@ -130,7 +130,7 @@ final class ModeratedCommandTest extends TestCase
             ->with('cache')
             ->willReturn($cacheDir);
 
-        $this->input->method('getOption')
+        $this->input->expects($this->exactly(4))->method('getOption')
             ->willReturnCallback(
                 fn (string $name): string|false|null => match ($name) {
                     'lock_mode'      => ModeratedCommand::MODE_PID,
@@ -176,7 +176,7 @@ final class ModeratedCommandTest extends TestCase
             ->with('cache')
             ->willReturn($cacheDir);
 
-        $this->input->method('getOption')
+        $this->input->expects($this->exactly(4))->method('getOption')
             ->willReturnCallback(
                 fn (string $name): string|false|null => match ($name) {
                     'lock_mode'      => ModeratedCommand::MODE_FLOCK,
@@ -227,7 +227,7 @@ final class ModeratedCommandTest extends TestCase
             ->method('get')
             ->willReturn(['dsn' => '']);
 
-        $this->input->method('getOption')
+        $this->input->expects($this->exactly(4))->method('getOption')
             ->willReturnCallback(
                 fn (string $name): string|false|null => match ($name) {
                     'lock_mode'      => ModeratedCommand::MODE_REDIS,

--- a/app/bundles/CoreBundle/Tests/Unit/Controller/AbstractFormControllerTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Controller/AbstractFormControllerTest.php
@@ -48,7 +48,7 @@ final class AbstractFormControllerTest extends \PHPUnit\Framework\TestCase
     {
         $this->prepareRequestStack(['company' => null]);
 
-        $this->formMock->method('getName')
+        $this->formMock->expects($this->once())->method('getName')
             ->willReturn('company');
         $isFormCancelled = $this->invokeIsFormCancelled($this->formMock);
         $this->assertFalse($isFormCancelled);
@@ -61,7 +61,7 @@ final class AbstractFormControllerTest extends \PHPUnit\Framework\TestCase
     {
         $this->prepareRequestStack(['company_merge' => ['buttons' => ['cancel' => null]]]);
 
-        $this->formMock->method('getName')
+        $this->formMock->expects($this->once())->method('getName')
             ->willReturn('company_merge');
         $isFormCancelled = $this->invokeIsFormCancelled($this->formMock);
         $this->assertTrue($isFormCancelled);
@@ -74,7 +74,7 @@ final class AbstractFormControllerTest extends \PHPUnit\Framework\TestCase
     {
         $this->prepareRequestStack(['company_merge' => ['buttons' => ['submit' => null]]]);
 
-        $this->formMock->method('getName')
+        $this->formMock->expects($this->once())->method('getName')
             ->willReturn('company_merge');
         $isFormCancelled = $this->invokeIsFormCancelled($this->formMock);
         $this->assertFalse($isFormCancelled);

--- a/app/bundles/CoreBundle/Tests/Unit/EventListener/DoctrineGeneratedColumnsListenerTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/EventListener/DoctrineGeneratedColumnsListenerTest.php
@@ -47,8 +47,8 @@ final class DoctrineGeneratedColumnsListenerTest extends \PHPUnit\Framework\Test
 
         $generatedColumns->add($generatedColumn);
 
-        $generatedColumnsProvider->method('getGeneratedColumns')->willReturn($generatedColumns);
-        $this->event->method('getSchema')->willReturn($this->schema);
+        $generatedColumnsProvider->expects($this->once())->method('getGeneratedColumns')->willReturn($generatedColumns);
+        $this->event->expects($this->once())->method('getSchema')->willReturn($this->schema);
     }
 
     public function testPostGenerateSchemaWhenTableDoesNotExist(): void

--- a/app/bundles/CoreBundle/Tests/Unit/EventListener/RequestSubscriberTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/EventListener/RequestSubscriberTest.php
@@ -47,7 +47,7 @@ final class RequestSubscriberTest extends \PHPUnit\Framework\TestCase
                 HttpKernelInterface::MAIN_REQUEST,
             ])->getMock();
 
-        $this->event->method('getRequest')->willReturn($this->request);
+        $this->event->expects($this->once())->method('getRequest')->willReturn($this->request);
 
         $this->subscriber = new RequestSubscriber(
             $csrfTokenManagerMock,

--- a/app/bundles/CoreBundle/Tests/Unit/Form/Type/ConfigTypeTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Form/Type/ConfigTypeTest.php
@@ -141,7 +141,7 @@ final class ConfigTypeTest extends TypeTestCase
         $configType = $this->getConfigFormType();
 
         $repoMock = $this->createMock(PageRepository::class);
-        $repoMock
+        $repoMock->expects($this->exactly(2))
                  ->method('getPageList')
                  ->willReturn([]);
 

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/FileUploaderTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/FileUploaderTest.php
@@ -90,7 +90,7 @@ final class FileUploaderTest extends \PHPUnit\Framework\TestCase
 
         $translatorMock = $this->createMock(Translator::class);
 
-        $translatorMock->method('trans')
+        $translatorMock->expects($this->once())->method('trans')
             ->willReturn('Could not upload filed');
 
         $fileMock = $this->createMock(UploadedFile::class);

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/ImportHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/ImportHelperTest.php
@@ -43,7 +43,7 @@ final class ImportHelperTest extends TestCase
         $pathsHelper       = $this->createMock(PathsHelper::class);
 
         $testTempDir = $systemTempDirBase.'/tmp';
-        $pathsHelper->method('getTemporaryPath')->willReturn($testTempDir);
+        $pathsHelper->expects($this->once())->method('getTemporaryPath')->willReturn($testTempDir);
         $filesystem->mkdir($testTempDir);
 
         $mediaDir = $systemTempDirBase.'/media';

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/IpLookupHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/IpLookupHelperTest.php
@@ -39,7 +39,7 @@ final class IpLookupHelperTest extends \PHPUnit\Framework\TestCase
     {
         $request = new Request([], [], [], [], [], ['REMOTE_ADDR' => '73.77.245.52']);
 
-        $this->deviceDetector
+        $this->deviceDetector->expects($this->once())
             ->method('isBot')
             ->willReturn(true);
 
@@ -51,7 +51,7 @@ final class IpLookupHelperTest extends \PHPUnit\Framework\TestCase
     {
         $request = new Request([], [], [], [], [], ['REMOTE_ADDR' => '73.77.245.53']);
 
-        $this->deviceDetector
+        $this->deviceDetector->expects($this->once())
             ->method('isBot')
             ->willReturn(false);
 

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/LanguageHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/LanguageHelperTest.php
@@ -120,7 +120,7 @@ final class LanguageHelperTest extends TestCase
         $langFile  = $this->tmpPath.'/../languageList.txt';
         file_put_contents($langFile, json_encode($languages));
 
-        $this->coreParametersHelper->method('get')
+        $this->coreParametersHelper->expects($this->once())->method('get')
             ->with('translations_fetch_url')
             ->willReturn('https://languages.test/');
 

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/PageHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/PageHelperTest.php
@@ -24,7 +24,7 @@ final class PageHelperTest extends \PHPUnit\Framework\TestCase
         $requestStack               = $this->createMock(RequestStack::class);
         $this->pageHelper           = new PageHelper($requestStack, $this->createStub(CoreParametersHelper::class), 'mautic.test', 0);
 
-        $requestStack->method('getSession')->willReturn($this->session);
+        $requestStack->expects($this->once())->method('getSession')->willReturn($this->session);
     }
 
     #[DataProvider('PageProvider')]

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/PathsHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/PathsHelperTest.php
@@ -30,7 +30,7 @@ final class PathsHelperTest extends TestCase
     protected function setUp(): void
     {
         $this->coreParametersHelper = $this->createMock(CoreParametersHelper::class);
-        $this->coreParametersHelper->method('get')
+        $this->coreParametersHelper->expects($this->exactly(7))->method('get')
             ->willReturnCallback(
                 fn (string $key): string => match ($key) {
                     'image_path' => 'media/images',
@@ -103,7 +103,7 @@ final class PathsHelperTest extends TestCase
         $campaignImportPath = __DIR__.'/resource/paths/import/campaigns';
 
         $this->coreParametersHelper = $this->createMock(CoreParametersHelper::class);
-        $this->coreParametersHelper->method('get')
+        $this->coreParametersHelper->expects($this->exactly(7))->method('get')
             ->willReturnCallback(
                 fn (string $key): string => match ($key) {
                     'import_campaigns_dir' => $campaignImportPath,
@@ -127,7 +127,7 @@ final class PathsHelperTest extends TestCase
 
         /** @var CoreParametersHelper&MockObject $coreParametersHelper */
         $coreParametersHelper = $this->createMock(CoreParametersHelper::class);
-        $coreParametersHelper->method('get')
+        $coreParametersHelper->expects($this->exactly(7))->method('get')
             ->willReturnCallback(
                 fn (string $key): string => match ($key) {
                     'tmp_path' => $tempPath,
@@ -155,14 +155,14 @@ final class PathsHelperTest extends TestCase
         /** @var UserHelper&MockObject $userHelper */
         $userHelper           = $this->createMock(UserHelper::class);
         $user                 = $this->createMock(User::class);
-        $user->method('getId')
+        $user->expects($this->once())->method('getId')
             ->willReturn(1);
-        $userHelper->method('getUser')
+        $userHelper->expects($this->once())->method('getUser')
             ->willReturn($user);
 
         /** @var CoreParametersHelper&MockObject $coreParametersHelper */
         $coreParametersHelper = $this->createMock(CoreParametersHelper::class);
-        $coreParametersHelper->method('get')
+        $coreParametersHelper->expects($this->exactly(7))->method('get')
             ->willReturnCallback(
                 fn (string $key): string => match ($key) {
                     'dashboard_import_dir' => $dashboardDir,

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/ThemeHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/ThemeHelperTest.php
@@ -92,7 +92,7 @@ final class ThemeHelperTest extends TestCase
     {
         $this->expectException(FileNotFoundException::class);
 
-        $this->pathsHelper->method('getSystemPath')
+        $this->pathsHelper->expects($this->once())->method('getSystemPath')
             ->with('themes', true)
             ->willReturn(__DIR__.'/resource/themes');
 
@@ -112,7 +112,7 @@ final class ThemeHelperTest extends TestCase
     {
         $this->expectException(FileNotFoundException::class);
 
-        $this->pathsHelper->method('getSystemPath')
+        $this->pathsHelper->expects($this->once())->method('getSystemPath')
             ->with('themes', true)
             ->willReturn(__DIR__.'/resource/themes');
 
@@ -132,7 +132,7 @@ final class ThemeHelperTest extends TestCase
     {
         $this->expectException(FileNotFoundException::class);
 
-        $this->pathsHelper->method('getSystemPath')
+        $this->pathsHelper->expects($this->once())->method('getSystemPath')
             ->with('themes', true)
             ->willReturn(__DIR__.'/resource/themes');
 
@@ -153,7 +153,7 @@ final class ThemeHelperTest extends TestCase
         $fs = new Filesystem();
         $fs->copy(__DIR__.'/resource/themes/good.zip', __DIR__.'/resource/themes/good-tmp.zip');
 
-        $this->pathsHelper->method('getSystemPath')
+        $this->pathsHelper->expects($this->once())->method('getSystemPath')
             ->with('themes', true)
             ->willReturn(__DIR__.'/resource/themes');
 
@@ -177,7 +177,7 @@ final class ThemeHelperTest extends TestCase
                 true, // default themes twig exists
             );
 
-        $this->pathsHelper->method('getSystemPath')
+        $this->pathsHelper->expects($this->exactly(46))->method('getSystemPath')
             ->willReturnCallback(
                 function ($path, $absolute) {
                     switch ($path) {
@@ -212,7 +212,7 @@ final class ThemeHelperTest extends TestCase
                 true
             );
 
-        $this->pathsHelper->method('getSystemPath')
+        $this->pathsHelper->expects($this->exactly(46))->method('getSystemPath')
             ->willReturnCallback(
                 function ($path, $absolute) {
                     switch ($path) {
@@ -404,10 +404,10 @@ final class ThemeHelperTest extends TestCase
 
     public function testLegacyThemesAreReturnedForFeatureIfNoCustomBuilderIsEnabled(): void
     {
-        $this->builderIntegrationsHelper->method('getBuilder')
+        $this->builderIntegrationsHelper->expects($this->exactly(6))->method('getBuilder')
             ->willThrowException(new IntegrationNotFoundException());
 
-        $this->pathsHelper->method('getSystemPath')
+        $this->pathsHelper->expects($this->exactly(4))->method('getSystemPath')
             ->willReturn(__DIR__.'/resource/themes');
 
         $themes = $this->themeHelper->getInstalledThemes('email');
@@ -423,7 +423,7 @@ final class ThemeHelperTest extends TestCase
     public function testCustomThemesAreReturnedForFeatureIfCustomBuilderIsEnabled(): void
     {
         $mockBuilder = $this->createMock(BuilderInterface::class);
-        $mockBuilder->method('getName')
+        $mockBuilder->expects($this->exactly(6))->method('getName')
             ->willReturn('custom');
 
         $integration = new Integration();
@@ -434,7 +434,7 @@ final class ThemeHelperTest extends TestCase
         $this->builderIntegrationsHelper->method('getBuilder')
             ->willReturn($mockBuilder);
 
-        $this->pathsHelper->method('getSystemPath')
+        $this->pathsHelper->expects($this->exactly(4))->method('getSystemPath')
             ->willReturn(__DIR__.'/resource/themes');
 
         $themes = $this->themeHelper->getInstalledThemes('page');
@@ -449,7 +449,7 @@ final class ThemeHelperTest extends TestCase
 
     public function testAllThemesAreReturned(): void
     {
-        $this->pathsHelper->method('getSystemPath')
+        $this->pathsHelper->expects($this->exactly(5))->method('getSystemPath')
             ->willReturn(__DIR__.'/resource/themes');
 
         $themes = $this->themeHelper->getInstalledThemes();
@@ -463,7 +463,7 @@ final class ThemeHelperTest extends TestCase
 
     public function testExtendedThemeDetailsAreReturned(): void
     {
-        $this->pathsHelper->method('getSystemPath')
+        $this->pathsHelper->expects($this->exactly(5))->method('getSystemPath')
             ->willReturn(__DIR__.'/resource/themes');
 
         $themes = $this->themeHelper->getInstalledThemes('all', true);
@@ -474,7 +474,7 @@ final class ThemeHelperTest extends TestCase
 
     public function testExtendedThemeDetailsWithoutDirectoriesAreReturned(): void
     {
-        $this->pathsHelper->method('getSystemPath')
+        $this->pathsHelper->expects($this->once())->method('getSystemPath')
             ->willReturn(__DIR__.'/resource/themes');
 
         $themes = $this->themeHelper->getInstalledThemes('all', true, false, false);
@@ -485,7 +485,7 @@ final class ThemeHelperTest extends TestCase
 
     public function testCachedThemesReturnAsExpected(): void
     {
-        $this->builderIntegrationsHelper->method('getBuilder')
+        $this->builderIntegrationsHelper->expects($this->exactly(6))->method('getBuilder')
             ->willThrowException(new IntegrationNotFoundException());
         $matcher = $this->exactly(2);
 
@@ -528,7 +528,7 @@ final class ThemeHelperTest extends TestCase
 
     public function testGetCurrentThemeWillReturnCodeModeIfTheThemeIsCodeMode(): void
     {
-        $this->pathsHelper->method('getSystemPath')
+        $this->pathsHelper->expects($this->once())->method('getSystemPath')
             ->willReturn(__DIR__.'/resource/themes');
 
         $this->assertTrue($this->themeHelper->exists('theme-legacy-email'));
@@ -536,7 +536,7 @@ final class ThemeHelperTest extends TestCase
 
     public function testExistsReturnsFalseIfThemeDoesNotExist(): void
     {
-        $this->pathsHelper->method('getSystemPath')
+        $this->pathsHelper->expects($this->once())->method('getSystemPath')
             ->willReturn(__DIR__.'/resource/themes');
 
         $this->assertFalse($this->themeHelper->exists('theme-legacy-email-foo'));
@@ -544,14 +544,14 @@ final class ThemeHelperTest extends TestCase
 
     public function testDefaultThemeNotShouldNotGetRemoved(): void
     {
-        $this->pathsHelper->method('getSystemPath')
+        $this->pathsHelper->expects($this->exactly(7))->method('getSystemPath')
             ->willReturn(__DIR__.'/resource/themes');
 
         $filesystem = $this->createMock(Filesystem::class);
         $filesystem->expects($this->exactly(5))
             ->method('exists')->willReturn(true);
 
-        $filesystem->method('readFile')->willReturn('{"name": "Test Theme"}');
+        $filesystem->expects($this->exactly(4))->method('readFile')->willReturn('{"name": "Test Theme"}');
 
         $themeHelper = new ThemeHelper(
             $this->pathsHelper,
@@ -570,7 +570,7 @@ final class ThemeHelperTest extends TestCase
 
     public function testDeleteThemeThrowsExceptionIfThemeDoesNotExist(): void
     {
-        $this->pathsHelper->method('getSystemPath')
+        $this->pathsHelper->expects($this->exactly(6))->method('getSystemPath')
             ->willReturn(__DIR__.'/resource/themes');
 
         $this->expectException(FileNotFoundException::class);

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/TokenSorterTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/TokenSorterTest.php
@@ -15,7 +15,7 @@ final class TokenSorterTest extends TestCase
     protected function setUp(): void
     {
         $translator = $this->createMock(TranslatorInterface::class);
-        $translator->method('trans')
+        $translator->expects($this->exactly(2))->method('trans')
             ->willReturnCallback(fn (string $key): string => match ($key) {
                 'mautic.page.token.thispage' => 'This page',
                 'mautic.email.email'         => 'Email',

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/TrailingSlashHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/TrailingSlashHelperTest.php
@@ -18,7 +18,7 @@ final class TrailingSlashHelperTest extends \PHPUnit\Framework\TestCase
     protected function setUp(): void
     {
         $this->coreParametersHelper = $this->createMock(CoreParametersHelper::class);
-        $this->coreParametersHelper->method('get')
+        $this->coreParametersHelper->expects($this->once())->method('get')
             ->with('site_url')
             ->willReturn('https://test.com');
     }

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/UpdateHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/UpdateHelperTest.php
@@ -430,7 +430,7 @@ final class UpdateHelperTest extends TestCase
 
     public function testRequestExceptionDoesNotGoUncaughtWhenThrownDuringUpdatingStats(): void
     {
-        $this->response->method('getStatusCode')->willReturn(200);
+        $this->response->expects($this->exactly(2))->method('getStatusCode')->willReturn(200);
 
         $cache = [
             'error'        => false,
@@ -676,7 +676,7 @@ final class UpdateHelperTest extends TestCase
 
     public function testErrorIfGuzzleException(): void
     {
-        $this->response->method('getStatusCode')->willReturn(200);
+        $this->response->expects($this->exactly(2))->method('getStatusCode')->willReturn(200);
 
         $cache = [
             'error'        => false,
@@ -920,7 +920,7 @@ final class UpdateHelperTest extends TestCase
 
         file_put_contents(__DIR__.'/resource/update/tmp/lastUpdateCheck.txt', json_encode($cache));
 
-        $this->coreParametersHelper->expects($this->once())
+        $this->coreParametersHelper
             ->method('get')
             ->with('update_stability')
             ->willReturn('stable');

--- a/app/bundles/CoreBundle/Tests/Unit/IpLookup/MaxMindDoNotSellListTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/IpLookup/MaxMindDoNotSellListTest.php
@@ -67,7 +67,7 @@ final class MaxMindDoNotSellListTest extends \PHPUnit\Framework\TestCase
      */
     public function testListPathNotConfigured(): void
     {
-        $this->coreParamsHelperMock->method('get')
+        $this->coreParamsHelperMock->expects($this->once())->method('get')
             ->with('maxmind_do_not_sell_list_path')
             ->willReturn('');
 
@@ -82,7 +82,7 @@ final class MaxMindDoNotSellListTest extends \PHPUnit\Framework\TestCase
      */
     public function testListFileNotDownloaded(): void
     {
-        $this->coreParamsHelperMock->method('get')
+        $this->coreParamsHelperMock->expects($this->once())->method('get')
             ->with('maxmind_do_not_sell_list_path')
             ->willReturn('path_to_missing_file.json');
 
@@ -97,7 +97,7 @@ final class MaxMindDoNotSellListTest extends \PHPUnit\Framework\TestCase
      */
     public function testFileWithBadData(): void
     {
-        $this->coreParamsHelperMock->method('get')
+        $this->coreParamsHelperMock->expects($this->once())->method('get')
             ->with('maxmind_do_not_sell_list_path')
             ->willReturn($this->badFilePath);
 
@@ -113,7 +113,7 @@ final class MaxMindDoNotSellListTest extends \PHPUnit\Framework\TestCase
      */
     public function testSuccessfulFileLoad(): void
     {
-        $this->coreParamsHelperMock->method('get')
+        $this->coreParamsHelperMock->expects($this->once())->method('get')
             ->with('maxmind_do_not_sell_list_path')
             ->willReturn($this->goodFilePath);
 

--- a/app/bundles/CoreBundle/Tests/Unit/IpLookup/MaxmindLookupTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/IpLookup/MaxmindLookupTest.php
@@ -160,7 +160,7 @@ final class MaxmindLookupTest extends \PHPUnit\Framework\TestCase
 }
 RESPONSE);
 
-        $this->mockHttp->expects($this->once())
+        $this->mockHttp
             ->method('get')
             ->willReturn($mockResponse);
     }
@@ -171,7 +171,7 @@ RESPONSE);
             ->setConstructorArgs(['test', null, $this->cacheDir, null, $this->mockHttp, $this->mockCoreParamsHelper])
             ->onlyMethods(['shouldPerformLookup'])
             ->getMock();
-        $ipService->method('shouldPerformLookup')->willReturn(true);
+        $ipService->expects($this->once())->method('shouldPerformLookup')->willReturn(true);
 
         $details = $ipService->setIpAddress('1.2.3.4')->getDetails();
 
@@ -184,7 +184,7 @@ RESPONSE);
             ->setConstructorArgs(['test', null, $this->cacheDir, null, $this->mockHttp, $this->mockCoreParamsHelper])
             ->onlyMethods(['shouldPerformLookup'])
             ->getMock();
-        $ipService->method('shouldPerformLookup')->willReturn(true);
+        $ipService->expects($this->once())->method('shouldPerformLookup')->willReturn(true);
 
         $details = $ipService->setIpAddress('1.2.3.4')->getDetails();
 
@@ -197,7 +197,7 @@ RESPONSE);
             ->setConstructorArgs(['test', null, $this->cacheDir, null, $this->mockHttp, $this->mockCoreParamsHelper])
             ->onlyMethods(['shouldPerformLookup'])
             ->getMock();
-        $ipService->method('shouldPerformLookup')->willReturn(true);
+        $ipService->expects($this->once())->method('shouldPerformLookup')->willReturn(true);
 
         $details = $ipService->setIpAddress('1.2.3.4')->getDetails();
 

--- a/app/bundles/CoreBundle/Tests/Unit/Model/FormModelTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Model/FormModelTest.php
@@ -56,7 +56,7 @@ final class FormModelTest extends TestCase
             ->method('getUser')
             ->willReturn(new User());
 
-        $this->entityManagerMock
+        $this->entityManagerMock->expects($this->once())
             ->method('getRepository')
             ->willReturn($this->createStub(FormRepository::class));
 

--- a/app/bundles/CoreBundle/Tests/Unit/Monolog/Handler/FileLogHandlerTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Monolog/Handler/FileLogHandlerTest.php
@@ -25,7 +25,7 @@ final class FileLogHandlerTest extends TestCase
 
     public function testPropertiesAreSetFromCoreParametersHelperWhenDebugModeEnabled(): void
     {
-        $this->coreParametersHelper->method('get')
+        $this->coreParametersHelper->expects($this->exactly(4))->method('get')
             ->willReturnCallback(
                 function ($key) {
                     switch ($key) {
@@ -55,7 +55,7 @@ final class FileLogHandlerTest extends TestCase
 
     public function testPropertiesAreSetFromCoreParametersHelperWhenDebugModeDisabled(): void
     {
-        $this->coreParametersHelper->method('get')
+        $this->coreParametersHelper->expects($this->exactly(4))->method('get')
             ->willReturnCallback(
                 function ($key) {
                     switch ($key) {

--- a/app/bundles/CoreBundle/Tests/Unit/Security/Permissions/CorePermissionsTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Security/Permissions/CorePermissionsTest.php
@@ -44,7 +44,7 @@ final class CorePermissionsTest extends \PHPUnit\Framework\TestCase
 
     public function testSettingPermissionObject(): void
     {
-        $this->coreParametersHelper->method('all')
+        $this->coreParametersHelper->expects($this->exactly(4))->method('all')
             ->willReturn(['parameter_a' => 'value_a']);
 
         $assetPermissions = new AssetPermissions($this->coreParametersHelper);

--- a/app/bundles/CoreBundle/Tests/Unit/Twig/Helper/AssetsHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Twig/Helper/AssetsHelperTest.php
@@ -29,7 +29,7 @@ final class AssetsHelperTest extends TestCase
 
     public function testAssetContext(): void
     {
-        $this->pathsHelper->method('getSystemPath')
+        $this->pathsHelper->expects($this->once())->method('getSystemPath')
             ->willReturn('');
 
         $this->assetHelper->addStylesheet('/app.css');

--- a/app/bundles/CoreBundle/Tests/Unit/Twig/Helper/DateHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Twig/Helper/DateHelperTest.php
@@ -195,7 +195,7 @@ final class DateHelperTest extends \PHPUnit\Framework\TestCase
             ->method('getTextDate')
             ->willReturn(false);
         // Mock toLocalString() which is called by format() when getTextDate returns false
-        $dateTimeHelperMock->method('toLocalString')
+        $dateTimeHelperMock->expects($this->once())->method('toLocalString')
             ->willReturn('December 31, 2023');
 
         // Inject the mock DateTimeHelper into DateHelper

--- a/app/bundles/CoreBundle/Tests/Unit/Update/Step/FinalizeUpdateStepTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Update/Step/FinalizeUpdateStepTest.php
@@ -49,10 +49,10 @@ final class FinalizeUpdateStepTest extends AbstractStepTestCase
         $this->appVersion   = $this->createMock(AppVersion::class);
         $request            = $this->createMock(Request::class);
 
-        $request->method('hasSession')->willReturn(true);
+        $request->expects($this->once())->method('hasSession')->willReturn(true);
         $request->method('getSession')->willReturn($this->session);
         $requestStack->method('getSession')->willReturn($this->session);
-        $requestStack->method('getCurrentRequest')->willReturn($request);
+        $requestStack->expects($this->once())->method('getCurrentRequest')->willReturn($request);
 
         $this->step = new FinalizeUpdateStep($this->translator, $this->pathsHelper, $requestStack, $this->appVersion);
     }

--- a/app/bundles/CoreBundle/Tests/Unit/Update/Step/InstallNewFilesStepTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Update/Step/InstallNewFilesStepTest.php
@@ -67,7 +67,7 @@ final class InstallNewFilesStepTest extends AbstractStepTestCase
             ->method('getRootPath')
             ->willReturn($resourcePath);
 
-        $this->translator
+        $this->translator->expects($this->exactly(4))
             ->method('trans')
             ->willReturn('');
 
@@ -103,7 +103,7 @@ final class InstallNewFilesStepTest extends AbstractStepTestCase
             ->with('update-package')
             ->willReturn($resourcePath.'/update-test.zip');
 
-        $this->translator
+        $this->translator->expects($this->exactly(3))
             ->method('trans')
             ->willReturn('');
 
@@ -148,7 +148,7 @@ final class InstallNewFilesStepTest extends AbstractStepTestCase
                 ]
             );
 
-        $this->translator
+        $this->translator->expects($this->exactly(5))
             ->method('trans')
             ->willReturn('');
 

--- a/app/bundles/CoreBundle/Tests/Unit/Update/Step/PreUpdateChecksStepTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Update/Step/PreUpdateChecksStepTest.php
@@ -46,7 +46,7 @@ final class PreUpdateChecksStepTest extends AbstractStepTestCase
                 ]
             );
 
-        $this->translator
+        $this->translator->expects($this->exactly(3))
             ->method('trans')
             ->willReturn('Dummy');
 
@@ -65,7 +65,7 @@ final class PreUpdateChecksStepTest extends AbstractStepTestCase
                 ]
             );
 
-        $this->translator
+        $this->translator->expects($this->once())
             ->method('trans')
             ->willReturn('Dummy');
 

--- a/app/bundles/CoreBundle/Tests/Unit/Update/Step/RemoveDeletedFilesStepTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Update/Step/RemoveDeletedFilesStepTest.php
@@ -38,7 +38,7 @@ final class RemoveDeletedFilesStepTest extends AbstractStepTestCase
 
     public function testNothingDoneIfDeletedFileListDoesNotExist(): void
     {
-        $this->pathsHelper->method('getRootPath')
+        $this->pathsHelper->expects($this->once())->method('getRootPath')
             ->willReturn(__DIR__);
 
         $step = $this->getStep();
@@ -56,12 +56,12 @@ final class RemoveDeletedFilesStepTest extends AbstractStepTestCase
 
         $this->assertFileExists($resourcePath.'/delete_me.txt');
 
-        $this->pathsHelper->method('getRootPath')
+        $this->pathsHelper->expects($this->once())->method('getRootPath')
             ->willReturn($resourcePath);
 
         $step = $this->getStep();
 
-        $this->translator
+        $this->translator->expects($this->once())
             ->method('trans')
             ->willReturn('');
 
@@ -78,12 +78,12 @@ final class RemoveDeletedFilesStepTest extends AbstractStepTestCase
 
         $this->assertFileDoesNotExist($resourcePath.'/delete_me.txt');
 
-        $this->pathsHelper->method('getRootPath')
+        $this->pathsHelper->expects($this->once())->method('getRootPath')
             ->willReturn($resourcePath);
 
         $step = $this->getStep();
 
-        $this->translator
+        $this->translator->expects($this->once())
             ->method('trans')
             ->willReturn('');
 

--- a/app/bundles/CoreBundle/Tests/Unit/Update/Step/UpdateSchemaStepTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Update/Step/UpdateSchemaStepTest.php
@@ -102,10 +102,10 @@ final class UpdateSchemaStepTest extends AbstractStepTestCase
     {
         $this->expectException(UpdateFailedException::class);
 
-        $this->migrateCommand->method('run')
+        $this->migrateCommand->expects($this->once())->method('run')
             ->willReturn(1);
 
-        $this->eventDispatcher->method('dispatch')
+        $this->eventDispatcher->expects($this->exactly(2))->method('dispatch')
             ->willReturnCallback(
                 function (ConsoleEvent $event, string $eventName): ConsoleEvent {
                     if ($event instanceof ConsoleCommandEvent) {
@@ -116,7 +116,7 @@ final class UpdateSchemaStepTest extends AbstractStepTestCase
                 }
             );
 
-        $this->translator
+        $this->translator->expects($this->exactly(2))
             ->method('trans')
             ->willReturn('');
 
@@ -125,10 +125,10 @@ final class UpdateSchemaStepTest extends AbstractStepTestCase
 
     public function testExceptionNotThrownIfMigrationsWereSuccessful(): void
     {
-        $this->migrateCommand->method('run')
+        $this->migrateCommand->expects($this->once())->method('run')
             ->willReturn(0);
 
-        $this->eventDispatcher->method('dispatch')
+        $this->eventDispatcher->expects($this->exactly(2))->method('dispatch')
             ->willReturnCallback(
                 function (ConsoleEvent $event, string $eventName): ConsoleEvent {
                     if ($event instanceof ConsoleCommandEvent) {

--- a/app/bundles/CoreBundle/Tests/Unit/Update/Step/UpdateTranslationsStepTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Update/Step/UpdateTranslationsStepTest.php
@@ -71,7 +71,7 @@ final class UpdateTranslationsStepTest extends AbstractStepTestCase
             ->method('error')
             ->with('UPDATE ERROR: there was an error');
 
-        $this->translator
+        $this->translator->expects($this->once())
             ->method('trans')
             ->willReturn('');
 
@@ -98,7 +98,7 @@ final class UpdateTranslationsStepTest extends AbstractStepTestCase
             ->with('es_MX')
             ->willReturn(['error' => false]);
 
-        $this->translator
+        $this->translator->expects($this->once())
             ->method('trans')
             ->willReturn('');
 
@@ -125,7 +125,7 @@ final class UpdateTranslationsStepTest extends AbstractStepTestCase
             ->with('es_MX')
             ->willReturn(['error' => true]);
 
-        $this->translator->method('trans')
+        $this->translator->expects($this->exactly(2))->method('trans')
             ->willReturnCallback(
                 fn (string $key): string => $key
             );

--- a/app/bundles/DynamicContentBundle/Tests/Unit/EventListener/DynamicContentSubscriberTest.php
+++ b/app/bundles/DynamicContentBundle/Tests/Unit/EventListener/DynamicContentSubscriberTest.php
@@ -335,20 +335,20 @@ HTML;
                 ]
             );
 
-        $this->pageTokenHelper
+        $this->pageTokenHelper->expects($this->once())
             ->method('findPageTokens')
             ->willReturn([]);
-        $this->assetTokenHelper
+        $this->assetTokenHelper->expects($this->once())
             ->method('findAssetTokens')
             ->willReturn([]);
-        $this->formTokenHelper
+        $this->formTokenHelper->expects($this->once())
             ->method('findFormTokens')
             ->willReturn([]);
-        $this->focusTokenHelper
+        $this->focusTokenHelper->expects($this->once())
             ->method('findFocusTokens')
             ->willReturn([]);
 
-        $this->trackableModel
+        $this->trackableModel->expects($this->once())
             ->method('parseContentForTrackables')
             ->willReturn([
                 $content,

--- a/app/bundles/DynamicContentBundle/Tests/Unit/Helper/DynamicContentHelperTest.php
+++ b/app/bundles/DynamicContentBundle/Tests/Unit/Helper/DynamicContentHelperTest.php
@@ -112,17 +112,17 @@ final class DynamicContentHelperTest extends \PHPUnit\Framework\TestCase
         $slot->setFilters([['field' => 'unicorn', 'type' => 'text', 'operator' => '=', 'filter' => 'magic']]);
         $slot->setContent('<p>test</p>');
 
-        $this->mockModel->method('getEntities')
+        $this->mockModel->expects($this->once())->method('getEntities')
             ->willReturn([$slot]);
 
-        $this->mockModel->method('getTranslatedEntity')
+        $this->mockModel->expects($this->once())->method('getTranslatedEntity')
             ->willReturn([$slot, $slot]);
 
-        $this->leadModel->method('getEntity')
+        $this->leadModel->expects($this->once())->method('getEntity')
             ->with(123)
             ->willReturn($contact);
 
-        $this->mockDispatcher->method('hasListeners')->willReturn(true);
+        $this->mockDispatcher->expects($this->once())->method('hasListeners')->willReturn(true);
         $matcher = $this->exactly(2);
         $this->mockDispatcher->expects($matcher)
             ->method('dispatch')->willReturnCallback(function (...$parameters) use ($matcher, $contact, $slot): object {
@@ -165,7 +165,7 @@ final class DynamicContentHelperTest extends \PHPUnit\Framework\TestCase
         $slot->setFilters([['field' => 'unicorn', 'type' => 'text', 'operator' => '=', 'filter' => 'magic']]);
         $slot->setContent('<p>test</p>');
 
-        $this->mockModel->method('getEntities')
+        $this->mockModel->expects($this->once())->method('getEntities')
             ->willReturn([$slot]);
 
         $this->mockModel->method('getTranslatedEntity')
@@ -175,7 +175,7 @@ final class DynamicContentHelperTest extends \PHPUnit\Framework\TestCase
             ->with(123)
             ->willReturn($contact);
 
-        $this->mockDispatcher->method('hasListeners')->willReturn(true);
+        $this->mockDispatcher->expects($this->once())->method('hasListeners')->willReturn(true);
         $matcher = $this->once();
         $this->mockDispatcher->expects($matcher)
             ->method('dispatch')
@@ -215,10 +215,10 @@ final class DynamicContentHelperTest extends \PHPUnit\Framework\TestCase
         $slot->setFilters([['field' => 'email', 'type' => 'email', 'operator' => '=', 'filter' => 'ma@ka.t']]);
         $slot->setContent('<p>test</p>');
 
-        $this->mockModel->method('getEntities')
+        $this->mockModel->expects($this->once())->method('getEntities')
             ->willReturn([$slot]);
 
-        $this->mockModel->method('getTranslatedEntity')
+        $this->mockModel->expects($this->once())->method('getTranslatedEntity')
             ->willReturn([$slot, $slot]);
 
         $this->leadModel->method('getEntity')
@@ -259,7 +259,7 @@ final class DynamicContentHelperTest extends \PHPUnit\Framework\TestCase
         $slot->setFilters([['field' => 'email', 'type' => 'email', 'operator' => '=', 'filter' => 'uni@co.rn']]);
         $slot->setContent('<p>test</p>');
 
-        $this->mockModel->method('getEntities')
+        $this->mockModel->expects($this->once())->method('getEntities')
             ->willReturn([$slot]);
 
         $this->mockModel->method('getTranslatedEntity')

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Auth/Provider/Oauth1aTwoLegged/HttpFactoryTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Auth/Provider/Oauth1aTwoLegged/HttpFactoryTest.php
@@ -27,8 +27,8 @@ final class HttpFactoryTest extends TestCase
     public function testGetClientWithFullCredentials(): void
     {
         $credentials = $this->createMock(CredentialsInterface::class);
-        $credentials->method('getConsumerKey')->willReturn('ConsumerKeyValue');
-        $credentials->method('getConsumerSecret')->willReturn('ConsumerSecretValue');
+        $credentials->expects($this->exactly(5))->method('getConsumerKey')->willReturn('ConsumerKeyValue');
+        $credentials->expects($this->exactly(2))->method('getConsumerSecret')->willReturn('ConsumerSecretValue');
         $credentials->method('getToken')->willReturn('TokenValue');
         $credentials->method('getTokenSecret')->willReturn('TokenSecretValue');
         $credentials->method('getAuthUrl')->willReturn('AuthUrlValue');

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Auth/Support/Oauth2/Token/TokenPersistenceFactoryTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Auth/Support/Oauth2/Token/TokenPersistenceFactoryTest.php
@@ -32,7 +32,7 @@ final class TokenPersistenceFactoryTest extends TestCase
             'expires_at'    => $expiresAt,
         ];
 
-        $this->integration
+        $this->integration->expects($this->exactly(3))
             ->method('getApiKeys')
             ->willReturn($apiKeys);
 
@@ -52,7 +52,7 @@ final class TokenPersistenceFactoryTest extends TestCase
             'expires_at'    => $expiresAt,
         ];
 
-        $this->integration
+        $this->integration->expects($this->exactly(3))
             ->method('getApiKeys')
             ->willReturn($apiKeys);
 

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Auth/Support/Oauth2/Token/TokenPersistenceTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Auth/Support/Oauth2/Token/TokenPersistenceTest.php
@@ -179,7 +179,7 @@ final class TokenPersistenceTest extends TestCase
         ];
 
         $integration = $this->createMock(Integration::class);
-        $integration->method('getApiKeys')
+        $integration->expects($this->exactly(5))->method('getApiKeys')
             ->willReturnOnConsecutiveCalls(null, $apiKeys, ['access_token' => $accessToken], null, null);
 
         $this->tokenPersistence->setIntegration($integration);

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Entity/FieldChangeRepositoryTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Entity/FieldChangeRepositoryTest.php
@@ -22,7 +22,7 @@ final class FieldChangeRepositoryTest extends TestCase
         parent::setUp();
 
         $this->repository = $this->configureRepository(FieldChange::class);
-        $this->connection->method('createQueryBuilder')->willReturnCallback(fn (): QueryBuilder => new QueryBuilder($this->connection));
+        $this->connection->expects($this->once())->method('createQueryBuilder')->willReturnCallback(fn (): QueryBuilder => new QueryBuilder($this->connection));
     }
 
     public function testWhereQueryPartForFindingChangesForSingleObject(): void

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Entity/ObjectMappingRepositoryTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Entity/ObjectMappingRepositoryTest.php
@@ -32,7 +32,7 @@ final class ObjectMappingRepositoryTest extends TestCase
 
         $this->repository = $this->configureRepository(ObjectMapping::class);
 
-        $this->entityManager->method('createQueryBuilder')->willReturnCallback(fn (): QueryBuilder => new QueryBuilder($this->entityManager));
+        $this->entityManager->expects($this->once())->method('createQueryBuilder')->willReturnCallback(fn (): QueryBuilder => new QueryBuilder($this->entityManager));
 
         // This is terrible, but the Query class is final and AbstractQuery doesn't have some methods used.
         $this->query = $this->getMockBuilder(Query::class)

--- a/app/bundles/IntegrationsBundle/Tests/Unit/EventListener/LeadSubscriberTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/EventListener/LeadSubscriberTest.php
@@ -168,7 +168,7 @@ final class LeadSubscriberTest extends TestCase
 
         $this->handleRecordFieldChanges($fieldChanges['fields'], $objectId, Lead::class);
 
-        $this->eventDispatcherInterfaceMock
+        $this->eventDispatcherInterfaceMock->expects($this->once())
             ->method('hasListeners')
             ->with(IntegrationEvents::INTEGRATION_BEFORE_CONTACT_FIELD_CHANGES)
             ->willReturn(true);
@@ -202,7 +202,7 @@ final class LeadSubscriberTest extends TestCase
 
         $this->handleRecordFieldChanges($fieldChanges['fields'], $objectId, Lead::class);
 
-        $this->eventDispatcherInterfaceMock
+        $this->eventDispatcherInterfaceMock->expects($this->once())
             ->method('hasListeners')
             ->with(IntegrationEvents::INTEGRATION_BEFORE_CONTACT_FIELD_CHANGES)
             ->willReturn(true);
@@ -236,7 +236,7 @@ final class LeadSubscriberTest extends TestCase
 
         $this->handleRecordFieldChanges($fieldChanges['fields'], $objectId, Lead::class);
 
-        $this->eventDispatcherInterfaceMock
+        $this->eventDispatcherInterfaceMock->expects($this->once())
             ->method('hasListeners')
             ->with(IntegrationEvents::INTEGRATION_BEFORE_CONTACT_FIELD_CHANGES)
             ->willReturn(true);
@@ -340,7 +340,7 @@ final class LeadSubscriberTest extends TestCase
 
         $this->handleRecordFieldChanges($fieldChanges['fields'], $objectId, Company::class);
 
-        $this->eventDispatcherInterfaceMock
+        $this->eventDispatcherInterfaceMock->expects($this->once())
             ->method('hasListeners')
             ->with(IntegrationEvents::INTEGRATION_BEFORE_COMPANY_FIELD_CHANGES)
             ->willReturn(true);
@@ -378,7 +378,7 @@ final class LeadSubscriberTest extends TestCase
 
         $this->handleRecordFieldChanges($fieldChanges['fields'], $objectId, Company::class);
 
-        $this->eventDispatcherInterfaceMock
+        $this->eventDispatcherInterfaceMock->expects($this->once())
             ->method('hasListeners')
             ->with(IntegrationEvents::INTEGRATION_BEFORE_COMPANY_FIELD_CHANGES)
             ->willReturn(true);
@@ -415,7 +415,7 @@ final class LeadSubscriberTest extends TestCase
         $integrationName     = 'testIntegration';
         $enabledIntegrations = [$integrationName];
 
-        $this->syncIntegrationsHelper
+        $this->syncIntegrationsHelper->expects($this->once())
             ->method('getEnabledIntegrations')
             ->willReturn($enabledIntegrations);
 

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Form/Type/IntegrationSyncSettingsObjectFieldTypeTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Form/Type/IntegrationSyncSettingsObjectFieldTypeTest.php
@@ -50,11 +50,11 @@ final class IntegrationSyncSettingsObjectFieldTypeTest extends \PHPUnit\Framewor
             ],
         ];
 
-        $field->method('showAsRequired')->willReturn(true);
-        $field->method('getName')->willReturn('Integration Field A');
-        $field->method('isBidirectionalSyncEnabled')->willReturn(false);
-        $field->method('isToIntegrationSyncEnabled')->willReturn(true);
-        $field->method('isToMauticSyncEnabled')->willReturn(true);
+        $field->expects($this->once())->method('showAsRequired')->willReturn(true);
+        $field->expects($this->exactly(2))->method('getName')->willReturn('Integration Field A');
+        $field->expects($this->once())->method('isBidirectionalSyncEnabled')->willReturn(false);
+        $field->expects($this->once())->method('isToIntegrationSyncEnabled')->willReturn(true);
+        $field->expects($this->once())->method('isToMauticSyncEnabled')->willReturn(true);
         $matcher = $this->exactly(2);
 
         $this->formBuilder->expects($matcher)

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Helper/FieldFilterHelperTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Helper/FieldFilterHelperTest.php
@@ -82,7 +82,7 @@ final class FieldFilterHelperTest extends TestCase
             ->willReturn('field five');
 
         $integrationObject = $this->createMock(ConfigFormSyncInterface::class);
-        $integrationObject->method('getAllFieldsForMapping')
+        $integrationObject->expects($this->once())->method('getAllFieldsForMapping')
             ->willReturn(
                 [
                     'field1' => $field1,

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/Helper/RelationsHelperTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/Helper/RelationsHelperTest.php
@@ -65,7 +65,7 @@ final class RelationsHelperTest extends TestCase
             ->method('getRelations')
             ->willReturn($relationsObject);
 
-        $this->mappingManual
+        $this->mappingManual->expects($this->exactly(2))
             ->method('getMappedInternalObjectsNames')
             ->willReturn(['company']);
 
@@ -119,7 +119,7 @@ final class RelationsHelperTest extends TestCase
             ->method('getObject')
             ->willReturn($objectDao);
 
-        $this->mappingManual
+        $this->mappingManual->expects($this->exactly(2))
             ->method('getMappedInternalObjectsNames')
             ->willReturn(['company']);
 

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/Helper/SyncDateHelperTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/Helper/SyncDateHelperTest.php
@@ -35,7 +35,7 @@ final class SyncDateHelperTest extends TestCase
     {
         $objectLastSyncDate = new \DateTimeImmutable('2018-10-08 00:00:00');
 
-        $this->syncDateHelper->method('getLastSyncDateForObject')
+        $this->syncDateHelper->expects($this->once())->method('getLastSyncDateForObject')
             ->willReturn($objectLastSyncDate);
 
         $this->assertEquals($objectLastSyncDate, $this->syncDateHelper->getSyncFromDateTime('Test', 'Object'));

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/Notification/Handler/HandlerContainerTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/Notification/Handler/HandlerContainerTest.php
@@ -24,9 +24,9 @@ final class HandlerContainerTest extends TestCase
         $this->expectException(HandlerNotSupportedException::class);
 
         $mockHandler = $this->createMock(HandlerInterface::class);
-        $mockHandler->method('getIntegration')
+        $mockHandler->expects($this->exactly(3))->method('getIntegration')
             ->willReturn('foo');
-        $mockHandler->method('getSupportedObject')
+        $mockHandler->expects($this->once())->method('getSupportedObject')
             ->willReturn('bogus');
 
         $handler = new HandlerContainer([$mockHandler]);
@@ -37,9 +37,9 @@ final class HandlerContainerTest extends TestCase
     public function testHandlerIsRegistered(): void
     {
         $mockHandler = $this->createMock(HandlerInterface::class);
-        $mockHandler->method('getIntegration')
+        $mockHandler->expects($this->exactly(3))->method('getIntegration')
             ->willReturn('foo');
-        $mockHandler->method('getSupportedObject')
+        $mockHandler->expects($this->once())->method('getSupportedObject')
             ->willReturn('bar');
 
         $handler = new HandlerContainer([$mockHandler]);

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Helper/FieldHelperTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Helper/FieldHelperTest.php
@@ -73,12 +73,12 @@ final class FieldHelperTest extends TestCase
         $objectName = Contact::NAME;
         $syncFields = ['email' => 'Email'];
 
-        $this->mauticSyncFieldsLoadEvent->method('getObjectName')
+        $this->mauticSyncFieldsLoadEvent->expects($this->once())->method('getObjectName')
             ->willReturn($objectName);
-        $this->mauticSyncFieldsLoadEvent->method('getFields')
+        $this->mauticSyncFieldsLoadEvent->expects($this->once())->method('getFields')
             ->willReturn($syncFields);
 
-        $this->fieldModel->method('getFieldList')
+        $this->fieldModel->expects($this->once())->method('getFieldList')
             ->willReturn($syncFields);
 
         $fields = $this->fieldHelper->getSyncFields($objectName);
@@ -99,12 +99,12 @@ final class FieldHelperTest extends TestCase
         $objectName = Contact::NAME;
         $syncFields = ['email' => 'Email'];
 
-        $this->mauticSyncFieldsLoadEvent->method('getObjectName')
+        $this->mauticSyncFieldsLoadEvent->expects($this->once())->method('getObjectName')
             ->willReturn($objectName);
-        $this->mauticSyncFieldsLoadEvent->method('getFields')
+        $this->mauticSyncFieldsLoadEvent->expects($this->once())->method('getFields')
             ->willReturn($syncFields);
 
-        $this->fieldModel->method('getFieldList')
+        $this->fieldModel->expects($this->once())->method('getFieldList')
             ->willReturn($syncFields);
 
         $fields = $this->fieldHelper->getSyncFields($objectName);

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/Executioner/FieldValidatorTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/Executioner/FieldValidatorTest.php
@@ -36,7 +36,7 @@ final class FieldValidatorTest extends TestCase
 
     public function testValidateFields(): void
     {
-        $this->leadFieldRepository->method('getFieldSchemaData')
+        $this->leadFieldRepository->expects($this->once())->method('getFieldSchemaData')
             ->willReturn([
                 'company' => [
                     'alias'             => 'company',

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/Executioner/ReferenceResolverTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/Executioner/ReferenceResolverTest.php
@@ -33,14 +33,14 @@ final class ReferenceResolverTest extends TestCase
     public function testResolveLeadReferences(): void
     {
         $result = $this->createMock(Result::class);
-        $result->method('fetchOne')
+        $result->expects($this->exactly(2))->method('fetchOne')
             ->willReturnOnConsecutiveCalls('Company name', false);
 
         $queryBuilder = $this->createMock(QueryBuilder::class);
-        $queryBuilder->method('executeQuery')
+        $queryBuilder->expects($this->exactly(2))->method('executeQuery')
             ->willReturn($result);
 
-        $this->connection->method('createQueryBuilder')
+        $this->connection->expects($this->exactly(2))->method('createQueryBuilder')
             ->willReturn($queryBuilder);
 
         $companyReference  = $this->createReference('company', 3);

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ObjectHelper/CompanyObjectHelperTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ObjectHelper/CompanyObjectHelperTest.php
@@ -66,7 +66,7 @@ final class CompanyObjectHelperTest extends TestCase
                 $property->setValue($company, $idMap[$company->getEmail()]);
             });
 
-        $this->repository->expects($this->exactly(2))
+        $this->repository
             ->method('detachEntity');
 
         // Test that two objects with the same unique identifier are merged into one
@@ -114,7 +114,7 @@ final class CompanyObjectHelperTest extends TestCase
                 $property->setValue($company, $idMap[$company->getEmail() ?? '']);
             });
 
-        $this->repository->expects($this->exactly(3))
+        $this->repository
             ->method('detachEntity');
 
         // Test that two objects with the same unique identifier are merged into one
@@ -162,10 +162,10 @@ final class CompanyObjectHelperTest extends TestCase
         ];
 
         $company1 = $this->createMock(Company::class);
-        $company1->method('getId')
+        $company1->expects($this->exactly(2))->method('getId')
             ->willReturn(0);
         $company2 = $this->createMock(Company::class);
-        $company2->method('getId')
+        $company2->expects($this->exactly(2))->method('getId')
             ->willReturn(1);
         $this->model->expects($this->once())
             ->method('getEntities')

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ObjectHelper/ContactObjectHelperTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ObjectHelper/ContactObjectHelperTest.php
@@ -93,7 +93,7 @@ final class ContactObjectHelperTest extends TestCase
                 $property->setValue($lead, $idMap[$lead->getEmail()]);
             });
 
-        $this->repository->expects($this->exactly(2))
+        $this->repository
             ->method('detachEntity');
 
         // Test that two objects with the same unique identifier are merged into one
@@ -143,7 +143,7 @@ final class ContactObjectHelperTest extends TestCase
                 $property->setValue($lead, $idMap[$lead->getEmail() ?? '']);
             });
 
-        $this->repository->expects($this->exactly(3))
+        $this->repository
             ->method('detachEntity');
 
         // Test that two objects with the same unique identifier are merged into one
@@ -203,10 +203,10 @@ final class ContactObjectHelperTest extends TestCase
         $objectChangeDaoA->addField($companyField);
 
         $contact1 = $this->createPartialMock(Lead::class, ['getId', 'addUpdatedField']);
-        $contact1->method('getId')
+        $contact1->expects($this->exactly(2))->method('getId')
             ->willReturn(0);
         $contact2 = $this->createPartialMock(Lead::class, ['getId']);
-        $contact2->method('getId')
+        $contact2->expects($this->exactly(2))->method('getId')
             ->willReturn(1);
         $this->model->expects($this->once())
             ->method('getEntities')
@@ -257,7 +257,7 @@ final class ContactObjectHelperTest extends TestCase
         ];
 
         $contact1 = $this->createMock(Lead::class);
-        $contact1->method('getId')
+        $contact1->expects($this->exactly(3))->method('getId')
             ->willReturn(1);
 
         $this->model->expects($this->once())
@@ -280,7 +280,7 @@ final class ContactObjectHelperTest extends TestCase
         ];
 
         $contact1 = $this->createMock(Lead::class);
-        $contact1->method('getId')
+        $contact1->expects($this->exactly(3))->method('getId')
             ->willReturn(1);
 
         $this->model->expects($this->once())
@@ -303,7 +303,7 @@ final class ContactObjectHelperTest extends TestCase
         ];
 
         $contact1 = $this->createMock(Lead::class);
-        $contact1->method('getId')
+        $contact1->expects($this->exactly(3))->method('getId')
             ->willReturn(1);
 
         $this->model->expects($this->once())

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/MauticSyncDataExchangeTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/MauticSyncDataExchangeTest.php
@@ -171,11 +171,11 @@ final class MauticSyncDataExchangeTest extends TestCase
             ->with($mappingManualDao, 'lead', $integrationObjectDao)
             ->willReturn(new ObjectDAO('lead', 123));
 
-        $this->mappingHelper->method('getMauticEntityClassName')
+        $this->mappingHelper->expects($this->once())->method('getMauticEntityClassName')
             ->with('lead')
             ->willReturn(Lead::class);
 
-        $this->fieldHelper->method('getFieldChangeObject')
+        $this->fieldHelper->expects($this->once())->method('getFieldChangeObject')
             ->with($fieldChange)
             ->willReturn(new FieldDAO('some-field-name', new NormalizedValueDAO('type', 'some-field-value')));
 

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncProcess/Direction/Integration/ObjectChangeGeneratorTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncProcess/Direction/Integration/ObjectChangeGeneratorTest.php
@@ -30,7 +30,7 @@ final class ObjectChangeGeneratorTest extends TestCase
 
     public function testFieldIsAddedToObjectChange(): void
     {
-        $this->valueHelper->method('getValueForIntegration')
+        $this->valueHelper->expects($this->exactly(2))->method('getValueForIntegration')
             ->willReturnCallback(
                 fn (NormalizedValueDAO $normalizedValueDAO, string $fieldState, string $syncDirection): NormalizedValueDAO => $normalizedValueDAO
             );
@@ -79,7 +79,7 @@ final class ObjectChangeGeneratorTest extends TestCase
 
     public function testFieldIsNotAddedToObjectChangeIfNotFound(): void
     {
-        $this->valueHelper->method('getValueForIntegration')
+        $this->valueHelper->expects($this->once())->method('getValueForIntegration')
             ->willReturnCallback(
                 fn (NormalizedValueDAO $normalizedValueDAO, string $fieldState, string $syncDirection): NormalizedValueDAO => $normalizedValueDAO
             );

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncProcess/Direction/Internal/ObjectChangeGeneratorTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncProcess/Direction/Internal/ObjectChangeGeneratorTest.php
@@ -49,7 +49,7 @@ final class ObjectChangeGeneratorTest extends TestCase
 
     public function testFieldsAreAddedToObjectChangeAndIntegrationFirstNameWins(): void
     {
-        $this->valueHelper->method('getValueForMautic')
+        $this->valueHelper->expects($this->exactly(2))->method('getValueForMautic')
             ->willReturnCallback(
                 fn (NormalizedValueDAO $normalizedValueDAO, string $fieldState, string $syncDirection): NormalizedValueDAO => $normalizedValueDAO
             );
@@ -106,7 +106,7 @@ final class ObjectChangeGeneratorTest extends TestCase
 
     public function testFieldsAreAddedToObjectChangeAndInternalFirstNameWins(): void
     {
-        $this->valueHelper->method('getValueForMautic')
+        $this->valueHelper->expects($this->exactly(2))->method('getValueForMautic')
             ->willReturnCallback(
                 fn (NormalizedValueDAO $normalizedValueDAO, string $fieldState, string $syncDirection): NormalizedValueDAO => $normalizedValueDAO
             );
@@ -175,7 +175,7 @@ final class ObjectChangeGeneratorTest extends TestCase
     {
         $exceptionMessage = 'exceptionMessage';
 
-        $this->valueHelper->method('getValueForMautic')
+        $this->valueHelper->expects($this->exactly(2))->method('getValueForMautic')
             ->willThrowException(new RequiredValueException($exceptionMessage));
 
         $integrationName  = 'Test';
@@ -240,7 +240,7 @@ final class ObjectChangeGeneratorTest extends TestCase
     {
         $exceptionMessage = 'exceptionMessage';
 
-        $this->valueHelper->method('getValueForMautic')
+        $this->valueHelper->expects($this->exactly(2))->method('getValueForMautic')
             ->willThrowException(new RequiredValueException($exceptionMessage));
 
         $integrationName = 'Test';
@@ -305,7 +305,7 @@ final class ObjectChangeGeneratorTest extends TestCase
     {
         $exceptionMessage = 'exceptionMessage';
 
-        $this->valueHelper->method('getValueForMautic')
+        $this->valueHelper->expects($this->once())->method('getValueForMautic')
             ->willThrowException(new RequiredValueException($exceptionMessage));
 
         $integrationName = 'Test';

--- a/app/bundles/LeadBundle/Tests/Unit/Services/CompanyColumnsDictionaryTest.php
+++ b/app/bundles/LeadBundle/Tests/Unit/Services/CompanyColumnsDictionaryTest.php
@@ -25,7 +25,7 @@ final class CompanyColumnsDictionaryTest extends TestCase
         $translator                 = $this->createMock(TranslatorInterface::class);
         $this->coreParametersHelper = $this->createMock(CoreParametersHelper::class);
 
-        $translator->method('trans')->willReturnArgument(0);
+        $translator->expects($this->exactly(6))->method('trans')->willReturnArgument(0);
 
         $fieldList->expects($this->once())
             ->method('getFieldList')

--- a/app/bundles/PointBundle/Tests/Unit/Model/PointModelTest.php
+++ b/app/bundles/PointBundle/Tests/Unit/Model/PointModelTest.php
@@ -82,8 +82,8 @@ final class PointModelTest extends TestCase
         $pointDelta      = 7;
         $pointGroup      = null;
         $ip              = $this->createStub(IpAddress::class);
-        $this->security->method('isAnonymous')->willReturn(true);
-        $this->ipLookupHelper->method('getIpAddress')->willReturn($ip);
+        $this->security->expects($this->once())->method('isAnonymous')->willReturn(true);
+        $this->ipLookupHelper->expects($this->once())->method('getIpAddress')->willReturn($ip);
 
         $lead = $this->createMock(Lead::class);
         $lead->expects($this->once())
@@ -117,13 +117,13 @@ final class PointModelTest extends TestCase
             ->willReturn(true);
 
         $point = $this->createMock(Point::class);
-        $point->method('getRepeatable')->willReturn(true);
-        $point->method('getType')->willReturn($type);
+        $point->expects($this->exactly(2))->method('getRepeatable')->willReturn(true);
+        $point->expects($this->exactly(4))->method('getType')->willReturn($type);
         $point->method('getId')->willReturn($pointId);
         $point->method('getName')->willReturn($pointName);
-        $point->method('getProperties')->willReturn($pointProperties);
+        $point->expects($this->once())->method('getProperties')->willReturn($pointProperties);
         $point->method('getDelta')->willReturn($pointDelta);
-        $point->method('getGroup')->willReturn($pointGroup);
+        $point->expects($this->once())->method('getGroup')->willReturn($pointGroup);
 
         $this->pointRepositoryMock->expects($this->once())
             ->method('getPublishedByType')

--- a/app/bundles/WebhookBundle/Tests/Unit/Controller/WebhookControllerTest.php
+++ b/app/bundles/WebhookBundle/Tests/Unit/Controller/WebhookControllerTest.php
@@ -97,13 +97,13 @@ final class WebhookControllerTest extends TestCase
         );
 
         $parameterBag = $this->createMock(ParameterBagInterface::class);
-        $parameterBag->method('get')
+        $parameterBag->expects($this->once())->method('get')
             ->with('kernel.environment')
             ->willReturn('test');
 
         $container = $this->createMock(ContainerInterface::class);
-        $container->method('has')->with('parameter_bag')->willReturn(true);
-        $container->method('get')->with('parameter_bag')->willReturn($parameterBag);
+        $container->expects($this->once())->method('has')->with('parameter_bag')->willReturn(true);
+        $container->expects($this->once())->method('get')->with('parameter_bag')->willReturn($parameterBag);
 
         $controller->setContainer($container);
 
@@ -123,7 +123,7 @@ final class WebhookControllerTest extends TestCase
             });
 
         $pathsHelper = $this->createMock(PathsHelper::class);
-        $pathsHelper->method('getSystemPath')->willReturn(realpath(dirname(__DIR__, 4)));
+        $pathsHelper->expects($this->once())->method('getSystemPath')->willReturn(realpath(dirname(__DIR__, 4)));
 
         // Send test action.
         $testResponse = $controller->sendHookTestAction($request, $client, $pathsHelper);
@@ -135,19 +135,19 @@ final class WebhookControllerTest extends TestCase
 
         // Now send the lead update event.
         $lead = $this->createMock(Lead::class);
-        $lead->method('isAnonymous')->willReturn(false);
-        $lead->method('getChanges')
+        $lead->expects($this->once())->method('isAnonymous')->willReturn(false);
+        $lead->expects($this->once())->method('getChanges')
             ->with(true)
             ->willReturn($changes);
 
         $event = new LeadEvent($lead, $isNew);
 
         $guzzleBody = $this->createMock(StreamInterface::class);
-        $guzzleBody->method('getContents')->willReturn('whatever');
+        $guzzleBody->expects($this->once())->method('getContents')->willReturn('whatever');
 
         $clientResponse = $this->createMock(GuzzleResponse::class);
-        $clientResponse->method('getStatusCode')->willReturn(Response::HTTP_OK);
-        $clientResponse->method('getBody')->willReturn($guzzleBody);
+        $clientResponse->expects($this->once())->method('getStatusCode')->willReturn(Response::HTTP_OK);
+        $clientResponse->expects($this->once())->method('getBody')->willReturn($guzzleBody);
 
         $client = $this->createMock(Client::class);
         $client->expects($this->once())
@@ -172,16 +172,16 @@ final class WebhookControllerTest extends TestCase
         $webhook = $this->createMock(Webhook::class);
         $webhook->method('getId')
             ->willReturn($webhookId);
-        $webhook->method('getMarkedUnhealthyAt')
+        $webhook->expects($this->once())->method('getMarkedUnhealthyAt')
             ->willReturn(null);
-        $webhook->method('getWebhookUrl')
+        $webhook->expects($this->once())->method('getWebhookUrl')
             ->willReturn($url);
-        $webhook->method('getSecret')
+        $webhook->expects($this->exactly(2))->method('getSecret')
             ->willReturn($secret);
 
         $webhookEvent = $this->createMock(Event::class);
-        $webhookEvent->method('getWebhook')->willReturn($webhook);
-        $webhookEvent->method('getEventType')->willReturn($eventUnderTest);
+        $webhookEvent->expects($this->once())->method('getWebhook')->willReturn($webhook);
+        $webhookEvent->expects($this->once())->method('getEventType')->willReturn($eventUnderTest);
 
         $webhookEventRepository = $this->createMock(EventRepository::class);
         $webhookEventRepository->expects($this->once())
@@ -204,7 +204,7 @@ final class WebhookControllerTest extends TestCase
         $em = $this->createStub(EntityManager::class);
 
         $serializer = $this->createMock(SerializerInterface::class);
-        $serializer->method('serialize')
+        $serializer->expects($this->once())->method('serialize')
             ->willReturnCallback(function (array $data, string $type) use ($contactPayload): string {
                 $this->assertArrayHasKey('contact', $data);
                 $this->assertSame('json', $type);

--- a/app/bundles/WebhookBundle/Tests/Unit/Helper/CampaignHelperTest.php
+++ b/app/bundles/WebhookBundle/Tests/Unit/Helper/CampaignHelperTest.php
@@ -42,7 +42,7 @@ final class CampaignHelperTest extends \PHPUnit\Framework\TestCase
             ->onlyMethods(['getCompaniesByLeadId'])
             ->getMock();
 
-        $companyRepository->method('getCompaniesByLeadId')->willReturn([new Company()]);
+        $companyRepository->expects($this->once())->method('getCompaniesByLeadId')->willReturn([new Company()]);
 
         $this->campaignHelper = new CampaignHelper($this->client, $this->createStub(EventDispatcherInterface::class), $companyRepository);
 

--- a/app/bundles/WebhookBundle/Tests/Unit/Model/WebhookModelTest.php
+++ b/app/bundles/WebhookBundle/Tests/Unit/Model/WebhookModelTest.php
@@ -93,13 +93,13 @@ final class WebhookModelTest extends TestCase
 
     public function testGetEventsOrderbyDirWhenNotSetInWebhook(): void
     {
-        $this->parametersHelperMock->method('get')->willReturn('DESC');
+        $this->parametersHelperMock->expects($this->exactly(9))->method('get')->willReturn('DESC');
         $this->assertEquals('DESC', $this->initModel()->getEventsOrderbyDir());
     }
 
     public function testGetEventsOrderbyDirWhenWebhookNotProvided(): void
     {
-        $this->parametersHelperMock->method('get')->willReturn('DESC');
+        $this->parametersHelperMock->expects($this->exactly(9))->method('get')->willReturn('DESC');
         $this->assertEquals('DESC', $this->initModel()->getEventsOrderbyDir());
     }
 
@@ -118,12 +118,12 @@ final class WebhookModelTest extends TestCase
         $webhook   = new Webhook();
         $event     = new Event();
         $event->setEventType('leads');
-        $queueMock->method('getPayload')->willReturn('{"the": "payload"}');
-        $queueMock->method('getEvent')->willReturn($event);
-        $queueMock->method('getDateAdded')->willReturn(new \DateTime('2018-04-10T15:04:57+00:00'));
-        $queueMock->method('getId')->willReturn('12');
+        $queueMock->expects($this->once())->method('getPayload')->willReturn('{"the": "payload"}');
+        $queueMock->expects($this->once())->method('getEvent')->willReturn($event);
+        $queueMock->expects($this->once())->method('getDateAdded')->willReturn(new \DateTime('2018-04-10T15:04:57+00:00'));
+        $queueMock->expects($this->exactly(2))->method('getId')->willReturn('12');
 
-        $this->parametersHelperMock->method('get')
+        $this->parametersHelperMock->expects($this->exactly(9))->method('get')
             ->willReturnCallback(function ($param): string|int|null {
                 if ('queue_mode' === $param) {
                     return WebhookModel::COMMAND_PROCESS;
@@ -165,7 +165,7 @@ final class WebhookModelTest extends TestCase
         $queue->setEvent($event);
         $queue->setDateAdded(new \DateTime('2018-04-10T15:04:57+00:00'));
 
-        $this->parametersHelperMock->method('get')
+        $this->parametersHelperMock->expects($this->exactly(9))->method('get')
             ->willReturnCallback(function ($param): ?string {
                 if ('queue_mode' === $param) {
                     return WebhookModel::IMMEDIATE_PROCESS;
@@ -209,7 +209,7 @@ final class WebhookModelTest extends TestCase
         $queue->setEvent($event);
         $queue->setDateAdded(new \DateTime('2021-04-01T16:00:00+00:00'));
 
-        $this->webhookQueueRepository
+        $this->webhookQueueRepository->expects($this->exactly(2))
             ->method('deleteQueuesById')
             ->with([1]);
 
@@ -221,7 +221,7 @@ final class WebhookModelTest extends TestCase
                 ],
             ],
         ];
-        $this->httpClientMock
+        $this->httpClientMock->expects($this->once())
             ->method('post')
             ->with('test-webhook.com', $responsePayload)
             ->willReturn(new Response(200, [], 'Success'));
@@ -240,7 +240,7 @@ final class WebhookModelTest extends TestCase
 
         $webhook->setEventsOrderbyDir('ASC');
 
-        $this->webhookQueueRepository->method('getTableAlias')->willReturn('w');
+        $this->webhookQueueRepository->expects($this->exactly(6))->method('getTableAlias')->willReturn('w');
 
         $webhookRetryTime = new \DateTimeImmutable()
             ->format(DateTimeHelper::FORMAT_DB);
@@ -310,7 +310,7 @@ final class WebhookModelTest extends TestCase
 
         $webhook->setEventsOrderbyDir('ASC');
 
-        $this->webhookQueueRepository->method('getTableAlias')->willReturn('w');
+        $this->webhookQueueRepository->expects($this->exactly(8))->method('getTableAlias')->willReturn('w');
         $webhookRetryTime = new \DateTimeImmutable()
             ->format(DateTimeHelper::FORMAT_DB);
         $expected = [

--- a/app/bundles/WebhookBundle/Tests/Unit/Notificator/WebhookKillNotificatorTest.php
+++ b/app/bundles/WebhookBundle/Tests/Unit/Notificator/WebhookKillNotificatorTest.php
@@ -87,13 +87,13 @@ final class WebhookKillNotificatorTest extends \PHPUnit\Framework\TestCase
         $eventDispatcher             = $this->createMock(EventDispatcherInterface::class);
 
         $webhookNotificationEventMock =  $this->createMock(WebhookNotificationEvent::class);
-        $webhookNotificationEventMock->method('canSend')->willReturn(true);
+        $webhookNotificationEventMock->expects($this->once())->method('canSend')->willReturn(true);
 
         $twig->expects($this->once())
             ->method('render')
             ->willReturn($this->details);
 
-        $eventDispatcher->method('dispatch')
+        $eventDispatcher->expects($this->once())->method('dispatch')
             ->willReturn(
                 $webhookNotificationEventMock
             );
@@ -213,7 +213,7 @@ final class WebhookKillNotificatorTest extends \PHPUnit\Framework\TestCase
 
     private function mockCommonMethods(int $sentToAuthor, ?string $emailToSend = null): void
     {
-        $this->coreParamHelperMock
+        $this->coreParamHelperMock->expects($this->exactly(2))
             ->method('get')
             ->willReturnOnConsecutiveCalls('from_name', $sentToAuthor, $emailToSend);
 

--- a/plugins/GrapesJsBuilderBundle/Tests/Unit/Controller/GrapesJsControllerTest.php
+++ b/plugins/GrapesJsBuilderBundle/Tests/Unit/Controller/GrapesJsControllerTest.php
@@ -38,11 +38,11 @@ final class GrapesJsControllerTest extends TestCase
     public function testEditorStateActionReturnsEditorStateFromJsonContent(): void
     {
         $security = $this->createMock(CorePermissions::class);
-        $security->method('hasEntityAccess')->willReturn(true);
+        $security->expects($this->once())->method('hasEntityAccess')->willReturn(true);
 
         $entity = $this->createMock(Email::class);
-        $entity->method('getCreatedBy')->willReturn(1);
-        $entity->method('getContent')->willReturn(json_encode([
+        $entity->expects($this->once())->method('getCreatedBy')->willReturn(1);
+        $entity->expects($this->once())->method('getContent')->willReturn(json_encode([
             'grapesjsbuilder' => [
                 'editorState' => json_encode(['components' => [['type' => 'text']]]),
             ],
@@ -57,11 +57,11 @@ final class GrapesJsControllerTest extends TestCase
     public function testEditorStateActionReturnsEditorStateFromSerializedContent(): void
     {
         $security = $this->createMock(CorePermissions::class);
-        $security->method('hasEntityAccess')->willReturn(true);
+        $security->expects($this->once())->method('hasEntityAccess')->willReturn(true);
 
         $entity = $this->createMock(Email::class);
-        $entity->method('getCreatedBy')->willReturn(1);
-        $entity->method('getContent')->willReturn('a:1:{s:15:"grapesjsbuilder";a:1:{s:11:"editorState";a:1:{s:5:"pages";a:0:{}}}}');
+        $entity->expects($this->once())->method('getCreatedBy')->willReturn(1);
+        $entity->expects($this->once())->method('getContent')->willReturn('a:1:{s:15:"grapesjsbuilder";a:1:{s:11:"editorState";a:1:{s:5:"pages";a:0:{}}}}');
 
         $controller = $this->getControllerForEditorState($security, $entity);
         $response   = $controller->editorStateAction('email', '33');
@@ -72,11 +72,11 @@ final class GrapesJsControllerTest extends TestCase
     public function testEditorStateActionReturnsNullWhenEditorStateCannotBeDecoded(): void
     {
         $security = $this->createMock(CorePermissions::class);
-        $security->method('hasEntityAccess')->willReturn(true);
+        $security->expects($this->once())->method('hasEntityAccess')->willReturn(true);
 
         $entity = $this->createMock(Email::class);
-        $entity->method('getCreatedBy')->willReturn(1);
-        $entity->method('getContent')->willReturn([
+        $entity->expects($this->once())->method('getCreatedBy')->willReturn(1);
+        $entity->expects($this->once())->method('getContent')->willReturn([
             'grapesjsbuilder' => [
                 'editorState' => 'not-a-json',
             ],

--- a/plugins/GrapesJsBuilderBundle/Tests/Unit/EventSubscriber/AssetsSubscriberTest.php
+++ b/plugins/GrapesJsBuilderBundle/Tests/Unit/EventSubscriber/AssetsSubscriberTest.php
@@ -68,7 +68,7 @@ final class AssetsSubscriberTest extends TestCase
     public function testInjectAssetsSkipsWhenPluginNotPublished(): void
     {
         $config = $this->createMock(Config::class);
-        $config->method('isPublished')->willReturn(false);
+        $config->expects($this->once())->method('isPublished')->willReturn(false);
         $this->assetsEvent->expects($this->never())->method('addScript');
 
         $this->makeSubscriber($config)->injectAssets($this->assetsEvent);

--- a/plugins/GrapesJsBuilderBundle/Tests/Unit/EventSubscriber/EmailSubscriberTest.php
+++ b/plugins/GrapesJsBuilderBundle/Tests/Unit/EventSubscriber/EmailSubscriberTest.php
@@ -70,7 +70,7 @@ final class EmailSubscriberTest extends TestCase
             ->method('isSaveAsDraft')
             ->willReturn(true);
 
-        $this->grapesJsBuilderRepo->method('findOneBy')
+        $this->grapesJsBuilderRepo->expects($this->once())->method('findOneBy')
             ->willReturn($grapesJsBuilder = $this->createMock(GrapesJsBuilder::class));
 
         $this->config->expects($this->once())
@@ -95,7 +95,7 @@ final class EmailSubscriberTest extends TestCase
             ->method('isApplyDraft')
             ->willReturn(true);
 
-        $this->grapesJsBuilderRepo->method('findOneBy')
+        $this->grapesJsBuilderRepo->expects($this->once())->method('findOneBy')
             ->willReturn($grapesJsBuilder = $this->createMock(GrapesJsBuilder::class));
 
         $this->config->expects($this->once())
@@ -124,7 +124,7 @@ final class EmailSubscriberTest extends TestCase
             ->method('hasDraft')
             ->willReturn(true);
 
-        $this->grapesJsBuilderRepo->method('findOneBy')
+        $this->grapesJsBuilderRepo->expects($this->once())->method('findOneBy')
             ->willReturn($grapesJsBuilder = $this->createMock(GrapesJsBuilder::class));
 
         $this->config->expects($this->once())

--- a/plugins/GrapesJsBuilderBundle/Tests/Unit/EventSubscriber/InjectCustomContentSubscriberTest.php
+++ b/plugins/GrapesJsBuilderBundle/Tests/Unit/EventSubscriber/InjectCustomContentSubscriberTest.php
@@ -52,7 +52,7 @@ final class InjectCustomContentSubscriberTest extends TestCase
     public function testInjectViewCustomContentExitsWhenPluginNotPublished(): void
     {
         $requestStack = new RequestStack([new Request()]);
-        $this->config->method('isPublished')->willReturn(false);
+        $this->config->expects($this->once())->method('isPublished')->willReturn(false);
 
         $subscriber = new InjectCustomContentSubscriber($this->config, $this->createStub(GrapesJsBuilderModel::class), $this->twig, $requestStack, $this->router, $this->grapesJsBuilderRepository);
         $event      = new CustomContentEvent('view', 'email.settings.advanced', ['email' => new Email()]);
@@ -73,9 +73,9 @@ final class InjectCustomContentSubscriberTest extends TestCase
 
         $requestStack = new RequestStack([$request]);
 
-        $this->grapesJsBuilderRepository->method('findOneBy')->willReturn(null);
+        $this->grapesJsBuilderRepository->expects($this->once())->method('findOneBy')->willReturn(null);
 
-        $this->config->method('isPublished')->willReturn(true);
+        $this->config->expects($this->once())->method('isPublished')->willReturn(true);
 
         $this->twig->expects($this->once())
             ->method('render')
@@ -95,11 +95,11 @@ final class InjectCustomContentSubscriberTest extends TestCase
         $requestStack = new RequestStack([new Request([], [], [], [], [], ['REQUEST_METHOD' => 'GET'])]);
 
         $grapesJsBuilder = $this->createMock(GrapesJsBuilder::class);
-        $grapesJsBuilder->method('getCustomMjml')->willReturn('<mjml>stored</mjml>');
+        $grapesJsBuilder->expects($this->once())->method('getCustomMjml')->willReturn('<mjml>stored</mjml>');
 
-        $this->grapesJsBuilderRepository->method('findOneBy')->willReturn($grapesJsBuilder);
+        $this->grapesJsBuilderRepository->expects($this->once())->method('findOneBy')->willReturn($grapesJsBuilder);
 
-        $this->config->method('isPublished')->willReturn(true);
+        $this->config->expects($this->once())->method('isPublished')->willReturn(true);
 
         $this->twig->expects($this->once())
             ->method('render')
@@ -118,7 +118,7 @@ final class InjectCustomContentSubscriberTest extends TestCase
     {
         $requestStack = new RequestStack([new Request()]);
 
-        $this->config->method('isPublished')->willReturn(true);
+        $this->config->expects($this->once())->method('isPublished')->willReturn(true);
 
         $this->router->expects($this->exactly(3))
             ->method('generate')

--- a/plugins/GrapesJsBuilderBundle/Tests/Unit/EventSubscriber/PageSubscriberTest.php
+++ b/plugins/GrapesJsBuilderBundle/Tests/Unit/EventSubscriber/PageSubscriberTest.php
@@ -35,7 +35,7 @@ final class PageSubscriberTest extends TestCase
 
     public function testOnPagePostSaveSkipsWhenPluginNotPublished(): void
     {
-        $this->config->method('isPublished')->willReturn(false);
+        $this->config->expects($this->once())->method('isPublished')->willReturn(false);
         $this->model->expects($this->never())->method('addOrEditPageEntity');
 
         $this->subscriber->onPagePostSave(new PageEvent(new Page()));
@@ -45,7 +45,7 @@ final class PageSubscriberTest extends TestCase
     {
         $page = new Page();
 
-        $this->config->method('isPublished')->willReturn(true);
+        $this->config->expects($this->once())->method('isPublished')->willReturn(true);
         $this->model->expects($this->once())
             ->method('addOrEditPageEntity')
             ->with($page);

--- a/plugins/GrapesJsBuilderBundle/Tests/Unit/Model/GrapesJsBuilderModelEditorStateTest.php
+++ b/plugins/GrapesJsBuilderBundle/Tests/Unit/Model/GrapesJsBuilderModelEditorStateTest.php
@@ -44,11 +44,11 @@ final class GrapesJsBuilderModelEditorStateTest extends TestCase
 
         /** @var MockObject&EmailModel $emailModel */
         $emailModel = $this->createMock(EmailModel::class);
-        $emailModel->method('isUpdatingTranslationChildren')->willReturn(false);
+        $emailModel->expects($this->once())->method('isUpdatingTranslationChildren')->willReturn(false);
 
         /** @var MockObject&GrapesJsBuilderRepository $grapesRepository */
         $grapesRepository = $this->createMock(GrapesJsBuilderRepository::class);
-        $grapesRepository->method('findOneBy')->willReturn(null);
+        $grapesRepository->expects($this->once())->method('findOneBy')->willReturn(null);
         $grapesRepository->expects($this->once())
             ->method('saveEntity')
             ->with(self::callback(static fn ($entity): bool => $entity instanceof GrapesJsBuilder && '<mjml/>' === $entity->getCustomMjml()));
@@ -87,7 +87,7 @@ final class GrapesJsBuilderModelEditorStateTest extends TestCase
 
         /** @var MockObject&EmailModel $emailModel */
         $emailModel = $this->createMock(EmailModel::class);
-        $emailModel->method('isUpdatingTranslationChildren')->willReturn(true);
+        $emailModel->expects($this->once())->method('isUpdatingTranslationChildren')->willReturn(true);
 
         /** @var MockObject&EntityManager $entityManager */
         $entityManager = $this->createMock(EntityManager::class);

--- a/plugins/MauticClearbitBundle/Tests/Unit/EventListener/ButtonSubscriberTest.php
+++ b/plugins/MauticClearbitBundle/Tests/Unit/EventListener/ButtonSubscriberTest.php
@@ -50,7 +50,7 @@ final class ButtonSubscriberTest extends TestCase
 
     public function testInjectViewButtonsDoesNothingWhenIntegrationNotFound(): void
     {
-        $this->integrationsHelper->method('getIntegration')->with('Clearbit')
+        $this->integrationsHelper->expects($this->once())->method('getIntegration')->with('Clearbit')
             ->willThrowException(new IntegrationNotFoundException());
 
         $event = $this->makeEvent(ButtonHelper::LOCATION_BULK_ACTIONS, 'mautic_contact_index');
@@ -62,7 +62,7 @@ final class ButtonSubscriberTest extends TestCase
 
     public function testInjectViewButtonsDoesNothingWhenIntegrationNotPublished(): void
     {
-        $this->integrationsHelper->method('getIntegration')->with('Clearbit')
+        $this->integrationsHelper->expects($this->once())->method('getIntegration')->with('Clearbit')
             ->willReturn($this->makeIntegration(false));
 
         $event = $this->makeEvent(ButtonHelper::LOCATION_BULK_ACTIONS, 'mautic_contact_index');
@@ -74,7 +74,7 @@ final class ButtonSubscriberTest extends TestCase
 
     public function testInjectViewButtonsAddsBulkActionButtonForContactRoute(): void
     {
-        $this->integrationsHelper->method('getIntegration')->with('Clearbit')
+        $this->integrationsHelper->expects($this->once())->method('getIntegration')->with('Clearbit')
             ->willReturn($this->makeIntegration(true));
 
         $event = $this->makeEvent(ButtonHelper::LOCATION_BULK_ACTIONS, 'mautic_contact_index');
@@ -86,12 +86,12 @@ final class ButtonSubscriberTest extends TestCase
 
     public function testInjectViewButtonsAddsPageActionButtonForContactViewWithItem(): void
     {
-        $this->integrationsHelper->method('getIntegration')->with('Clearbit')
+        $this->integrationsHelper->expects($this->once())->method('getIntegration')->with('Clearbit')
             ->willReturn($this->makeIntegration(true));
 
         $lead = $this->createMock(Lead::class);
-        $lead->method('getEmail')->willReturn('john@example.com');
-        $lead->method('getId')->willReturn(42);
+        $lead->expects($this->once())->method('getEmail')->willReturn('john@example.com');
+        $lead->expects($this->once())->method('getId')->willReturn(42);
 
         $event = $this->makeEvent(
             ButtonHelper::LOCATION_PAGE_ACTIONS,
@@ -107,7 +107,7 @@ final class ButtonSubscriberTest extends TestCase
 
     public function testInjectViewButtonsAddsBulkActionButtonForCompanyRoute(): void
     {
-        $this->integrationsHelper->method('getIntegration')->with('Clearbit')
+        $this->integrationsHelper->expects($this->once())->method('getIntegration')->with('Clearbit')
             ->willReturn($this->makeIntegration(true));
 
         $event = $this->makeEvent(ButtonHelper::LOCATION_BULK_ACTIONS, 'mautic_company_index');
@@ -119,7 +119,7 @@ final class ButtonSubscriberTest extends TestCase
 
     public function testInjectViewButtonsAddsNothingForUnrelatedRoute(): void
     {
-        $this->integrationsHelper->method('getIntegration')->with('Clearbit')
+        $this->integrationsHelper->expects($this->once())->method('getIntegration')->with('Clearbit')
             ->willReturn($this->makeIntegration(true));
 
         $event = $this->makeEvent(ButtonHelper::LOCATION_BULK_ACTIONS, 'mautic_email_index');

--- a/plugins/MauticClearbitBundle/Tests/Unit/Helper/LookupHelperTest.php
+++ b/plugins/MauticClearbitBundle/Tests/Unit/Helper/LookupHelperTest.php
@@ -53,7 +53,7 @@ final class LookupHelperTest extends TestCase
 
     public function testConstructorLeavesIntegrationNullWhenNotFound(): void
     {
-        $this->integrationsHelper->method('getIntegration')->with('Clearbit')
+        $this->integrationsHelper->expects($this->once())->method('getIntegration')->with('Clearbit')
             ->willThrowException(new IntegrationNotFoundException());
 
         $helper = $this->makeHelper();
@@ -63,7 +63,7 @@ final class LookupHelperTest extends TestCase
 
     public function testGetClearbitReturnsFalseWhenIntegrationNotPublished(): void
     {
-        $this->integrationsHelper->method('getIntegration')->with('Clearbit')
+        $this->integrationsHelper->expects($this->once())->method('getIntegration')->with('Clearbit')
             ->willReturn($this->makeIntegration(false));
 
         $helper = $this->makeHelper();
@@ -73,7 +73,7 @@ final class LookupHelperTest extends TestCase
 
     public function testGetClearbitReturnsPersonInstanceWhenPublished(): void
     {
-        $this->integrationsHelper->method('getIntegration')->with('Clearbit')
+        $this->integrationsHelper->expects($this->once())->method('getIntegration')->with('Clearbit')
             ->willReturn($this->makeIntegration(true, ['apikey' => 'abc123']));
 
         $helper = $this->makeHelper();
@@ -83,7 +83,7 @@ final class LookupHelperTest extends TestCase
 
     public function testGetClearbitReturnsCompanyInstanceWhenPublishedAndPersonFalse(): void
     {
-        $this->integrationsHelper->method('getIntegration')->with('Clearbit')
+        $this->integrationsHelper->expects($this->once())->method('getIntegration')->with('Clearbit')
             ->willReturn($this->makeIntegration(true, ['apikey' => 'abc123']));
 
         $helper = $this->makeHelper();
@@ -93,11 +93,11 @@ final class LookupHelperTest extends TestCase
 
     public function testLookupContactReturnsEarlyWhenLeadHasNoEmail(): void
     {
-        $this->integrationsHelper->method('getIntegration')->with('Clearbit')
+        $this->integrationsHelper->expects($this->once())->method('getIntegration')->with('Clearbit')
             ->willReturn($this->makeIntegration(true, ['apikey' => 'abc123']));
 
         $lead = $this->createMock(Lead::class);
-        $lead->method('getEmail')->willReturn(null);
+        $lead->expects($this->once())->method('getEmail')->willReturn(null);
 
         $this->leadModel->expects($this->never())->method('saveEntity');
         $this->leadRepository->expects($this->never())->method('saveEntity');
@@ -107,11 +107,11 @@ final class LookupHelperTest extends TestCase
 
     public function testLookupContactSkipsLookupWhenCheckAutoAndAutoUpdateDisabled(): void
     {
-        $this->integrationsHelper->method('getIntegration')->with('Clearbit')
+        $this->integrationsHelper->expects($this->once())->method('getIntegration')->with('Clearbit')
             ->willReturn($this->makeIntegration(true, ['apikey' => 'abc123', 'auto_update' => '0']));
 
         $lead = $this->createMock(Lead::class);
-        $lead->method('getEmail')->willReturn('john@example.com');
+        $lead->expects($this->once())->method('getEmail')->willReturn('john@example.com');
 
         $this->leadModel->expects($this->never())->method('saveEntity');
         $this->leadRepository->expects($this->never())->method('saveEntity');
@@ -121,11 +121,11 @@ final class LookupHelperTest extends TestCase
 
     public function testLookupCompanyReturnsEarlyWhenNoWebsite(): void
     {
-        $this->integrationsHelper->method('getIntegration')->with('Clearbit')
+        $this->integrationsHelper->expects($this->once())->method('getIntegration')->with('Clearbit')
             ->willReturn($this->makeIntegration(true, ['apikey' => 'abc123']));
 
         $company = $this->createMock(Company::class);
-        $company->method('getFieldValue')->with('companywebsite')->willReturn(null);
+        $company->expects($this->once())->method('getFieldValue')->with('companywebsite')->willReturn(null);
 
         $this->companyModel->expects($this->never())->method('saveEntity');
         $this->companyRepository->expects($this->never())->method('saveEntity');
@@ -135,14 +135,14 @@ final class LookupHelperTest extends TestCase
 
     public function testValidateRequestReturnsFalseWhenNonceDoesNotMatch(): void
     {
-        $this->integrationsHelper->method('getIntegration')->with('Clearbit')
+        $this->integrationsHelper->expects($this->once())->method('getIntegration')->with('Clearbit')
             ->willThrowException(new IntegrationNotFoundException());
 
         $lead = new Lead();
         $lead->setId(7);
         $lead->setSocialCache(['clearbit' => ['clearbit#7#2026072612' => 'x', 'nonce' => 'right-nonce']]);
 
-        $this->leadModel->method('getEntity')->with('7')->willReturn($lead);
+        $this->leadModel->expects($this->once())->method('getEntity')->with('7')->willReturn($lead);
 
         $result = $this->makeHelper()->validateRequest('clearbit#7#2026072612#3#wrong-nonce', 'person');
 
@@ -151,14 +151,14 @@ final class LookupHelperTest extends TestCase
 
     public function testValidateRequestReturnsEntityWhenNonceMatches(): void
     {
-        $this->integrationsHelper->method('getIntegration')->with('Clearbit')
+        $this->integrationsHelper->expects($this->once())->method('getIntegration')->with('Clearbit')
             ->willThrowException(new IntegrationNotFoundException());
 
         $lead = new Lead();
         $lead->setId(7);
         $lead->setSocialCache(['clearbit' => ['clearbit_notify#7#2026072612' => 'x', 'nonce' => 'the-nonce']]);
 
-        $this->leadModel->method('getEntity')->with('7')->willReturn($lead);
+        $this->leadModel->expects($this->once())->method('getEntity')->with('7')->willReturn($lead);
 
         $result = $this->makeHelper()->validateRequest('clearbit_notify#7#2026072612#3#the-nonce', 'person');
 
@@ -169,10 +169,10 @@ final class LookupHelperTest extends TestCase
 
     public function testValidateRequestReturnsFalseWhenEntityNotFound(): void
     {
-        $this->integrationsHelper->method('getIntegration')->with('Clearbit')
+        $this->integrationsHelper->expects($this->once())->method('getIntegration')->with('Clearbit')
             ->willThrowException(new IntegrationNotFoundException());
 
-        $this->leadModel->method('getEntity')->with('99')->willReturn(null);
+        $this->leadModel->expects($this->once())->method('getEntity')->with('99')->willReturn(null);
 
         $result = $this->makeHelper()->validateRequest('clearbit#99#2026072612#3#some-nonce', 'person');
 


### PR DESCRIPTION
Follow-up to #17063 - that pull request adds `AddExpectsOnceToMockMethodCallRector` but keeps it skipped in `rector.php`. Here the skip is removed and the rule is applied to `app/bundles/**/Tests/Unit` and `plugins/**/Tests/Unit`.

```diff
 $queueMock = $this->createMock(WebhookQueue::class);
-$queueMock->method('getPayload')
+$queueMock->expects($this->once())->method('getPayload')
     ->willReturn('{"the": "payload"}');
```
