### PR TITLE
ci: run every test that needs no database outside the database job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -114,14 +114,14 @@ jobs:
         export DB_PORT="${{ job.services.database.ports[3306] }}"
         export SAML_PORT="${{ job.services.saml.ports[8080] }}"
 
-        # The "Container smoke tests" and "Static analysis rule tests" suites need no database,
-        # they run in the separate "no-database-tests" job below.
+        # Everything that needs no database runs in the "no-database-tests" job below: the two
+        # suites left out here, and every test outside the "database" group.
         SUITES="Project Test Suite,Plugin tests,Middleware tests"
 
         if [[ "$COVERAGE" == "true" ]]; then
-          php -d zend.assertions=1 -d pcov.enabled=1 bin/phpunit -d memory_limit=3G --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist --testsuite "$SUITES" --coverage-clover=coverage.xml --log-junit=junit.xml
+          php -d zend.assertions=1 -d pcov.enabled=1 bin/phpunit -d memory_limit=3G --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist --testsuite "$SUITES" --group database --coverage-clover=coverage.xml --log-junit=junit.xml
         else
-          php -d zend.assertions=1 bin/phpunit -d memory_limit=2G --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist --testsuite "$SUITES"
+          php -d zend.assertions=1 bin/phpunit -d memory_limit=2G --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist --testsuite "$SUITES" --group database
         fi
 
     - name: Upload coverage report
@@ -175,7 +175,9 @@ jobs:
       uses: "ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda" # 4.0.0
 
     - name: Run tests
-      run: bin/phpunit --configuration app/phpunit.xml.dist --testsuite "Container smoke tests,Static analysis rule tests"
+      run: |
+        bin/phpunit --configuration app/phpunit.xml.dist --testsuite "Container smoke tests,Static analysis rule tests"
+        bin/phpunit --configuration app/phpunit.xml.dist --testsuite "Project Test Suite,Plugin tests,Middleware tests" --exclude-group database
 
   e2e-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -114,10 +114,14 @@ jobs:
         export DB_PORT="${{ job.services.database.ports[3306] }}"
         export SAML_PORT="${{ job.services.saml.ports[8080] }}"
 
+        # The "Container smoke tests" and "Static analysis rule tests" suites need no database,
+        # they run in the separate "no-database-tests" job below.
+        SUITES="Project Test Suite,Plugin tests,Middleware tests"
+
         if [[ "$COVERAGE" == "true" ]]; then
-          php -d zend.assertions=1 -d pcov.enabled=1 bin/phpunit -d memory_limit=3G --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist --coverage-clover=coverage.xml --log-junit=junit.xml
+          php -d zend.assertions=1 -d pcov.enabled=1 bin/phpunit -d memory_limit=3G --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist --testsuite "$SUITES" --coverage-clover=coverage.xml --log-junit=junit.xml
         else
-          php -d zend.assertions=1 bin/phpunit -d memory_limit=2G --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist
+          php -d zend.assertions=1 bin/phpunit -d memory_limit=2G --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist --testsuite "$SUITES"
         fi
 
     - name: Upload coverage report
@@ -151,6 +155,27 @@ jobs:
       with:
         name: logs-${{ matrix.php-versions }}-${{ env.DB_LOG_NAME }}
         path: ./var/logs/*
+
+  no-database-tests:
+    runs-on: ubuntu-latest
+
+    name: PHPUnit without database
+
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+    - name: Setup PHP, with composer and extensions
+      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
+      with:
+        php-version: '8.4'
+        extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, mysql, pdo_mysql
+        coverage: none
+
+    - name: Install dependencies
+      uses: "ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda" # 4.0.0
+
+    - name: Run tests
+      run: bin/phpunit --configuration app/phpunit.xml.dist --testsuite "Container smoke tests,Static analysis rule tests"
 
   e2e-tests:
     runs-on: ubuntu-latest

--- a/app/bundles/ApiBundle/Tests/Functional/Controller/ClientControllerTest.php
+++ b/app/bundles/ApiBundle/Tests/Functional/Controller/ClientControllerTest.php
@@ -6,10 +6,12 @@ namespace Mautic\ApiBundle\Tests\Functional\Controller;
 
 use Mautic\ApiBundle\Entity\oAuth2\Client;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[Group('database')]
 final class ClientControllerTest extends MauticMysqlTestCase
 {
     private const int TOTAL_COUNT = 6;

--- a/app/bundles/ApiBundle/Tests/Functional/Controller/CommonApiControllerTest.php
+++ b/app/bundles/ApiBundle/Tests/Functional/Controller/CommonApiControllerTest.php
@@ -10,9 +10,11 @@ use Mautic\CoreBundle\Tests\Functional\CreateTestEntitiesTrait;
 use Mautic\UserBundle\Entity\Role;
 use Mautic\UserBundle\Entity\User;
 use Mautic\UserBundle\Security\UserTokenSetter;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[Group('database')]
 final class CommonApiControllerTest extends MauticMysqlTestCase
 {
     use CreateTestEntitiesTrait;

--- a/app/bundles/ApiBundle/Tests/Functional/Oauth2Test.php
+++ b/app/bundles/ApiBundle/Tests/Functional/Oauth2Test.php
@@ -9,6 +9,7 @@ use Mautic\ApiBundle\Entity\oAuth2\Client;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\UserBundle\Entity\User;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Symfony\Component\HttpFoundation\Request;
@@ -20,6 +21,7 @@ use Symfony\Component\HttpFoundation\Response;
  */
 #[PreserveGlobalState(false)]
 #[RunTestsInSeparateProcesses]
+#[Group('database')]
 final class Oauth2Test extends MauticMysqlTestCase
 {
     protected function setUp(): void

--- a/app/bundles/ApiBundle/Tests/Functional/OwnershipScopedSecurityMetadataTest.php
+++ b/app/bundles/ApiBundle/Tests/Functional/OwnershipScopedSecurityMetadataTest.php
@@ -11,6 +11,7 @@ use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInter
 use ApiPlatform\Metadata\Resource\Factory\ResourceNameCollectionFactoryInterface;
 use Mautic\CoreBundle\Entity\IpAddress;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Contract test: every ownership-scoped item operation in every API v2 resource
@@ -20,6 +21,7 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
  * grant access to any user holding the `own` permission bit — regardless of
  * whether they actually own that specific entity.
  */
+#[Group('database')]
 final class OwnershipScopedSecurityMetadataTest extends MauticMysqlTestCase
 {
     public function testAllOwnershipScopedItemOperationsPassObjectToSecurityExpression(): void

--- a/app/bundles/ApiBundle/Tests/Functional/Serializer/PutOperationTest.php
+++ b/app/bundles/ApiBundle/Tests/Functional/Serializer/PutOperationTest.php
@@ -7,12 +7,14 @@ namespace Mautic\ApiBundle\Tests\Functional\Serializer;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\PageBundle\Entity\Page;
 use Mautic\ProjectBundle\Entity\Project;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Functional test to verify that PUT operations update existing entities
  * instead of creating new ones. This tests the PutProcessor fix end-to-end.
  */
+#[Group('database')]
 final class PutOperationTest extends MauticMysqlTestCase
 {
     /**

--- a/app/bundles/AssetBundle/Tests/Controller/Api/AssetApiControllerFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Controller/Api/AssetApiControllerFunctionalTest.php
@@ -6,7 +6,9 @@ namespace Mautic\AssetBundle\Tests\Controller\Api;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class AssetApiControllerFunctionalTest extends MauticMysqlTestCase
 {
     protected function setUp(): void

--- a/app/bundles/AssetBundle/Tests/Controller/Api/AssetWidgetDataApiControllerFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Controller/Api/AssetWidgetDataApiControllerFunctionalTest.php
@@ -6,7 +6,9 @@ namespace Mautic\AssetBundle\Tests\Controller\Api;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class AssetWidgetDataApiControllerFunctionalTest extends MauticMysqlTestCase
 {
     /**

--- a/app/bundles/AssetBundle/Tests/Controller/AssetControllerFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Controller/AssetControllerFunctionalTest.php
@@ -15,11 +15,13 @@ use Mautic\UserBundle\Entity\User;
 use Mautic\UserBundle\Model\RoleModel;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
+#[Group('database')]
 final class AssetControllerFunctionalTest extends AbstractAssetTestCase
 {
     use ControllerTrait;

--- a/app/bundles/AssetBundle/Tests/Controller/AssetDetailFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Controller/AssetDetailFunctionalTest.php
@@ -6,7 +6,9 @@ namespace Mautic\AssetBundle\Tests\Controller;
 
 use Mautic\AssetBundle\Entity\Asset;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class AssetDetailFunctionalTest extends MauticMysqlTestCase
 {
     public function testLeadViewPreventsXSS(): void

--- a/app/bundles/AssetBundle/Tests/Controller/AssetDownloadFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Controller/AssetDownloadFunctionalTest.php
@@ -12,9 +12,11 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\PageBundle\Entity\Page;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class AssetDownloadFunctionalTest extends MauticMysqlTestCase
 {
     public function testDownloadOfNotFoundAsset(): void

--- a/app/bundles/AssetBundle/Tests/Controller/AssetProjectSearchFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Controller/AssetProjectSearchFunctionalTest.php
@@ -7,7 +7,9 @@ namespace Mautic\AssetBundle\Tests\Controller;
 use Mautic\AssetBundle\Entity\Asset;
 use Mautic\ProjectBundle\Tests\Functional\AbstractProjectSearchTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class AssetProjectSearchFunctionalTest extends AbstractProjectSearchTestCase
 {
     #[DataProvider('searchDataProvider')]

--- a/app/bundles/AssetBundle/Tests/Controller/PublicControllerFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Controller/PublicControllerFunctionalTest.php
@@ -7,8 +7,10 @@ namespace Mautic\AssetBundle\Tests\Controller;
 use Mautic\AssetBundle\Entity\Download;
 use Mautic\AssetBundle\Tests\Asset\AbstractAssetTestCase;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class PublicControllerFunctionalTest extends AbstractAssetTestCase
 {
     /**

--- a/app/bundles/AssetBundle/Tests/Controller/UploadControllerFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Controller/UploadControllerFunctionalTest.php
@@ -6,11 +6,13 @@ namespace Mautic\AssetBundle\Tests\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class UploadControllerFunctionalTest extends MauticMysqlTestCase
 {
     private string $assetPath;

--- a/app/bundles/AssetBundle/Tests/DataFixtures/LoadAssetDataTest.php
+++ b/app/bundles/AssetBundle/Tests/DataFixtures/LoadAssetDataTest.php
@@ -7,7 +7,9 @@ namespace Mautic\AssetBundle\Tests\DataFixtures;
 use Mautic\AssetBundle\DataFixtures\ORM\LoadAssetData;
 use Mautic\AssetBundle\Entity\Asset;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class LoadAssetDataTest extends MauticMysqlTestCase
 {
     public function testLoadFixtures(): void

--- a/app/bundles/AssetBundle/Tests/EventListener/LeadSubscriberFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/EventListener/LeadSubscriberFunctionalTest.php
@@ -9,7 +9,9 @@ use Mautic\AssetBundle\Entity\Download;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Model\LeadModel;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class LeadSubscriberFunctionalTest extends MauticMysqlTestCase
 {
     /**

--- a/app/bundles/AssetBundle/Tests/EventListener/ReportSubscriberFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/EventListener/ReportSubscriberFunctionalTest.php
@@ -9,7 +9,9 @@ use Mautic\AssetBundle\Entity\Download;
 use Mautic\LeadBundle\Entity\DoNotContact;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\ReportBundle\Tests\Functional\AbstractReportSubscriberTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class ReportSubscriberFunctionalTest extends AbstractReportSubscriberTestCase
 {
     public function testAssetDownloadReportWithDncListColumn(): void

--- a/app/bundles/AssetBundle/Tests/Functional/ApiPlatform/DownloadOwnershipApiV2AuthorizationRegressionTest.php
+++ b/app/bundles/AssetBundle/Tests/Functional/ApiPlatform/DownloadOwnershipApiV2AuthorizationRegressionTest.php
@@ -8,12 +8,14 @@ use Mautic\AssetBundle\Entity\Asset;
 use Mautic\AssetBundle\Entity\Download;
 use Mautic\LeadBundle\Tests\Functional\ApiPlatform\OwnershipScopedApiAuthorizationTestBase;
 use Mautic\UserBundle\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Tests that Download entity correctly uses getPermissionUser() to resolve ownership
  * through its parent Asset entity, since Download doesn't have a direct createdBy field.
  */
+#[Group('database')]
 final class DownloadOwnershipApiV2AuthorizationRegressionTest extends OwnershipScopedApiAuthorizationTestBase
 {
     public function testViewOwnItemCannotReadForeignDownloadOnApiV2(): void

--- a/app/bundles/AssetBundle/Tests/Functional/Entity/DownloadRepositoryFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Functional/Entity/DownloadRepositoryFunctionalTest.php
@@ -9,7 +9,9 @@ use Mautic\AssetBundle\Entity\DownloadRepository;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\PageBundle\Entity\Page;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class DownloadRepositoryFunctionalTest extends MauticMysqlTestCase
 {
     private DownloadRepository $downloadRepository;

--- a/app/bundles/AssetBundle/Tests/Model/AssetModelFunctionalTest.php
+++ b/app/bundles/AssetBundle/Tests/Model/AssetModelFunctionalTest.php
@@ -9,7 +9,9 @@ use Mautic\AssetBundle\Model\AssetModel;
 use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class AssetModelFunctionalTest extends MauticMysqlTestCase
 {
     protected function beforeBeginTransaction(): void

--- a/app/bundles/CampaignBundle/Tests/Command/Api/CampaignApiControllerFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Command/Api/CampaignApiControllerFunctionalTest.php
@@ -11,8 +11,10 @@ use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class CampaignApiControllerFunctionalTest extends MauticMysqlTestCase
 {
     #[DataProvider('withContactCountsProvider')]

--- a/app/bundles/CampaignBundle/Tests/Command/Api/EventLogApiControllerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Command/Api/EventLogApiControllerTest.php
@@ -9,7 +9,9 @@ use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CampaignBundle\Entity\Lead as CampaignMember;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class EventLogApiControllerTest extends MauticMysqlTestCase
 {
     public function testBatchEditEventsPut(): void

--- a/app/bundles/CampaignBundle/Tests/Command/CampaignDeleteEventLogsCommandFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Command/CampaignDeleteEventLogsCommandFunctionalTest.php
@@ -10,9 +10,11 @@ use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CampaignBundle\Entity\LeadEventLog;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\ApplicationTester;
 
+#[Group('database')]
 final class CampaignDeleteEventLogsCommandFunctionalTest extends MauticMysqlTestCase
 {
     public function testWithEventIds(): void

--- a/app/bundles/CampaignBundle/Tests/Command/CampaignSummarizationFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Command/CampaignSummarizationFunctionalTest.php
@@ -12,7 +12,9 @@ use Mautic\CampaignBundle\Entity\Summary;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class CampaignSummarizationFunctionalTest extends MauticMysqlTestCase
 {
     protected function setUp(): void

--- a/app/bundles/CampaignBundle/Tests/Command/ExecuteEventCommandTest.php
+++ b/app/bundles/CampaignBundle/Tests/Command/ExecuteEventCommandTest.php
@@ -9,7 +9,9 @@ use Mautic\CampaignBundle\Entity\LeadEventLogRepository;
 use Mautic\CampaignBundle\Executioner\ScheduledExecutioner;
 use Mautic\CampaignBundle\Tests\Functional\Fixtures\FixtureHelper;
 use Mautic\CoreBundle\Helper\DateTimeHelper;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class ExecuteEventCommandTest extends AbstractCampaignCommand
 {
     public function testEventsAreExecutedForInactiveEventWithSingleContact(): void

--- a/app/bundles/CampaignBundle/Tests/Command/ResumeStuckCampaignCommandTest.php
+++ b/app/bundles/CampaignBundle/Tests/Command/ResumeStuckCampaignCommandTest.php
@@ -8,10 +8,12 @@ use Mautic\CampaignBundle\Command\ResumeStuckCampaignCommand;
 use Mautic\CampaignBundle\Entity\Campaign;
 use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CampaignBundle\Entity\LeadEventLog;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\RuntimeException;
 
+#[Group('database')]
 final class ResumeStuckCampaignCommandTest extends AbstractCampaignCommand
 {
     protected function setUp(): void

--- a/app/bundles/CampaignBundle/Tests/Command/SummarizeCommandTest.php
+++ b/app/bundles/CampaignBundle/Tests/Command/SummarizeCommandTest.php
@@ -8,7 +8,9 @@ use Mautic\CampaignBundle\Command\SummarizeCommand;
 use Mautic\CampaignBundle\Entity\Summary;
 use Mautic\CampaignBundle\Entity\SummaryRepository;
 use Mautic\CampaignBundle\Tests\Campaign\AbstractCampaignTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class SummarizeCommandTest extends AbstractCampaignTestCase
 {
     /**

--- a/app/bundles/CampaignBundle/Tests/Command/TriggerCampaignCommandTest.php
+++ b/app/bundles/CampaignBundle/Tests/Command/TriggerCampaignCommandTest.php
@@ -21,7 +21,9 @@ use Mautic\LeadBundle\Entity\ListLeadRepository;
 use Mautic\LeadBundle\Helper\SegmentCountCacheHelper;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class TriggerCampaignCommandTest extends AbstractCampaignCommand
 {
     use CampaignAuditLogTrait;

--- a/app/bundles/CampaignBundle/Tests/Command/ValidateEventCommandTest.php
+++ b/app/bundles/CampaignBundle/Tests/Command/ValidateEventCommandTest.php
@@ -6,7 +6,9 @@ namespace Mautic\CampaignBundle\Tests\Command;
 
 use Mautic\CampaignBundle\Executioner\InactiveExecutioner;
 use Mautic\CampaignBundle\Executioner\ScheduledExecutioner;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class ValidateEventCommandTest extends AbstractCampaignCommand
 {
     public function testEventsAreExecutedForInactiveEventWithSingleContact(): void

--- a/app/bundles/CampaignBundle/Tests/Controller/AjaxControllerFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/AjaxControllerFunctionalTest.php
@@ -8,8 +8,10 @@ use Mautic\CampaignBundle\Entity\LeadEventLog;
 use Mautic\CampaignBundle\Entity\LeadEventLogRepository;
 use Mautic\CampaignBundle\Tests\Functional\Fixtures\FixtureHelper;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class AjaxControllerFunctionalTest extends MauticMysqlTestCase
 {
     private FixtureHelper $campaignFixturesHelper;

--- a/app/bundles/CampaignBundle/Tests/Controller/Api/CampaignApiControllerFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/Api/CampaignApiControllerFunctionalTest.php
@@ -19,10 +19,12 @@ use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\ListLead;
 use Mautic\UserBundle\Entity\User;
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class CampaignApiControllerFunctionalTest extends MauticMysqlTestCase
 {
     use UserEntityTrait;

--- a/app/bundles/CampaignBundle/Tests/Controller/Api/ContactCampaignApiControllerFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/Api/ContactCampaignApiControllerFunctionalTest.php
@@ -8,8 +8,10 @@ use Mautic\CampaignBundle\Entity\Lead as CampaignMember;
 use Mautic\CampaignBundle\Tests\Campaign\AbstractCampaignTestCase;
 use Mautic\LeadBundle\Entity\Lead;
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class ContactCampaignApiControllerFunctionalTest extends AbstractCampaignTestCase
 {
     public function testContactCampaignApiEndpoints(): void

--- a/app/bundles/CampaignBundle/Tests/Controller/CampaignControllerFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/CampaignControllerFunctionalTest.php
@@ -11,10 +11,12 @@ use Mautic\CampaignBundle\Entity\LeadEventLog;
 use Mautic\CampaignBundle\Model\CampaignModel;
 use Mautic\CampaignBundle\Tests\Campaign\AbstractCampaignTestCase;
 use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[Group('database')]
 final class CampaignControllerFunctionalTest extends AbstractCampaignTestCase
 {
     private const string CAMPAIGN_SUMMARY_PARAM = 'campaign_use_summary';

--- a/app/bundles/CampaignBundle/Tests/Controller/CampaignControllerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/CampaignControllerTest.php
@@ -8,8 +8,10 @@ use Mautic\CampaignBundle\Entity\Campaign;
 use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\ProjectBundle\Entity\Project;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class CampaignControllerTest extends MauticMysqlTestCase
 {
     /**

--- a/app/bundles/CampaignBundle/Tests/Controller/CampaignMapStatsControllerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/CampaignMapStatsControllerTest.php
@@ -19,9 +19,11 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\PageBundle\Entity\Hit;
 use Mautic\PageBundle\Entity\Redirect;
 use Mautic\PageBundle\Entity\Trackable;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class CampaignMapStatsControllerTest extends MauticMysqlTestCase
 {
     private CampaignMapStatsController $mapController;

--- a/app/bundles/CampaignBundle/Tests/Controller/CampaignMetricsControllerFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/CampaignMetricsControllerFunctionalTest.php
@@ -11,9 +11,11 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\EmailBundle\Entity\Stat;
 use Mautic\EmailBundle\Tests\Functional\Fixtures\EmailFixturesHelper;
 use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class CampaignMetricsControllerFunctionalTest extends MauticMysqlTestCase
 {
     private FixtureHelper $campaignFixturesHelper;

--- a/app/bundles/CampaignBundle/Tests/Controller/CampaignProjectSearchFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/CampaignProjectSearchFunctionalTest.php
@@ -7,7 +7,9 @@ namespace Mautic\CampaignBundle\Tests\Controller;
 use Mautic\CampaignBundle\Entity\Campaign;
 use Mautic\ProjectBundle\Tests\Functional\AbstractProjectSearchTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class CampaignProjectSearchFunctionalTest extends AbstractProjectSearchTestCase
 {
     #[DataProvider('searchDataProvider')]

--- a/app/bundles/CampaignBundle/Tests/Controller/CampaignUnpublishedWorkflowFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/CampaignUnpublishedWorkflowFunctionalTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Mautic\CampaignBundle\Tests\Controller;
 
 use Mautic\CampaignBundle\Tests\Campaign\AbstractCampaignTestCase;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[Group('database')]
 final class CampaignUnpublishedWorkflowFunctionalTest extends AbstractCampaignTestCase
 {
     public function testCreateCampaignPageShouldNotContainConformation(): void

--- a/app/bundles/CampaignBundle/Tests/Controller/EventControllerFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/EventControllerFunctionalTest.php
@@ -9,9 +9,11 @@ use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class EventControllerFunctionalTest extends MauticMysqlTestCase
 {
     #[DataProvider('fieldAndValueProvider')]

--- a/app/bundles/CampaignBundle/Tests/Controller/SourceControllerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/SourceControllerTest.php
@@ -7,7 +7,9 @@ namespace Mautic\CampaignBundle\Tests\Controller;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\FormBundle\Entity\Form;
 use Mautic\LeadBundle\Entity\LeadList;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class SourceControllerTest extends MauticMysqlTestCase
 {
     private const string ACCESS_DENIED      = 'You do not have access to the requested area\/action';

--- a/app/bundles/CampaignBundle/Tests/Controller/VisitedPageConditionControllerFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/VisitedPageConditionControllerFunctionalTest.php
@@ -6,8 +6,10 @@ namespace Mautic\CampaignBundle\Tests\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\DomCrawler\Crawler;
 
+#[Group('database')]
 final class VisitedPageConditionControllerFunctionalTest extends MauticMysqlTestCase
 {
     /**

--- a/app/bundles/CampaignBundle/Tests/Entity/CampaignRepositoryFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Entity/CampaignRepositoryFunctionalTest.php
@@ -13,7 +13,9 @@ use Mautic\CampaignBundle\Entity\Result\CountResult;
 use Mautic\CampaignBundle\Executioner\ContactFinder\Limiter\ContactLimiter;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class CampaignRepositoryFunctionalTest extends MauticMysqlTestCase
 {
     private CampaignRepository $repository;

--- a/app/bundles/CampaignBundle/Tests/Entity/EventRepositoryFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Entity/EventRepositoryFunctionalTest.php
@@ -13,7 +13,9 @@ use Mautic\EmailBundle\Entity\Email;
 use Mautic\LeadBundle\Entity\Lead;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class EventRepositoryFunctionalTest extends MauticMysqlTestCase
 {
     /**

--- a/app/bundles/CampaignBundle/Tests/EventListener/CampaignEventSubscriberFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/EventListener/CampaignEventSubscriberFunctionalTest.php
@@ -13,8 +13,10 @@ use Mautic\CoreBundle\Entity\Notification;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
+#[Group('database')]
 final class CampaignEventSubscriberFunctionalTest extends MauticMysqlTestCase
 {
     /**

--- a/app/bundles/CampaignBundle/Tests/EventListener/ReportSubscriberFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/EventListener/ReportSubscriberFunctionalTest.php
@@ -8,7 +8,9 @@ use Mautic\CampaignBundle\Tests\Functional\Fixtures\FixtureHelper;
 use Mautic\LeadBundle\Entity\DoNotContact;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\ReportBundle\Tests\Functional\AbstractReportSubscriberTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class ReportSubscriberFunctionalTest extends AbstractReportSubscriberTestCase
 {
     public function testCampaignLeadLogReportWithDncListColumn(): void

--- a/app/bundles/CampaignBundle/Tests/Executioner/EventExecutionerLockTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/EventExecutionerLockTest.php
@@ -14,8 +14,10 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\CoreBundle\Tests\Traits\LoggerTrait;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\LeadEvents;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
+#[Group('database')]
 final class EventExecutionerLockTest extends MauticMysqlTestCase
 {
     use LoggerTrait {

--- a/app/bundles/CampaignBundle/Tests/Executioner/ScheduledExecutionerExtendTriggerDateTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/ScheduledExecutionerExtendTriggerDateTest.php
@@ -14,7 +14,9 @@ use Mautic\CampaignBundle\Tests\Command\AbstractCampaignCommand;
 use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\LeadBundle\Entity\Lead;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class ScheduledExecutionerExtendTriggerDateTest extends AbstractCampaignCommand
 {
     use CampaignAuditLogTrait;

--- a/app/bundles/CampaignBundle/Tests/Executioner/ScheduledExecutionerFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/ScheduledExecutionerFunctionalTest.php
@@ -14,8 +14,10 @@ use Mautic\CampaignBundle\Executioner\ScheduledExecutioner;
 use Mautic\CampaignBundle\Executioner\TestScheduledExecutioner;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\Console\Output\BufferedOutput;
 
+#[Group('database')]
 final class ScheduledExecutionerFunctionalTest extends MauticMysqlTestCase
 {
     private ScheduledExecutioner $scheduledExecutioner;

--- a/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/EventSchedulerExtendTriggerDateFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/EventSchedulerExtendTriggerDateFunctionalTest.php
@@ -11,7 +11,9 @@ use Mautic\CampaignBundle\Entity\LeadEventLog;
 use Mautic\CoreBundle\Entity\AuditLog;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class EventSchedulerExtendTriggerDateFunctionalTest extends MauticMysqlTestCase
 {
     private function createPublishAuditLog(Campaign $campaign, \DateTime $dateAdded, bool $isPublished): void

--- a/app/bundles/CampaignBundle/Tests/Functional/Api/CampaignApiEventDeleteTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Api/CampaignApiEventDeleteTest.php
@@ -8,7 +8,9 @@ use Mautic\CampaignBundle\Entity\Campaign;
 use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\LeadList;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class CampaignApiEventDeleteTest extends MauticMysqlTestCase
 {
     public function testEventAndSourceDeleteViaPutReproducesApiBug(): void

--- a/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest.php
@@ -12,7 +12,9 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class CampaignActionJumpToEventWithIntervalTriggerModeFunctionalTest extends MauticMysqlTestCase
 {
     private const string HOUR_DATE_FORMAT = 'Y-m-d H:00:00';

--- a/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignDecisionTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignDecisionTest.php
@@ -13,7 +13,9 @@ use Mautic\CampaignBundle\Entity\LeadEventLog;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Tests\Traits\LeadFieldTestTrait;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class CampaignDecisionTest extends MauticMysqlTestCase
 {
     use CampaignEntitiesTrait;

--- a/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignEventDetailsTimelineFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignEventDetailsTimelineFunctionalTest.php
@@ -8,8 +8,10 @@ use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\OptimisticLockException;
 use Doctrine\Persistence\Mapping\MappingException;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[Group('database')]
 final class CampaignEventDetailsTimelineFunctionalTest extends MauticMysqlTestCase
 {
     use CampaignEntitiesTrait;

--- a/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignMembershipFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignMembershipFunctionalTest.php
@@ -11,7 +11,9 @@ use Mautic\CampaignBundle\Membership\Action\Adder;
 use Mautic\CampaignBundle\Membership\Exception\ContactCannotBeAddedToCampaignException;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class CampaignMembershipFunctionalTest extends MauticMysqlTestCase
 {
     protected function setUp(): void

--- a/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignRestartFromSegmentTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignRestartFromSegmentTest.php
@@ -10,10 +10,12 @@ use Mautic\CampaignBundle\Entity\LeadEventLog;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\ListLead;
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * @see https://github.com/mautic/mautic/issues/16026
  */
+#[Group('database')]
 final class CampaignRestartFromSegmentTest extends MauticMysqlTestCase
 {
     use CampaignEntitiesTrait;

--- a/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignRotationTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignRotationTest.php
@@ -14,11 +14,13 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Tracker\ContactTracker;
 use Mautic\PageBundle\Entity\Page;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 use Symfony\Component\HttpFoundation\Session\Session;
 
+#[Group('database')]
 final class CampaignRotationTest extends MauticMysqlTestCase
 {
     private Campaign $campaignWithoutJump;

--- a/app/bundles/CampaignBundle/Tests/Functional/Campaign/DetailsTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Campaign/DetailsTest.php
@@ -6,7 +6,9 @@ namespace Mautic\CampaignBundle\Tests\Functional\Campaign;
 
 use Mautic\CampaignBundle\Entity\Campaign;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class DetailsTest extends MauticMysqlTestCase
 {
     public function testDetailsPageLoadCorrectly(): void

--- a/app/bundles/CampaignBundle/Tests/Functional/Campaign/JumpToActionTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Campaign/JumpToActionTest.php
@@ -11,7 +11,9 @@ use Mautic\CampaignBundle\Entity\LeadEventLog;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\Tag;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class JumpToActionTest extends MauticMysqlTestCase
 {
     /**

--- a/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignAuditLogTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignAuditLogTest.php
@@ -9,10 +9,12 @@ use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CampaignBundle\Model\CampaignModel;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\CoreBundle\Tests\Functional\CreateTestEntitiesTrait;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[Group('database')]
 final class CampaignAuditLogTest extends MauticMysqlTestCase
 {
     use CreateTestEntitiesTrait;

--- a/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignBuilderEditFieldValueConditionTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignBuilderEditFieldValueConditionTest.php
@@ -10,8 +10,10 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\CoreBundle\Tests\Functional\CreateTestEntitiesTrait;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class CampaignBuilderEditFieldValueConditionTest extends MauticMysqlTestCase
 {
     use CampaignControllerTrait;

--- a/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignControllerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignControllerTest.php
@@ -20,10 +20,12 @@ use Mautic\FormBundle\Entity\Form;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\UserBundle\Entity\User;
 use Mautic\UserBundle\Entity\UserRepository;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class CampaignControllerTest extends MauticMysqlTestCase
 {
     use CreateTestEntitiesTrait;

--- a/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignEventStatsTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignEventStatsTest.php
@@ -7,8 +7,10 @@ namespace Mautic\CampaignBundle\Tests\Functional\Controller;
 use Mautic\CampaignBundle\Entity\Campaign;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\CoreBundle\Tests\Functional\CreateTestEntitiesTrait;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\DomCrawler\Crawler;
 
+#[Group('database')]
 final class CampaignEventStatsTest extends MauticMysqlTestCase
 {
     use CreateTestEntitiesTrait;

--- a/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignImportControllerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignImportControllerTest.php
@@ -10,9 +10,11 @@ use Mautic\CoreBundle\Event\EntityImportEvent;
 use Mautic\CoreBundle\Helper\ImportHelper;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\UserBundle\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class CampaignImportControllerTest extends MauticMysqlTestCase
 {
     protected function setUp(): void

--- a/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignOptimisticLockTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignOptimisticLockTest.php
@@ -9,7 +9,9 @@ use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class CampaignOptimisticLockTest extends MauticMysqlTestCase
 {
     use CampaignControllerTrait;

--- a/app/bundles/CampaignBundle/Tests/Functional/Entity/CampaignRepositoryFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Entity/CampaignRepositoryFunctionalTest.php
@@ -12,7 +12,9 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\ListLead;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class CampaignRepositoryFunctionalTest extends MauticMysqlTestCase
 {
     public function testGetCampaignsSegmentShare(): void

--- a/app/bundles/CampaignBundle/Tests/Functional/Entity/LeadEventLogRepositoryTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Entity/LeadEventLogRepositoryTest.php
@@ -10,7 +10,9 @@ use Mautic\CampaignBundle\Entity\LeadEventLog;
 use Mautic\CampaignBundle\Entity\LeadEventLogRepository;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class LeadEventLogRepositoryTest extends MauticMysqlTestCase
 {
     private LeadEventLogRepository $repository;

--- a/app/bundles/CampaignBundle/Tests/Functional/EventListener/CampaignSubscriberFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/EventListener/CampaignSubscriberFunctionalTest.php
@@ -13,7 +13,9 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadField;
 use Mautic\LeadBundle\EventListener\CampaignSubscriber;
 use Mautic\LeadBundle\Model\FieldModel;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/CampaignBundle/Tests/Functional/EventListener/LeadSubscriberFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/EventListener/LeadSubscriberFunctionalTest.php
@@ -12,6 +12,7 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Event\LeadMergeEvent;
 
+#[PHPUnit\Framework\Attributes\Group('database')]
 final class LeadSubscriberFunctionalTest extends MauticMysqlTestCase
 {
     public function testCampaignLeadMerge(): void

--- a/app/bundles/CampaignBundle/Tests/Functional/Executioner/InactiveExecutionerFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Executioner/InactiveExecutionerFunctionalTest.php
@@ -14,12 +14,14 @@ use Mautic\CampaignBundle\Executioner\Result\Counter;
 use Mautic\CampaignBundle\Executioner\TestInactiveExecutioner;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\Console\Output\BufferedOutput;
 
 /**
  * Functional tests for decision event redirection scenarios.
  * Tests redirection FROM decision events TO other event types (actions/conditions).
  */
+#[Group('database')]
 final class InactiveExecutionerFunctionalTest extends MauticMysqlTestCase
 {
     private InactiveExecutioner $inactiveExecutioner;

--- a/app/bundles/CampaignBundle/Tests/Functional/Form/Validator/Constraints/InfiniteLoopValidatorFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Form/Validator/Constraints/InfiniteLoopValidatorFunctionalTest.php
@@ -7,8 +7,10 @@ namespace Mautic\CampaignBundle\Tests\Functional\Form\Validator\Constraints;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\LeadList;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\DomCrawler\Crawler;
 
+#[Group('database')]
 final class InfiniteLoopValidatorFunctionalTest extends MauticMysqlTestCase
 {
     #[DataProvider('delayDataProvider')]

--- a/app/bundles/CampaignBundle/Tests/Functional/Model/EventModelFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Model/EventModelFunctionalTest.php
@@ -8,7 +8,9 @@ use Mautic\CampaignBundle\Entity\Campaign;
 use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CampaignBundle\Model\EventModel;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class EventModelFunctionalTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/CampaignBundle/Tests/Functional/Service/CampaignAuditServiceFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Service/CampaignAuditServiceFunctionalTest.php
@@ -11,9 +11,11 @@ use Mautic\CampaignBundle\Service\CampaignAuditService;
 use Mautic\CoreBundle\Service\FlashBag;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\EmailBundle\Entity\Email;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
+#[Group('database')]
 final class CampaignAuditServiceFunctionalTest extends MauticMysqlTestCase
 {
     private CampaignAuditService $campaignAuditService;

--- a/app/bundles/CampaignBundle/Tests/Functional/Validator/OrphanEventsValidationFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Validator/OrphanEventsValidationFunctionalTest.php
@@ -10,7 +10,9 @@ use Mautic\CampaignBundle\Tests\Functional\Controller\CampaignControllerTrait;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\FormBundle\Entity\Form;
 use Mautic\LeadBundle\Entity\LeadList;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class OrphanEventsValidationFunctionalTest extends MauticMysqlTestCase
 {
     use CampaignControllerTrait;

--- a/app/bundles/CampaignBundle/Tests/Model/CampaignModelFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Model/CampaignModelFunctionalTest.php
@@ -19,7 +19,9 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\PageBundle\Entity\Hit;
 use Mautic\PageBundle\Entity\Redirect;
 use Mautic\PageBundle\Entity\Trackable;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class CampaignModelFunctionalTest extends MauticMysqlTestCase
 {
     /**

--- a/app/bundles/CampaignBundle/Tests/Service/CampaignAuditServiceTest.php
+++ b/app/bundles/CampaignBundle/Tests/Service/CampaignAuditServiceTest.php
@@ -10,9 +10,11 @@ use Mautic\CampaignBundle\Service\CampaignAuditService;
 use Mautic\CoreBundle\Service\FlashBag;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\EmailBundle\Entity\Email;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
+#[Group('database')]
 final class CampaignAuditServiceTest extends MauticMysqlTestCase
 {
     private const string CAMPAIGN_NAME = 'Test Campaign';

--- a/app/bundles/CampaignBundle/Tests/Service/PublishStateServiceTest.php
+++ b/app/bundles/CampaignBundle/Tests/Service/PublishStateServiceTest.php
@@ -11,7 +11,9 @@ use Mautic\CampaignBundle\Tests\CampaignAuditLogTrait;
 use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class PublishStateServiceTest extends MauticMysqlTestCase
 {
     use CampaignAuditLogTrait;

--- a/app/bundles/CategoryBundle/Tests/Controller/Api/CategoryApiControllerFunctionalTest.php
+++ b/app/bundles/CategoryBundle/Tests/Controller/Api/CategoryApiControllerFunctionalTest.php
@@ -10,7 +10,9 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadCategory;
 use Mautic\UserBundle\Entity\Role;
 use Mautic\UserBundle\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class CategoryApiControllerFunctionalTest extends MauticMysqlTestCase
 {
     /**

--- a/app/bundles/CategoryBundle/Tests/Controller/CategoryControllerFunctionalTest.php
+++ b/app/bundles/CategoryBundle/Tests/Controller/CategoryControllerFunctionalTest.php
@@ -11,11 +11,13 @@ use Mautic\StageBundle\Entity\Stage;
 use Mautic\UserBundle\Entity\Role;
 use Mautic\UserBundle\Entity\User;
 use Mautic\UserBundle\Model\UserModel;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 use Symfony\Component\PasswordHasher\PasswordHasherInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[Group('database')]
 final class CategoryControllerFunctionalTest extends MauticMysqlTestCase
 {
     private TranslatorInterface $translator;

--- a/app/bundles/ChannelBundle/Tests/Command/ProcessMarketingMessagesQueueCommandFunctionalTest.php
+++ b/app/bundles/ChannelBundle/Tests/Command/ProcessMarketingMessagesQueueCommandFunctionalTest.php
@@ -11,7 +11,9 @@ use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Entity\Stat;
 use Mautic\EmailBundle\Entity\StatRepository;
 use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class ProcessMarketingMessagesQueueCommandFunctionalTest extends MauticMysqlTestCase
 {
     use CreateTestEntitiesTrait;

--- a/app/bundles/ChannelBundle/Tests/Command/SendChannelBroadcastCommandTest.php
+++ b/app/bundles/ChannelBundle/Tests/Command/SendChannelBroadcastCommandTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Mautic\ChannelBundle\Tests\Command;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class SendChannelBroadcastCommandTest extends MauticMysqlTestCase
 {
     public function testBroadcastCommand(): void

--- a/app/bundles/ChannelBundle/Tests/Controller/Api/MessageApiControllerTest.php
+++ b/app/bundles/ChannelBundle/Tests/Controller/Api/MessageApiControllerTest.php
@@ -8,7 +8,9 @@ use Mautic\ChannelBundle\Entity\Channel;
 use Mautic\ChannelBundle\Entity\Message;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class MessageApiControllerTest extends MauticMysqlTestCase
 {
     public function testCreateMessage(): void

--- a/app/bundles/ChannelBundle/Tests/Controller/MessageControllerFunctionalTest.php
+++ b/app/bundles/ChannelBundle/Tests/Controller/MessageControllerFunctionalTest.php
@@ -7,7 +7,9 @@ namespace Mautic\ChannelBundle\Tests\Controller;
 use Mautic\ChannelBundle\Entity\Message;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\ProjectBundle\Entity\Project;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class MessageControllerFunctionalTest extends MauticMysqlTestCase
 {
     public function testFormWithProject(): void

--- a/app/bundles/ChannelBundle/Tests/Controller/MessageControllerTest.php
+++ b/app/bundles/ChannelBundle/Tests/Controller/MessageControllerTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Mautic\ChannelBundle\Tests\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class MessageControllerTest extends MauticMysqlTestCase
 {
     public function testMMUiWorkflow(): void

--- a/app/bundles/ChannelBundle/Tests/Controller/MessageProjectSearchFunctionalTest.php
+++ b/app/bundles/ChannelBundle/Tests/Controller/MessageProjectSearchFunctionalTest.php
@@ -8,7 +8,9 @@ use Mautic\ChannelBundle\Entity\Channel;
 use Mautic\ChannelBundle\Entity\Message;
 use Mautic\ProjectBundle\Tests\Functional\AbstractProjectSearchTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class MessageProjectSearchFunctionalTest extends AbstractProjectSearchTestCase
 {
     #[DataProvider('searchDataProvider')]

--- a/app/bundles/ConfigBundle/Tests/Controller/ConfigControllerFunctionalTest.php
+++ b/app/bundles/ConfigBundle/Tests/Controller/ConfigControllerFunctionalTest.php
@@ -6,12 +6,14 @@ namespace Mautic\ConfigBundle\Tests\Controller;
 
 use Mautic\ConfigBundle\Form\Helper\RestrictionHelper;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\DomCrawler\Field\ChoiceFormField;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[Group('database')]
 final class ConfigControllerFunctionalTest extends MauticMysqlTestCase
 {
     private const string SUBDOMAIN_URL = 'subdomain_url.com';

--- a/app/bundles/ConfigBundle/Tests/Controller/SysinfoControllerTest.php
+++ b/app/bundles/ConfigBundle/Tests/Controller/SysinfoControllerTest.php
@@ -6,8 +6,10 @@ namespace Mautic\ConfigBundle\Tests\Controller;
 
 use Mautic\ConfigBundle\Model\SysinfoModel;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class SysinfoControllerTest extends MauticMysqlTestCase
 {
     public function testDbInfoIsShown(): void

--- a/app/bundles/CoreBundle/Test/FunctionalWarmupTest.php
+++ b/app/bundles/CoreBundle/Test/FunctionalWarmupTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\Test;
 
+use PHPUnit\Framework\Attributes\Group;
+
+#[Group('database')]
 final class FunctionalWarmupTest extends MauticMysqlTestCase
 {
     public function testWarmup(): void

--- a/app/bundles/CoreBundle/Tests/Command/CleanupMaintenanceCommandTest.php
+++ b/app/bundles/CoreBundle/Tests/Command/CleanupMaintenanceCommandTest.php
@@ -7,7 +7,9 @@ namespace Mautic\CoreBundle\Tests\Command;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Model\LeadModel;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class CleanupMaintenanceCommandTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/CoreBundle/Tests/Command/GenerateProductionAssetsCommandTest.php
+++ b/app/bundles/CoreBundle/Tests/Command/GenerateProductionAssetsCommandTest.php
@@ -7,7 +7,9 @@ namespace Mautic\CoreBundle\Tests\Command;
 use Mautic\CoreBundle\Helper\Filesystem;
 use Mautic\CoreBundle\Helper\PathsHelper;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class GenerateProductionAssetsCommandTest extends MauticMysqlTestCase
 {
     private const string CKEDITOR_FILE_NAME      = 'ckeditor.js';

--- a/app/bundles/CoreBundle/Tests/Command/PullTransifexCommandFunctionalTest.php
+++ b/app/bundles/CoreBundle/Tests/Command/PullTransifexCommandFunctionalTest.php
@@ -9,8 +9,10 @@ use Mautic\CoreBundle\Command\PullTransifexCommand;
 use Mautic\CoreBundle\Helper\Filesystem;
 use Mautic\CoreBundle\Test\Guzzle\ClientMockTrait;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
+#[Group('database')]
 final class PullTransifexCommandFunctionalTest extends MauticMysqlTestCase
 {
     use ClientMockTrait;

--- a/app/bundles/CoreBundle/Tests/Command/PushTransifexCommandFunctionalTest.php
+++ b/app/bundles/CoreBundle/Tests/Command/PushTransifexCommandFunctionalTest.php
@@ -8,9 +8,11 @@ use GuzzleHttp\Psr7\Response;
 use Mautic\CoreBundle\Command\PushTransifexCommand;
 use Mautic\CoreBundle\Test\Guzzle\ClientMockTrait;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 use Psr\Http\Message\RequestInterface;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
+#[Group('database')]
 final class PushTransifexCommandFunctionalTest extends MauticMysqlTestCase
 {
     use ClientMockTrait;

--- a/app/bundles/CoreBundle/Tests/Command/RemoveAnonymousContactsCommandFunctionalTest.php
+++ b/app/bundles/CoreBundle/Tests/Command/RemoveAnonymousContactsCommandFunctionalTest.php
@@ -13,7 +13,9 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\ListLead;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class RemoveAnonymousContactsCommandFunctionalTest extends MauticMysqlTestCase
 {
     /**

--- a/app/bundles/CoreBundle/Tests/Command/UnusedIpDeleteCommandFunctionalTest.php
+++ b/app/bundles/CoreBundle/Tests/Command/UnusedIpDeleteCommandFunctionalTest.php
@@ -7,7 +7,9 @@ namespace Mautic\CoreBundle\Tests\Command;
 use Mautic\CoreBundle\Entity\IpAddress;
 use Mautic\CoreBundle\Entity\IpAddressRepository;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class UnusedIpDeleteCommandFunctionalTest extends MauticMysqlTestCase
 {
     /**

--- a/app/bundles/CoreBundle/Tests/Functional/Command/AnonymizeIpCommandTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Command/AnonymizeIpCommandTest.php
@@ -7,7 +7,9 @@ namespace Mautic\CoreBundle\Tests\Functional\Command;
 use Mautic\CoreBundle\Command\AnonymizeIpCommand;
 use Mautic\CoreBundle\Entity\IpAddress;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class AnonymizeIpCommandTest extends MauticMysqlTestCase
 {
     protected function setUp(): void

--- a/app/bundles/CoreBundle/Tests/Functional/Command/EntityExportCommandTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Command/EntityExportCommandTest.php
@@ -7,7 +7,9 @@ namespace Mautic\CoreBundle\Tests\Functional\Command;
 use Mautic\CampaignBundle\Entity\Campaign;
 use Mautic\CoreBundle\Command\EntityExportCommand;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class EntityExportCommandTest extends MauticMysqlTestCase
 {
     protected function setUp(): void

--- a/app/bundles/CoreBundle/Tests/Functional/Command/MaxMindDoNotSellPurgeCommandTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Command/MaxMindDoNotSellPurgeCommandTest.php
@@ -7,7 +7,9 @@ namespace Mautic\CoreBundle\Tests\Functional\Command;
 use Mautic\CoreBundle\Entity\IpAddress;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class MaxMindDoNotSellPurgeCommandTest extends MauticMysqlTestCase
 {
     protected function setUp(): void

--- a/app/bundles/CoreBundle/Tests/Functional/Command/MessageOfTheDayCommandTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Command/MessageOfTheDayCommandTest.php
@@ -7,11 +7,13 @@ namespace Mautic\CoreBundle\Tests\Functional\Command;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use PHPUnit\Framework\Attributes\After;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
+#[Group('database')]
 final class MessageOfTheDayCommandTest extends MauticMysqlTestCase
 {
     private string $cachePath;

--- a/app/bundles/CoreBundle/Tests/Functional/Controller/AbstractFormControllerTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Controller/AbstractFormControllerTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Mautic\CoreBundle\Tests\Functional\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class AbstractFormControllerTest extends MauticMysqlTestCase
 {
     public function testUnlockActionWithValidReturnUrl(): void

--- a/app/bundles/CoreBundle/Tests/Functional/Controller/AjaxControllerTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Controller/AjaxControllerTest.php
@@ -40,6 +40,7 @@ use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 use Symfony\Component\PasswordHasher\PasswordHasherInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\Group('database')]
 final class AjaxControllerTest extends MauticMysqlTestCase
 {
     use ClientMockTrait;

--- a/app/bundles/CoreBundle/Tests/Functional/Controller/ConfigControllerTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Controller/ConfigControllerTest.php
@@ -6,8 +6,10 @@ namespace Mautic\CoreBundle\Tests\Functional\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class ConfigControllerTest extends MauticMysqlTestCase
 {
     protected function setUp(): void

--- a/app/bundles/CoreBundle/Tests/Functional/Controller/ExportControllerTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Controller/ExportControllerTest.php
@@ -11,11 +11,13 @@ use Mautic\ReportBundle\Model\ReportModel;
 use Mautic\UserBundle\Entity\Permission;
 use Mautic\UserBundle\Entity\Role;
 use Mautic\UserBundle\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 use Symfony\Component\PasswordHasher\PasswordHasherInterface;
 
+#[Group('database')]
 final class ExportControllerTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback   = false;

--- a/app/bundles/CoreBundle/Tests/Functional/Controller/FileControllerTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Controller/FileControllerTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Mautic\CoreBundle\Tests\Functional\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
+#[Group('database')]
 final class FileControllerTest extends MauticMysqlTestCase
 {
     private ?string $uploadedFilePath = null;

--- a/app/bundles/CoreBundle/Tests/Functional/Controller/JsControllerTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Controller/JsControllerTest.php
@@ -6,6 +6,7 @@ namespace Mautic\CoreBundle\Tests\Functional\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
@@ -14,6 +15,7 @@ use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
  */
 #[PreserveGlobalState(false)]
 #[RunTestsInSeparateProcesses]
+#[Group('database')]
 final class JsControllerTest extends MauticMysqlTestCase
 {
     protected function setUp(): void

--- a/app/bundles/CoreBundle/Tests/Functional/Controller/ThemeControllerTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Controller/ThemeControllerTest.php
@@ -9,8 +9,10 @@ use Mautic\CoreBundle\Helper\PathsHelper;
 use Mautic\CoreBundle\Helper\ThemeHelper;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\UserBundle\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class ThemeControllerTest extends MauticMysqlTestCase
 {
     private PathsHelper $pathsHelper;

--- a/app/bundles/CoreBundle/Tests/Functional/DependencyInjection/Compiler/SystemThemeTemplatePathPassTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/DependencyInjection/Compiler/SystemThemeTemplatePathPassTest.php
@@ -7,10 +7,12 @@ namespace Mautic\CoreBundle\Tests\Functional\DependencyInjection\Compiler;
 use Mautic\CoreBundle\Helper\PathsHelper;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class SystemThemeTemplatePathPassTest extends MauticMysqlTestCase
 {
     protected function setUp(): void

--- a/app/bundles/CoreBundle/Tests/Functional/Doctrine/Helper/ColumnSchemaHelperFunctionalTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Doctrine/Helper/ColumnSchemaHelperFunctionalTest.php
@@ -10,7 +10,9 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\LeadField;
 use Mautic\LeadBundle\Model\FieldModel;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class ColumnSchemaHelperFunctionalTest extends MauticMysqlTestCase
 {
     private LeadField $field;

--- a/app/bundles/CoreBundle/Tests/Functional/Doctrine/Paginator/SimplePaginatorTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Doctrine/Paginator/SimplePaginatorTest.php
@@ -8,8 +8,10 @@ use Mautic\CoreBundle\Doctrine\Paginator\SimplePaginator;
 use Mautic\CoreBundle\Entity\IpAddress;
 use Mautic\CoreBundle\Entity\IpAddressRepository;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Bridge\Doctrine\Middleware\Debug\DebugDataHolder;
 
+#[Group('database')]
 final class SimplePaginatorTest extends MauticMysqlTestCase
 {
     /**

--- a/app/bundles/CoreBundle/Tests/Functional/Entity/AuditLogRepositoryTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Entity/AuditLogRepositoryTest.php
@@ -11,7 +11,9 @@ use Mautic\LeadBundle\Entity\DoNotContact;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Model\LeadModel;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class AuditLogRepositoryTest extends MauticMysqlTestCase
 {
     /**

--- a/app/bundles/CoreBundle/Tests/Functional/Entity/CommonRepositoryTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Entity/CommonRepositoryTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Mautic\CoreBundle\Tests\Functional\Entity;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\TestDox;
 
+#[Group('database')]
 final class CommonRepositoryTest extends MauticMysqlTestCase
 {
     #[TestDox('Test that is:mine does not throw an exception due to bad DQL')]

--- a/app/bundles/CoreBundle/Tests/Functional/Entity/CommonRepositoryUpsertTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Entity/CommonRepositoryUpsertTest.php
@@ -7,7 +7,9 @@ namespace Mautic\CoreBundle\Tests\Functional\Entity;
 use Mautic\CoreBundle\Entity\IpAddress;
 use Mautic\CoreBundle\Entity\IpAddressRepository;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class CommonRepositoryUpsertTest extends MauticMysqlTestCase
 {
     protected function beforeBeginTransaction(): void

--- a/app/bundles/CoreBundle/Tests/Functional/Entity/NotificationRepositoryTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Entity/NotificationRepositoryTest.php
@@ -8,7 +8,9 @@ use Mautic\CoreBundle\Entity\Notification;
 use Mautic\CoreBundle\Entity\NotificationRepository;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\UserBundle\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class NotificationRepositoryTest extends MauticMysqlTestCase
 {
     public function testIsDuplicate(): void

--- a/app/bundles/CoreBundle/Tests/Functional/EventListener/ConfigSubscriberTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/EventListener/ConfigSubscriberTest.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Mautic\CoreBundle\Tests\Functional\EventListener;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\KernelInterface;
 
+#[Group('database')]
 final class ConfigSubscriberTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/CoreBundle/Tests/Functional/EventListener/EditorFontsSubscriberTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/EventListener/EditorFontsSubscriberTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Mautic\CoreBundle\Tests\Functional\EventListener;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class EditorFontsSubscriberTest extends MauticMysqlTestCase
 {
     protected function setUp(): void

--- a/app/bundles/CoreBundle/Tests/Functional/EventListener/MaintenanceSubscriberTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/EventListener/MaintenanceSubscriberTest.php
@@ -7,9 +7,11 @@ namespace Mautic\CoreBundle\Tests\Functional\EventListener;
 use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Event\MaintenanceEvent;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[Group('database')]
 final class MaintenanceSubscriberTest extends MauticMysqlTestCase
 {
     public function testMaintenanceDataCleanUp(): void

--- a/app/bundles/CoreBundle/Tests/Functional/EventListener/MigrationCommandSubscriberTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/EventListener/MigrationCommandSubscriberTest.php
@@ -9,12 +9,14 @@ use Mautic\CoreBundle\Doctrine\GeneratedColumn\GeneratedColumn;
 use Mautic\CoreBundle\Event\GeneratedColumnsEvent;
 use Mautic\CoreBundle\Helper\ExitCode;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 
+#[Group('database')]
 final class MigrationCommandSubscriberTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/CoreBundle/Tests/Functional/Field/Notification/CustomFieldNotificationFunctionalTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Field/Notification/CustomFieldNotificationFunctionalTest.php
@@ -10,8 +10,10 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\LeadField;
 use Mautic\LeadBundle\Field\Notification\CustomFieldNotification;
 use Mautic\LeadBundle\Model\FieldModel;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[Group('database')]
 final class CustomFieldNotificationFunctionalTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/CoreBundle/Tests/Functional/Form/Validator/FileEncodingValidatorTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Form/Validator/FileEncodingValidatorTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Mautic\CoreBundle\Tests\Functional\Form\Validator;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class FileEncodingValidatorTest extends MauticMysqlTestCase
 {
     public function testFileNONUTF8(): void

--- a/app/bundles/CoreBundle/Tests/Functional/Helper/Chart/ChartQueryTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Helper/Chart/ChartQueryTest.php
@@ -9,7 +9,9 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadEventLog;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Segment\Stat\ChartQuery\SegmentContactsLineChartQuery;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class ChartQueryTest extends MauticMysqlTestCase
 {
     public function testSegmentContactsLineChartQuery(): void

--- a/app/bundles/CoreBundle/Tests/Functional/Helper/ChartQueryFunctionalTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Helper/ChartQueryFunctionalTest.php
@@ -7,7 +7,9 @@ namespace Mautic\CoreBundle\Tests\Functional\Helper;
 use Mautic\CoreBundle\Helper\Chart\ChartQuery;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class ChartQueryFunctionalTest extends MauticMysqlTestCase
 {
     public function testGetCountQueryWithUniqueOptionsExecutesAgainstDatabase(): void

--- a/app/bundles/CoreBundle/Tests/Functional/Helper/CommandHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Helper/CommandHelperTest.php
@@ -6,7 +6,9 @@ namespace Mautic\CoreBundle\Tests\Functional\Helper;
 
 use Mautic\CoreBundle\Helper\CommandHelper;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class CommandHelperTest extends MauticMysqlTestCase
 {
     private CommandHelper $commandHelper;

--- a/app/bundles/CoreBundle/Tests/Functional/Helper/LanguageHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Helper/LanguageHelperTest.php
@@ -7,7 +7,9 @@ namespace Mautic\CoreBundle\Tests\Functional\Helper;
 use Mautic\CoreBundle\Helper\LanguageHelper;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class LanguageHelperTest extends MauticMysqlTestCase
 {
     public function testGettingLanguageFiles(): void

--- a/app/bundles/CoreBundle/Tests/Functional/ParametersTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/ParametersTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Mautic\CoreBundle\Tests\Functional;
 
 use Mautic\CoreBundle\Test\AbstractMauticTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class ParametersTest extends AbstractMauticTestCase
 {
     public function testRememberMeParameterUsesIntProcessor(): void

--- a/app/bundles/CoreBundle/Tests/Functional/SamlTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/SamlTest.php
@@ -8,6 +8,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Cookie\CookieJar as GuzzleCookieJar;
 use GuzzleHttp\RequestOptions;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\DomCrawler\Field\ChoiceFormField;
 use Symfony\Component\DomCrawler\Field\FileFormField;
@@ -15,6 +16,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Twig\Environment;
 
+#[Group('database')]
 final class SamlTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/CoreBundle/Tests/Functional/Security/Permissions/CorePermissionsTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Security/Permissions/CorePermissionsTest.php
@@ -11,7 +11,9 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\UserBundle\Entity\User;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class CorePermissionsTest extends MauticMysqlTestCase
 {
     /**

--- a/app/bundles/CoreBundle/Tests/Functional/Service/LocalFileAdapterServiceTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Service/LocalFileAdapterServiceTest.php
@@ -9,9 +9,11 @@ use FM\ElfinderBundle\Loader\ElFinderLoader;
 use Mautic\CoreBundle\Helper\PathsHelper;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\UserBundle\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class LocalFileAdapterServiceTest extends MauticMysqlTestCase
 {
     private ?string $folderName = null;

--- a/app/bundles/CoreBundle/Tests/Functional/Twig/Extension/ConfigExtensionTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Twig/Extension/ConfigExtensionTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Mautic\CoreBundle\Tests\Functional\Twig\Extension;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class ConfigExtensionTest extends MauticMysqlTestCase
 {
     protected function setUp(): void

--- a/app/bundles/CoreBundle/Tests/Functional/Validator/SafeRemoteUrlValidatorTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/Validator/SafeRemoteUrlValidatorTest.php
@@ -9,11 +9,13 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\CoreBundle\Validator\SafeRemoteUrl;
 use Mautic\CoreBundle\Validator\SafeRemoteUrlValidator;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\Validator\Constraints;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
+#[Group('database')]
 final class SafeRemoteUrlValidatorTest extends MauticMysqlTestCase
 {
     protected function setUp(): void

--- a/app/bundles/CoreBundle/Tests/Helper/MapHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Helper/MapHelperTest.php
@@ -7,7 +7,9 @@ namespace Mautic\CoreBundle\Tests\Helper;
 use Mautic\CampaignBundle\Controller\CampaignMapStatsController;
 use Mautic\CoreBundle\Helper\MapHelper;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class MapHelperTest extends MauticMysqlTestCase
 {
     /**

--- a/app/bundles/CoreBundle/Tests/Translation/TranslatorTest.php
+++ b/app/bundles/CoreBundle/Tests/Translation/TranslatorTest.php
@@ -6,9 +6,11 @@ namespace Mautic\CoreBundle\Tests\Translation;
 
 use Mautic\CoreBundle\Test\AbstractMauticTestCase;
 use Mautic\CoreBundle\Translation\Translator;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\Translation\Loader\ArrayLoader;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[Group('database')]
 final class TranslatorTest extends AbstractMauticTestCase
 {
     public function testMissingPluralOptions(): void

--- a/app/bundles/CoreBundle/Tests/Twig/TwigFunctionSmokeTest.php
+++ b/app/bundles/CoreBundle/Tests/Twig/TwigFunctionSmokeTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Mautic\CoreBundle\Tests\Twig;
 
 use Mautic\CoreBundle\Form\Type\TelType;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Twig\Environment;
 
@@ -14,6 +15,7 @@ use Twig\Environment;
  *
  * @see TwigCallableRegistrationTest for the same check on a standalone Twig environment
  */
+#[Group('database')]
 final class TwigFunctionSmokeTest extends KernelTestCase
 {
     /**

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/Update/PreUpdateChecks/CheckDatabaseDriverAndVersionTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/Update/PreUpdateChecks/CheckDatabaseDriverAndVersionTest.php
@@ -7,7 +7,9 @@ namespace Mautic\CoreBundle\Tests\Unit\Helper\Update\PreUpdateChecks;
 use Mautic\CoreBundle\Helper\Update\PreUpdateChecks\CheckDatabaseDriverAndVersion;
 use Mautic\CoreBundle\Release\Metadata;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class CheckDatabaseDriverAndVersionTest extends MauticMysqlTestCase
 {
     public function testDatabaseDriverAndVersionOk(): void

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/Update/PreUpdateChecks/CheckPhpVersionTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/Update/PreUpdateChecks/CheckPhpVersionTest.php
@@ -7,7 +7,9 @@ namespace Mautic\CoreBundle\Tests\Unit\Helper\Update\PreUpdateChecks;
 use Mautic\CoreBundle\Helper\Update\PreUpdateChecks\CheckPhpVersion;
 use Mautic\CoreBundle\Release\Metadata;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class CheckPhpVersionTest extends MauticMysqlTestCase
 {
     public function testPhpVersionOk(): void

--- a/app/bundles/CoreBundle/Tests/Unit/Twig/Extension/AssetExtensionTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Twig/Extension/AssetExtensionTest.php
@@ -6,7 +6,9 @@ namespace Mautic\CoreBundle\Tests\Unit\Twig\Extension;
 
 use Mautic\CoreBundle\Test\AbstractMauticTestCase;
 use Mautic\CoreBundle\Twig\Extension\AssetExtension;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class AssetExtensionTest extends AbstractMauticTestCase
 {
     public function testGetCountryFlag(): void

--- a/app/bundles/CoreBundle/Tests/Unit/Twig/Extension/MenuExtensionTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Twig/Extension/MenuExtensionTest.php
@@ -8,7 +8,9 @@ use Knp\Menu\ItemInterface;
 use Knp\Menu\MenuFactory;
 use Mautic\CoreBundle\Test\AbstractMauticTestCase;
 use Mautic\CoreBundle\Twig\Extension\MenuExtension;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class MenuExtensionTest extends AbstractMauticTestCase
 {
     public function testParseMenuAttributes(): void

--- a/app/bundles/DashboardBundle/Tests/Controller/DashboardControllerFunctionalTest.php
+++ b/app/bundles/DashboardBundle/Tests/Controller/DashboardControllerFunctionalTest.php
@@ -13,9 +13,11 @@ use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\ReportBundle\Entity\Report;
 use Mautic\UserBundle\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class DashboardControllerFunctionalTest extends MauticMysqlTestCase
 {
     use CreateTestEntitiesTrait;

--- a/app/bundles/DynamicContentBundle/Tests/Controller/DynamicContentApiControllerFunctionalTest.php
+++ b/app/bundles/DynamicContentBundle/Tests/Controller/DynamicContentApiControllerFunctionalTest.php
@@ -10,6 +10,7 @@ use Mautic\DynamicContentBundle\Entity\DynamicContent;
 use Mautic\DynamicContentBundle\Entity\DynamicContentLeadData;
 use Mautic\EmailBundle\Entity\Stat;
 use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Symfony\Component\HttpFoundation\Request;
@@ -17,6 +18,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[PreserveGlobalState(false)]
 #[RunTestsInSeparateProcesses]
+#[Group('database')]
 final class DynamicContentApiControllerFunctionalTest extends MauticMysqlTestCase
 {
     public function testDwcGetEndpointForNoSlotNorContact(): void

--- a/app/bundles/DynamicContentBundle/Tests/Controller/DynamicContentControllerFunctionalTest.php
+++ b/app/bundles/DynamicContentBundle/Tests/Controller/DynamicContentControllerFunctionalTest.php
@@ -10,12 +10,14 @@ use Mautic\ProjectBundle\Entity\Project;
 use Mautic\UserBundle\Entity\Permission;
 use Mautic\UserBundle\Entity\Role;
 use Mautic\UserBundle\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 use Symfony\Component\PasswordHasher\PasswordHasherInterface;
 
+#[Group('database')]
 final class DynamicContentControllerFunctionalTest extends MauticMysqlTestCase
 {
     public const string PERMISSION_CREATE       = 'dynamiccontent:dynamiccontents:create';

--- a/app/bundles/DynamicContentBundle/Tests/Controller/DynamicContentProjectSearchFunctionalTest.php
+++ b/app/bundles/DynamicContentBundle/Tests/Controller/DynamicContentProjectSearchFunctionalTest.php
@@ -7,7 +7,9 @@ namespace Mautic\DynamicContentBundle\Tests\Controller;
 use Mautic\DynamicContentBundle\Entity\DynamicContent;
 use Mautic\ProjectBundle\Tests\Functional\AbstractProjectSearchTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class DynamicContentProjectSearchFunctionalTest extends AbstractProjectSearchTestCase
 {
     #[DataProvider('searchDataProvider')]

--- a/app/bundles/DynamicContentBundle/Tests/Form/Type/DynamicContentFilterChoicesTest.php
+++ b/app/bundles/DynamicContentBundle/Tests/Form/Type/DynamicContentFilterChoicesTest.php
@@ -6,6 +6,7 @@ namespace Mautic\DynamicContentBundle\Tests\Form\Type;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\DynamicContentBundle\Entity\DynamicContent;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -13,6 +14,7 @@ use Symfony\Component\HttpFoundation\Request;
  * controller with locale, timezone and region filter values to prove the form
  * actually accepts those choices and persists them.
  */
+#[Group('database')]
 final class DynamicContentFilterChoicesTest extends MauticMysqlTestCase
 {
     private const string LOCALE_VALUE   = 'en_US';

--- a/app/bundles/DynamicContentBundle/Tests/Functional/DynamicContentCloneTest.php
+++ b/app/bundles/DynamicContentBundle/Tests/Functional/DynamicContentCloneTest.php
@@ -6,8 +6,10 @@ namespace Mautic\DynamicContentBundle\Tests\Functional;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\DynamicContentBundle\Entity\DynamicContent;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class DynamicContentCloneTest extends MauticMysqlTestCase
 {
     public function testCloneActionForDynamicContent(): void

--- a/app/bundles/EmailBundle/Tests/Controller/AjaxControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/AjaxControllerFunctionalTest.php
@@ -19,12 +19,14 @@ use Mautic\PageBundle\Entity\Redirect;
 use Mautic\PageBundle\Entity\Trackable;
 use Mautic\UserBundle\Entity\User;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Mime\Email as EmailMime;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[Group('database')]
 final class AjaxControllerFunctionalTest extends MauticMysqlTestCase
 {
     #[DataProvider('provideSendToDncStatus')]

--- a/app/bundles/EmailBundle/Tests/Controller/Api/EmailApiControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/Api/EmailApiControllerFunctionalTest.php
@@ -21,12 +21,14 @@ use Mautic\UserBundle\Entity\Role;
 use Mautic\UserBundle\Entity\User;
 use Mautic\UserBundle\Model\RoleModel;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Mailer\Mailer;
 use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 use Symfony\Component\PasswordHasher\PasswordHasherInterface;
 
+#[Group('database')]
 final class EmailApiControllerFunctionalTest extends MauticMysqlTestCase
 {
     private SmtpTransport $transport;

--- a/app/bundles/EmailBundle/Tests/Controller/Api/EmailApiDefaultsFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/Api/EmailApiDefaultsFunctionalTest.php
@@ -8,6 +8,7 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\PageBundle\Entity\Page;
 use Mautic\UserBundle\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -15,6 +16,7 @@ use Symfony\Component\HttpFoundation\Response;
  * Functional tests proving that persisted email defaults from config are applied
  * when creating emails via the API (EMAIL_PRE_SAVE subscriber).
  */
+#[Group('database')]
 final class EmailApiDefaultsFunctionalTest extends MauticMysqlTestCase
 {
     /**

--- a/app/bundles/EmailBundle/Tests/Controller/Api/SMimeFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/Api/SMimeFunctionalTest.php
@@ -12,9 +12,11 @@ use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\ListLead;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Mime\RawMessage;
 
+#[Group('database')]
 final class SMimeFunctionalTest extends MauticMysqlTestCase
 {
     private string $certPath;

--- a/app/bundles/EmailBundle/Tests/Controller/ConfigControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/ConfigControllerFunctionalTest.php
@@ -6,9 +6,11 @@ namespace Mautic\EmailBundle\Tests\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\KernelInterface;
 
+#[Group('database')]
 final class ConfigControllerFunctionalTest extends MauticMysqlTestCase
 {
     public function testValuesAreEscapedProperly(): void

--- a/app/bundles/EmailBundle/Tests/Controller/EmailControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailControllerFunctionalTest.php
@@ -26,6 +26,7 @@ use Mautic\UserBundle\Entity\User;
 use Mautic\UserBundle\Model\RoleModel;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Bridge\Doctrine\DataCollector\DoctrineDataCollector;
 
 use function Symfony\Component\Clock\now;
@@ -33,6 +34,7 @@ use function Symfony\Component\Clock\now;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class EmailControllerFunctionalTest extends MauticMysqlTestCase
 {
     use ControllerTrait;

--- a/app/bundles/EmailBundle/Tests/Controller/EmailDefaultsFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailDefaultsFunctionalTest.php
@@ -8,6 +8,7 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\PageBundle\Entity\Page;
 use Mautic\UserBundle\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -16,6 +17,7 @@ use Symfony\Component\HttpFoundation\Request;
  * These tests run with the config params set so they do not bleed into the
  * unrelated tests in EmailFunctionalTest.
  */
+#[Group('database')]
 final class EmailDefaultsFunctionalTest extends MauticMysqlTestCase
 {
     public const string SAVE_AND_CLOSE = 'Save & Close';

--- a/app/bundles/EmailBundle/Tests/Controller/EmailDraftFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailDraftFunctionalTest.php
@@ -7,8 +7,10 @@ namespace Mautic\EmailBundle\Tests\Controller;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Entity\EmailDraft;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class EmailDraftFunctionalTest extends MauticMysqlTestCase
 {
     protected function setUp(): void

--- a/app/bundles/EmailBundle/Tests/Controller/EmailExampleFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailExampleFunctionalTest.php
@@ -9,9 +9,11 @@ use Mautic\CoreBundle\Tests\Functional\CreateTestEntitiesTrait;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Mailer\Message\MauticMessage;
 use Mautic\UserBundle\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class EmailExampleFunctionalTest extends MauticMysqlTestCase
 {
     use CreateTestEntitiesTrait;

--- a/app/bundles/EmailBundle/Tests/Controller/EmailFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailFunctionalTest.php
@@ -12,9 +12,11 @@ use Mautic\EmailBundle\Entity\Email;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\PageBundle\Entity\Page;
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\DomCrawler\Field\ChoiceFormField;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class EmailFunctionalTest extends MauticMysqlTestCase
 {
     public const string SAVE_AND_CLOSE = 'Save & Close';

--- a/app/bundles/EmailBundle/Tests/Controller/EmailGraphStatsControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailGraphStatsControllerFunctionalTest.php
@@ -8,8 +8,10 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\CoreBundle\Tests\Functional\CreateTestEntitiesTrait;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\LeadBundle\Entity\LeadList;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class EmailGraphStatsControllerFunctionalTest extends MauticMysqlTestCase
 {
     use CreateTestEntitiesTrait;

--- a/app/bundles/EmailBundle/Tests/Controller/EmailListTypeFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailListTypeFunctionalTest.php
@@ -7,8 +7,10 @@ namespace Mautic\EmailBundle\Tests\Controller;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\EmailBundle\Entity\Email;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class EmailListTypeFunctionalTest extends MauticMysqlTestCase
 {
     private const string PARENT_EMAIL      = 'Parent Email';

--- a/app/bundles/EmailBundle/Tests/Controller/EmailMapStatsControllerTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailMapStatsControllerTest.php
@@ -14,9 +14,11 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\PageBundle\Entity\Hit;
 use Mautic\PageBundle\Entity\Redirect;
 use Mautic\PageBundle\Entity\Trackable;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class EmailMapStatsControllerTest extends MauticMysqlTestCase
 {
     /**

--- a/app/bundles/EmailBundle/Tests/Controller/EmailProjectSearchFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailProjectSearchFunctionalTest.php
@@ -7,7 +7,9 @@ namespace Mautic\EmailBundle\Tests\Controller;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\ProjectBundle\Tests\Functional\AbstractProjectSearchTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class EmailProjectSearchFunctionalTest extends AbstractProjectSearchTestCase
 {
     #[DataProvider('searchDataProvider')]

--- a/app/bundles/EmailBundle/Tests/Controller/EmailSendDisabledTrackingFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailSendDisabledTrackingFunctionalTest.php
@@ -9,8 +9,10 @@ use Mautic\CoreBundle\Tests\Functional\CreateTestEntitiesTrait;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Mailer\Message\MauticMessage;
 use Mautic\LeadBundle\Entity\LeadList;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class EmailSendDisabledTrackingFunctionalTest extends MauticMysqlTestCase
 {
     use CreateTestEntitiesTrait;

--- a/app/bundles/EmailBundle/Tests/Controller/EmailSendFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailSendFunctionalTest.php
@@ -10,9 +10,11 @@ use Mautic\EmailBundle\Mailer\Message\MauticMessage;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\ListLead;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Mime\Message;
 
+#[Group('database')]
 final class EmailSendFunctionalTest extends MauticMysqlTestCase
 {
     protected function setUp(): void

--- a/app/bundles/EmailBundle/Tests/Controller/PreviewFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/PreviewFunctionalTest.php
@@ -11,9 +11,11 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\ListLead;
 use Mautic\UserBundle\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class PreviewFunctionalTest extends MauticMysqlTestCase
 {
     use CreateTestEntitiesTrait;

--- a/app/bundles/EmailBundle/Tests/Controller/PreviewSettingsFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/PreviewSettingsFunctionalTest.php
@@ -6,8 +6,10 @@ namespace Mautic\EmailBundle\Tests\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\EmailBundle\Entity\Email;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class PreviewSettingsFunctionalTest extends MauticMysqlTestCase
 {
     public function testPreviewSettingsAllEnabled(): void

--- a/app/bundles/EmailBundle/Tests/Controller/PublicControllerFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/PublicControllerFunctionalTest.php
@@ -20,11 +20,13 @@ use Mautic\PageBundle\Entity\Page;
 use Mautic\PageBundle\Entity\PageRepository;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[Group('database')]
 final class PublicControllerFunctionalTest extends MauticMysqlTestCase
 {
     private ?int $leadId = null;

--- a/app/bundles/EmailBundle/Tests/Controller/PublicControllerPreferenceCenterFallbackFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/PublicControllerPreferenceCenterFallbackFunctionalTest.php
@@ -9,8 +9,10 @@ use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Entity\Stat;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\PageBundle\Entity\Page;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class PublicControllerPreferenceCenterFallbackFunctionalTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/EmailBundle/Tests/Entity/EmailRepositoryFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Entity/EmailRepositoryFunctionalTest.php
@@ -14,7 +14,9 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadCategory;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\ListLead;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class EmailRepositoryFunctionalTest extends MauticMysqlTestCase
 {
     private EmailRepository $emailRepository;

--- a/app/bundles/EmailBundle/Tests/Entity/PendingQueryFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Entity/PendingQueryFunctionalTest.php
@@ -12,12 +12,14 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\ListLead;
 use Mautic\LeadBundle\Model\LeadModel;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * This test ensures that the pending query will work even if a contact was deleted between batches.
  * After the refactoring from NOT EXISTS to NOT IN the single deleted contact could cause the
  * pending query to find no contacts due to null value in the lead_id column.
  */
+#[Group('database')]
 final class PendingQueryFunctionalTest extends MauticMysqlTestCase
 {
     public function testDelayedSends(): void

--- a/app/bundles/EmailBundle/Tests/Entity/StatRepositoryFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Entity/StatRepositoryFunctionalTest.php
@@ -8,7 +8,9 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Entity\Stat;
 use Mautic\EmailBundle\Entity\StatRepository;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class StatRepositoryFunctionalTest extends MauticMysqlTestCase
 {
     private StatRepository $statRepository;

--- a/app/bundles/EmailBundle/Tests/EventListener/BroadcastSubscriberFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/BroadcastSubscriberFunctionalTest.php
@@ -12,8 +12,10 @@ use Mautic\EmailBundle\EventListener\BroadcastSubscriber;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\ListLead;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\Console\Output\BufferedOutput;
 
+#[Group('database')]
 final class BroadcastSubscriberFunctionalTest extends MauticMysqlTestCase
 {
     use CreateTestEntitiesTrait;

--- a/app/bundles/EmailBundle/Tests/EventListener/BuilderSubscriberFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/BuilderSubscriberFunctionalTest.php
@@ -11,8 +11,10 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\ListLead;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class BuilderSubscriberFunctionalTest extends MauticMysqlTestCase
 {
     protected function setUp(): void

--- a/app/bundles/EmailBundle/Tests/EventListener/CampaignSubscriberActionEmailToContactFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/CampaignSubscriberActionEmailToContactFunctionalTest.php
@@ -9,8 +9,10 @@ use Mautic\CategoryBundle\Entity\Category;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\CoreBundle\Tests\Functional\CreateTestEntitiesTrait;
 use Mautic\EmailBundle\Entity\Email;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[Group('database')]
 final class CampaignSubscriberActionEmailToContactFunctionalTest extends MauticMysqlTestCase
 {
     use CreateTestEntitiesTrait;

--- a/app/bundles/EmailBundle/Tests/EventListener/EmailImportExportSubscriberFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/EmailImportExportSubscriberFunctionalTest.php
@@ -7,8 +7,10 @@ namespace Mautic\EmailBundle\Tests\EventListener;
 use Mautic\CoreBundle\Event\EntityExportEvent;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\EmailBundle\Entity\Email;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
+#[Group('database')]
 final class EmailImportExportSubscriberFunctionalTest extends MauticMysqlTestCase
 {
     private EventDispatcherInterface $dispatcher;

--- a/app/bundles/EmailBundle/Tests/EventListener/PointSubscriberFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/PointSubscriberFunctionalTest.php
@@ -9,8 +9,10 @@ use Mautic\CoreBundle\Tests\Functional\CreateTestEntitiesTrait;
 use Mautic\EmailBundle\EmailEvents;
 use Mautic\EmailBundle\Event\EmailSendEvent;
 use Mautic\PointBundle\Entity\Point;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
+#[Group('database')]
 final class PointSubscriberFunctionalTest extends MauticMysqlTestCase
 {
     use CreateTestEntitiesTrait;

--- a/app/bundles/EmailBundle/Tests/EventListener/ReportSubscriberFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/ReportSubscriberFunctionalTest.php
@@ -14,9 +14,11 @@ use Mautic\PageBundle\Entity\Redirect;
 use Mautic\PageBundle\Entity\Trackable;
 use Mautic\ReportBundle\Entity\Report;
 use Mautic\ReportBundle\Tests\Functional\AbstractReportSubscriberTestCase;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class ReportSubscriberFunctionalTest extends AbstractReportSubscriberTestCase
 {
     public function testEmailReportGraphWithMostClickedLinks(): void

--- a/app/bundles/EmailBundle/Tests/EventListener/SegmentSubscriberFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/SegmentSubscriberFunctionalTest.php
@@ -6,8 +6,10 @@ namespace Mautic\EmailBundle\Tests\EventListener;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\LeadEvents;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
+#[Group('database')]
 final class SegmentSubscriberFunctionalTest extends MauticMysqlTestCase
 {
     public function testLeadListChangeEventHasListeners(): void

--- a/app/bundles/EmailBundle/Tests/EventListener/WebhookSubscriberFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/WebhookSubscriberFunctionalTest.php
@@ -16,8 +16,10 @@ use Mautic\WebhookBundle\Entity\Event;
 use Mautic\WebhookBundle\Entity\Webhook;
 use Mautic\WebhookBundle\Entity\WebhookQueue;
 use Mautic\WebhookBundle\Model\WebhookModel;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class WebhookSubscriberFunctionalTest extends MauticMysqlTestCase
 {
     protected function setUp(): void

--- a/app/bundles/EmailBundle/Tests/Functional/ApiPlatform/EmailOwnershipApiV2AuthorizationRegressionTest.php
+++ b/app/bundles/EmailBundle/Tests/Functional/ApiPlatform/EmailOwnershipApiV2AuthorizationRegressionTest.php
@@ -7,7 +7,9 @@ namespace Mautic\EmailBundle\Tests\Functional\ApiPlatform;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\LeadBundle\Tests\Functional\ApiPlatform\OwnershipScopedApiAuthorizationTestBase;
 use Mautic\UserBundle\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class EmailOwnershipApiV2AuthorizationRegressionTest extends OwnershipScopedApiAuthorizationTestBase
 {
     public function testViewOwnCollectionCannotSeeForeignEmailOnApiV2(): void

--- a/app/bundles/EmailBundle/Tests/Functional/BotRatioHelperFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Functional/BotRatioHelperFunctionalTest.php
@@ -7,8 +7,10 @@ namespace Mautic\EmailBundle\Tests\Functional;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\EmailBundle\Entity\Stat;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class BotRatioHelperFunctionalTest extends MauticMysqlTestCase
 {
     private const string DO_NOT_TRACK_IP = '218.30.65.10';

--- a/app/bundles/EmailBundle/Tests/Functional/EmailClickTrackingTest.php
+++ b/app/bundles/EmailBundle/Tests/Functional/EmailClickTrackingTest.php
@@ -11,8 +11,10 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\PageBundle\Entity\Hit;
 use Mautic\PageBundle\Entity\HitRepository;
 use Mautic\PageBundle\Entity\Page;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class EmailClickTrackingTest extends MauticMysqlTestCase
 {
     public function testEmailClick(): void

--- a/app/bundles/EmailBundle/Tests/Functional/EmailContactGridTest.php
+++ b/app/bundles/EmailBundle/Tests/Functional/EmailContactGridTest.php
@@ -15,9 +15,11 @@ use Mautic\EmailBundle\Entity\Stat;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\UserBundle\Entity\User;
 use Mautic\UserBundle\Entity\UserRepository;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class EmailContactGridTest extends MauticMysqlTestCase
 {
     use CreateTestEntitiesTrait;

--- a/app/bundles/EmailBundle/Tests/Functional/EmailDependenciesFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Functional/EmailDependenciesFunctionalTest.php
@@ -14,7 +14,9 @@ use Mautic\PointBundle\Entity\Point;
 use Mautic\PointBundle\Entity\Trigger;
 use Mautic\PointBundle\Entity\TriggerEvent;
 use Mautic\ReportBundle\Entity\Report;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class EmailDependenciesFunctionalTest extends MauticMysqlTestCase
 {
     private FixtureHelper $campaignFixturesHelper;

--- a/app/bundles/EmailBundle/Tests/Functional/EmailTokenTest.php
+++ b/app/bundles/EmailBundle/Tests/Functional/EmailTokenTest.php
@@ -13,9 +13,11 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadField;
 use Mautic\LeadBundle\Model\FieldModel;
 use Mautic\LeadBundle\Model\LeadModel;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class EmailTokenTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/EmailBundle/Tests/Functional/EmailVariantInCampaignFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Functional/EmailVariantInCampaignFunctionalTest.php
@@ -14,7 +14,9 @@ use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Entity\Stat;
 use Mautic\EmailBundle\Entity\StatRepository;
 use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class EmailVariantInCampaignFunctionalTest extends MauticMysqlTestCase
 {
     public function testMarketingEmailWithVariantShouldBeSentOnce(): void

--- a/app/bundles/EmailBundle/Tests/Functional/Form/Type/EmailTypeTest.php
+++ b/app/bundles/EmailBundle/Tests/Functional/Form/Type/EmailTypeTest.php
@@ -18,10 +18,12 @@ use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\ListLead;
 use Mautic\LeadBundle\Model\DoNotContact as DoNotContactModel;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class EmailTypeTest extends MauticMysqlTestCase
 {
     /**

--- a/app/bundles/EmailBundle/Tests/Functional/OwnerFieldTokenEmailFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Functional/OwnerFieldTokenEmailFunctionalTest.php
@@ -11,9 +11,11 @@ use Mautic\EmailBundle\Entity\Stat;
 use Mautic\EmailBundle\Entity\StatRepository;
 use Mautic\EmailBundle\Model\EmailModel;
 use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class OwnerFieldTokenEmailFunctionalTest extends MauticMysqlTestCase
 {
     use UserEntityTrait;

--- a/app/bundles/EmailBundle/Tests/Functional/PendingCountTest.php
+++ b/app/bundles/EmailBundle/Tests/Functional/PendingCountTest.php
@@ -10,8 +10,10 @@ use Mautic\EmailBundle\Entity\Stat;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\ListLead;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class PendingCountTest extends MauticMysqlTestCase
 {
     /**

--- a/app/bundles/EmailBundle/Tests/Functional/Security/Permissions/EmailPermissionsTest.php
+++ b/app/bundles/EmailBundle/Tests/Functional/Security/Permissions/EmailPermissionsTest.php
@@ -6,8 +6,10 @@ namespace Mautic\EmailBundle\Tests\Functional\Security\Permissions;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\UserBundle\Entity\Role;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class EmailPermissionsTest extends MauticMysqlTestCase
 {
     public function testEmailSendToDncPermissionIsAvailable(): void

--- a/app/bundles/EmailBundle/Tests/Functional/Stats/Helper/BouncedHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Functional/Stats/Helper/BouncedHelperTest.php
@@ -18,10 +18,12 @@ use Mautic\StatsBundle\Aggregate\Collection\StatCollection;
 use Mautic\UserBundle\Entity\Role;
 use Mautic\UserBundle\Entity\User;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests email bounce statistics generation with various filters and permissions.
  */
+#[Group('database')]
 final class BouncedHelperTest extends MauticMysqlTestCase
 {
     private BouncedHelper $bouncedHelper;

--- a/app/bundles/EmailBundle/Tests/Functional/Stats/Helper/UnsubscribedHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Functional/Stats/Helper/UnsubscribedHelperTest.php
@@ -18,10 +18,12 @@ use Mautic\StatsBundle\Aggregate\Collection\StatCollection;
 use Mautic\UserBundle\Entity\Role;
 use Mautic\UserBundle\Entity\User;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests email unsubscribe statistics generation with various filters and permissions.
  */
+#[Group('database')]
 final class UnsubscribedHelperTest extends MauticMysqlTestCase
 {
     private UnsubscribedHelper $unsubscribedHelper;

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelBuildUrlTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelBuildUrlTest.php
@@ -6,7 +6,9 @@ namespace Mautic\EmailBundle\Tests\Model;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\EmailBundle\Model\EmailModel;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class EmailModelBuildUrlTest extends MauticMysqlTestCase
 {
     protected function setUp(): void

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelFrequencyRuleFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelFrequencyRuleFunctionalTest.php
@@ -14,6 +14,7 @@ use Mautic\LeadBundle\Entity\FrequencyRule;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\UserBundle\Entity\User;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Frequency rules are configured by the "email_frequency_number" config parameter, which is read
@@ -21,6 +22,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
  * MauticMysqlTestCase forbids re-creating the client while transaction rollback cleanup
  * is active, so we fall back to resetDatabase() for cleanup instead.
  */
+#[Group('database')]
 final class EmailModelFrequencyRuleFunctionalTest extends MauticMysqlTestCase
 {
     private const int EMAILS_A_MONTH = 2;

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelFunctionalTest.php
@@ -25,8 +25,10 @@ use Mautic\LeadBundle\Model\ListModel;
 use Mautic\PageBundle\Entity\Hit;
 use Mautic\PageBundle\Entity\Redirect;
 use Mautic\PageBundle\Entity\Trackable;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
+#[Group('database')]
 final class EmailModelFunctionalTest extends MauticMysqlTestCase
 {
     use CreateTestEntitiesTrait;

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelTranslationCountFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelTranslationCountFunctionalTest.php
@@ -12,7 +12,9 @@ use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Model\EmailModel;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Model\LeadModel;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class EmailModelTranslationCountFunctionalTest extends MauticMysqlTestCase
 {
     private const int CONTACT_COUNT = 10;

--- a/app/bundles/FormBundle/Tests/Command/DeleteFormResultsTableCommandTest.php
+++ b/app/bundles/FormBundle/Tests/Command/DeleteFormResultsTableCommandTest.php
@@ -10,9 +10,11 @@ use Mautic\FormBundle\Entity\FormRepository;
 use Mautic\FormBundle\Entity\Submission;
 use Mautic\FormBundle\Entity\SubmissionRepository;
 use Mautic\FormBundle\Tests\FormTestHelperTrait;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
+#[Group('database')]
 final class DeleteFormResultsTableCommandTest extends MauticMysqlTestCase
 {
     use FormTestHelperTrait;

--- a/app/bundles/FormBundle/Tests/Command/DeleteOrphanSubmissionRecordsFromResultsTableCommandTest.php
+++ b/app/bundles/FormBundle/Tests/Command/DeleteOrphanSubmissionRecordsFromResultsTableCommandTest.php
@@ -8,9 +8,11 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\FormBundle\Entity\Submission;
 use Mautic\FormBundle\Entity\SubmissionRepository;
 use Mautic\FormBundle\Tests\FormTestHelperTrait;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
+#[Group('database')]
 final class DeleteOrphanSubmissionRecordsFromResultsTableCommandTest extends MauticMysqlTestCase
 {
     use FormTestHelperTrait;

--- a/app/bundles/FormBundle/Tests/Controller/ActionControllerFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/ActionControllerFunctionalTest.php
@@ -6,9 +6,11 @@ namespace Mautic\FormBundle\Tests\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\FormBundle\Entity\Form;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class ActionControllerFunctionalTest extends MauticMysqlTestCase
 {
     /**

--- a/app/bundles/FormBundle/Tests/Controller/AjaxControllerFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/AjaxControllerFunctionalTest.php
@@ -6,8 +6,10 @@ namespace Mautic\FormBundle\Tests\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class AjaxControllerFunctionalTest extends MauticMysqlTestCase
 {
     public function testGetFieldsForObjectAction(): void

--- a/app/bundles/FormBundle/Tests/Controller/Api/FormApiControllerFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/Api/FormApiControllerFunctionalTest.php
@@ -10,9 +10,11 @@ use Mautic\LeadBundle\Entity\Company;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\UserBundle\Entity\User;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class FormApiControllerFunctionalTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/FormBundle/Tests/Controller/Api/FormApiControllerTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/Api/FormApiControllerTest.php
@@ -7,8 +7,10 @@ namespace Mautic\FormBundle\Tests\Controller\Api;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\FormBundle\Entity\Form;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class FormApiControllerTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/FormBundle/Tests/Controller/AutoFillReadOnlyFormSubmissionTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/AutoFillReadOnlyFormSubmissionTest.php
@@ -8,8 +8,10 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\FormBundle\Entity\Field;
 use Mautic\FormBundle\Entity\Form;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\DomCrawler\Crawler;
 
+#[Group('database')]
 final class AutoFillReadOnlyFormSubmissionTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/FormBundle/Tests/Controller/AutoFillTopLevelFieldVisibilityFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/AutoFillTopLevelFieldVisibilityFunctionalTest.php
@@ -8,10 +8,12 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\FormBundle\Model\FormModel;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Tracker\ContactTracker;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class AutoFillTopLevelFieldVisibilityFunctionalTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/FormBundle/Tests/Controller/FieldControllerFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/FieldControllerFunctionalTest.php
@@ -7,10 +7,12 @@ namespace Mautic\FormBundle\Tests\Controller;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\FormBundle\Entity\Form;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class FieldControllerFunctionalTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/FormBundle/Tests/Controller/FormControllerFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/FormControllerFunctionalTest.php
@@ -16,12 +16,14 @@ use Mautic\LeadBundle\Entity\LeadField;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\ProjectBundle\Entity\Project;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[Group('database')]
 final class FormControllerFunctionalTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/FormBundle/Tests/Controller/FormProjectSearchFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/FormProjectSearchFunctionalTest.php
@@ -7,7 +7,9 @@ namespace Mautic\FormBundle\Tests\Controller;
 use Mautic\FormBundle\Entity\Form;
 use Mautic\ProjectBundle\Tests\Functional\AbstractProjectSearchTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class FormProjectSearchFunctionalTest extends AbstractProjectSearchTestCase
 {
     #[DataProvider('searchDataProvider')]

--- a/app/bundles/FormBundle/Tests/Controller/PublicControllerFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/PublicControllerFunctionalTest.php
@@ -8,11 +8,13 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\FormBundle\Entity\Field;
 use Mautic\FormBundle\Entity\Form;
 use Mautic\LeadBundle\Entity\Company;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class PublicControllerFunctionalTest extends MauticMysqlTestCase
 {
     #[PreserveGlobalState(false)]

--- a/app/bundles/FormBundle/Tests/Controller/ResultControllerFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/ResultControllerFunctionalTest.php
@@ -7,10 +7,12 @@ namespace Mautic\FormBundle\Tests\Controller;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\FormBundle\Helper\FormUploader;
 use Mautic\FormBundle\Model\FieldModel;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class ResultControllerFunctionalTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/FormBundle/Tests/Controller/SubmissionFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/SubmissionFunctionalTest.php
@@ -21,11 +21,13 @@ use Mautic\UserBundle\Entity\RoleRepository;
 use Mautic\UserBundle\Entity\User;
 use Mautic\UserBundle\Entity\UserRepository;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 use Symfony\Component\PasswordHasher\PasswordHasherInterface;
 
+#[Group('database')]
 final class SubmissionFunctionalTest extends MauticMysqlTestCase
 {
     use FormTestHelperTrait;

--- a/app/bundles/FormBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
@@ -11,10 +11,12 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\FormBundle\FormEvents;
 use Mautic\LeadBundle\Entity\Lead;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
+#[Group('database')]
 final class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/FormBundle/Tests/EventListener/CustomFieldSubscriberFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/EventListener/CustomFieldSubscriberFunctionalTest.php
@@ -6,9 +6,11 @@ namespace Mautic\FormBundle\Tests\EventListener;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\FormBundle\Collector\FieldCollector;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class CustomFieldSubscriberFunctionalTest extends MauticMysqlTestCase
 {
     private const string CUSTOM_FIELD_ALIAS = 'test_select_field';

--- a/app/bundles/FormBundle/Tests/EventListener/ReportSubscriberFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/EventListener/ReportSubscriberFunctionalTest.php
@@ -7,10 +7,12 @@ namespace Mautic\FormBundle\Tests\EventListener;
 use Mautic\LeadBundle\Entity\DoNotContact;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\ReportBundle\Tests\Functional\AbstractReportSubscriberTestCase;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class ReportSubscriberFunctionalTest extends AbstractReportSubscriberTestCase
 {
     public function testLeadReportWithDncListColumn(): void

--- a/app/bundles/FormBundle/Tests/EventListener/ReportSubscriberTest.php
+++ b/app/bundles/FormBundle/Tests/EventListener/ReportSubscriberTest.php
@@ -22,10 +22,12 @@ use Mautic\ReportBundle\Event\ReportBuilderEvent;
 use Mautic\ReportBundle\Event\ReportGeneratorEvent;
 use Mautic\ReportBundle\Event\ReportGraphEvent;
 use Mautic\ReportBundle\Helper\ReportHelper;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[Group('database')]
 final class ReportSubscriberTest extends AbstractMauticTestCase
 {
     /**

--- a/app/bundles/FormBundle/Tests/Functional/FormSubmissionFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Functional/FormSubmissionFunctionalTest.php
@@ -14,8 +14,10 @@ use Mautic\FormBundle\Entity\SubmissionRepository;
 use Mautic\FormBundle\Tests\Model\FormSubmissionTrait;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\PageBundle\Entity\Page;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class FormSubmissionFunctionalTest extends MauticMysqlTestCase
 {
     use FormSubmissionTrait;

--- a/app/bundles/FormBundle/Tests/Functional/Model/SubmissionOwnerAndStageFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Functional/Model/SubmissionOwnerAndStageFunctionalTest.php
@@ -13,9 +13,11 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\StageBundle\Entity\Stage;
 use Mautic\UserBundle\Entity\User;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class SubmissionOwnerAndStageFunctionalTest extends MauticMysqlTestCase
 {
     private const string STAGE_NAME_TOKEN       = '%stage_name%';

--- a/app/bundles/FormBundle/Tests/Functional/UpdateLeadFormActionFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Functional/UpdateLeadFormActionFunctionalTest.php
@@ -8,9 +8,11 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\FormBundle\Entity\Form;
 use Mautic\LeadBundle\Entity\Lead;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class UpdateLeadFormActionFunctionalTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/FormBundle/Tests/Model/FieldModelFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Model/FieldModelFunctionalTest.php
@@ -10,8 +10,10 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\FormBundle\Entity\Form;
 use Mautic\FormBundle\Model\FieldModel;
 use Mautic\FormBundle\Model\FormModel;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class FieldModelFunctionalTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/FormBundle/Tests/Model/FormCaptchaHoneypotFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Model/FormCaptchaHoneypotFunctionalTest.php
@@ -7,9 +7,11 @@ namespace Mautic\FormBundle\Tests\Model;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\FormBundle\Entity\Form;
 use Mautic\FormBundle\Model\FormModel;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class FormCaptchaHoneypotFunctionalTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/FormBundle/Tests/Model/FormModelFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Model/FormModelFunctionalTest.php
@@ -12,9 +12,11 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadField;
 use Mautic\LeadBundle\Model\FieldModel;
 use Mautic\LeadBundle\Tracker\ContactTracker;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class FormModelFunctionalTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/FormBundle/Tests/Model/SubmissionModelFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Model/SubmissionModelFunctionalTest.php
@@ -7,9 +7,11 @@ namespace Mautic\FormBundle\Tests\Model;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Company;
 use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class SubmissionModelFunctionalTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/FormBundle/Tests/Twig/FieldTemplateTest.php
+++ b/app/bundles/FormBundle/Tests/Twig/FieldTemplateTest.php
@@ -6,9 +6,11 @@ namespace Mautic\FormBundle\Tests\Twig;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\FormBundle\Entity\Field;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\DomCrawler\Crawler;
 use Twig\Environment;
 
+#[Group('database')]
 final class FieldTemplateTest extends MauticMysqlTestCase
 {
     private const string FIELD_LABEL         = 'Test Field';

--- a/app/bundles/InstallBundle/Tests/Functional/InstallWorkflowTest.php
+++ b/app/bundles/InstallBundle/Tests/Functional/InstallWorkflowTest.php
@@ -9,6 +9,7 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\InstallBundle\Configurator\Step\CheckStep;
 use Mautic\LeadBundle\Entity\LeadField;
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Symfony\Component\HttpFoundation\Request;
@@ -21,6 +22,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 #[PreserveGlobalState(false)]
 #[RunTestsInSeparateProcesses]
+#[Group('database')]
 final class InstallWorkflowTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/InstallBundle/Tests/Install/InstallSchemaTest.php
+++ b/app/bundles/InstallBundle/Tests/Install/InstallSchemaTest.php
@@ -12,11 +12,13 @@ use Doctrine\DBAL\Schema\Table;
 use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CoreBundle\Test\EnvLoader;
 use Mautic\InstallBundle\Helper\SchemaHelper;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @template T of AbstractPlatform
  */
+#[Group('database')]
 final class InstallSchemaTest extends TestCase
 {
     private Connection $connection;

--- a/app/bundles/InstallBundle/Tests/Install/InstallServiceTest.php
+++ b/app/bundles/InstallBundle/Tests/Install/InstallServiceTest.php
@@ -13,6 +13,7 @@ use Mautic\CoreBundle\Helper\PathsHelper;
 use Mautic\InstallBundle\Install\InstallService;
 use Mautic\UserBundle\Entity\User;
 use Mautic\UserBundle\Entity\UserRepository;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasher;
@@ -21,6 +22,11 @@ use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+/**
+ * Reads the real app/config/local.php, which only exists once the functional tests have run,
+ * so this test stays in the job that runs them.
+ */
+#[Group('database')]
 final class InstallServiceTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/IntegrationsBundle/Tests/Functional/Command/CleanupCommandTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Functional/Command/CleanupCommandTest.php
@@ -8,8 +8,10 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\IntegrationsBundle\Command\CleanupCommand;
 use Mautic\IntegrationsBundle\Entity\FieldChange;
 use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\Console\Command\Command;
 
+#[Group('database')]
 final class CleanupCommandTest extends MauticMysqlTestCase
 {
     public function testOrphanFieldChangeRecordDeleted(): void

--- a/app/bundles/IntegrationsBundle/Tests/Functional/Entity/FieldChangeRepositoryTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Functional/Entity/FieldChangeRepositoryTest.php
@@ -8,7 +8,9 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\IntegrationsBundle\Entity\FieldChange;
 use Mautic\IntegrationsBundle\Entity\FieldChangeRepository;
 use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class FieldChangeRepositoryTest extends MauticMysqlTestCase
 {
     private const string INTEGRATION = 'someIntegration';

--- a/app/bundles/IntegrationsBundle/Tests/Functional/Entity/ObjectMappingRepositoryTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Functional/Entity/ObjectMappingRepositoryTest.php
@@ -8,7 +8,9 @@ use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\IntegrationsBundle\Entity\ObjectMapping;
 use Mautic\IntegrationsBundle\Entity\ObjectMappingRepository;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class ObjectMappingRepositoryTest extends MauticMysqlTestCase
 {
     private const string INTEGRATION             = 'integration';

--- a/app/bundles/IntegrationsBundle/Tests/Functional/EventListener/LeadSubscriberTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Functional/EventListener/LeadSubscriberTest.php
@@ -10,8 +10,10 @@ use Mautic\IntegrationsBundle\Helper\SyncIntegrationsHelper;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Event\LeadEvent;
 use Mautic\LeadBundle\LeadEvents;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
+#[Group('database')]
 final class LeadSubscriberTest extends MauticMysqlTestCase
 {
     private EventDispatcherInterface $dispatcher;

--- a/app/bundles/IntegrationsBundle/Tests/Functional/EventListener/UIContactIntegrationsTabSubscriberTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Functional/EventListener/UIContactIntegrationsTabSubscriberTest.php
@@ -8,7 +8,9 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\IntegrationsBundle\Entity\ObjectMapping;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\Object\Contact;
 use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class UIContactIntegrationsTabSubscriberTest extends MauticMysqlTestCase
 {
     public function testIntegrationMappingIsShown(): void

--- a/app/bundles/IntegrationsBundle/Tests/Functional/Services/SyncDataExchange/Internal/ObjectHelper/CompanyObjectHelperTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Functional/Services/SyncDataExchange/Internal/ObjectHelper/CompanyObjectHelperTest.php
@@ -14,7 +14,9 @@ use Mautic\IntegrationsBundle\Sync\SyncDataExchange\MauticSyncDataExchange;
 use Mautic\LeadBundle\Entity\Company;
 use Mautic\LeadBundle\Model\CompanyModel;
 use Mautic\UserBundle\Model\UserModel;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class CompanyObjectHelperTest extends MauticMysqlTestCase
 {
     public function testUpdateEmpty(): void

--- a/app/bundles/IntegrationsBundle/Tests/Functional/Services/SyncService/SyncServiceTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Functional/Services/SyncService/SyncServiceTest.php
@@ -14,7 +14,9 @@ use Mautic\IntegrationsBundle\Tests\Functional\Services\SyncService\TestExamples
 use Mautic\IntegrationsBundle\Tests\Functional\Services\SyncService\TestExamples\Sync\SyncDataExchange\ExampleSyncDataExchange;
 use Mautic\LeadBundle\DataFixtures\ORM\LoadLeadData;
 use Mautic\PluginBundle\Entity\Integration;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class SyncServiceTest extends MauticMysqlTestCase
 {
     protected function setUp(): void

--- a/app/bundles/IntegrationsBundle/Tests/Functional/Sync/Notification/BulkNotificationTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Functional/Sync/Notification/BulkNotificationTest.php
@@ -7,7 +7,9 @@ namespace Mautic\IntegrationsBundle\Tests\Functional\Sync\Notification;
 use Mautic\CoreBundle\Entity\Notification;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\IntegrationsBundle\Sync\Notification\BulkNotification;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class BulkNotificationTest extends MauticMysqlTestCase
 {
     private BulkNotification $bulkNotification;

--- a/app/bundles/IntegrationsBundle/Tests/Functional/Sync/Notification/Helper/UserNotificationBuilderTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Functional/Sync/Notification/Helper/UserNotificationBuilderTest.php
@@ -8,7 +8,9 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\IntegrationsBundle\Sync\Notification\Helper\UserNotificationBuilder;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\UserBundle\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class UserNotificationBuilderTest extends MauticMysqlTestCase
 {
     private UserNotificationBuilder $notificationBuilder;

--- a/app/bundles/IntegrationsBundle/Tests/Functional/Sync/Notification/NotifierTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Functional/Sync/Notification/NotifierTest.php
@@ -15,7 +15,9 @@ use Mautic\IntegrationsBundle\Tests\Functional\Services\SyncService\TestExamples
 use Mautic\IntegrationsBundle\Tests\Functional\Services\SyncService\TestExamples\Sync\SyncDataExchange\ExampleSyncDataExchange;
 use Mautic\LeadBundle\DataFixtures\ORM\LoadLeadData;
 use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class NotifierTest extends MauticMysqlTestCase
 {
     public function testNotifications(): void

--- a/app/bundles/LeadBundle/Tests/Command/CleanupExportedFilesCommandFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/CleanupExportedFilesCommandFunctionalTest.php
@@ -11,8 +11,10 @@ use Mautic\LeadBundle\Command\ContactScheduledExportCommand;
 use Mautic\LeadBundle\Entity\ContactExportScheduler;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Model\LeadModel;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class CleanupExportedFilesCommandFunctionalTest extends MauticMysqlTestCase
 {
     protected function setUp(): void

--- a/app/bundles/LeadBundle/Tests/Command/DeduplicateCommandFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/DeduplicateCommandFunctionalTest.php
@@ -10,7 +10,9 @@ use Mautic\LeadBundle\Command\DeduplicateCommand;
 use Mautic\LeadBundle\Deduplicate\ContactDeduper;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadField;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class DeduplicateCommandFunctionalTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/LeadBundle/Tests/Command/DeduplicateIdsCommandFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/DeduplicateIdsCommandFunctionalTest.php
@@ -7,7 +7,9 @@ namespace Mautic\LeadBundle\Tests\Command;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Command\DeduplicateIdsCommand;
 use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class DeduplicateIdsCommandFunctionalTest extends MauticMysqlTestCase
 {
     public function testDeduplicateCommandWithContactIdsParam(): void

--- a/app/bundles/LeadBundle/Tests/Command/DeleteCompanyLeadsFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/DeleteCompanyLeadsFunctionalTest.php
@@ -13,7 +13,9 @@ use Mautic\LeadBundle\Entity\CompanyRepository;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Tests\TestEntityCreationTrait;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class DeleteCompanyLeadsFunctionalTest extends MauticMysqlTestCase
 {
     use TestEntityCreationTrait;

--- a/app/bundles/LeadBundle/Tests/Command/DeleteContactSecondaryCompaniesCommandTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/DeleteContactSecondaryCompaniesCommandTest.php
@@ -11,7 +11,9 @@ use Mautic\LeadBundle\Entity\CompanyLead;
 use Mautic\LeadBundle\Entity\CompanyLeadRepository;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Model\LeadModel;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class DeleteContactSecondaryCompaniesCommandTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/LeadBundle/Tests/Command/DeleteLeadListsCommandFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/DeleteLeadListsCommandFunctionalTest.php
@@ -11,7 +11,9 @@ use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\LeadListRepository;
 use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Model\ListModel;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class DeleteLeadListsCommandFunctionalTest extends MauticMysqlTestCase
 {
     protected function setUp(): void

--- a/app/bundles/LeadBundle/Tests/Command/SegmentCountCacheCommandFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/SegmentCountCacheCommandFunctionalTest.php
@@ -11,8 +11,10 @@ use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\LeadListRepository;
 use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Helper\SegmentCountCacheHelper;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class SegmentCountCacheCommandFunctionalTest extends MauticMysqlTestCase
 {
     /**

--- a/app/bundles/LeadBundle/Tests/Command/SegmentFilterOnUpdateCommandFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/SegmentFilterOnUpdateCommandFunctionalTest.php
@@ -9,7 +9,9 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Entity\ListLead;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class SegmentFilterOnUpdateCommandFunctionalTest extends MauticMysqlTestCase
 {
     public function testSegmentFilterOnUpdateCommand(): void

--- a/app/bundles/LeadBundle/Tests/Command/SegmentFilterWithRelativeTimeFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/SegmentFilterWithRelativeTimeFunctionalTest.php
@@ -13,7 +13,9 @@ use Mautic\LeadBundle\Entity\LeadListRepository;
 use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Entity\ListLead;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class SegmentFilterWithRelativeTimeFunctionalTest extends MauticMysqlTestCase
 {
     #[DataProvider('getRelativeHours')]

--- a/app/bundles/LeadBundle/Tests/Command/SegmentFiltersFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/SegmentFiltersFunctionalTest.php
@@ -15,7 +15,9 @@ use Mautic\LeadBundle\Model\FieldModel;
 use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\LeadBundle\Segment\OperatorOptions;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class SegmentFiltersFunctionalTest extends MauticMysqlTestCase
 {
     private const string FIELD_NAME = 'car';

--- a/app/bundles/LeadBundle/Tests/Command/SegmentNumberFilterWithOrsCommandFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/SegmentNumberFilterWithOrsCommandFunctionalTest.php
@@ -8,7 +8,9 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\ListLead;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class SegmentNumberFilterWithOrsCommandFunctionalTest extends MauticMysqlTestCase
 {
     public function testSegmentNuberFilterWithOrsCommand(): void

--- a/app/bundles/LeadBundle/Tests/Command/SegmentStatCommandTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/SegmentStatCommandTest.php
@@ -7,7 +7,9 @@ namespace Mautic\LeadBundle\Tests\Command;
 use Mautic\CampaignBundle\Entity\Campaign;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\LeadList;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class SegmentStatCommandTest extends MauticMysqlTestCase
 {
     /**

--- a/app/bundles/LeadBundle/Tests/Command/SegmentStressTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/SegmentStressTest.php
@@ -8,8 +8,10 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\CoreBundle\Tests\Functional\CreateTestEntitiesTrait;
 use Mautic\LeadBundle\Command\UpdateLeadListsCommand;
 use Mautic\LeadBundle\Entity\LeadList;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\Console\Command\Command;
 
+#[Group('database')]
 final class SegmentStressTest extends MauticMysqlTestCase
 {
     use CreateTestEntitiesTrait;

--- a/app/bundles/LeadBundle/Tests/Command/UpdateCompanyNameOnLeadsCommandFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/UpdateCompanyNameOnLeadsCommandFunctionalTest.php
@@ -11,7 +11,9 @@ use Mautic\LeadBundle\Entity\CompanyRepository;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Tests\TestEntityCreationTrait;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class UpdateCompanyNameOnLeadsCommandFunctionalTest extends MauticMysqlTestCase
 {
     use TestEntityCreationTrait;

--- a/app/bundles/LeadBundle/Tests/Command/UpdateLeadListCommandFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/UpdateLeadListCommandFunctionalTest.php
@@ -19,8 +19,10 @@ use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\LeadBundle\Segment\OperatorOptions;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\Console\Command\Command;
 
+#[Group('database')]
 final class UpdateLeadListCommandFunctionalTest extends MauticMysqlTestCase
 {
     use CreateTestEntitiesTrait;

--- a/app/bundles/LeadBundle/Tests/Command/UpdateLeadListsCommandCircularDependencyTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/UpdateLeadListsCommandCircularDependencyTest.php
@@ -8,7 +8,9 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Command\UpdateLeadListsCommand;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Segment\Exception\SegmentQueryException;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class UpdateLeadListsCommandCircularDependencyTest extends MauticMysqlTestCase
 {
     /**

--- a/app/bundles/LeadBundle/Tests/Controller/AjaxControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/AjaxControllerFunctionalTest.php
@@ -19,10 +19,12 @@ use Mautic\UserBundle\Entity\UserRepository;
 use MauticPlugin\MauticTagManagerBundle\Entity\Tag;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 use Symfony\Component\PasswordHasher\PasswordHasherInterface;
 
+#[Group('database')]
 final class AjaxControllerFunctionalTest extends MauticMysqlTestCase
 {
     protected function beforeBeginTransaction(): void

--- a/app/bundles/LeadBundle/Tests/Controller/Api/CompanyApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/CompanyApiControllerFunctionalTest.php
@@ -13,8 +13,10 @@ use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Tests\TestEntityCreationTrait;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class CompanyApiControllerFunctionalTest extends MauticMysqlTestCase
 {
     use TestEntityCreationTrait;

--- a/app/bundles/LeadBundle/Tests/Controller/Api/DeviceApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/DeviceApiControllerFunctionalTest.php
@@ -6,9 +6,11 @@ namespace Mautic\LeadBundle\Tests\Controller\Api;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class DeviceApiControllerFunctionalTest extends MauticMysqlTestCase
 {
     public function testPutEditWithInexistingIdSoItShouldCreate(): void

--- a/app/bundles/LeadBundle/Tests/Controller/Api/FieldApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/FieldApiControllerFunctionalTest.php
@@ -15,11 +15,13 @@ use Mautic\LeadBundle\Model\LeadModel;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 #[CoversClass(FieldApiController::class)]
 #[CoversClass(CreateCustomFieldCommand::class)]
+#[Group('database')]
 final class FieldApiControllerFunctionalTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerFunctionalTest.php
@@ -22,10 +22,12 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadNote;
 use Mautic\UserBundle\Entity\User;
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Session;
 
+#[Group('database')]
 final class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
 {
     use ApiTestUserTrait;

--- a/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerProfilerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerProfilerTest.php
@@ -9,12 +9,14 @@ use Doctrine\Common\Cache\CacheProvider;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadRepository;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Tests that enable debug and profiler to test performance optimizations.
  * These tests are slower as debug and profiler are enabled. Add tests here only if you need profiler.
  */
+#[Group('database')]
 final class LeadApiControllerProfilerTest extends MauticMysqlTestCase
 {
     /**

--- a/app/bundles/LeadBundle/Tests/Controller/Api/ListApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/ListApiControllerFunctionalTest.php
@@ -19,10 +19,12 @@ use Mautic\LeadBundle\Model\FieldModel;
 use Mautic\LeadBundle\Model\ListModel;
 use Mautic\LeadBundle\Segment\OperatorOptions;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[Group('database')]
 final class ListApiControllerFunctionalTest extends MauticMysqlTestCase
 {
     private ListModel $listModel;

--- a/app/bundles/LeadBundle/Tests/Controller/Api/NoteApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/NoteApiControllerFunctionalTest.php
@@ -7,8 +7,10 @@ namespace Mautic\LeadBundle\Tests\Controller\Api;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadNote;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class NoteApiControllerFunctionalTest extends MauticMysqlTestCase
 {
     use ApiTestUserTrait;

--- a/app/bundles/LeadBundle/Tests/Controller/Api/TagApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/TagApiControllerFunctionalTest.php
@@ -7,8 +7,10 @@ namespace Mautic\LeadBundle\Tests\Controller\Api;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Tag;
 use Mautic\LeadBundle\Entity\TagRepository;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class TagApiControllerFunctionalTest extends MauticMysqlTestCase
 {
     public function testTagWorkflow(): void

--- a/app/bundles/LeadBundle/Tests/Controller/AuditLogControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/AuditLogControllerTest.php
@@ -9,8 +9,10 @@ use Doctrine\ORM\OptimisticLockException;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\CoreBundle\Tests\Functional\CreateTestEntitiesTrait;
 use Mautic\UserBundle\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class AuditLogControllerTest extends MauticMysqlTestCase
 {
     use CreateTestEntitiesTrait;

--- a/app/bundles/LeadBundle/Tests/Controller/CompanyControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/CompanyControllerTest.php
@@ -12,11 +12,13 @@ use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Model\CompanyModel;
 use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\ProjectBundle\Entity\Project;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[Group('database')]
 final class CompanyControllerTest extends MauticMysqlTestCase
 {
     private const string COUNTRY_UNITED_STATES = 'United States';

--- a/app/bundles/LeadBundle/Tests/Controller/CompanyProjectSearchFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/CompanyProjectSearchFunctionalTest.php
@@ -7,7 +7,9 @@ namespace Mautic\LeadBundle\Tests\Controller;
 use Mautic\LeadBundle\Entity\Company;
 use Mautic\ProjectBundle\Tests\Functional\AbstractProjectSearchTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class CompanyProjectSearchFunctionalTest extends AbstractProjectSearchTestCase
 {
     #[DataProvider('searchDataProvider')]

--- a/app/bundles/LeadBundle/Tests/Controller/FieldControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/FieldControllerTest.php
@@ -10,8 +10,10 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\LeadField;
 use Mautic\LeadBundle\Entity\LeadFieldRepository;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class FieldControllerTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/LeadBundle/Tests/Controller/FieldFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/FieldFunctionalTest.php
@@ -10,9 +10,11 @@ use Mautic\LeadBundle\Entity\LeadField;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Model\FieldModel;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\DomCrawler\Field\InputFormField;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class FieldFunctionalTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/LeadBundle/Tests/Controller/ImportControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/ImportControllerTest.php
@@ -23,6 +23,7 @@ use Mautic\UserBundle\Entity\Permission;
 use Mautic\UserBundle\Entity\Role;
 use Mautic\UserBundle\Entity\User;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\DomCrawler\Form;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
@@ -31,6 +32,7 @@ use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 use Symfony\Component\PasswordHasher\PasswordHasherInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[Group('database')]
 final class ImportControllerTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/LeadBundle/Tests/Controller/LeadCompanyControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/LeadCompanyControllerTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Mautic\LeadBundle\Tests\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class LeadCompanyControllerTest extends MauticMysqlTestCase
 {
     protected function setUp(): void

--- a/app/bundles/LeadBundle/Tests/Controller/LeadControllerListingPageTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/LeadControllerListingPageTest.php
@@ -8,7 +8,9 @@ use Doctrine\ORM\Exception\ORMException;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class LeadControllerListingPageTest extends MauticMysqlTestCase
 {
     protected function setUp(): void

--- a/app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/LeadControllerTest.php
@@ -38,6 +38,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\Group('database')]
 final class LeadControllerTest extends MauticMysqlTestCase
 {
     use CreateTestEntitiesTrait;

--- a/app/bundles/LeadBundle/Tests/Controller/LeadDetailFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/LeadDetailFunctionalTest.php
@@ -8,8 +8,10 @@ use Doctrine\DBAL\ArrayParameterType;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadField;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[Group('database')]
 final class LeadDetailFunctionalTest extends MauticMysqlTestCase
 {
     public function testCustomFieldOrderIsRespected(): void

--- a/app/bundles/LeadBundle/Tests/Controller/LeadListProjectSearchFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/LeadListProjectSearchFunctionalTest.php
@@ -7,7 +7,9 @@ namespace Mautic\LeadBundle\Tests\Controller;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\ProjectBundle\Tests\Functional\AbstractProjectSearchTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class LeadListProjectSearchFunctionalTest extends AbstractProjectSearchTestCase
 {
     #[DataProvider('searchDataProvider')]

--- a/app/bundles/LeadBundle/Tests/Controller/LeadListSearchFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/LeadListSearchFunctionalTest.php
@@ -11,8 +11,10 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\ListLead;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class LeadListSearchFunctionalTest extends MauticMysqlTestCase
 {
     /**

--- a/app/bundles/LeadBundle/Tests/Controller/ListControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/ListControllerFunctionalTest.php
@@ -19,11 +19,13 @@ use Mautic\LeadBundle\Model\ListModel;
 use Mautic\ProjectBundle\Entity\Project;
 use Mautic\ProjectBundle\Model\ProjectModel;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[Group('database')]
 final class ListControllerFunctionalTest extends MauticMysqlTestCase
 {
     private ListModel $listModel;

--- a/app/bundles/LeadBundle/Tests/Controller/ListControllerPermissionFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/ListControllerPermissionFunctionalTest.php
@@ -12,11 +12,13 @@ use Mautic\UserBundle\Entity\Permission;
 use Mautic\UserBundle\Entity\Role;
 use Mautic\UserBundle\Entity\User;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 use Symfony\Component\PasswordHasher\PasswordHasherInterface;
 
+#[Group('database')]
 final class ListControllerPermissionFunctionalTest extends MauticMysqlTestCase
 {
     private const string SEGMENTS_ROUTE = '/s/segments';

--- a/app/bundles/LeadBundle/Tests/Controller/ListControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/ListControllerTest.php
@@ -10,7 +10,9 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadField;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\ListLead;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class ListControllerTest extends MauticMysqlTestCase
 {
     use ControllerTrait;

--- a/app/bundles/LeadBundle/Tests/Controller/NoteControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/NoteControllerTest.php
@@ -10,11 +10,13 @@ use Mautic\LeadBundle\Entity\LeadNote;
 use Mautic\UserBundle\Entity\Role;
 use Mautic\UserBundle\Entity\User;
 use Mautic\UserBundle\Model\RoleModel;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 use Symfony\Component\PasswordHasher\PasswordHasherInterface;
 
+#[Group('database')]
 final class NoteControllerTest extends MauticMysqlTestCase
 {
     protected function beforeBeginTransaction(): void

--- a/app/bundles/LeadBundle/Tests/Controller/TimelineControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/TimelineControllerTest.php
@@ -9,8 +9,10 @@ use Doctrine\ORM\OptimisticLockException;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\CoreBundle\Tests\Functional\CreateTestEntitiesTrait;
 use Mautic\UserBundle\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class TimelineControllerTest extends MauticMysqlTestCase
 {
     use CreateTestEntitiesTrait;

--- a/app/bundles/LeadBundle/Tests/Deduplicate/ContactMergerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Deduplicate/ContactMergerFunctionalTest.php
@@ -13,7 +13,9 @@ use Mautic\LeadBundle\Entity\CompanyLeadRepository;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Model\CompanyModel;
 use Mautic\LeadBundle\Model\LeadModel;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class ContactMergerFunctionalTest extends MauticMysqlTestCase
 {
     public function testMergedContactFound(): void

--- a/app/bundles/LeadBundle/Tests/Entity/CompanyLeadRepositoryFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/CompanyLeadRepositoryFunctionalTest.php
@@ -9,7 +9,9 @@ use Mautic\LeadBundle\Entity\Company;
 use Mautic\LeadBundle\Entity\CompanyLead;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Model\CompanyModel;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class CompanyLeadRepositoryFunctionalTest extends MauticMysqlTestCase
 {
     public function testGetCompaniesByLeadIds(): void

--- a/app/bundles/LeadBundle/Tests/Entity/CompanyTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/CompanyTest.php
@@ -9,9 +9,11 @@ use Doctrine\ORM\ORMException;
 use Doctrine\Persistence\Mapping\MappingException;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Company;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\DomCrawler\Form;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class CompanyTest extends MauticMysqlTestCase
 {
     public function testChangingPropertiesHydratesFieldChanges(): void

--- a/app/bundles/LeadBundle/Tests/Entity/ContactExportSchedulerTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/ContactExportSchedulerTest.php
@@ -7,7 +7,9 @@ namespace Mautic\LeadBundle\Tests\Entity;
 use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\ContactExportScheduler;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class ContactExportSchedulerTest extends MauticMysqlTestCase
 {
     private string $previousTimeZone;

--- a/app/bundles/LeadBundle/Tests/Entity/DoNotContactRepositoryFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/DoNotContactRepositoryFunctionalTest.php
@@ -8,7 +8,9 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\DoNotContact;
 use Mautic\LeadBundle\Entity\DoNotContactRepository;
 use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class DoNotContactRepositoryFunctionalTest extends MauticMysqlTestCase
 {
     public function testGetChannelList(): void

--- a/app/bundles/LeadBundle/Tests/Entity/FrequencyRuleRepositoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/FrequencyRuleRepositoryTest.php
@@ -12,7 +12,9 @@ use Mautic\EmailBundle\Entity\Stat;
 use Mautic\LeadBundle\Entity\FrequencyRule;
 use Mautic\LeadBundle\Entity\FrequencyRuleRepository;
 use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class FrequencyRuleRepositoryTest extends MauticMysqlTestCase
 {
     private FrequencyRuleRepository $frequencyRuleRepository;

--- a/app/bundles/LeadBundle/Tests/Entity/LeadCategoryRepositoryFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadCategoryRepositoryFunctionalTest.php
@@ -8,6 +8,7 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\CoreBundle\Tests\Functional\CreateTestEntitiesTrait;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Model\LeadModel;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Symfony\Component\DomCrawler\Crawler;
@@ -15,6 +16,7 @@ use Symfony\Component\HttpFoundation\Request;
 
 #[PreserveGlobalState(false)]
 #[RunTestsInSeparateProcesses]
+#[Group('database')]
 final class LeadCategoryRepositoryFunctionalTest extends MauticMysqlTestCase
 {
     use CreateTestEntitiesTrait;

--- a/app/bundles/LeadBundle/Tests/Entity/LeadDeviceRepositoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadDeviceRepositoryTest.php
@@ -8,7 +8,9 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadDevice;
 use Mautic\LeadBundle\Entity\LeadDeviceRepository;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class LeadDeviceRepositoryTest extends MauticMysqlTestCase
 {
     public function testFindExistingDevice(): void

--- a/app/bundles/LeadBundle/Tests/Entity/LeadFieldRepositoryFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadFieldRepositoryFunctionalTest.php
@@ -9,7 +9,9 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadField;
 use Mautic\LeadBundle\Model\FieldModel;
 use Mautic\LeadBundle\Model\LeadModel;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class LeadFieldRepositoryFunctionalTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback     = false;

--- a/app/bundles/LeadBundle/Tests/Entity/LeadListRepositoryFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadListRepositoryFunctionalTest.php
@@ -9,7 +9,9 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\LeadListRepository;
 use Mautic\LeadBundle\Entity\ListLead;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class LeadListRepositoryFunctionalTest extends AbstractMauticTestCase
 {
     public function testCheckLeadSegmentsByIds(): void

--- a/app/bundles/LeadBundle/Tests/Entity/LeadRepositoryFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadRepositoryFunctionalTest.php
@@ -9,8 +9,10 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Model\LeadModel;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class LeadRepositoryFunctionalTest extends MauticMysqlTestCase
 {
     private Lead $lead;

--- a/app/bundles/LeadBundle/Tests/Entity/ListLeadRepositoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/ListLeadRepositoryTest.php
@@ -9,7 +9,9 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\ListLead;
 use Mautic\LeadBundle\Entity\ListLeadRepository;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class ListLeadRepositoryTest extends MauticMysqlTestCase
 {
     private ListLeadRepository $listLeadRepository;

--- a/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
@@ -31,6 +31,7 @@ use Symfony\Component\Console\Tester\ApplicationTester;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Response;
 
+#[\PHPUnit\Framework\Attributes\Group('database')]
 final class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
 {
     use LeadFieldTestTrait;

--- a/app/bundles/LeadBundle/Tests/EventListener/Issue9488Test.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/Issue9488Test.php
@@ -10,10 +10,12 @@ use Mautic\CampaignBundle\Entity\Lead as CampaignLead;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadRepository;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\ApplicationTester;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class Issue9488Test extends MauticMysqlTestCase
 {
     private LeadRepository $contactRepository;

--- a/app/bundles/LeadBundle/Tests/EventListener/ReportDevicesSubscriberFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/ReportDevicesSubscriberFunctionalTest.php
@@ -8,8 +8,10 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadDevice;
 use Mautic\ReportBundle\Entity\Report;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class ReportDevicesSubscriberFunctionalTest extends MauticMysqlTestCase
 {
     /**

--- a/app/bundles/LeadBundle/Tests/EventListener/ReportNormalizeSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/ReportNormalizeSubscriberTest.php
@@ -11,9 +11,11 @@ use Mautic\LeadBundle\Model\FieldModel;
 use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\ReportBundle\Entity\Report;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class ReportNormalizeSubscriberTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/LeadBundle/Tests/EventListener/ReportSubscriberFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/ReportSubscriberFunctionalTest.php
@@ -7,7 +7,9 @@ namespace Mautic\LeadBundle\Tests\EventListener;
 use Mautic\LeadBundle\Entity\DoNotContact;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\ReportBundle\Tests\Functional\AbstractReportSubscriberTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class ReportSubscriberFunctionalTest extends AbstractReportSubscriberTestCase
 {
     public function testLeadReportWithDncListColumn(): void

--- a/app/bundles/LeadBundle/Tests/EventListener/SearchSubscriberFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/SearchSubscriberFunctionalTest.php
@@ -13,9 +13,11 @@ use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\ListLead;
 use Mautic\LeadBundle\Event\LeadBuildSearchEvent;
 use Mautic\LeadBundle\LeadEvents;
+use PHPUnit\Framework\Attributes\Group;
 use Ramsey\Uuid\Uuid;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
+#[Group('database')]
 final class SearchSubscriberFunctionalTest extends MauticMysqlTestCase
 {
     private Email $email;

--- a/app/bundles/LeadBundle/Tests/EventListener/SegmentLogReportSubscriberFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/SegmentLogReportSubscriberFunctionalTest.php
@@ -8,7 +8,9 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\CoreBundle\Tests\Functional\CreateTestEntitiesTrait;
 use Mautic\LeadBundle\EventListener\SegmentLogReportSubscriber;
 use Mautic\ReportBundle\Entity\Report;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class SegmentLogReportSubscriberFunctionalTest extends MauticMysqlTestCase
 {
     use CreateTestEntitiesTrait;

--- a/app/bundles/LeadBundle/Tests/EventListener/SegmentStatsSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/SegmentStatsSubscriberTest.php
@@ -12,7 +12,9 @@ use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\LeadListRepository;
 use Mautic\LeadBundle\Event\GetStatDataEvent;
 use Mautic\LeadBundle\EventListener\SegmentStatsSubscriber;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class SegmentStatsSubscriberTest extends MauticMysqlTestCase
 {
     private SegmentStatsSubscriber $subscriber;

--- a/app/bundles/LeadBundle/Tests/EventListener/WebhookSubscriberFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/WebhookSubscriberFunctionalTest.php
@@ -14,7 +14,9 @@ use Mautic\WebhookBundle\Entity\Webhook;
 use Mautic\WebhookBundle\Entity\WebhookQueue;
 use Mautic\WebhookBundle\Entity\WebhookQueueRepository;
 use Mautic\WebhookBundle\Model\WebhookModel;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class WebhookSubscriberFunctionalTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/LeadBundle/Tests/Field/Command/AnalyseCustomFieldCommandFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Field/Command/AnalyseCustomFieldCommandFunctionalTest.php
@@ -10,7 +10,9 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadField;
 use Mautic\LeadBundle\Model\FieldModel;
 use Mautic\LeadBundle\Model\LeadModel;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class AnalyseCustomFieldCommandFunctionalTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/LeadBundle/Tests/Field/Command/ModifyCustomFieldCommandFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Field/Command/ModifyCustomFieldCommandFunctionalTest.php
@@ -7,8 +7,10 @@ namespace Mautic\LeadBundle\Tests\Field\Command;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\LeadField;
 use Mautic\LeadBundle\Model\FieldModel;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\Console\Command\Command;
 
+#[Group('database')]
 final class ModifyCustomFieldCommandFunctionalTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/LeadBundle/Tests/Form/Type/CampaignEventLeadStagesTypeTest.php
+++ b/app/bundles/LeadBundle/Tests/Form/Type/CampaignEventLeadStagesTypeTest.php
@@ -7,9 +7,11 @@ namespace Mautic\LeadBundle\Tests\Form\Type;
 use Mautic\CoreBundle\Test\AbstractMauticTestCase;
 use Mautic\LeadBundle\Form\Type\CampaignEventLeadStagesType;
 use Mautic\StageBundle\Form\Type\StageListType;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Form\FormBuilderInterface;
 
+#[Group('database')]
 final class CampaignEventLeadStagesTypeTest extends AbstractMauticTestCase
 {
     private CampaignEventLeadStagesType $campaignEventLeadStagesType;

--- a/app/bundles/LeadBundle/Tests/Form/Type/ChangeOwnerTypeFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Form/Type/ChangeOwnerTypeFunctionalTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Mautic\LeadBundle\Tests\Form\Type;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\DomCrawler\Crawler;
 
+#[Group('database')]
 final class ChangeOwnerTypeFunctionalTest extends MauticMysqlTestCase
 {
     private const string TEMP_CAMPAIGN_ID = 'mautic_89f7f52426c1dff3daa3beaea708a6b39fe7a775';

--- a/app/bundles/LeadBundle/Tests/Form/Type/ContactChannelsTypeTest.php
+++ b/app/bundles/LeadBundle/Tests/Form/Type/ContactChannelsTypeTest.php
@@ -6,9 +6,11 @@ namespace Mautic\LeadBundle\Tests\Form\Type;
 
 use Mautic\CoreBundle\Test\AbstractMauticTestCase;
 use Mautic\LeadBundle\Form\Type\ContactChannelsType;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 
+#[Group('database')]
 final class ContactChannelsTypeTest extends AbstractMauticTestCase
 {
     protected function setUp(): void

--- a/app/bundles/LeadBundle/Tests/Form/Type/EmailTypeFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Form/Type/EmailTypeFunctionalTest.php
@@ -7,9 +7,11 @@ namespace Mautic\LeadBundle\Tests\Form\Type;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\EmailBundle\Entity\Copy;
 use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class EmailTypeFunctionalTest extends MauticMysqlTestCase
 {
     /**

--- a/app/bundles/LeadBundle/Tests/Functional/ApiPlatform/CompanyOwnershipApiV2AuthorizationRegressionTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/ApiPlatform/CompanyOwnershipApiV2AuthorizationRegressionTest.php
@@ -6,7 +6,9 @@ namespace Mautic\LeadBundle\Tests\Functional\ApiPlatform;
 
 use Mautic\LeadBundle\Entity\Company;
 use Mautic\UserBundle\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class CompanyOwnershipApiV2AuthorizationRegressionTest extends OwnershipScopedApiAuthorizationTestBase
 {
     public function testViewOwnCollectionCannotSeeForeignCompanyOnApiV2(): void

--- a/app/bundles/LeadBundle/Tests/Functional/ApiPlatform/ContactOwnershipApiV2AuthorizationRegressionTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/ApiPlatform/ContactOwnershipApiV2AuthorizationRegressionTest.php
@@ -7,8 +7,10 @@ namespace Mautic\LeadBundle\Tests\Functional\ApiPlatform;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\UserBundle\Entity\User;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class ContactOwnershipApiV2AuthorizationRegressionTest extends OwnershipScopedApiAuthorizationTestBase
 {
     #[DataProvider('endpointProvider')]

--- a/app/bundles/LeadBundle/Tests/Functional/Command/CreateCustomFieldCommandTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Command/CreateCustomFieldCommandTest.php
@@ -10,10 +10,12 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadField;
 use Mautic\LeadBundle\Field\Command\CreateCustomFieldCommand;
 use Mautic\LeadBundle\Field\Notification\CustomFieldNotification;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\HttpKernel\KernelInterface;
 
+#[Group('database')]
 final class CreateCustomFieldCommandTest extends MauticMysqlTestCase
 {
     protected function setUp(): void

--- a/app/bundles/LeadBundle/Tests/Functional/Command/ImportCommandTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Command/ImportCommandTest.php
@@ -8,8 +8,10 @@ use Mautic\CoreBundle\Helper\CsvHelper;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Import;
 use Mautic\LeadBundle\Model\ImportModel;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class ImportCommandTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/LeadBundle/Tests/Functional/ContactExportLimitFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/ContactExportLimitFunctionalTest.php
@@ -9,9 +9,11 @@ use Mautic\LeadBundle\DataFixtures\ORM\LoadLeadData;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Model\LeadModel;
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class ContactExportLimitFunctionalTest extends MauticMysqlTestCase
 {
     protected function setUp(): void

--- a/app/bundles/LeadBundle/Tests/Functional/Controller/CompanyControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Controller/CompanyControllerTest.php
@@ -7,9 +7,11 @@ namespace Mautic\LeadBundle\Tests\Functional\Controller;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\UserBundle\Entity\Role;
 use Mautic\UserBundle\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 use Symfony\Component\PasswordHasher\PasswordHasherInterface;
 
+#[Group('database')]
 final class CompanyControllerTest extends MauticMysqlTestCase
 {
     public const string USERNAME = 'jhony';

--- a/app/bundles/LeadBundle/Tests/Functional/Controller/CompanyListColumnConfigurationFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Controller/CompanyListColumnConfigurationFunctionalTest.php
@@ -6,7 +6,9 @@ namespace Mautic\LeadBundle\Tests\Functional\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Company;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class CompanyListColumnConfigurationFunctionalTest extends MauticMysqlTestCase
 {
     protected function setUp(): void

--- a/app/bundles/LeadBundle/Tests/Functional/Controller/ContactExportAdminNotificationsDisabledTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Controller/ContactExportAdminNotificationsDisabledTest.php
@@ -15,11 +15,13 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\UserBundle\Entity\Role;
 use Mautic\UserBundle\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 use Symfony\Component\PasswordHasher\PasswordHasherInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
+#[Group('database')]
 final class ContactExportAdminNotificationsDisabledTest extends MauticMysqlTestCase
 {
     /**

--- a/app/bundles/LeadBundle/Tests/Functional/Controller/ImportControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Controller/ImportControllerFunctionalTest.php
@@ -18,10 +18,12 @@ use Mautic\UserBundle\Entity\User;
 use Mautic\UserBundle\Security\UserTokenSetter;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[Group('database')]
 final class ImportControllerFunctionalTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/LeadBundle/Tests/Functional/Controller/ImportUrlValidationTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Controller/ImportUrlValidationTest.php
@@ -11,9 +11,11 @@ use Mautic\LeadBundle\Entity\LeadField;
 use Mautic\LeadBundle\Model\FieldModel;
 use Mautic\LeadBundle\Model\ImportModel;
 use Mautic\UserBundle\Security\UserTokenSetter;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class ImportUrlValidationTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/LeadBundle/Tests/Functional/Controller/LeadControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Controller/LeadControllerTest.php
@@ -15,11 +15,13 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\UserBundle\Entity\Role;
 use Mautic\UserBundle\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 use Symfony\Component\PasswordHasher\PasswordHasherInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
+#[Group('database')]
 final class LeadControllerTest extends MauticMysqlTestCase
 {
     public const string USERNAME           = 'jhony';

--- a/app/bundles/LeadBundle/Tests/Functional/Controller/SendEmailToContactTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Controller/SendEmailToContactTest.php
@@ -9,10 +9,12 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Helper\SMimeHelper;
 use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Mime\Message;
 
+#[Group('database')]
 final class SendEmailToContactTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/LeadBundle/Tests/Functional/DncSearchFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/DncSearchFunctionalTest.php
@@ -7,8 +7,10 @@ namespace Mautic\LeadBundle\Tests\Functional;
 use Doctrine\DBAL\Types\Types;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class DncSearchFunctionalTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/LeadBundle/Tests/Functional/Entity/CompanyRepositoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Entity/CompanyRepositoryTest.php
@@ -13,9 +13,11 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\ListLead;
 use Mautic\LeadBundle\Model\CompanyModel;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Mailer\Mailer;
 
+#[Group('database')]
 final class CompanyRepositoryTest extends MauticMysqlTestCase
 {
     private SmtpTransport $transport;

--- a/app/bundles/LeadBundle/Tests/Functional/Entity/DoNotContactFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Entity/DoNotContactFunctionalTest.php
@@ -10,7 +10,9 @@ use Mautic\LeadBundle\Entity\DoNotContactRepository;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\ListLead;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class DoNotContactFunctionalTest extends MauticMysqlTestCase
 {
     public function testGetCount(): void

--- a/app/bundles/LeadBundle/Tests/Functional/Entity/LeadRepositoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Entity/LeadRepositoryTest.php
@@ -9,9 +9,11 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadRepository;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Bridge\Doctrine\DataCollector\DoctrineDataCollector;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class LeadRepositoryTest extends MauticMysqlTestCase
 {
     protected function setUp(): void

--- a/app/bundles/LeadBundle/Tests/Functional/EventListener/CampaignSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/EventListener/CampaignSubscriberTest.php
@@ -14,7 +14,9 @@ use Mautic\LeadBundle\Entity\LeadField;
 use Mautic\LeadBundle\EventListener\CampaignSubscriber;
 use Mautic\LeadBundle\Model\FieldModel;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class CampaignSubscriberTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/LeadBundle/Tests/Functional/EventListener/CompanySubscriberFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/EventListener/CompanySubscriberFunctionalTest.php
@@ -14,7 +14,9 @@ use Mautic\LeadBundle\Model\CompanyModel;
 use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\UserBundle\Entity\User;
 use Mautic\UserBundle\Model\UserModel;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class CompanySubscriberFunctionalTest extends MauticMysqlTestCase
 {
     /**

--- a/app/bundles/LeadBundle/Tests/Functional/EventListener/LeadSubscriberFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/EventListener/LeadSubscriberFunctionalTest.php
@@ -10,7 +10,9 @@ use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\ListLead;
 use Mautic\LeadBundle\Event\LeadMergeEvent;
 use Mautic\LeadBundle\EventListener\LeadSubscriber;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class LeadSubscriberFunctionalTest extends MauticMysqlTestCase
 {
     public function testUpdateLead(): void

--- a/app/bundles/LeadBundle/Tests/Functional/EventListener/OwnerSubscriberFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/EventListener/OwnerSubscriberFunctionalTest.php
@@ -8,8 +8,10 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\CoreBundle\Tests\Functional\UserEntityTrait;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\PageBundle\Event\UrlTokenReplaceEvent;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
+#[Group('database')]
 final class OwnerSubscriberFunctionalTest extends MauticMysqlTestCase
 {
     use UserEntityTrait;

--- a/app/bundles/LeadBundle/Tests/Functional/EventListener/SegmentSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/EventListener/SegmentSubscriberTest.php
@@ -11,9 +11,11 @@ use Mautic\LeadBundle\Entity\LeadListRepository;
 use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Model\ListModel;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[Group('database')]
 final class SegmentSubscriberTest extends MauticMysqlTestCase
 {
     protected function setUp(): void

--- a/app/bundles/LeadBundle/Tests/Functional/FormSearchFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/FormSearchFunctionalTest.php
@@ -9,8 +9,10 @@ use Mautic\FormBundle\Entity\Form;
 use Mautic\FormBundle\Entity\Submission;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadRepository;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class FormSearchFunctionalTest extends MauticMysqlTestCase
 {
     public function testFormSearchReturnsContactsAssociatedWithFormSubmissions(): void

--- a/app/bundles/LeadBundle/Tests/Functional/Helper/SegmentCountCacheHelperTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Helper/SegmentCountCacheHelperTest.php
@@ -6,7 +6,9 @@ namespace Mautic\LeadBundle\Tests\Functional\Helper;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Helper\SegmentCountCacheHelper;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class SegmentCountCacheHelperTest extends MauticMysqlTestCase
 {
     private const int SEGMENT_ID = 1;

--- a/app/bundles/LeadBundle/Tests/Functional/Model/CompanyModelFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Model/CompanyModelFunctionalTest.php
@@ -10,7 +10,9 @@ use Mautic\LeadBundle\Entity\Company;
 use Mautic\LeadBundle\Entity\CompanyLead;
 use Mautic\LeadBundle\Entity\CompanyLeadRepository;
 use Mautic\LeadBundle\Model\CompanyModel;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class CompanyModelFunctionalTest extends MauticMysqlTestCase
 {
     use CreateTestEntitiesTrait;

--- a/app/bundles/LeadBundle/Tests/Functional/Model/LeadModelSelectFieldTrimTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Model/LeadModelSelectFieldTrimTest.php
@@ -9,7 +9,9 @@ use Mautic\CampaignBundle\Model\EventModel;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\CoreBundle\Tests\Functional\CreateTestEntitiesTrait;
 use Mautic\LeadBundle\Entity\LeadField;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class LeadModelSelectFieldTrimTest extends MauticMysqlTestCase
 {
     use CreateTestEntitiesTrait;

--- a/app/bundles/LeadBundle/Tests/Functional/SearchWithCustomFieldDataFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/SearchWithCustomFieldDataFunctionalTest.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Mautic\LeadBundle\Tests\Functional;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[Group('database')]
 final class SearchWithCustomFieldDataFunctionalTest extends AbstractSearchTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/LeadBundle/Tests/Functional/SearchWithSpecialCharactersInFieldTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/SearchWithSpecialCharactersInFieldTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Mautic\LeadBundle\Tests\Functional;
 
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\DomCrawler\Crawler;
 
+#[Group('database')]
 final class SearchWithSpecialCharactersInFieldTest extends AbstractSearchTestCase
 {
     public function testGlobalSearchContactWithSpecialCharacterInName(): void

--- a/app/bundles/LeadBundle/Tests/Model/FieldModelCustomFieldsFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/FieldModelCustomFieldsFunctionalTest.php
@@ -7,7 +7,9 @@ namespace Mautic\LeadBundle\Tests\Model;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\LeadField;
 use Mautic\LeadBundle\Model\FieldModel;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class FieldModelCustomFieldsFunctionalTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/LeadBundle/Tests/Model/FieldModelDeleteTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/FieldModelDeleteTest.php
@@ -8,7 +8,9 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\LeadField;
 use Mautic\LeadBundle\Entity\LeadFieldRepository;
 use Mautic\LeadBundle\Model\FieldModel;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class FieldModelDeleteTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/LeadBundle/Tests/Model/FieldModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/FieldModelTest.php
@@ -23,10 +23,12 @@ use Mautic\LeadBundle\Field\LeadFieldSaver;
 use Mautic\LeadBundle\Model\FieldModel;
 use Mautic\LeadBundle\Model\ListModel;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
+#[Group('database')]
 final class FieldModelTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/LeadBundle/Tests/Model/LeadModelFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/LeadModelFunctionalTest.php
@@ -19,9 +19,11 @@ use Mautic\LeadBundle\LeadEvents;
 use Mautic\LeadBundle\Model\FieldModel;
 use Mautic\LeadBundle\Model\LeadModel;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
+#[Group('database')]
 final class LeadModelFunctionalTest extends MauticMysqlTestCase
 {
     private bool $pointsAdded = false;

--- a/app/bundles/LeadBundle/Tests/Model/ListModelFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/ListModelFunctionalTest.php
@@ -11,7 +11,9 @@ use Mautic\LeadBundle\Entity\LeadListRepository;
 use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Model\ListModel;
 use Mautic\UserBundle\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class ListModelFunctionalTest extends MauticMysqlTestCase
 {
     public function testPublicSegmentsInContactPreferences(): void

--- a/app/bundles/LeadBundle/Tests/Model/SetFrequencyRulesFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/SetFrequencyRulesFunctionalTest.php
@@ -8,7 +8,9 @@ use Mautic\CategoryBundle\Entity\Category;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\CoreBundle\Tests\Functional\CreateTestEntitiesTrait;
 use Mautic\LeadBundle\Model\LeadModel;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class SetFrequencyRulesFunctionalTest extends MauticMysqlTestCase
 {
     use CreateTestEntitiesTrait;

--- a/app/bundles/LeadBundle/Tests/Model/TagModelFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/TagModelFunctionalTest.php
@@ -8,7 +8,9 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Tag;
 use Mautic\LeadBundle\Entity\TagRepository;
 use Mautic\LeadBundle\Model\TagModel;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class TagModelFunctionalTest extends MauticMysqlTestCase
 {
     public function testDeleteOrphanTags(): void

--- a/app/bundles/LeadBundle/Tests/Security/LeadPermissionsFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Security/LeadPermissionsFunctionalTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Mautic\LeadBundle\Tests\Security;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class LeadPermissionsFunctionalTest extends MauticMysqlTestCase
 {
     public function testRolePageForPermissionAvailability(): void

--- a/app/bundles/LeadBundle/Tests/Segment/ContactSegmentFilterFactoryFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/ContactSegmentFilterFactoryFunctionalTest.php
@@ -9,6 +9,7 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Entity\ListLead;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\ApplicationTester;
 
@@ -17,6 +18,7 @@ use Symfony\Component\Console\Tester\ApplicationTester;
  *
  * @see \Mautic\LeadBundle\Segment\ContactSegmentFilterFactory
  */
+#[Group('database')]
 final class ContactSegmentFilterFactoryFunctionalTest extends MauticMysqlTestCase
 {
     /**

--- a/app/bundles/LeadBundle/Tests/Segment/ContactSegmentServiceFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/ContactSegmentServiceFunctionalTest.php
@@ -22,10 +22,12 @@ use Mautic\LeadBundle\Tests\DataFixtures\ORM\LoadTagData;
 use Mautic\PageBundle\DataFixtures\ORM\LoadPageCategoryData;
 use Mautic\UserBundle\DataFixtures\ORM\LoadRoleData;
 use Mautic\UserBundle\DataFixtures\ORM\LoadUserData;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * These tests cover same tests like \Mautic\LeadBundle\Tests\Model\ListModelFunctionalTest.
  */
+#[Group('database')]
 final class ContactSegmentServiceFunctionalTest extends MauticMysqlTestCase
 {
     private ReferenceRepository $fixtures;

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/RelativeDateFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/RelativeDateFunctionalTest.php
@@ -17,7 +17,9 @@ use Mautic\LeadBundle\Segment\ContactSegmentService;
 use Mautic\LeadBundle\Tests\DataFixtures\ORM\LoadSegmentsData;
 use Mautic\UserBundle\DataFixtures\ORM\LoadRoleData;
 use Mautic\UserBundle\DataFixtures\ORM\LoadUserData;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class RelativeDateFunctionalTest extends MauticMysqlTestCase
 {
     private ReferenceRepository $fixtures;

--- a/app/bundles/LeadBundle/Tests/Segment/LeadEmailReadDateSegmentFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/LeadEmailReadDateSegmentFunctionalTest.php
@@ -11,12 +11,14 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\ListLead;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\ApplicationTester;
 
 /**
  * @see https://github.com/mautic/mautic/issues/16166
  */
+#[Group('database')]
 final class LeadEmailReadDateSegmentFunctionalTest extends MauticMysqlTestCase
 {
     /**

--- a/app/bundles/LeadBundle/Tests/Segment/Query/Filter/SegmentReferenceFilterQueryBuilderGlueTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Query/Filter/SegmentReferenceFilterQueryBuilderGlueTest.php
@@ -7,7 +7,9 @@ namespace Mautic\LeadBundle\Tests\Segment\Query\Filter;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\CoreBundle\Tests\Functional\CreateTestEntitiesTrait;
 use Mautic\LeadBundle\Model\ListModel;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class SegmentReferenceFilterQueryBuilderGlueTest extends MauticMysqlTestCase
 {
     use CreateTestEntitiesTrait;

--- a/app/bundles/LeadBundle/Tests/Segment/SegmentFilterFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/SegmentFilterFunctionalTest.php
@@ -10,7 +10,9 @@ use Mautic\LeadBundle\Entity\LeadField;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Model\FieldModel;
 use Mautic\LeadBundle\Segment\ContactSegmentService;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class SegmentFilterFunctionalTest extends MauticMysqlTestCase
 {
     /**

--- a/app/bundles/LeadBundle/Tests/Tracker/ContactTrackerFunctionalLastActiveTest.php
+++ b/app/bundles/LeadBundle/Tests/Tracker/ContactTrackerFunctionalLastActiveTest.php
@@ -14,9 +14,11 @@ use Mautic\LeadBundle\Helper\ContactRequestHelper;
 use Mautic\PageBundle\Entity\Page;
 use Mautic\PageBundle\Model\PageModel;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
+#[Group('database')]
 final class ContactTrackerFunctionalLastActiveTest extends MauticMysqlTestCase
 {
     protected function setUp(): void

--- a/app/bundles/LeadBundle/Tests/Tracker/ContactTrackerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Tracker/ContactTrackerFunctionalTest.php
@@ -8,10 +8,12 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadDevice;
 use Mautic\LeadBundle\Tracker\ContactTracker;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
+#[Group('database')]
 final class ContactTrackerFunctionalTest extends MauticMysqlTestCase
 {
     private ContactTracker $contactTracker;

--- a/app/bundles/LeadBundle/Tests/Validator/Constraints/EmailAddressValidatorTest.php
+++ b/app/bundles/LeadBundle/Tests/Validator/Constraints/EmailAddressValidatorTest.php
@@ -8,10 +8,12 @@ use Mautic\CoreBundle\Test\AbstractMauticTestCase;
 use Mautic\LeadBundle\Form\Validator\Constraints\EmailAddress;
 use Mautic\LeadBundle\Form\Validator\Constraints\EmailAddressValidator;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\Validator\Context\ExecutionContext;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[Group('database')]
 final class EmailAddressValidatorTest extends AbstractMauticTestCase
 {
     #[DataProvider('provider')]

--- a/app/bundles/MarketplaceBundle/Tests/Functional/Command/InstallCommandTest.php
+++ b/app/bundles/MarketplaceBundle/Tests/Functional/Command/InstallCommandTest.php
@@ -11,8 +11,10 @@ use Mautic\MarketplaceBundle\DTO\ConsoleOutput;
 use Mautic\MarketplaceBundle\DTO\PackageDetail;
 use Mautic\MarketplaceBundle\Exception\ApiException;
 use Mautic\MarketplaceBundle\Model\PackageModel;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 
+#[Group('database')]
 final class InstallCommandTest extends AbstractMauticTestCase
 {
     /**

--- a/app/bundles/MarketplaceBundle/Tests/Functional/Command/ListCommandTest.php
+++ b/app/bundles/MarketplaceBundle/Tests/Functional/Command/ListCommandTest.php
@@ -10,8 +10,10 @@ use Mautic\MarketplaceBundle\Command\ListCommand;
 use Mautic\MarketplaceBundle\DTO\Allowlist as DTOAllowlist;
 use Mautic\MarketplaceBundle\Service\Allowlist;
 use Mautic\MarketplaceBundle\Service\PluginCollector;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Exception;
 
+#[Group('database')]
 final class ListCommandTest extends AbstractMauticTestCase
 {
     public function testCommand(): void

--- a/app/bundles/MarketplaceBundle/Tests/Functional/Command/RemoveCommandTest.php
+++ b/app/bundles/MarketplaceBundle/Tests/Functional/Command/RemoveCommandTest.php
@@ -8,8 +8,10 @@ use Mautic\CoreBundle\Helper\ComposerHelper;
 use Mautic\CoreBundle\Test\AbstractMauticTestCase;
 use Mautic\MarketplaceBundle\Command\RemoveCommand;
 use Mautic\MarketplaceBundle\DTO\ConsoleOutput;
+use PHPUnit\Framework\Attributes\Group;
 use Psr\Log\LoggerInterface;
 
+#[Group('database')]
 final class RemoveCommandTest extends AbstractMauticTestCase
 {
     private string $packageName;

--- a/app/bundles/MarketplaceBundle/Tests/Functional/Controller/AjaxControllerTest.php
+++ b/app/bundles/MarketplaceBundle/Tests/Functional/Controller/AjaxControllerTest.php
@@ -18,12 +18,14 @@ use Mautic\MarketplaceBundle\Controller\AjaxController;
 use Mautic\MarketplaceBundle\DTO\ConsoleOutput;
 use Mautic\MarketplaceBundle\Security\Permissions\MarketplacePermissions;
 use Mautic\MarketplaceBundle\Service\Config;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
+#[Group('database')]
 final class AjaxControllerTest extends AbstractMauticTestCase
 {
     /**

--- a/app/bundles/MarketplaceBundle/Tests/Functional/Controller/DetailControllerTest.php
+++ b/app/bundles/MarketplaceBundle/Tests/Functional/Controller/DetailControllerTest.php
@@ -9,8 +9,10 @@ use Mautic\CoreBundle\Test\Guzzle\ClientMockTrait;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\MarketplaceBundle\Service\Allowlist;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
+#[Group('database')]
 final class DetailControllerTest extends MauticMysqlTestCase
 {
     use ClientMockTrait;

--- a/app/bundles/MarketplaceBundle/Tests/Functional/Controller/ListControllerTest.php
+++ b/app/bundles/MarketplaceBundle/Tests/Functional/Controller/ListControllerTest.php
@@ -9,8 +9,10 @@ use Mautic\CoreBundle\Test\Guzzle\ClientMockTrait;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\MarketplaceBundle\Service\Allowlist;
 use Mautic\MarketplaceBundle\Service\Config;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
+#[Group('database')]
 final class ListControllerTest extends MauticMysqlTestCase
 {
     use ClientMockTrait;

--- a/app/bundles/MessengerBundle/Tests/Form/Type/ConfigTypeTest.php
+++ b/app/bundles/MessengerBundle/Tests/Form/Type/ConfigTypeTest.php
@@ -6,8 +6,10 @@ namespace Mautic\MessengerBundle\Tests\Form\Type;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class ConfigTypeTest extends MauticMysqlTestCase
 {
     private const string MULTIPLIER_FIELD = 'config[messengerconfig][messenger_retry_strategy_multiplier]';

--- a/app/bundles/NotificationBundle/Tests/Functional/Controller/MobileNotificationControllerTest.php
+++ b/app/bundles/NotificationBundle/Tests/Functional/Controller/MobileNotificationControllerTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Mautic\NotificationBundle\Tests\Functional\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class MobileNotificationControllerTest extends MauticMysqlTestCase
 {
     /**

--- a/app/bundles/NotificationBundle/Tests/Functional/Controller/MobileNotificationTranslationFunctionalTest.php
+++ b/app/bundles/NotificationBundle/Tests/Functional/Controller/MobileNotificationTranslationFunctionalTest.php
@@ -9,8 +9,10 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\NotificationBundle\Entity\Notification;
 use Mautic\NotificationBundle\Entity\Stat;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class MobileNotificationTranslationFunctionalTest extends MauticMysqlTestCase
 {
     public function testNotificationCanBeCreatedWithTranslationParent(): void

--- a/app/bundles/NotificationBundle/Tests/Functional/Controller/NotificationControllerTest.php
+++ b/app/bundles/NotificationBundle/Tests/Functional/Controller/NotificationControllerTest.php
@@ -6,10 +6,12 @@ namespace Mautic\NotificationBundle\Tests\Functional\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\NotificationBundle\Tests\NotificationTrait;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class NotificationControllerTest extends MauticMysqlTestCase
 {
     use NotificationTrait;

--- a/app/bundles/NotificationBundle/Tests/Functional/Controller/PopupControllerTest.php
+++ b/app/bundles/NotificationBundle/Tests/Functional/Controller/PopupControllerTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Mautic\NotificationBundle\Tests\Functional\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class PopupControllerTest extends MauticMysqlTestCase
 {
     /**

--- a/app/bundles/NotificationBundle/Tests/Functional/EventListener/CampaignSubscriberTest.php
+++ b/app/bundles/NotificationBundle/Tests/Functional/EventListener/CampaignSubscriberTest.php
@@ -22,10 +22,12 @@ use Mautic\NotificationBundle\Model\NotificationModel;
 use Mautic\NotificationBundle\Tests\NotificationTrait;
 use Mautic\PluginBundle\Helper\IntegrationHelper;
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\Group;
 use Psr\Http\Message\RequestInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[Group('database')]
 final class CampaignSubscriberTest extends MauticMysqlTestCase
 {
     use NotificationTrait;

--- a/app/bundles/PageBundle/Tests/Controller/AjaxControllerFunctionalTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/AjaxControllerFunctionalTest.php
@@ -8,9 +8,11 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\PageBundle\Entity\Page;
 use Mautic\PageBundle\Event\PageEvent;
 use Mautic\PageBundle\PageEvents;
+use PHPUnit\Framework\Attributes\Group;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class AjaxControllerFunctionalTest extends MauticMysqlTestCase
 {
     public function testGetBuilderTokensAction(): void

--- a/app/bundles/PageBundle/Tests/Controller/DeviceTrackingServiceClearCookiesTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/DeviceTrackingServiceClearCookiesTest.php
@@ -7,9 +7,11 @@ namespace Mautic\PageBundle\Tests\Controller;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\PageBundle\Entity\Page;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class DeviceTrackingServiceClearCookiesTest extends MauticMysqlTestCase
 {
     /**

--- a/app/bundles/PageBundle/Tests/Controller/NotFoundFunctionalTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/NotFoundFunctionalTest.php
@@ -6,9 +6,11 @@ namespace Mautic\PageBundle\Tests\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\PageBundle\Entity\Page;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class NotFoundFunctionalTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/PageBundle/Tests/Controller/PageControllerFunctionalTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PageControllerFunctionalTest.php
@@ -9,8 +9,10 @@ use Mautic\DynamicContentBundle\Entity\DynamicContent;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\PageBundle\Entity\Page;
 use Mautic\ProjectBundle\Entity\Project;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class PageControllerFunctionalTest extends MauticMysqlTestCase
 {
     public function testPagePreview(): void

--- a/app/bundles/PageBundle/Tests/Controller/PageControllerSqlRollbackFunctionalTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PageControllerSqlRollbackFunctionalTest.php
@@ -10,8 +10,10 @@ use Mautic\EmailBundle\Entity\Stat;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\PageBundle\Entity\Hit;
 use Mautic\PageBundle\Entity\Redirect;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class PageControllerSqlRollbackFunctionalTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/PageBundle/Tests/Controller/PageControllerTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PageControllerTest.php
@@ -11,9 +11,11 @@ use Mautic\PageBundle\DataFixtures\ORM\LoadPageCategoryData;
 use Mautic\PageBundle\DataFixtures\ORM\LoadPageData;
 use Mautic\PageBundle\Entity\Page;
 use Mautic\PageBundle\Model\PageModel;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class PageControllerTest extends MauticMysqlTestCase
 {
     use ControllerTrait;

--- a/app/bundles/PageBundle/Tests/Controller/PageDraftFunctionalTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PageDraftFunctionalTest.php
@@ -7,8 +7,10 @@ namespace Mautic\PageBundle\Tests\Controller;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\PageBundle\Entity\Page;
 use Mautic\PageBundle\Entity\PageDraft;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class PageDraftFunctionalTest extends MauticMysqlTestCase
 {
     protected function setUp(): void

--- a/app/bundles/PageBundle/Tests/Controller/PageProjectSearchFunctionalTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PageProjectSearchFunctionalTest.php
@@ -7,7 +7,9 @@ namespace Mautic\PageBundle\Tests\Controller;
 use Mautic\PageBundle\Entity\Page;
 use Mautic\ProjectBundle\Tests\Functional\AbstractProjectSearchTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class PageProjectSearchFunctionalTest extends AbstractProjectSearchTestCase
 {
     #[DataProvider('searchDataProvider')]

--- a/app/bundles/PageBundle/Tests/Controller/PreviewFunctionalTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PreviewFunctionalTest.php
@@ -10,9 +10,11 @@ use Mautic\DynamicContentBundle\Entity\DynamicContent;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\PageBundle\Entity\Page;
 use Mautic\UserBundle\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class PreviewFunctionalTest extends MauticMysqlTestCase
 {
     public function testPreviewPageWithContact(): void

--- a/app/bundles/PageBundle/Tests/Controller/PreviewSettingsFunctionalTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PreviewSettingsFunctionalTest.php
@@ -6,8 +6,10 @@ namespace Mautic\PageBundle\Tests\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\PageBundle\Entity\Page;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class PreviewSettingsFunctionalTest extends MauticMysqlTestCase
 {
     public function testPreviewSettingsAllEnabled(): void

--- a/app/bundles/PageBundle/Tests/Controller/PublicControllerFunctionalTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PublicControllerFunctionalTest.php
@@ -10,8 +10,10 @@ use Mautic\PageBundle\Entity\Page;
 use Mautic\UserBundle\Entity\User;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class PublicControllerFunctionalTest extends MauticMysqlTestCase
 {
     public function testTrackingImageAction(): void

--- a/app/bundles/PageBundle/Tests/Controller/PublicControllerRedirectTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PublicControllerRedirectTest.php
@@ -12,10 +12,12 @@ use Mautic\PageBundle\Entity\Hit;
 use Mautic\PageBundle\Entity\Page;
 use Mautic\PageBundle\Entity\Redirect;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class PublicControllerRedirectTest extends MauticMysqlTestCase
 {
     #[DataProvider('redirectTypeOptions')]

--- a/app/bundles/PageBundle/Tests/Controller/VisitPageWitIpAnonymizationOffFunctionalTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/VisitPageWitIpAnonymizationOffFunctionalTest.php
@@ -8,8 +8,10 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\PageBundle\Entity\Hit;
 use Mautic\PageBundle\Entity\HitRepository;
 use Mautic\PageBundle\Entity\Page;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class VisitPageWitIpAnonymizationOffFunctionalTest extends MauticMysqlTestCase
 {
     protected function setUp(): void

--- a/app/bundles/PageBundle/Tests/Controller/VisitPageWitIpAnonymizationOnFunctionalTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/VisitPageWitIpAnonymizationOnFunctionalTest.php
@@ -8,8 +8,10 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\PageBundle\Entity\Hit;
 use Mautic\PageBundle\Entity\HitRepository;
 use Mautic\PageBundle\Entity\Page;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class VisitPageWitIpAnonymizationOnFunctionalTest extends MauticMysqlTestCase
 {
     protected function setUp(): void

--- a/app/bundles/PageBundle/Tests/Entity/HitRepositoryTest.php
+++ b/app/bundles/PageBundle/Tests/Entity/HitRepositoryTest.php
@@ -11,7 +11,9 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\PageBundle\Entity\Hit;
 use Mautic\PageBundle\Entity\HitRepository;
 use Mautic\PageBundle\Entity\Page;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class HitRepositoryTest extends MauticMysqlTestCase
 {
     private HitRepository $hitRepository;

--- a/app/bundles/PageBundle/Tests/Entity/PageRepositoryFunctionalTest.php
+++ b/app/bundles/PageBundle/Tests/Entity/PageRepositoryFunctionalTest.php
@@ -7,7 +7,9 @@ namespace Mautic\PageBundle\Tests\Entity;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\PageBundle\Entity\Page;
 use Mautic\PageBundle\Model\PageModel;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class PageRepositoryFunctionalTest extends MauticMysqlTestCase
 {
     public function testResetVariants(): void

--- a/app/bundles/PageBundle/Tests/Entity/TrackableRepositoryFunctionalTest.php
+++ b/app/bundles/PageBundle/Tests/Entity/TrackableRepositoryFunctionalTest.php
@@ -12,7 +12,9 @@ use Mautic\PageBundle\Entity\Hit;
 use Mautic\PageBundle\Entity\Redirect;
 use Mautic\PageBundle\Entity\Trackable;
 use Mautic\PageBundle\Model\TrackableModel;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class TrackableRepositoryFunctionalTest extends MauticMysqlTestCase
 {
     private TrackableModel $model;

--- a/app/bundles/PageBundle/Tests/EventListener/PreferencePageTest.php
+++ b/app/bundles/PageBundle/Tests/EventListener/PreferencePageTest.php
@@ -13,11 +13,13 @@ use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\PageBundle\Entity\Page;
 use Mautic\PageBundle\Event\PageDisplayEvent;
 use Mautic\PageBundle\PageEvents;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Translation\Translator;
 
+#[Group('database')]
 final class PreferencePageTest extends MauticMysqlTestCase
 {
     private EventDispatcherInterface $dispatcher;

--- a/app/bundles/PageBundle/Tests/EventListener/ReportSubscriberFunctionalTest.php
+++ b/app/bundles/PageBundle/Tests/EventListener/ReportSubscriberFunctionalTest.php
@@ -8,7 +8,9 @@ use Mautic\LeadBundle\Entity\DoNotContact;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\PageBundle\Entity\Hit;
 use Mautic\ReportBundle\Tests\Functional\AbstractReportSubscriberTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class ReportSubscriberFunctionalTest extends AbstractReportSubscriberTestCase
 {
     public function testPageHitReportWithDncListColumn(): void

--- a/app/bundles/PageBundle/Tests/EventListener/ReportSubscriberFunctionalTestCase.php
+++ b/app/bundles/PageBundle/Tests/EventListener/ReportSubscriberFunctionalTestCase.php
@@ -7,7 +7,9 @@ namespace Mautic\PageBundle\Tests\EventListener;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\PageBundle\Entity\Hit;
 use Mautic\ReportBundle\Tests\Functional\AbstractReportSubscriberTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class ReportSubscriberFunctionalTestCase extends AbstractReportSubscriberTestCase
 {
     public function testPageHitReportWithTimeSpent(): void

--- a/app/bundles/PageBundle/Tests/EventListener/SegmentTrackingSubscriberFunctionalTest.php
+++ b/app/bundles/PageBundle/Tests/EventListener/SegmentTrackingSubscriberFunctionalTest.php
@@ -10,6 +10,7 @@ use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\ListLead;
 use Mautic\PageBundle\Event\UrlTokenReplaceEvent;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -17,6 +18,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  *
  * Tests the VWO segment tracking feature that appends segment IDs to tracking URLs.
  */
+#[Group('database')]
 final class SegmentTrackingSubscriberFunctionalTest extends MauticMysqlTestCase
 {
     private const string TEST_URL = 'https://example.com/page';

--- a/app/bundles/PageBundle/Tests/Functional/Controller/ThemeHelperSandboxTest.php
+++ b/app/bundles/PageBundle/Tests/Functional/Controller/ThemeHelperSandboxTest.php
@@ -7,6 +7,7 @@ namespace Mautic\PageBundle\Tests\Functional\Controller;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\PageBundle\Entity\Page;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -18,6 +19,7 @@ use Symfony\Component\HttpFoundation\Request;
  * - configGetParameter() for credential/secret leakage
  * - source() for arbitrary file read
  */
+#[Group('database')]
 final class ThemeHelperSandboxTest extends MauticMysqlTestCase
 {
     private string $themesDir;

--- a/app/bundles/PageBundle/Tests/Functional/Controller/TrackingConfigTest.php
+++ b/app/bundles/PageBundle/Tests/Functional/Controller/TrackingConfigTest.php
@@ -6,8 +6,10 @@ namespace Mautic\PageBundle\Tests\Functional\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class TrackingConfigTest extends MauticMysqlTestCase
 {
     public function testTrackingScriptOptionsAreRendered(): void

--- a/app/bundles/PageBundle/Tests/Functional/EventListener/BuilderSubscriberTest.php
+++ b/app/bundles/PageBundle/Tests/Functional/EventListener/BuilderSubscriberTest.php
@@ -13,12 +13,14 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList as Segment;
 use Mautic\PageBundle\Entity\Page;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 #[PreserveGlobalState(false)]
 #[RunTestsInSeparateProcesses]
+#[Group('database')]
 final class BuilderSubscriberTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/PageBundle/Tests/Functional/Model/PageHitCookieTest.php
+++ b/app/bundles/PageBundle/Tests/Functional/Model/PageHitCookieTest.php
@@ -7,9 +7,11 @@ namespace Mautic\PageBundle\Tests\Functional\Model;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\PageBundle\Entity\HitRepository;
 use Mautic\PageBundle\Entity\Page;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class PageHitCookieTest extends MauticMysqlTestCase
 {
     private HitRepository $hitRepository;

--- a/app/bundles/PageBundle/Tests/Functional/Model/PageModelTest.php
+++ b/app/bundles/PageBundle/Tests/Functional/Model/PageModelTest.php
@@ -14,8 +14,10 @@ use Mautic\PageBundle\Entity\Page;
 use Mautic\PageBundle\Entity\Redirect;
 use Mautic\PageBundle\Model\RedirectModel;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class PageModelTest extends MauticMysqlTestCase
 {
     private HitRepository $pageHitRepository;

--- a/app/bundles/PageBundle/Tests/Functional/Model/PageModelValidationTest.php
+++ b/app/bundles/PageBundle/Tests/Functional/Model/PageModelValidationTest.php
@@ -14,8 +14,10 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\PageBundle\Entity\Hit;
 use Mautic\PageBundle\Entity\HitRepository;
 use Mautic\PageBundle\Entity\Page;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class PageModelValidationTest extends MauticMysqlTestCase
 {
     private HitRepository $pageHitRepository;

--- a/app/bundles/PageBundle/Tests/Helper/PointActionHelperFunctionalTest.php
+++ b/app/bundles/PageBundle/Tests/Helper/PointActionHelperFunctionalTest.php
@@ -9,7 +9,9 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\PageBundle\Entity\Hit;
 use Mautic\PageBundle\Helper\PointActionHelper;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class PointActionHelperFunctionalTest extends MauticMysqlTestCase
 {
     private PointActionHelper $pointActionHelper;

--- a/app/bundles/PageBundle/Tests/Model/TrackableModelFunctionalTest.php
+++ b/app/bundles/PageBundle/Tests/Model/TrackableModelFunctionalTest.php
@@ -7,7 +7,9 @@ namespace Mautic\PageBundle\Tests\Model;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\PageBundle\Model\TrackableModel;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class TrackableModelFunctionalTest extends MauticMysqlTestCase
 {
     private TrackableModel $trackableModel;

--- a/app/bundles/PluginBundle/Tests/ConfigFormTest.php
+++ b/app/bundles/PluginBundle/Tests/ConfigFormTest.php
@@ -16,10 +16,12 @@ use Mautic\PluginBundle\Event\PluginIntegrationKeyEvent;
 use Mautic\PluginBundle\Helper\IntegrationHelper;
 use Mautic\PluginBundle\Model\PluginModel;
 use Mautic\PluginBundle\PluginEvents;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Twig\Environment;
 
+#[Group('database')]
 final class ConfigFormTest extends KernelTestCase
 {
     protected function setUp(): void

--- a/app/bundles/PluginBundle/Tests/Controller/PluginControllerTest.php
+++ b/app/bundles/PluginBundle/Tests/Controller/PluginControllerTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Mautic\PluginBundle\Tests\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class PluginControllerTest extends MauticMysqlTestCase
 {
     public function testConfigurePluginSuccessValidation(): void

--- a/app/bundles/PluginBundle/Tests/Entity/IntegrationEntityRepositoryTest.php
+++ b/app/bundles/PluginBundle/Tests/Entity/IntegrationEntityRepositoryTest.php
@@ -8,10 +8,12 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\PluginBundle\Entity\IntegrationEntity;
 use Mautic\PluginBundle\Entity\IntegrationEntityRepository;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * IntegrationRepository.
  */
+#[Group('database')]
 final class IntegrationEntityRepositoryTest extends MauticMysqlTestCase
 {
     public const string INTEGRATION        = 'someIntegration';

--- a/app/bundles/PointBundle/Tests/Controller/Api/PointGroupsApiControllerTest.php
+++ b/app/bundles/PointBundle/Tests/Controller/Api/PointGroupsApiControllerTest.php
@@ -12,6 +12,7 @@ use Mautic\PointBundle\Entity\Group;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\Group('database')]
 final class PointGroupsApiControllerTest extends MauticMysqlTestCase
 {
     public function testPointGroupCRUDActions(): void

--- a/app/bundles/PointBundle/Tests/Controller/Api/PointInsightApiControllerTest.php
+++ b/app/bundles/PointBundle/Tests/Controller/Api/PointInsightApiControllerTest.php
@@ -7,9 +7,11 @@ namespace Mautic\PointBundle\Tests\Controller\Api;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\CoreBundle\Translation\Translator;
 use Mautic\PointBundle\Entity\PointInsight;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[Group('database')]
 final class PointInsightApiControllerTest extends MauticMysqlTestCase
 {
     private const string UPDATED_NAME = 'Updated Point Insight';

--- a/app/bundles/PointBundle/Tests/Controller/InsightControllerTest.php
+++ b/app/bundles/PointBundle/Tests/Controller/InsightControllerTest.php
@@ -7,9 +7,11 @@ namespace Mautic\PointBundle\Tests\Controller;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\PointBundle\Entity\PointInsight;
 use Mautic\PointBundle\Model\InsightModel;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class InsightControllerTest extends MauticMysqlTestCase
 {
     public function testInsightIndexActionWithoutPage(): void

--- a/app/bundles/PointBundle/Tests/Controller/PointControllerTest.php
+++ b/app/bundles/PointBundle/Tests/Controller/PointControllerTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Mautic\PointBundle\Tests\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class PointControllerTest extends MauticMysqlTestCase
 {
     public function testIndexActionWithoutPage(): void

--- a/app/bundles/PointBundle/Tests/Controller/TriggerControllerTest.php
+++ b/app/bundles/PointBundle/Tests/Controller/TriggerControllerTest.php
@@ -7,9 +7,11 @@ namespace Mautic\PointBundle\Tests\Controller;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\PointBundle\Model\TriggerModel;
 use Mautic\PointBundle\Tests\Functional\TriggerTrait;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class TriggerControllerTest extends MauticMysqlTestCase
 {
     use TriggerTrait;

--- a/app/bundles/PointBundle/Tests/Entity/PointEntityValidationTest.php
+++ b/app/bundles/PointBundle/Tests/Entity/PointEntityValidationTest.php
@@ -9,10 +9,12 @@ use Mautic\CoreBundle\Helper\IntHelper;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\PointBundle\Entity\Point;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\DomCrawler\Form;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class PointEntityValidationTest extends MauticMysqlTestCase
 {
     /**

--- a/app/bundles/PointBundle/Tests/Functional/Controller/PointControllerTest.php
+++ b/app/bundles/PointBundle/Tests/Functional/Controller/PointControllerTest.php
@@ -7,7 +7,9 @@ namespace Mautic\PointBundle\Tests\Functional\Controller;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\PointBundle\Entity\Point;
 use Mautic\ProjectBundle\Entity\Project;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class PointControllerTest extends MauticMysqlTestCase
 {
     public function testPointWithProject(): void

--- a/app/bundles/PointBundle/Tests/Functional/Controller/PointProjectSearchFunctionalTest.php
+++ b/app/bundles/PointBundle/Tests/Functional/Controller/PointProjectSearchFunctionalTest.php
@@ -7,7 +7,9 @@ namespace Mautic\PointBundle\Tests\Functional\Controller;
 use Mautic\PointBundle\Entity\Point;
 use Mautic\ProjectBundle\Tests\Functional\AbstractProjectSearchTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class PointProjectSearchFunctionalTest extends AbstractProjectSearchTestCase
 {
     #[DataProvider('searchDataProvider')]

--- a/app/bundles/PointBundle/Tests/Functional/Controller/TriggerControllerTest.php
+++ b/app/bundles/PointBundle/Tests/Functional/Controller/TriggerControllerTest.php
@@ -7,7 +7,9 @@ namespace Mautic\PointBundle\Tests\Functional\Controller;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\PointBundle\Entity\Trigger;
 use Mautic\ProjectBundle\Entity\Project;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class TriggerControllerTest extends MauticMysqlTestCase
 {
     public function testPointTriggerWithProject(): void

--- a/app/bundles/PointBundle/Tests/Functional/Controller/TriggerProjectSearchFunctionalTest.php
+++ b/app/bundles/PointBundle/Tests/Functional/Controller/TriggerProjectSearchFunctionalTest.php
@@ -7,7 +7,9 @@ namespace Mautic\PointBundle\Tests\Functional\Controller;
 use Mautic\PointBundle\Entity\Trigger;
 use Mautic\ProjectBundle\Tests\Functional\AbstractProjectSearchTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class TriggerProjectSearchFunctionalTest extends AbstractProjectSearchTestCase
 {
     #[DataProvider('searchDataProvider')]

--- a/app/bundles/PointBundle/Tests/Functional/EmailTriggerTest.php
+++ b/app/bundles/PointBundle/Tests/Functional/EmailTriggerTest.php
@@ -8,12 +8,14 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\PointBundle\Entity\Trigger;
 use Mautic\PointBundle\Entity\TriggerEvent;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\DomCrawler\Form;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class EmailTriggerTest extends MauticMysqlTestCase
 {
     #[PreserveGlobalState(false)]

--- a/app/bundles/PointBundle/Tests/Functional/EventListener/LeadSubscriberTest.php
+++ b/app/bundles/PointBundle/Tests/Functional/EventListener/LeadSubscriberTest.php
@@ -15,7 +15,9 @@ use Mautic\PointBundle\Entity\Trigger;
 use Mautic\PointBundle\Entity\TriggerEvent;
 use Mautic\PointBundle\EventListener\LeadSubscriber;
 use Mautic\PointBundle\Model\PointModel;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class LeadSubscriberTest extends MauticMysqlTestCase
 {
     private PointModel $model;

--- a/app/bundles/PointBundle/Tests/Functional/GroupScoreRepositoryFunctionalTest.php
+++ b/app/bundles/PointBundle/Tests/Functional/GroupScoreRepositoryFunctionalTest.php
@@ -10,6 +10,7 @@ use Mautic\PointBundle\Entity\Group;
 use Mautic\PointBundle\Entity\GroupContactScore;
 use Mautic\PointBundle\Entity\GroupContactScoreRepository;
 
+#[\PHPUnit\Framework\Attributes\Group('database')]
 final class GroupScoreRepositoryFunctionalTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/PointBundle/Tests/Functional/PointActionFunctionalTest.php
+++ b/app/bundles/PointBundle/Tests/Functional/PointActionFunctionalTest.php
@@ -13,6 +13,7 @@ use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\PointBundle\Entity\Group;
 use Mautic\PointBundle\Entity\Point;
 
+#[\PHPUnit\Framework\Attributes\Group('database')]
 final class PointActionFunctionalTest extends MauticMysqlTestCase
 {
     public function testPointActionReadEmail(): void

--- a/app/bundles/PointBundle/Tests/Functional/PointInsightsFunctionalTest.php
+++ b/app/bundles/PointBundle/Tests/Functional/PointInsightsFunctionalTest.php
@@ -13,6 +13,7 @@ use Mautic\PointBundle\Entity\Group;
 use Mautic\PointBundle\Entity\PointInsight;
 use Mautic\PointBundle\Model\PointGroupModel;
 
+#[\PHPUnit\Framework\Attributes\Group('database')]
 final class PointInsightsFunctionalTest extends MauticMysqlTestCase
 {
     private const string GROUP_A_SUFFIX = ' (Group A)';

--- a/app/bundles/PointBundle/Tests/Functional/PointTriggerFunctionalTest.php
+++ b/app/bundles/PointBundle/Tests/Functional/PointTriggerFunctionalTest.php
@@ -12,6 +12,7 @@ use Mautic\PointBundle\Entity\Group;
 use Mautic\PointBundle\Model\PointGroupModel;
 use Mautic\PointBundle\Model\TriggerModel;
 
+#[\PHPUnit\Framework\Attributes\Group('database')]
 final class PointTriggerFunctionalTest extends MauticMysqlTestCase
 {
     use TriggerTrait;

--- a/app/bundles/PointBundle/Tests/Functional/ReportSubscriberFunctionalTest.php
+++ b/app/bundles/PointBundle/Tests/Functional/ReportSubscriberFunctionalTest.php
@@ -14,6 +14,7 @@ use Mautic\ReportBundle\Entity\Report;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request;
 
+#[\PHPUnit\Framework\Attributes\Group('database')]
 final class ReportSubscriberFunctionalTest extends MauticMysqlTestCase
 {
     protected function setUp(): void

--- a/app/bundles/PointBundle/Tests/Functional/SegmentFilterFunctionalTest.php
+++ b/app/bundles/PointBundle/Tests/Functional/SegmentFilterFunctionalTest.php
@@ -12,6 +12,7 @@ use Mautic\PointBundle\Entity\GroupContactScore;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Tester\ApplicationTester;
 
+#[\PHPUnit\Framework\Attributes\Group('database')]
 final class SegmentFilterFunctionalTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/ProjectBundle/Tests/Functional/Controller/AjaxControllerTest.php
+++ b/app/bundles/ProjectBundle/Tests/Functional/Controller/AjaxControllerTest.php
@@ -9,7 +9,9 @@ use Mautic\ProjectBundle\Entity\Project;
 use Mautic\ProjectBundle\Model\ProjectModel;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class AjaxControllerTest extends MauticMysqlTestCase
 {
     public function testCreatingProjectViaMultiselectInput(): void

--- a/app/bundles/ProjectBundle/Tests/Functional/Controller/ProjectAddEntityTest.php
+++ b/app/bundles/ProjectBundle/Tests/Functional/Controller/ProjectAddEntityTest.php
@@ -11,8 +11,10 @@ use Mautic\ProjectBundle\Entity\Project;
 use Mautic\ProjectBundle\Model\ProjectModel;
 use Mautic\UserBundle\Entity\Role;
 use Mautic\UserBundle\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 
+#[Group('database')]
 final class ProjectAddEntityTest extends MauticMysqlTestCase
 {
     private Project $testProject;

--- a/app/bundles/ProjectBundle/Tests/Functional/Controller/ProjectControllerTest.php
+++ b/app/bundles/ProjectBundle/Tests/Functional/Controller/ProjectControllerTest.php
@@ -12,10 +12,12 @@ use Mautic\ProjectBundle\Model\ProjectModel;
 use Mautic\UserBundle\Entity\Role;
 use Mautic\UserBundle\Entity\User;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 use Symfony\Component\PasswordHasher\PasswordHasherInterface;
 
+#[Group('database')]
 final class ProjectControllerTest extends MauticMysqlTestCase
 {
     public const string USERNAME = 'johny';

--- a/app/bundles/ProjectBundle/Tests/Functional/Controller/ProjectEntityLookupLimitTest.php
+++ b/app/bundles/ProjectBundle/Tests/Functional/Controller/ProjectEntityLookupLimitTest.php
@@ -8,8 +8,10 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Model\EmailModel;
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class ProjectEntityLookupLimitTest extends MauticMysqlTestCase
 {
     private const string LOOKUP_CHOICE_LIST_URL = '/s/ajax?action=project:getLookupChoiceList';

--- a/app/bundles/ProjectBundle/Tests/Functional/Controller/ProjectPopoverSecurityTest.php
+++ b/app/bundles/ProjectBundle/Tests/Functional/Controller/ProjectPopoverSecurityTest.php
@@ -9,7 +9,9 @@ use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Model\EmailModel;
 use Mautic\ProjectBundle\Entity\Project;
 use Mautic\ProjectBundle\Model\ProjectModel;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class ProjectPopoverSecurityTest extends MauticMysqlTestCase
 {
     public function testProjectPopoverEscapesProjectNameAndDescription(): void

--- a/app/bundles/ProjectBundle/Tests/Functional/Validator/UniqueNameValidatorFunctionalTest.php
+++ b/app/bundles/ProjectBundle/Tests/Functional/Validator/UniqueNameValidatorFunctionalTest.php
@@ -6,8 +6,10 @@ namespace Mautic\ProjectBundle\Tests\Functional\Validator;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\ProjectBundle\Entity\Project;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class UniqueNameValidatorFunctionalTest extends MauticMysqlTestCase
 {
     public function testDuplicateProjectName(): void

--- a/app/bundles/ReportBundle/Tests/Command/ExportSchedulerCommandTest.php
+++ b/app/bundles/ReportBundle/Tests/Command/ExportSchedulerCommandTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Mautic\ReportBundle\Tests\Command;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class ExportSchedulerCommandTest extends MauticMysqlTestCase
 {
     public function testCommand(): void

--- a/app/bundles/ReportBundle/Tests/Controller/Api/ReportApiControllerTest.php
+++ b/app/bundles/ReportBundle/Tests/Controller/Api/ReportApiControllerTest.php
@@ -11,10 +11,12 @@ use Mautic\UserBundle\Entity\Permission;
 use Mautic\UserBundle\Entity\Role;
 use Mautic\UserBundle\Entity\User;
 use Mautic\UserBundle\Model\RoleModel;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 use Symfony\Component\PasswordHasher\PasswordHasherInterface;
 
+#[Group('database')]
 final class ReportApiControllerTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/ReportBundle/Tests/Controller/ReportControllerFunctionalTest.php
+++ b/app/bundles/ReportBundle/Tests/Controller/ReportControllerFunctionalTest.php
@@ -19,10 +19,12 @@ use Mautic\ReportBundle\Model\ReportFileWriter;
 use Mautic\ReportBundle\Model\ReportModel;
 use Mautic\ReportBundle\Scheduler\Enum\SchedulerEnum;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class ReportControllerFunctionalTest extends MauticMysqlTestCase
 {
     private const string TEST_EMAIL         = 'test@email.com';

--- a/app/bundles/ReportBundle/Tests/Controller/ReportControllerTest.php
+++ b/app/bundles/ReportBundle/Tests/Controller/ReportControllerTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Mautic\ReportBundle\Tests\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class ReportControllerTest extends MauticMysqlTestCase
 {
     /**

--- a/app/bundles/ReportBundle/Tests/Functional/Api/ReportApiDateHandlingTest.php
+++ b/app/bundles/ReportBundle/Tests/Functional/Api/ReportApiDateHandlingTest.php
@@ -9,8 +9,10 @@ use Mautic\FormBundle\Entity\Form;
 use Mautic\FormBundle\Entity\Submission;
 use Mautic\ReportBundle\Entity\Report;
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class ReportApiDateHandlingTest extends MauticMysqlTestCase
 {
     private Report $report;

--- a/app/bundles/ReportBundle/Tests/Functional/ReportOnDashboardAsTableFunctionalTest.php
+++ b/app/bundles/ReportBundle/Tests/Functional/ReportOnDashboardAsTableFunctionalTest.php
@@ -9,8 +9,10 @@ use Mautic\DashboardBundle\Entity\Widget;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\ReportBundle\Entity\Report;
 use Mautic\UserBundle\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\DomCrawler\Crawler;
 
+#[Group('database')]
 final class ReportOnDashboardAsTableFunctionalTest extends MauticMysqlTestCase
 {
     public function testReportOnDashboardAsTable(): void

--- a/app/bundles/ReportBundle/Tests/Scheduler/Command/ExportSchedulerCommandTest.php
+++ b/app/bundles/ReportBundle/Tests/Scheduler/Command/ExportSchedulerCommandTest.php
@@ -9,7 +9,9 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\ReportBundle\Entity\Report;
 use Mautic\ReportBundle\Entity\Scheduler;
 use Mautic\ReportBundle\Scheduler\Enum\SchedulerEnum;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class ExportSchedulerCommandTest extends MauticMysqlTestCase
 {
     /**

--- a/app/bundles/ReportBundle/Tests/Unit/Model/ReportModelTest.php
+++ b/app/bundles/ReportBundle/Tests/Unit/Model/ReportModelTest.php
@@ -10,10 +10,12 @@ use Mautic\FormBundle\Entity\Form;
 use Mautic\FormBundle\Entity\Submission;
 use Mautic\ReportBundle\Entity\Report;
 use Mautic\ReportBundle\Model\ReportModel;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Session;
 
+#[Group('database')]
 final class ReportModelTest extends MauticMysqlTestCase
 {
     public function testThatGetReportDataUsesCorrectDataRange(): void

--- a/app/bundles/SmsBundle/Tests/Controller/AjaxControllerFunctionalTest.php
+++ b/app/bundles/SmsBundle/Tests/Controller/AjaxControllerFunctionalTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Mautic\SmsBundle\Tests\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class AjaxControllerFunctionalTest extends MauticMysqlTestCase
 {
     public function testGetBuilderTokensAction(): void

--- a/app/bundles/SmsBundle/Tests/Controller/SMSControllerFunctionalTest.php
+++ b/app/bundles/SmsBundle/Tests/Controller/SMSControllerFunctionalTest.php
@@ -7,8 +7,10 @@ namespace Mautic\SmsBundle\Tests\Controller;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\ProjectBundle\Entity\Project;
 use Mautic\SmsBundle\Entity\Sms;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class SMSControllerFunctionalTest extends MauticMysqlTestCase
 {
     private const string EDIT_SMS_PATH       = '/s/sms/edit/';

--- a/app/bundles/SmsBundle/Tests/Controller/SmsProjectSearchFunctionalTest.php
+++ b/app/bundles/SmsBundle/Tests/Controller/SmsProjectSearchFunctionalTest.php
@@ -7,7 +7,9 @@ namespace Mautic\SmsBundle\Tests\Controller;
 use Mautic\ProjectBundle\Tests\Functional\AbstractProjectSearchTestCase;
 use Mautic\SmsBundle\Entity\Sms;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class SmsProjectSearchFunctionalTest extends AbstractProjectSearchTestCase
 {
     #[DataProvider('searchDataProvider')]

--- a/app/bundles/SmsBundle/Tests/EventListener/SmsSubscriberTokenTest.php
+++ b/app/bundles/SmsBundle/Tests/EventListener/SmsSubscriberTokenTest.php
@@ -12,7 +12,9 @@ use Mautic\PageBundle\Entity\Page;
 use Mautic\SmsBundle\Entity\Sms;
 use Mautic\SmsBundle\Model\SmsModel;
 use Mautic\SmsBundle\Tests\SmsTestHelperTrait;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class SmsSubscriberTokenTest extends MauticMysqlTestCase
 {
     use SmsTestHelperTrait;

--- a/app/bundles/SmsBundle/Tests/Functional/SmsControllerFunctionalTest.php
+++ b/app/bundles/SmsBundle/Tests/Functional/SmsControllerFunctionalTest.php
@@ -7,8 +7,10 @@ namespace Mautic\SmsBundle\Tests\Functional;
 use Mautic\CoreBundle\Entity\TranslationEntityInterface;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\SmsBundle\Entity\Sms;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class SmsControllerFunctionalTest extends MauticMysqlTestCase
 {
     use CreateEntitiesTrait;

--- a/app/bundles/SmsBundle/Tests/Functional/SmsModelFunctionalTest.php
+++ b/app/bundles/SmsBundle/Tests/Functional/SmsModelFunctionalTest.php
@@ -11,7 +11,9 @@ use Mautic\SmsBundle\Entity\Sms;
 use Mautic\SmsBundle\Model\SmsModel;
 use Mautic\SmsBundle\Sms\TransportChain;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class SmsModelFunctionalTest extends MauticMysqlTestCase
 {
     use CreateEntitiesTrait;

--- a/app/bundles/SmsBundle/Tests/Functional/SmsTranslationFunctionalTest.php
+++ b/app/bundles/SmsBundle/Tests/Functional/SmsTranslationFunctionalTest.php
@@ -10,8 +10,10 @@ use Mautic\LeadBundle\Entity\LeadEventLog;
 use Mautic\SmsBundle\Entity\Sms;
 use Mautic\SmsBundle\Entity\Stat;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class SmsTranslationFunctionalTest extends MauticMysqlTestCase
 {
     #[DataProvider('smsTimelineStatusProvider')]

--- a/app/bundles/SmsBundle/Tests/Integration/Twilio/TwilioConfigurationFunctionalTest.php
+++ b/app/bundles/SmsBundle/Tests/Integration/Twilio/TwilioConfigurationFunctionalTest.php
@@ -8,7 +8,9 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\PluginBundle\Entity\Integration;
 use Mautic\SmsBundle\Integration\TwilioIntegration;
 use Mautic\SmsBundle\Tests\SmsTestHelperTrait;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class TwilioConfigurationFunctionalTest extends MauticMysqlTestCase
 {
     use SmsTestHelperTrait;

--- a/app/bundles/SmsBundle/Tests/Sms/TransportChainTest.php
+++ b/app/bundles/SmsBundle/Tests/Sms/TransportChainTest.php
@@ -15,8 +15,10 @@ use Mautic\SmsBundle\Sms\BulkTransportInterface;
 use Mautic\SmsBundle\Sms\MMSTransportInterface;
 use Mautic\SmsBundle\Sms\TransportChain;
 use Mautic\SmsBundle\Sms\TransportInterface;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 
+#[Group('database')]
 final class TransportChainTest extends MauticMysqlTestCase
 {
     private TransportChain $transportChain;

--- a/app/bundles/StageBundle/Tests/Functional/Controller/StageControllerFunctionalTest.php
+++ b/app/bundles/StageBundle/Tests/Functional/Controller/StageControllerFunctionalTest.php
@@ -9,8 +9,10 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\ProjectBundle\Entity\Project;
 use Mautic\StageBundle\Entity\Stage;
 use Mautic\StageBundle\Model\StageModel;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class StageControllerFunctionalTest extends MauticMysqlTestCase
 {
     private const string COUNT_SQL_PREFIX    = 'SELECT COUNT(*) FROM ';

--- a/app/bundles/StageBundle/Tests/Functional/Controller/StageProjectSearchFunctionalTest.php
+++ b/app/bundles/StageBundle/Tests/Functional/Controller/StageProjectSearchFunctionalTest.php
@@ -7,7 +7,9 @@ namespace Mautic\StageBundle\Tests\Controller;
 use Mautic\ProjectBundle\Tests\Functional\AbstractProjectSearchTestCase;
 use Mautic\StageBundle\Entity\Stage;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class StageProjectSearchFunctionalTest extends AbstractProjectSearchTestCase
 {
     #[DataProvider('searchDataProvider')]

--- a/app/bundles/StageBundle/Tests/Functional/EventListener/LeadSubscriberTest.php
+++ b/app/bundles/StageBundle/Tests/Functional/EventListener/LeadSubscriberTest.php
@@ -12,7 +12,9 @@ use Mautic\StageBundle\Entity\LeadStageLog;
 use Mautic\StageBundle\Entity\Stage;
 use Mautic\StageBundle\EventListener\LeadSubscriber;
 use Mautic\StageBundle\Model\StageModel;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class LeadSubscriberTest extends MauticMysqlTestCase
 {
     private StageModel $model;

--- a/app/bundles/UserBundle/Tests/Controller/Api/UserApiControllerFunctionalTest.php
+++ b/app/bundles/UserBundle/Tests/Controller/Api/UserApiControllerFunctionalTest.php
@@ -10,11 +10,13 @@ use Mautic\UserBundle\Entity\Role;
 use Mautic\UserBundle\Entity\User;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 use Symfony\Component\PasswordHasher\PasswordHasherInterface;
 
+#[Group('database')]
 final class UserApiControllerFunctionalTest extends MauticMysqlTestCase
 {
     public function testRoleUpdateByApiGivesErrorResponseIfUserDoesNotExist(): void

--- a/app/bundles/UserBundle/Tests/Controller/ProfileControllerTest.php
+++ b/app/bundles/UserBundle/Tests/Controller/ProfileControllerTest.php
@@ -6,8 +6,10 @@ namespace Mautic\UserBundle\Tests\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\UserBundle\Tests\Traits\CreateEntityTrait;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class ProfileControllerTest extends MauticMysqlTestCase
 {
     use CreateEntityTrait;

--- a/app/bundles/UserBundle/Tests/Controller/SecurityControllerTest.php
+++ b/app/bundles/UserBundle/Tests/Controller/SecurityControllerTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Mautic\UserBundle\Tests\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[Group('database')]
 final class SecurityControllerTest extends MauticMysqlTestCase
 {
     protected function setUp(): void

--- a/app/bundles/UserBundle/Tests/Controller/UserControllerTest.php
+++ b/app/bundles/UserBundle/Tests/Controller/UserControllerTest.php
@@ -6,8 +6,10 @@ namespace Mautic\UserBundle\Tests\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\UserBundle\Tests\Traits\CreateEntityTrait;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class UserControllerTest extends MauticMysqlTestCase
 {
     use CreateEntityTrait;

--- a/app/bundles/UserBundle/Tests/Entity/RoleRepositoryFunctionalTest.php
+++ b/app/bundles/UserBundle/Tests/Entity/RoleRepositoryFunctionalTest.php
@@ -8,7 +8,9 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\UserBundle\Entity\Role;
 use Mautic\UserBundle\Entity\RoleRepository;
 use Mautic\UserBundle\Tests\Traits\CreateEntityTrait;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class RoleRepositoryFunctionalTest extends MauticMysqlTestCase
 {
     use CreateEntityTrait;

--- a/app/bundles/UserBundle/Tests/EventListener/LightSAMLExceptionListenerTest.php
+++ b/app/bundles/UserBundle/Tests/EventListener/LightSAMLExceptionListenerTest.php
@@ -12,6 +12,7 @@ use LightSaml\Model\Protocol\Status;
 use LightSaml\Model\Protocol\StatusCode;
 use Mautic\CoreBundle\EventListener\ExceptionListener;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -19,6 +20,7 @@ use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Routing\Router;
 
+#[Group('database')]
 final class LightSAMLExceptionListenerTest extends MauticMysqlTestCase
 {
     protected function setUp(): void

--- a/app/bundles/UserBundle/Tests/Functional/ApiPlatform/UserApiTest.php
+++ b/app/bundles/UserBundle/Tests/Functional/ApiPlatform/UserApiTest.php
@@ -6,6 +6,7 @@ namespace Mautic\UserBundle\Tests\Functional\ApiPlatform;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\UserBundle\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests that the User API endpoints properly handle password as write-only field.
@@ -18,6 +19,7 @@ use Mautic\UserBundle\Entity\User;
  * This ensures that password hashes are never exposed through the API,
  * which is critical for security.
  */
+#[Group('database')]
 final class UserApiTest extends MauticMysqlTestCase
 {
     protected function beforeBeginTransaction(): void

--- a/app/bundles/UserBundle/Tests/Functional/Controller/PublicControllerTest.php
+++ b/app/bundles/UserBundle/Tests/Functional/Controller/PublicControllerTest.php
@@ -8,8 +8,10 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\UserBundle\Entity\Role;
 use Mautic\UserBundle\Entity\User;
 use Mautic\UserBundle\Entity\UserInvite;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class PublicControllerTest extends MauticMysqlTestCase
 {
     private const string PASSWORD_RESET_URI = '/passwordreset';

--- a/app/bundles/UserBundle/Tests/Functional/Controller/RoleControllerFunctionalTest.php
+++ b/app/bundles/UserBundle/Tests/Functional/Controller/RoleControllerFunctionalTest.php
@@ -8,9 +8,11 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\UserBundle\Entity\Permission;
 use Mautic\UserBundle\Entity\Role;
 use Mautic\UserBundle\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class RoleControllerFunctionalTest extends MauticMysqlTestCase
 {
     private const string ROLE_NAME_FIELD        = 'role[name]';

--- a/app/bundles/UserBundle/Tests/Functional/Controller/UserControllerFunctionalTest.php
+++ b/app/bundles/UserBundle/Tests/Functional/Controller/UserControllerFunctionalTest.php
@@ -9,7 +9,9 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\UserBundle\Entity\Role;
 use Mautic\UserBundle\Entity\User;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class UserControllerFunctionalTest extends MauticMysqlTestCase
 {
     protected function setUp(): void

--- a/app/bundles/UserBundle/Tests/Functional/Entity/UserTokenRepositoryTest.php
+++ b/app/bundles/UserBundle/Tests/Functional/Entity/UserTokenRepositoryTest.php
@@ -8,7 +8,9 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\UserBundle\Entity\User;
 use Mautic\UserBundle\Entity\UserToken;
 use Mautic\UserBundle\Entity\UserTokenRepository;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class UserTokenRepositoryTest extends MauticMysqlTestCase
 {
     private UserTokenRepository $repository;

--- a/app/bundles/UserBundle/Tests/Functional/SearchTest.php
+++ b/app/bundles/UserBundle/Tests/Functional/SearchTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Mautic\UserBundle\Tests\Functional;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class SearchTest extends MauticMysqlTestCase
 {
     public function testSearchingUsersByName(): void

--- a/app/bundles/UserBundle/Tests/Functional/UserLogoutFunctionalTest.php
+++ b/app/bundles/UserBundle/Tests/Functional/UserLogoutFunctionalTest.php
@@ -7,10 +7,12 @@ namespace Mautic\UserBundle\Tests\Functional;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\UserBundle\Entity\Role;
 use Mautic\UserBundle\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 use Symfony\Component\PasswordHasher\PasswordHasherInterface;
 
+#[Group('database')]
 final class UserLogoutFunctionalTest extends MauticMysqlTestCase
 {
     public function testLogout(): void

--- a/app/bundles/UserBundle/Tests/Model/PasswordStrengthEstimatorModelTest.php
+++ b/app/bundles/UserBundle/Tests/Model/PasswordStrengthEstimatorModelTest.php
@@ -8,10 +8,12 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\UserBundle\Entity\RoleRepository;
 use Mautic\UserBundle\Entity\User;
 use Mautic\UserBundle\Form\Validator\Constraints\NotWeak;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
+#[Group('database')]
 final class PasswordStrengthEstimatorModelTest extends MauticMysqlTestCase
 {
     private PasswordHasherFactoryInterface $passwordHasher;

--- a/app/bundles/UserBundle/Tests/Security/UserLoginTest.php
+++ b/app/bundles/UserBundle/Tests/Security/UserLoginTest.php
@@ -6,9 +6,11 @@ namespace Mautic\UserBundle\Tests\Security;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\UserBundle\Tests\Traits\CreateEntityTrait;
+use PHPUnit\Framework\Attributes\Group;
 use Ramsey\Uuid\Uuid;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class UserLoginTest extends MauticMysqlTestCase
 {
     use CreateEntityTrait;

--- a/app/bundles/UserBundle/Tests/Security/UserTokenSetterTest.php
+++ b/app/bundles/UserBundle/Tests/Security/UserTokenSetterTest.php
@@ -9,9 +9,11 @@ use Mautic\CoreBundle\Test\AbstractMauticTestCase;
 use Mautic\UserBundle\Entity\User;
 use Mautic\UserBundle\Model\UserModel;
 use Mautic\UserBundle\Security\UserTokenSetter;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
+#[Group('database')]
 final class UserTokenSetterTest extends AbstractMauticTestCase
 {
     public function testSetUserMakesTheUserAvailableToUserHelper(): void

--- a/app/bundles/WebhookBundle/Tests/Form/Type/ConfigTypeFunctionalTest.php
+++ b/app/bundles/WebhookBundle/Tests/Form/Type/ConfigTypeFunctionalTest.php
@@ -6,7 +6,9 @@ namespace Mautic\WebhookBundle\Tests\Form\Type;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class ConfigTypeFunctionalTest extends MauticMysqlTestCase
 {
     public function testSendEmailDetailsToggleIsOnByDefault(): void

--- a/app/bundles/WebhookBundle/Tests/Functional/Command/DeleteWebhookLogsCommandTest.php
+++ b/app/bundles/WebhookBundle/Tests/Functional/Command/DeleteWebhookLogsCommandTest.php
@@ -10,7 +10,9 @@ use Mautic\WebhookBundle\Entity\Event;
 use Mautic\WebhookBundle\Entity\Log;
 use Mautic\WebhookBundle\Entity\Webhook;
 use Mautic\WebhookBundle\Model\WebhookModel;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class DeleteWebhookLogsCommandTest extends MauticMysqlTestCase
 {
     private WebhookModel $webhookModel;

--- a/app/bundles/WebhookBundle/Tests/Functional/Command/ProcessWebhookQueuesCommandTest.php
+++ b/app/bundles/WebhookBundle/Tests/Functional/Command/ProcessWebhookQueuesCommandTest.php
@@ -13,9 +13,11 @@ use Mautic\WebhookBundle\Entity\Log;
 use Mautic\WebhookBundle\Entity\Webhook;
 use Mautic\WebhookBundle\Entity\WebhookQueue;
 use Mautic\WebhookBundle\Model\WebhookModel;
+use PHPUnit\Framework\Attributes\Group;
 use Psr\Http\Message\RequestInterface;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
+#[Group('database')]
 final class ProcessWebhookQueuesCommandTest extends MauticMysqlTestCase
 {
     use ClientMockTrait;

--- a/app/bundles/WebhookBundle/Tests/Functional/Controller/AjaxControllerTest.php
+++ b/app/bundles/WebhookBundle/Tests/Functional/Controller/AjaxControllerTest.php
@@ -6,9 +6,11 @@ namespace Mautic\WebhookBundle\Tests\Functional\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class AjaxControllerTest extends MauticMysqlTestCase
 {
     public function testSendHookTestWithMissingUrl(): void

--- a/app/bundles/WebhookBundle/Tests/Functional/Controller/WebhookControllerTest.php
+++ b/app/bundles/WebhookBundle/Tests/Functional/Controller/WebhookControllerTest.php
@@ -8,8 +8,10 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\WebhookBundle\Entity\Event;
 use Mautic\WebhookBundle\Entity\Log;
 use Mautic\WebhookBundle\Entity\Webhook;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class WebhookControllerTest extends MauticMysqlTestCase
 {
     public function testViewWebhookDetail(): void

--- a/app/bundles/WebhookBundle/Tests/Functional/Entity/WebhookQueueFunctionalTest.php
+++ b/app/bundles/WebhookBundle/Tests/Functional/Entity/WebhookQueueFunctionalTest.php
@@ -8,7 +8,9 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\WebhookBundle\Entity\Event;
 use Mautic\WebhookBundle\Entity\Webhook;
 use Mautic\WebhookBundle\Entity\WebhookQueue;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class WebhookQueueFunctionalTest extends MauticMysqlTestCase
 {
     public function testPayloadCompressed(): void

--- a/app/bundles/WebhookBundle/Tests/Functional/Model/WebhookModelProcessFailureTest.php
+++ b/app/bundles/WebhookBundle/Tests/Functional/Model/WebhookModelProcessFailureTest.php
@@ -13,7 +13,9 @@ use Mautic\WebhookBundle\Entity\Log;
 use Mautic\WebhookBundle\Entity\Webhook;
 use Mautic\WebhookBundle\Model\WebhookModel;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class WebhookModelProcessFailureTest extends MauticMysqlTestCase
 {
     private WebhookModel $webhookModel;

--- a/app/bundles/WebhookBundle/Tests/Functional/Model/WebhookModelTest.php
+++ b/app/bundles/WebhookBundle/Tests/Functional/Model/WebhookModelTest.php
@@ -10,7 +10,9 @@ use Mautic\WebhookBundle\Entity\Event;
 use Mautic\WebhookBundle\Entity\Webhook;
 use Mautic\WebhookBundle\Entity\WebhookQueue;
 use Mautic\WebhookBundle\Model\WebhookModel;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class WebhookModelTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/app/bundles/WebhookBundle/Tests/Functional/WebhookFunctionalTest.php
+++ b/app/bundles/WebhookBundle/Tests/Functional/WebhookFunctionalTest.php
@@ -18,10 +18,12 @@ use Mautic\WebhookBundle\Entity\WebhookQueueRepository;
 use Mautic\WebhookBundle\Entity\WebhookRepository;
 use Mautic\WebhookBundle\Model\WebhookModel;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Psr\Http\Message\RequestInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class WebhookFunctionalTest extends MauticMysqlTestCase
 {
     use ClientMockTrait;

--- a/app/middlewares/Tests/HSTSMiddlewareTest.php
+++ b/app/middlewares/Tests/HSTSMiddlewareTest.php
@@ -6,10 +6,12 @@ namespace Mautic\Middleware\Tests;
 
 use Mautic\CoreBundle\Test\AbstractMauticTestCase;
 use Mautic\Middleware\HSTSMiddleware;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\ExpectationFailedException as PHPUnitException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class HSTSMiddlewareTest extends AbstractMauticTestCase
 {
     public const HSTS_KEY = 'strict-transport-security';

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -251,6 +251,7 @@ rules:
 	- Utils\PHPStan\Rule\NoGetModelWithStringInControllerRule
 	- Utils\PHPStan\Rule\NoRequiredMethodWithConstructorInControllerRule
 	- Utils\PHPStan\Rule\CommandMustHaveAsCommandAttributeRule
+	- Utils\PHPStan\Rule\KernelTestMustHaveDatabaseGroupRule
 	- Utils\PHPStan\Rule\ConstraintMustHaveAttributeRule
 	- Utils\PHPStan\Rule\NoNullableServiceInConstructorRule
 	- Utils\PHPStan\Rule\NoGetRepositoryWithEntityInRepositoryRule

--- a/plugins/GrapesJsBuilderBundle/Tests/Functional/Controller/AssertCustomMjmlTest.php
+++ b/plugins/GrapesJsBuilderBundle/Tests/Functional/Controller/AssertCustomMjmlTest.php
@@ -11,7 +11,9 @@ use Mautic\PluginBundle\Entity\Integration;
 use Mautic\PluginBundle\Entity\Plugin;
 use MauticPlugin\GrapesJsBuilderBundle\Entity\GrapesJsBuilder;
 use MauticPlugin\GrapesJsBuilderBundle\Entity\GrapesJsBuilderRepository;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class AssertCustomMjmlTest extends MauticMysqlTestCase
 {
     protected function setUp(): void

--- a/plugins/GrapesJsBuilderBundle/Tests/Functional/Controller/FileManagerControllerFunctionalTest.php
+++ b/plugins/GrapesJsBuilderBundle/Tests/Functional/Controller/FileManagerControllerFunctionalTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace MauticPlugin\GrapesJsBuilderBundle\Tests\Functional\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class FileManagerControllerFunctionalTest extends MauticMysqlTestCase
 {
     private const string ASSETS_ENDPOINT = '/s/grapesjsbuilder/media';

--- a/plugins/GrapesJsBuilderBundle/Tests/InstallFixtures/ORM/GrapeJsDataTest.php
+++ b/plugins/GrapesJsBuilderBundle/Tests/InstallFixtures/ORM/GrapeJsDataTest.php
@@ -8,7 +8,9 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\PluginBundle\Entity\Integration;
 use Mautic\PluginBundle\Entity\Plugin;
 use MauticPlugin\GrapesJsBuilderBundle\InstallFixtures\ORM\GrapesJsData;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class GrapeJsDataTest extends MauticMysqlTestCase
 {
     protected $useCleanupRollback = false;

--- a/plugins/MauticClearbitBundle/Tests/Functional/Controller/ConfigControllerTest.php
+++ b/plugins/MauticClearbitBundle/Tests/Functional/Controller/ConfigControllerTest.php
@@ -9,9 +9,11 @@ use Mautic\IntegrationsBundle\Helper\IntegrationsHelper;
 use Mautic\PluginBundle\Entity\Integration;
 use Mautic\PluginBundle\Entity\Plugin;
 use MauticPlugin\MauticClearbitBundle\Integration\Support\ConfigSupport;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\DomCrawler\Field\ChoiceFormField;
 use Symfony\Component\Routing\RouterInterface;
 
+#[Group('database')]
 final class ConfigControllerTest extends MauticMysqlTestCase
 {
     private const string API_KEY = 'test_api_key_123';

--- a/plugins/MauticFocusBundle/Tests/Controller/Api/FocusApiControllerTest.php
+++ b/plugins/MauticFocusBundle/Tests/Controller/Api/FocusApiControllerTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace MauticPlugin\MauticFocusBundle\Tests\Controller\Api;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class FocusApiControllerTest extends MauticMysqlTestCase
 {
     /**

--- a/plugins/MauticFocusBundle/Tests/Controller/FocusAjaxControllerFunctionalTest.php
+++ b/plugins/MauticFocusBundle/Tests/Controller/FocusAjaxControllerFunctionalTest.php
@@ -10,8 +10,10 @@ use Mautic\PageBundle\Entity\Hit;
 use MauticPlugin\MauticFocusBundle\Entity\Focus;
 use MauticPlugin\MauticFocusBundle\Entity\Stat;
 use MauticPlugin\MauticFocusBundle\Model\FocusModel;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class FocusAjaxControllerFunctionalTest extends MauticMysqlTestCase
 {
     public function testViewsCount(): void

--- a/plugins/MauticFocusBundle/Tests/Controller/FocusControllerTest.php
+++ b/plugins/MauticFocusBundle/Tests/Controller/FocusControllerTest.php
@@ -7,10 +7,12 @@ namespace MauticPlugin\MauticFocusBundle\Tests\Controller;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use MauticPlugin\MauticFocusBundle\Entity\Focus;
 use MauticPlugin\MauticFocusBundle\Model\FocusModel;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[Group('database')]
 final class FocusControllerTest extends MauticMysqlTestCase
 {
     public function testIndexActionIsSuccessful(): void

--- a/plugins/MauticFocusBundle/Tests/Controller/FocusPublicControllerFunctionalTest.php
+++ b/plugins/MauticFocusBundle/Tests/Controller/FocusPublicControllerFunctionalTest.php
@@ -7,10 +7,12 @@ namespace MauticPlugin\MauticFocusBundle\Tests\Controller;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use MauticPlugin\MauticFocusBundle\Entity\Focus;
 use MauticPlugin\MauticFocusBundle\Model\FocusModel;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class FocusPublicControllerFunctionalTest extends MauticMysqlTestCase
 {
     #[PreserveGlobalState(false)]

--- a/plugins/MauticFocusBundle/Tests/Entity/StatRepositoryFunctionalTest.php
+++ b/plugins/MauticFocusBundle/Tests/Entity/StatRepositoryFunctionalTest.php
@@ -10,7 +10,9 @@ use Mautic\PageBundle\Entity\Hit;
 use MauticPlugin\MauticFocusBundle\Entity\Focus;
 use MauticPlugin\MauticFocusBundle\Entity\Stat;
 use MauticPlugin\MauticFocusBundle\Model\FocusModel;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class StatRepositoryFunctionalTest extends MauticMysqlTestCase
 {
     private FocusModel $focusModel;

--- a/plugins/MauticFocusBundle/Tests/EventListener/LeadSubscriberFunctionalTest.php
+++ b/plugins/MauticFocusBundle/Tests/EventListener/LeadSubscriberFunctionalTest.php
@@ -10,7 +10,9 @@ use Mautic\PageBundle\Entity\Hit;
 use MauticPlugin\MauticFocusBundle\Entity\Focus;
 use MauticPlugin\MauticFocusBundle\Entity\Stat;
 use MauticPlugin\MauticFocusBundle\Model\FocusModel;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class LeadSubscriberFunctionalTest extends MauticMysqlTestCase
 {
     private Lead $lead;

--- a/plugins/MauticFocusBundle/Tests/EventListener/ReportSubscriberFunctionalTest.php
+++ b/plugins/MauticFocusBundle/Tests/EventListener/ReportSubscriberFunctionalTest.php
@@ -12,9 +12,11 @@ use Mautic\ReportBundle\Entity\Report;
 use MauticPlugin\MauticFocusBundle\Entity\Focus;
 use MauticPlugin\MauticFocusBundle\Entity\Stat;
 use MauticPlugin\MauticFocusBundle\EventListener\ReportSubscriber;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class ReportSubscriberFunctionalTest extends MauticMysqlTestCase
 {
     public function testGenerateFocusItemReportWithAllAvailableColumns(): void

--- a/plugins/MauticFocusBundle/Tests/Functional/Controller/FocusControllerTest.php
+++ b/plugins/MauticFocusBundle/Tests/Functional/Controller/FocusControllerTest.php
@@ -7,7 +7,9 @@ namespace MauticPlugin\MauticFocusBundle\Tests\Functional\Controller;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\ProjectBundle\Entity\Project;
 use MauticPlugin\MauticFocusBundle\Entity\Focus;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class FocusControllerTest extends MauticMysqlTestCase
 {
     public function testFocusWithProject(): void

--- a/plugins/MauticFocusBundle/Tests/Functional/Controller/FocusProjectSearchFunctionalTest.php
+++ b/plugins/MauticFocusBundle/Tests/Functional/Controller/FocusProjectSearchFunctionalTest.php
@@ -7,7 +7,9 @@ namespace MauticPlugin\MauticFocusBundle\Tests\Functional\Controller;
 use Mautic\ProjectBundle\Tests\Functional\AbstractProjectSearchTestCase;
 use MauticPlugin\MauticFocusBundle\Entity\Focus;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class FocusProjectSearchFunctionalTest extends AbstractProjectSearchTestCase
 {
     #[DataProvider('searchDataProvider')]

--- a/plugins/MauticFocusBundle/Tests/Functional/Controller/PublicControllerTest.php
+++ b/plugins/MauticFocusBundle/Tests/Functional/Controller/PublicControllerTest.php
@@ -7,6 +7,7 @@ namespace MauticPlugin\MauticFocusBundle\Tests\Functional\Controller;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\PageBundle\Entity\Redirect;
 use MauticPlugin\MauticFocusBundle\Entity\Focus;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use Symfony\Component\HttpFoundation\Request;
@@ -15,6 +16,7 @@ use Twig\Environment;
 use Twig\Extension\EscaperExtension;
 use Twig\Runtime\EscaperRuntime;
 
+#[Group('database')]
 final class PublicControllerTest extends MauticMysqlTestCase
 {
     #[PreserveGlobalState(false)]

--- a/plugins/MauticFocusBundle/Tests/Functional/Model/FocusFormAutoFillTest.php
+++ b/plugins/MauticFocusBundle/Tests/Functional/Model/FocusFormAutoFillTest.php
@@ -11,7 +11,9 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Tracker\ContactTracker;
 use MauticPlugin\MauticFocusBundle\Entity\Focus;
 use MauticPlugin\MauticFocusBundle\Model\FocusModel;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class FocusFormAutoFillTest extends MauticMysqlTestCase
 {
     protected function setUp(): void

--- a/plugins/MauticFocusBundle/Tests/Model/FocusModelFunctionalTest.php
+++ b/plugins/MauticFocusBundle/Tests/Model/FocusModelFunctionalTest.php
@@ -10,7 +10,9 @@ use Mautic\PageBundle\Entity\Hit;
 use MauticPlugin\MauticFocusBundle\Entity\Focus;
 use MauticPlugin\MauticFocusBundle\Entity\Stat;
 use MauticPlugin\MauticFocusBundle\Model\FocusModel;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class FocusModelFunctionalTest extends MauticMysqlTestCase
 {
     private Lead $lead;

--- a/plugins/MauticSocialBundle/Tests/Functional/Controller/MonitoringControllerTest.php
+++ b/plugins/MauticSocialBundle/Tests/Functional/Controller/MonitoringControllerTest.php
@@ -7,9 +7,11 @@ namespace MauticPlugin\MauticSocialBundle\Tests\Functional\Controller;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\UserBundle\Entity\Role;
 use Mautic\UserBundle\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 use Symfony\Component\PasswordHasher\PasswordHasherInterface;
 
+#[Group('database')]
 final class MonitoringControllerTest extends MauticMysqlTestCase
 {
     public const string USERNAME = 'jhony';

--- a/plugins/MauticSocialBundle/Tests/Functional/Controller/TweetControllerTest.php
+++ b/plugins/MauticSocialBundle/Tests/Functional/Controller/TweetControllerTest.php
@@ -8,8 +8,10 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use MauticPlugin\MauticSocialBundle\Entity\Tweet;
 use MauticPlugin\MauticSocialBundle\Entity\TweetRepository;
 use MauticPlugin\MauticSocialBundle\Model\TweetModel;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class TweetControllerTest extends MauticMysqlTestCase
 {
     private TweetRepository $tweetsRepo;

--- a/plugins/MauticSocialBundle/Tests/Functional/SocialCommandsTest.php
+++ b/plugins/MauticSocialBundle/Tests/Functional/SocialCommandsTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace MauticPlugin\MauticSocialBundle\Tests\Functional;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class SocialCommandsTest extends MauticMysqlTestCase
 {
     public function testSocialMonitoringCommand(): void

--- a/plugins/MauticSocialBundle/Tests/Functional/SocialMonitoringFunctionalTest.php
+++ b/plugins/MauticSocialBundle/Tests/Functional/SocialMonitoringFunctionalTest.php
@@ -7,7 +7,9 @@ namespace MauticPlugin\MauticSocialBundle\Tests\Functional;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\PluginBundle\Entity\Integration;
 use Mautic\PluginBundle\Entity\Plugin;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class SocialMonitoringFunctionalTest extends MauticMysqlTestCase
 {
     public function testHideSocialMonitoring(): void

--- a/plugins/MauticSocialBundle/Tests/Functional/V2API/MonitoringV2ApiTest.php
+++ b/plugins/MauticSocialBundle/Tests/Functional/V2API/MonitoringV2ApiTest.php
@@ -6,8 +6,10 @@ namespace MauticPlugin\MauticSocialBundle\Tests\Functional\V2API;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use MauticPlugin\MauticSocialBundle\Entity\Monitoring;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Response;
 
+#[Group('database')]
 final class MonitoringV2ApiTest extends MauticMysqlTestCase
 {
     private function createMonitoring(

--- a/plugins/MauticTagManagerBundle/Tests/Functional/Controller/BatchControllerTest.php
+++ b/plugins/MauticTagManagerBundle/Tests/Functional/Controller/BatchControllerTest.php
@@ -10,7 +10,9 @@ use Mautic\LeadBundle\Entity\Tag;
 use Mautic\LeadBundle\Entity\TagRepository;
 use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\LeadBundle\Model\TagModel;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class BatchControllerTest extends MauticMysqlTestCase
 {
     private TagRepository $tagRepository;

--- a/plugins/MauticTagManagerBundle/Tests/Functional/Controller/TagControllerTest.php
+++ b/plugins/MauticTagManagerBundle/Tests/Functional/Controller/TagControllerTest.php
@@ -20,9 +20,11 @@ use Mautic\ReportBundle\Entity\Report;
 use Mautic\UserBundle\Entity\Permission;
 use Mautic\UserBundle\Entity\Role;
 use Mautic\UserBundle\Entity\User;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request;
 
+#[Group('database')]
 final class TagControllerTest extends MauticMysqlTestCase
 {
     private const string MERGE_ROUTE_BASE = '/s/tags/merge/';

--- a/plugins/MauticTagManagerBundle/Tests/Functional/Entity/TagRepositoryTest.php
+++ b/plugins/MauticTagManagerBundle/Tests/Functional/Entity/TagRepositoryTest.php
@@ -7,7 +7,9 @@ namespace MauticPlugin\MauticTagManagerBundle\Tests\Functional\Entity;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Tag;
 use MauticPlugin\MauticTagManagerBundle\Entity\TagRepository;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class TagRepositoryTest extends MauticMysqlTestCase
 {
     private TagRepository $tagRepository;

--- a/plugins/MauticTagManagerBundle/Tests/Functional/Stats/TagDependenciesTest.php
+++ b/plugins/MauticTagManagerBundle/Tests/Functional/Stats/TagDependenciesTest.php
@@ -16,7 +16,9 @@ use Mautic\LeadBundle\Entity\Tag;
 use Mautic\PointBundle\Entity\Trigger;
 use Mautic\PointBundle\Entity\TriggerEvent;
 use Mautic\ReportBundle\Entity\Report;
+use PHPUnit\Framework\Attributes\Group;
 
+#[Group('database')]
 final class TagDependenciesTest extends MauticMysqlTestCase
 {
     public function testTagUsageInCampaigns(): void

--- a/rector.php
+++ b/rector.php
@@ -31,6 +31,7 @@ return RectorConfig::configure()
         Rector\TypeDeclarationDocblocks\Rector\ClassMethod\NarrowArrayCollectionUnionReturnDocblockRector::class,
         UnserializeToSerializerDecodeRector::class,
         Utils\Rector\AddExpectsOnceToMockMethodCallRector::class,
+        Utils\Rector\AddDatabaseGroupToKernelTestRector::class,
 
         // DI
         Utils\Rector\ModelGetRepositoryToRepositoryServiceRector::class,
@@ -50,7 +51,7 @@ return RectorConfig::configure()
         // applied in a follow-up pull request
         Utils\Rector\AddExpectsOnceToMockMethodCallRector::class,
 
-        Rector\Symfony\CodeQuality\Rector\Class_\LoadValidatorMetadataToAttributeRector::class,
+        // Rector\Symfony\CodeQuality\Rector\Class_\LoadValidatorMetadataToAttributeRector::class,
         Utils\Rector\ModelGetRepositoryToRepositoryServiceRector::class => [
             __DIR__.'/app/bundles/PageBundle/Form/Type/PreferenceCenterListType.php',
         ],

--- a/utils/phpstan/src/Rule/KernelTestMustHaveDatabaseGroupRule.php
+++ b/utils/phpstan/src/Rule/KernelTestMustHaveDatabaseGroupRule.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Rule;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Class_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Every test that boots the Symfony kernel must declare #[Group('database')].
+ *
+ * CI splits the test run on this group: the job with a database service runs --group database,
+ * the job without one runs --exclude-group database. A kernel test missing the attribute lands
+ * in the job that has no database and fails there.
+ *
+ * @implements Rule<Class_>
+ */
+final class KernelTestMustHaveDatabaseGroupRule implements Rule
+{
+    private const GROUP_ATTRIBUTE = 'PHPUnit\Framework\Attributes\Group';
+
+    private const DATABASE_GROUP = 'database';
+
+    public function __construct(
+        private readonly ReflectionProvider $reflectionProvider,
+    ) {
+    }
+
+    public function getNodeType(): string
+    {
+        return Class_::class;
+    }
+
+    /**
+     * @param Class_ $node
+     *
+     * @return list<\PHPStan\Rules\IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        // an anonymous class carries no name to report, and PHPUnit never runs it as a test
+        if (!$node->name instanceof Node\Identifier) {
+            return [];
+        }
+
+        // an abstract base test case is never run on its own, the concrete child carries the group
+        if ($node->isAbstract()) {
+            return [];
+        }
+
+        $className = (string) $node->namespacedName;
+        if (!$this->reflectionProvider->hasClass($className)) {
+            return [];
+        }
+
+        if (!$this->reflectionProvider->getClass($className)->is(KernelTestCase::class)) {
+            return [];
+        }
+
+        if ($this->hasDatabaseGroupAttribute($node)) {
+            return [];
+        }
+
+        $ruleError = RuleErrorBuilder::message(sprintf(
+            'Class "%s" boots the kernel but is missing the #[Group(\'database\')] attribute.',
+            $className
+        ))
+            ->identifier('mautic.databaseGroupAttribute')
+            ->build();
+
+        return [$ruleError];
+    }
+
+    private function hasDatabaseGroupAttribute(Class_ $class): bool
+    {
+        foreach ($class->attrGroups as $attrGroup) {
+            foreach ($attrGroup->attrs as $attribute) {
+                if (self::GROUP_ATTRIBUTE !== $attribute->name->toString()) {
+                    continue;
+                }
+
+                $firstArg = $attribute->args[0] ?? null;
+                if (!$firstArg instanceof Arg) {
+                    continue;
+                }
+
+                if ($firstArg->value instanceof String_ && self::DATABASE_GROUP === $firstArg->value->value) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/AbstractBaseKernelTest.php
+++ b/utils/phpstan/tests/Rule/Fixture/AbstractBaseKernelTest.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+abstract class AbstractBaseKernelTest extends KernelTestCase
+{
+}

--- a/utils/phpstan/tests/Rule/Fixture/KernelTestMissingDatabaseGroup.php
+++ b/utils/phpstan/tests/Rule/Fixture/KernelTestMissingDatabaseGroup.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class KernelTestMissingDatabaseGroup extends KernelTestCase
+{
+}

--- a/utils/phpstan/tests/Rule/Fixture/KernelTestWithDatabaseGroup.php
+++ b/utils/phpstan/tests/Rule/Fixture/KernelTestWithDatabaseGroup.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+#[Group('database')]
+final class KernelTestWithDatabaseGroup extends KernelTestCase
+{
+}

--- a/utils/phpstan/tests/Rule/Fixture/PlainUnitTest.php
+++ b/utils/phpstan/tests/Rule/Fixture/PlainUnitTest.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class PlainUnitTest extends TestCase
+{
+}

--- a/utils/phpstan/tests/Rule/KernelTestMustHaveDatabaseGroupRuleTest.php
+++ b/utils/phpstan/tests/Rule/KernelTestMustHaveDatabaseGroupRuleTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use Utils\PHPStan\Rule\KernelTestMustHaveDatabaseGroupRule;
+
+/**
+ * @extends RuleTestCase<KernelTestMustHaveDatabaseGroupRule>
+ */
+final class KernelTestMustHaveDatabaseGroupRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new KernelTestMustHaveDatabaseGroupRule($this->createReflectionProvider());
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/KernelTestMissingDatabaseGroup.php'], [
+            [
+                'Class "Utils\PHPStan\Tests\Rule\Fixture\KernelTestMissingDatabaseGroup" boots the kernel but is missing the #[Group(\'database\')] attribute.',
+                9,
+            ],
+        ]);
+    }
+
+    public function testSkipKernelTestWithDatabaseGroup(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/KernelTestWithDatabaseGroup.php'], []);
+    }
+
+    public function testSkipAbstractBaseKernelTest(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/AbstractBaseKernelTest.php'], []);
+    }
+
+    public function testSkipPlainUnitTest(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/PlainUnitTest.php'], []);
+    }
+}

--- a/utils/rector/src/AddDatabaseGroupToKernelTestRector.php
+++ b/utils/rector/src/AddDatabaseGroupToKernelTestRector.php
@@ -1,0 +1,232 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\Rector;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\AttributeGroup;
+use PhpParser\Node\Name;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\Namespace_;
+use PhpParser\Node\Stmt\Use_;
+use PhpParser\Node\UseItem;
+use PHPStan\Reflection\ReflectionProvider;
+use Rector\Rector\AbstractRector;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Marks every test that boots the Symfony kernel with #[Group('database')].
+ *
+ *   final class LeadControllerTest extends MauticMysqlTestCase
+ *   ->
+ *   #[Group('database')]
+ *   final class LeadControllerTest extends MauticMysqlTestCase
+ *
+ * The group is what lets CI split the suite: the database job runs --group database, the job
+ * without a database service runs --exclude-group database. PHPUnit does not inherit class
+ * attributes from a parent class, so the attribute has to sit on every concrete test class.
+ *
+ * Left alone:
+ *   - tests that already carry the attribute
+ *   - abstract base test cases, which PHPUnit never runs on their own
+ */
+final class AddDatabaseGroupToKernelTestRector extends AbstractRector
+{
+    private const GROUP_ATTRIBUTE = 'PHPUnit\Framework\Attributes\Group';
+
+    private const DATABASE_GROUP = 'database';
+
+    public function __construct(
+        private readonly ReflectionProvider $reflectionProvider,
+    ) {
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        // the namespace owns both the class and the use imports, the bare class covers the rare
+        // test file that declares no namespace at all
+        return [Namespace_::class, Class_::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        if ($node instanceof Namespace_) {
+            return $this->refactorNamespace($node);
+        }
+
+        if ($node instanceof Class_) {
+            return $this->refactorClassWithoutNamespace($node);
+        }
+
+        return null;
+    }
+
+    private function refactorNamespace(Namespace_ $namespace): ?Namespace_
+    {
+        $classesToMark = [];
+
+        foreach ($namespace->stmts as $stmt) {
+            if (!$stmt instanceof Class_) {
+                continue;
+            }
+
+            if (!$this->isKernelBootingTest($stmt)) {
+                continue;
+            }
+
+            $classesToMark[] = $stmt;
+        }
+
+        if ([] === $classesToMark) {
+            return null;
+        }
+
+        // a handful of tests already import another "Group" class, e.g. a Mautic entity
+        $canImportGroup = !$this->hasConflictingGroupImport($namespace);
+        $attributeName  = $canImportGroup ? new Name('Group') : new FullyQualified(self::GROUP_ATTRIBUTE);
+
+        foreach ($classesToMark as $class) {
+            $class->attrGroups[] = $this->createGroupAttributeGroup($attributeName);
+        }
+
+        if ($canImportGroup) {
+            $this->addGroupUseImport($namespace);
+        }
+
+        return $namespace;
+    }
+
+    private function refactorClassWithoutNamespace(Class_ $class): ?Class_
+    {
+        // classes inside a namespace are handled through the namespace node, where the import goes
+        if ($class->namespacedName instanceof Name && $class->namespacedName->isQualified()) {
+            return null;
+        }
+
+        if (!$this->isKernelBootingTest($class)) {
+            return null;
+        }
+
+        // there is no namespace to hang an import on, so the attribute spells out the full name
+        $class->attrGroups[] = $this->createGroupAttributeGroup(new FullyQualified(self::GROUP_ATTRIBUTE));
+
+        return $class;
+    }
+
+    private function createGroupAttributeGroup(Name $attributeName): AttributeGroup
+    {
+        $groupAttribute = new Attribute($attributeName, [new Arg(new String_(self::DATABASE_GROUP))]);
+
+        return new AttributeGroup([$groupAttribute]);
+    }
+
+    private function hasConflictingGroupImport(Namespace_ $namespace): bool
+    {
+        foreach ($namespace->stmts as $stmt) {
+            if (!$stmt instanceof Use_) {
+                continue;
+            }
+
+            foreach ($stmt->uses as $useItem) {
+                if ($this->isName($useItem->name, self::GROUP_ATTRIBUTE)) {
+                    continue;
+                }
+
+                $shortName = $useItem->alias instanceof Node\Identifier
+                    ? $useItem->alias->toString()
+                    : $useItem->name->getLast();
+
+                if ('Group' === $shortName) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private function isKernelBootingTest(Class_ $class): bool
+    {
+        // an abstract base test case is never run on its own, the concrete child carries the group
+        if ($class->isAbstract()) {
+            return false;
+        }
+
+        if (!$class->name instanceof Node\Identifier) {
+            return false;
+        }
+
+        if ($this->hasDatabaseGroupAttribute($class)) {
+            return false;
+        }
+
+        // a test file without a namespace declaration carries no namespacedName
+        $className = (string) ($class->namespacedName ?? $class->name);
+        if (!$this->reflectionProvider->hasClass($className)) {
+            return false;
+        }
+
+        return $this->reflectionProvider->getClass($className)->is(KernelTestCase::class);
+    }
+
+    private function hasDatabaseGroupAttribute(Class_ $class): bool
+    {
+        foreach ($class->attrGroups as $attrGroup) {
+            foreach ($attrGroup->attrs as $attribute) {
+                if (!$this->isName($attribute->name, self::GROUP_ATTRIBUTE)) {
+                    continue;
+                }
+
+                $firstArg = $attribute->args[0] ?? null;
+                if (!$firstArg instanceof Arg) {
+                    continue;
+                }
+
+                if ($firstArg->value instanceof String_ && self::DATABASE_GROUP === $firstArg->value->value) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private function addGroupUseImport(Namespace_ $namespace): void
+    {
+        $lastUseKey    = null;
+        $firstLaterKey = null;
+
+        foreach ($namespace->stmts as $key => $stmt) {
+            if (!$stmt instanceof Use_) {
+                continue;
+            }
+
+            foreach ($stmt->uses as $useItem) {
+                if ($this->isName($useItem->name, self::GROUP_ATTRIBUTE)) {
+                    return;
+                }
+
+                // the coding standard sorts imports alphabetically, so the new one slots in
+                if (null === $firstLaterKey && strcasecmp($useItem->name->toString(), self::GROUP_ATTRIBUTE) > 0) {
+                    $firstLaterKey = $key;
+                }
+            }
+
+            $lastUseKey = $key;
+        }
+
+        $groupUse = new Use_([new UseItem(new Name(self::GROUP_ATTRIBUTE))]);
+
+        // keep the imports together, otherwise the file starts with the new import
+        $insertKey = $firstLaterKey ?? (null === $lastUseKey ? 0 : $lastUseKey + 1);
+        array_splice($namespace->stmts, $insertKey, 0, [$groupUse]);
+    }
+}

--- a/utils/rector/tests/AddDatabaseGroupToKernelTestRector/AddDatabaseGroupToKernelTestRectorTest.php
+++ b/utils/rector/tests/AddDatabaseGroupToKernelTestRector/AddDatabaseGroupToKernelTestRectorTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\Rector\Tests\AddDatabaseGroupToKernelTestRector;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class AddDatabaseGroupToKernelTestRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__.'/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__.'/config/configured_rule.php';
+    }
+}

--- a/utils/rector/tests/AddDatabaseGroupToKernelTestRector/Fixture/conflicting_group_import.php.inc
+++ b/utils/rector/tests/AddDatabaseGroupToKernelTestRector/Fixture/conflicting_group_import.php.inc
@@ -1,0 +1,32 @@
+<?php
+
+namespace Utils\Rector\Tests\AddDatabaseGroupToKernelTestRector\Fixture;
+
+use Mautic\LeadBundle\Entity\Group;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class ConflictingGroupImport extends KernelTestCase
+{
+    public function testSomething()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Utils\Rector\Tests\AddDatabaseGroupToKernelTestRector\Fixture;
+
+use Mautic\LeadBundle\Entity\Group;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+#[\PHPUnit\Framework\Attributes\Group('database')]
+final class ConflictingGroupImport extends KernelTestCase
+{
+    public function testSomething()
+    {
+    }
+}
+
+?>

--- a/utils/rector/tests/AddDatabaseGroupToKernelTestRector/Fixture/kernel_test_without_group.php.inc
+++ b/utils/rector/tests/AddDatabaseGroupToKernelTestRector/Fixture/kernel_test_without_group.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+namespace Utils\Rector\Tests\AddDatabaseGroupToKernelTestRector\Fixture;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class KernelTestWithoutGroup extends KernelTestCase
+{
+    public function testSomething()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Utils\Rector\Tests\AddDatabaseGroupToKernelTestRector\Fixture;
+
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+#[Group('database')]
+final class KernelTestWithoutGroup extends KernelTestCase
+{
+    public function testSomething()
+    {
+    }
+}
+
+?>

--- a/utils/rector/tests/AddDatabaseGroupToKernelTestRector/Fixture/kernel_test_without_namespace.php.inc
+++ b/utils/rector/tests/AddDatabaseGroupToKernelTestRector/Fixture/kernel_test_without_namespace.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class KernelTestWithoutNamespace extends KernelTestCase
+{
+    public function testSomething()
+    {
+    }
+}
+
+?>
+-----
+<?php
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+#[\PHPUnit\Framework\Attributes\Group('database')]
+final class KernelTestWithoutNamespace extends KernelTestCase
+{
+    public function testSomething()
+    {
+    }
+}
+
+?>

--- a/utils/rector/tests/AddDatabaseGroupToKernelTestRector/Fixture/skip_abstract_test_case.php.inc
+++ b/utils/rector/tests/AddDatabaseGroupToKernelTestRector/Fixture/skip_abstract_test_case.php.inc
@@ -1,0 +1,9 @@
+<?php
+
+namespace Utils\Rector\Tests\AddDatabaseGroupToKernelTestRector\Fixture;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+abstract class SkipAbstractTestCase extends KernelTestCase
+{
+}

--- a/utils/rector/tests/AddDatabaseGroupToKernelTestRector/Fixture/skip_existing_group.php.inc
+++ b/utils/rector/tests/AddDatabaseGroupToKernelTestRector/Fixture/skip_existing_group.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+namespace Utils\Rector\Tests\AddDatabaseGroupToKernelTestRector\Fixture;
+
+use PHPUnit\Framework\Attributes\Group;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+#[Group('database')]
+final class SkipExistingGroup extends KernelTestCase
+{
+    public function testSomething()
+    {
+    }
+}

--- a/utils/rector/tests/AddDatabaseGroupToKernelTestRector/Fixture/skip_plain_unit_test.php.inc
+++ b/utils/rector/tests/AddDatabaseGroupToKernelTestRector/Fixture/skip_plain_unit_test.php.inc
@@ -1,0 +1,12 @@
+<?php
+
+namespace Utils\Rector\Tests\AddDatabaseGroupToKernelTestRector\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipPlainUnitTest extends TestCase
+{
+    public function testSomething()
+    {
+    }
+}

--- a/utils/rector/tests/AddDatabaseGroupToKernelTestRector/config/configured_rule.php
+++ b/utils/rector/tests/AddDatabaseGroupToKernelTestRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Utils\Rector\AddDatabaseGroupToKernelTestRector;
+
+return RectorConfig::configure()
+    ->withRules([AddDatabaseGroupToKernelTestRector::class]);


### PR DESCRIPTION
Most of our test suite needs no database, yet every test waits for the MySQL/MariaDB service and runs once per matrix leg. This PR pulls the database-free tests into a standalone job.

Two parts.

**1. Two whole suites need no database**

* `Container smoke tests` - boots the container and checks controllers/commands/subscribers are wireable
* `Static analysis rule tests` - PHPStan and Rector rule tests from `utils/`

They move to a new `PHPUnit without database` job. The matrix job keeps `Project Test Suite`, `Plugin tests` and `Middleware tests`.

**2. Inside those three suites, only the kernel tests need a database**

PHPUnit does not inherit class attributes from a parent class, so the group cannot live on `MauticMysqlTestCase` - it has to sit on every concrete test class. A Rector rule puts it there:

```diff
+use PHPUnit\Framework\Attributes\Group;
+
+#[Group('database')]
 final class LeadControllerTest extends MauticMysqlTestCase
```

A PHPStan rule keeps it there, so a new functional test cannot silently land in the job that has no database:

```php
// bad - fails in the job without a database service
final class LeadControllerTest extends MauticMysqlTestCase

// good
#[Group('database')]
final class LeadControllerTest extends MauticMysqlTestCase
```

The CI split then rides on the group:

```diff
-bin/phpunit ... --configuration app/phpunit.xml.dist
+bin/phpunit ... --configuration app/phpunit.xml.dist --testsuite "$SUITES" --group database
```

and the standalone job runs the same three suites with `--exclude-group database`.

**Numbers**

477 test classes got the attribute. That leaves 4449 of the 6702 tests - two thirds - outside the database job. Locally they run in ~31 s, on a cold cache, with no database reachable at all:

```
$ bin/phpunit --configuration app/phpunit.xml.dist \
    --testsuite "Project Test Suite,Plugin tests,Middleware tests" --exclude-group database
OK, but there were issues!
Tests: 4449, Assertions: 26526, Deprecations: 2, PHPUnit Notices: 1552, Skipped: 3.
```

Two tests needed a hand, as they reach a database without extending a kernel test case:

* `InstallSchemaTest` opens a raw DBAL connection - marked manually
* `TaggedServiceWiringSmokeTest` and friends extend `AbstractContainerSmokeTestCase`, which extends plain `TestCase` - they pass without a database, so they stay in the fast job

**One side effect worth naming**

The tests that moved out no longer contribute to the coverage report, since the new job runs without pcov. Happy to add a second coverage upload if that is preferred.
