### PR TITLE
[rector] Convert loadValidatorMetadata() constraints to attributes

### DIFF
--- a/app/bundles/DynamicContentBundle/Entity/DynamicContent.php
+++ b/app/bundles/DynamicContentBundle/Entity/DynamicContent.php
@@ -59,6 +59,7 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
  * @use TranslationEntityTrait<DynamicContent>
  * @use VariantEntityTrait<DynamicContent>
  */
+#[SlotNameType]
 class DynamicContent extends FormEntity implements VariantEntityInterface, TranslationEntityInterface, UuidInterface
 {
     use TranslationEntityTrait;
@@ -76,9 +77,11 @@ class DynamicContent extends FormEntity implements VariantEntityInterface, Trans
     private $id;
 
     #[Groups(['dynamicContent:read', 'dynamicContent:write'])]
+    #[NotBlank(message: 'mautic.core.name.required')]
     private ?string $name = null;
 
     #[Groups(['dynamicContent:read', 'dynamicContent:write'])]
+    #[NotBlank(message: 'mautic.core.type.required')]
     private string $type = TypeList::HTML;
 
     #[Groups(['dynamicContent:read', 'dynamicContent:write'])]
@@ -103,6 +106,7 @@ class DynamicContent extends FormEntity implements VariantEntityInterface, Trans
      * @var string|null
      */
     #[Groups(['dynamicContent:read', 'dynamicContent:write'])]
+    #[NoNesting]
     private $content;
 
     /**
@@ -231,13 +235,7 @@ class DynamicContent extends FormEntity implements VariantEntityInterface, Trans
      */
     public static function loadValidatorMetaData(ClassMetadata $metadata): void
     {
-        $metadata->addPropertyConstraint('name', new NotBlank(message: 'mautic.core.name.required'));
-        $metadata->addPropertyConstraint('content', new NoNesting());
-
-        $metadata->addPropertyConstraint('type', new NotBlank(message: 'mautic.core.type.required'));
         $metadata->addPropertyConstraint('type', new Choice(choices: new TypeList()->getChoices()));
-
-        $metadata->addConstraint(new SlotNameType());
 
         $metadata->addConstraint(new Callback(
             function (self $dwc, ExecutionContextInterface $context): void {

--- a/app/bundles/EmailBundle/Entity/Email.php
+++ b/app/bundles/EmailBundle/Entity/Email.php
@@ -116,6 +116,7 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
     #[Groups(['email:read', 'email:write', 'download:read'])]
     #[NotBlank(message: 'mautic.core.subject.required')]
     #[Length(max: self::MAX_NAME_SUBJECT_LENGTH, maxMessage: 'mautic.email.subject.length')]
+    #[TextOnlyDynamicContent]
     private $subject;
 
     /**
@@ -135,6 +136,7 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
      * @var string|null
      */
     #[Groups(['email:read', 'email:write', 'download:read'])]
+    #[EmailOrEmailTokenList(allowMultiple: false)]
     private $fromAddress;
 
     /**
@@ -478,13 +480,6 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
 
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
-        $metadata->addPropertyConstraint(
-            'fromAddress',
-            new EmailOrEmailTokenList(allowMultiple: false),
-        );
-
-        $metadata->addPropertyConstraint('subject', new TextOnlyDynamicContent());
-
         $metadata->addConstraint(new Callback(
             function (Email $email, ExecutionContextInterface $context): void {
                 if ($email->isVariant()) {

--- a/app/bundles/NotificationBundle/Entity/Notification.php
+++ b/app/bundles/NotificationBundle/Entity/Notification.php
@@ -60,6 +60,7 @@ class Notification extends FormEntity implements UuidInterface, TranslationEntit
      * @var string
      */
     #[Groups(['notification:read', 'notification:write'])]
+    #[NotBlank(message: 'mautic.core.name.required')]
     private $name;
 
     /**
@@ -78,12 +79,14 @@ class Notification extends FormEntity implements UuidInterface, TranslationEntit
      * @var string
      */
     #[Groups(['notification:read', 'notification:write'])]
+    #[NotBlank(message: 'mautic.core.heading.required')]
     private $heading;
 
     /**
      * @var string
      */
     #[Groups(['notification:read', 'notification:write'])]
+    #[NotBlank(message: 'mautic.core.message.required')]
     private $message;
 
     /**
@@ -250,27 +253,6 @@ class Notification extends FormEntity implements UuidInterface, TranslationEntit
 
     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
-        $metadata->addPropertyConstraint(
-            'name',
-            new NotBlank(
-                message: 'mautic.core.name.required'
-            )
-        );
-
-        $metadata->addPropertyConstraint(
-            'heading',
-            new NotBlank(
-                message: 'mautic.core.heading.required'
-            )
-        );
-
-        $metadata->addPropertyConstraint(
-            'message',
-            new NotBlank(
-                message: 'mautic.core.message.required'
-            )
-        );
-
         $metadata->addConstraint(new Callback(
             function (Notification $notification, ExecutionContextInterface $context): void {
                 $type = $notification->getNotificationType();


### PR DESCRIPTION
Applies `Rector\Symfony\CodeQuality\Rector\Class_\LoadValidatorMetadataToAttributeRector` to the codebase.

The rule moves property-level validation constraints out of the imperative `loadValidatorMetadata()` method and onto the properties as native PHP attributes. Class-level and closure/`Callback` constraints that the rule cannot express as attributes are left in place.

### Example change

```diff
     #[Groups(['notification:read', 'notification:write'])]
+    #[NotBlank(message: 'mautic.core.name.required')]
     private $name;

     public static function loadValidatorMetadata(ClassMetadata $metadata): void
     {
-        $metadata->addPropertyConstraint(
-            'name',
-            new NotBlank(message: 'mautic.core.name.required')
-        );
-
         $metadata->addConstraint(new Callback(...));
     }
```

### Scope

3 entities:

- `DynamicContentBundle/Entity/DynamicContent.php`
- `EmailBundle/Entity/Email.php`
- `NotificationBundle/Entity/Notification.php`

The rule emits fully-qualified attribute names; these were shortened to the already-imported class names to match the surrounding style.
