### PR TITLE
[removal] remove 3 more low-hanging deprecations

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -91,7 +91,6 @@
 - Deprecated method `Mautic\CampaignBundle\Entity\CampaignRepository::getCampaignLeadCount()` removed with no replacement. It had no callers left.
 - Deprecated constant `Mautic\CoreBundle\Command\ModeratedCommand::MODE_LOCK` (`file_lock`) removed, together with the branch that silently rewrote that mode to `flock`. `--lock_mode=file_lock` now fails with `Unknown locking method specified.` — use `--lock_mode=flock`. The `pid`, `flock` and `redis` modes are unchanged.
 - Deprecated method `Mautic\CoreBundle\Controller\CommonController::accessDenied()` removed. Use `throwAccessDenied()` (throws `AccessDeniedHttpException`) or `getAccessDeniedFlash()` instead. Note the removed method always threw as well — its `array` return value was unreachable — so `Mautic\LeadBundle\Controller\NoteController::newAction()` and `::editAction()` lost `array` from their return types.
-<<<<<<< HEAD
 - Deprecated parameters `$removeEmpty` and `$deprecatedIgnoreNumerical` removed from `Mautic\CoreBundle\Helper\AbstractFormFieldHelper::parseList()`, which now takes the list only. `$removeEmpty` was never read; pass the list to `parseBooleanList()` directly in place of `$deprecatedIgnoreNumerical = true`:
 
 ```diff
@@ -106,7 +105,6 @@
 - Deprecated method `Mautic\LeadBundle\Model\FieldModel::getFieldList()` removed. Use `Mautic\LeadBundle\Field\FieldList::getFieldList()` instead — the removed method only proxied to it. `FieldModel` no longer takes `FieldList` as a constructor argument, and the classes that used the proxy take `FieldList` instead of (or next to) `FieldModel`: `Mautic\LeadBundle\Deduplicate\ContactDeduper`, `Mautic\LeadBundle\Deduplicate\CompanyDeduper` (both via `DeduperTrait`, whose `$fieldModel` property is now `$fieldList`), `Mautic\LeadBundle\Form\Type\LeadFieldsType`, `Mautic\LeadBundle\Services\ContactColumnsDictionary`, `Mautic\LeadBundle\Model\LeadModel` and `Mautic\IntegrationsBundle\Sync\SyncDataExchange\Helper\FieldHelper`.
 - Deprecated constructor argument `$operators` removed from `Mautic\LeadBundle\Event\LeadListFiltersOperatorsEvent`; the event now starts with an empty operator list. Subscribe to `LeadEvents::LIST_FILTERS_OPERATORS_ON_GENERATE` and call `addOperator()` instead of passing operators in.
 - Deprecated template parameter `public` removed from the legacy Mautic 1 page rendering in `Mautic\PageBundle\Controller\PublicController`. Themes still reading `{{ public }}` in `page.html.twig` must drop it.
-=======
 - Deprecated parameters `$shortenUrl` and `$utmTags` removed from `Mautic\PageBundle\Model\RedirectModel::generateRedirectUrl()`, which now takes the redirect and the clickthrough only. Call the public `shortenUrl()` and `applyUtmTags()` methods on the returned URL instead:
 
 ```diff
@@ -117,4 +115,3 @@
 
 - Deprecated support for `:`-prefixed parameter keys removed from `Mautic\LeadBundle\Segment\Query\QueryBuilder::setParameter()`. Pass the key without the colon — `setParameter('foo', $bar)`, not `setParameter(':foo', $bar)`. The `:foo` placeholder in the query string itself is unchanged.
 - Deprecated `models` key in bundle `Config/config.php` `services` removed. Services listed under it are no longer registered with the `mautic.model` tag; register models by their class name and let autowiring resolve them.
->>>>>>> f8ae284463 ([removal] remove 3 more low-hanging deprecations)

--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -91,6 +91,7 @@
 - Deprecated method `Mautic\CampaignBundle\Entity\CampaignRepository::getCampaignLeadCount()` removed with no replacement. It had no callers left.
 - Deprecated constant `Mautic\CoreBundle\Command\ModeratedCommand::MODE_LOCK` (`file_lock`) removed, together with the branch that silently rewrote that mode to `flock`. `--lock_mode=file_lock` now fails with `Unknown locking method specified.` — use `--lock_mode=flock`. The `pid`, `flock` and `redis` modes are unchanged.
 - Deprecated method `Mautic\CoreBundle\Controller\CommonController::accessDenied()` removed. Use `throwAccessDenied()` (throws `AccessDeniedHttpException`) or `getAccessDeniedFlash()` instead. Note the removed method always threw as well — its `array` return value was unreachable — so `Mautic\LeadBundle\Controller\NoteController::newAction()` and `::editAction()` lost `array` from their return types.
+<<<<<<< HEAD
 - Deprecated parameters `$removeEmpty` and `$deprecatedIgnoreNumerical` removed from `Mautic\CoreBundle\Helper\AbstractFormFieldHelper::parseList()`, which now takes the list only. `$removeEmpty` was never read; pass the list to `parseBooleanList()` directly in place of `$deprecatedIgnoreNumerical = true`:
 
 ```diff
@@ -105,3 +106,15 @@
 - Deprecated method `Mautic\LeadBundle\Model\FieldModel::getFieldList()` removed. Use `Mautic\LeadBundle\Field\FieldList::getFieldList()` instead — the removed method only proxied to it. `FieldModel` no longer takes `FieldList` as a constructor argument, and the classes that used the proxy take `FieldList` instead of (or next to) `FieldModel`: `Mautic\LeadBundle\Deduplicate\ContactDeduper`, `Mautic\LeadBundle\Deduplicate\CompanyDeduper` (both via `DeduperTrait`, whose `$fieldModel` property is now `$fieldList`), `Mautic\LeadBundle\Form\Type\LeadFieldsType`, `Mautic\LeadBundle\Services\ContactColumnsDictionary`, `Mautic\LeadBundle\Model\LeadModel` and `Mautic\IntegrationsBundle\Sync\SyncDataExchange\Helper\FieldHelper`.
 - Deprecated constructor argument `$operators` removed from `Mautic\LeadBundle\Event\LeadListFiltersOperatorsEvent`; the event now starts with an empty operator list. Subscribe to `LeadEvents::LIST_FILTERS_OPERATORS_ON_GENERATE` and call `addOperator()` instead of passing operators in.
 - Deprecated template parameter `public` removed from the legacy Mautic 1 page rendering in `Mautic\PageBundle\Controller\PublicController`. Themes still reading `{{ public }}` in `page.html.twig` must drop it.
+=======
+- Deprecated parameters `$shortenUrl` and `$utmTags` removed from `Mautic\PageBundle\Model\RedirectModel::generateRedirectUrl()`, which now takes the redirect and the clickthrough only. Call the public `shortenUrl()` and `applyUtmTags()` methods on the returned URL instead:
+
+```diff
+-$url = $redirectModel->generateRedirectUrl($redirect, $clickthrough, true, $utmTags);
++$url = $redirectModel->applyUtmTags($redirectModel->generateRedirectUrl($redirect, $clickthrough), $utmTags);
++$url = $redirectModel->shortenUrl($url);
+```
+
+- Deprecated support for `:`-prefixed parameter keys removed from `Mautic\LeadBundle\Segment\Query\QueryBuilder::setParameter()`. Pass the key without the colon — `setParameter('foo', $bar)`, not `setParameter(':foo', $bar)`. The `:foo` placeholder in the query string itself is unchanged.
+- Deprecated `models` key in bundle `Config/config.php` `services` removed. Services listed under it are no longer registered with the `mautic.model` tag; register models by their class name and let autowiring resolve them.
+>>>>>>> f8ae284463 ([removal] remove 3 more low-hanging deprecations)

--- a/app/bundles/CoreBundle/DependencyInjection/Compiler/ServicePass.php
+++ b/app/bundles/CoreBundle/DependencyInjection/Compiler/ServicePass.php
@@ -31,36 +31,16 @@ final class ServicePass implements CompilerPassInterface
             if (!empty($bundle['config']['services'])) {
                 $config = $bundle['config']['services'];
                 foreach ($config as $type => $services) {
-                    switch ($type) {
-                        case 'events':
-                            $defaultTag = 'kernel.event_subscriber';
-                            break;
-                        case 'forms':
-                            $defaultTag = 'form.type';
-                            break;
-                        case 'helpers':
-                            $defaultTag = 'twig.helper';
-                            break;
-                        case 'menus':
-                            $defaultTag = 'knp_menu.menu';
-                            break;
-                        case 'models':
-                            $defaultTag = 'mautic.model';
-                            @trigger_error('Setting "models" in config is deprecated. Convert to using autowiring.', E_USER_DEPRECATED);
-                            break;
-                        case 'permissions':
-                            $defaultTag = 'mautic.permissions';
-                            break;
-                        case 'integrations':
-                            $defaultTag = 'mautic.integration';
-                            break;
-                        case 'controllers':
-                            $defaultTag = 'controller.service_arguments';
-                            break;
-                        default:
-                            $defaultTag = false;
-                            break;
-                    }
+                    $defaultTag = match ($type) {
+                        'events' => 'kernel.event_subscriber',
+                        'forms' => 'form.type',
+                        'helpers' => 'twig.helper',
+                        'menus' => 'knp_menu.menu',
+                        'permissions' => 'mautic.permissions',
+                        'integrations' => 'mautic.integration',
+                        'controllers' => 'controller.service_arguments',
+                        default => false,
+                    };
 
                     foreach ($services as $name => $details) {
                         if (isset($serviceNames[$name])) {

--- a/app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
@@ -39,12 +39,6 @@ class QueryBuilder extends BaseQueryBuilder
 
     public function setParameter($key, $value, $type = null)
     {
-        if (str_starts_with($key, ':')) {
-            // For consistency sake, remove the :
-            $key = substr($key, 1);
-            @\trigger_error('Using query key with ":" is deprecated. Use key without ":" instead.', \E_USER_DEPRECATED);
-        }
-
         if (is_bool($value)) {
             $value = (int) $value;
         }

--- a/app/bundles/PageBundle/Model/RedirectModel.php
+++ b/app/bundles/PageBundle/Model/RedirectModel.php
@@ -46,27 +46,13 @@ class RedirectModel extends FormModel
      * Generate a Mautic redirect/passthrough URL.
      *
      * @param array $clickthrough
-     * @param bool  $shortenUrl
-     * @param array $utmTags
      *
      * @return string
      */
     public function generateRedirectUrl(
         Redirect $redirect,
         $clickthrough = [],
-        $shortenUrl = false,
-        $utmTags = [],
     ) {
-        if (func_num_args() > 2) {
-            $deprecation = '$shortenUrl is deprecated. Please use \Mautic\PageBundle\Model\RedirectModel::shortenUrl.';
-            trigger_error($deprecation, E_USER_DEPRECATED);
-        }
-
-        if (func_num_args() > 3) {
-            $deprecation = '$utmTags is deprecated. Please use \Mautic\PageBundle\Model\RedirectModel::applyUtmTags.';
-            trigger_error($deprecation, E_USER_DEPRECATED);
-        }
-
         if ($this->dispatcher->hasListeners(PageEvents::ON_REDIRECT_GENERATE)) {
             $event = new RedirectGenerationEvent($redirect, $clickthrough);
             $this->dispatcher->dispatch($event, PageEvents::ON_REDIRECT_GENERATE);
@@ -74,22 +60,12 @@ class RedirectModel extends FormModel
             $clickthrough = $event->getClickthrough();
         }
 
-        $url = $this->buildUrl(
+        return $this->buildUrl(
             'mautic_url_redirect',
             ['redirectId' => $redirect->getRedirectId()],
             true,
             $clickthrough
         );
-
-        if ([] !== $utmTags) {
-            $url = $this->applyUtmTags($url, $utmTags);
-        }
-
-        if ($shortenUrl) {
-            return $this->shortenUrl($url);
-        }
-
-        return $url;
     }
 
     /**


### PR DESCRIPTION
Removes 3 low-hanging deprecations with no live callers.

**1. `RedirectModel::generateRedirectUrl()`** — drops the deprecated `$shortenUrl` and `$utmTags` params; now takes redirect + clickthrough only.

```diff
-$url = $redirectModel->generateRedirectUrl($redirect, $clickthrough, true, $utmTags);
+$url = $redirectModel->applyUtmTags($redirectModel->generateRedirectUrl($redirect, $clickthrough), $utmTags);
+$url = $redirectModel->shortenUrl($url);
```

**2. `QueryBuilder::setParameter()`** — drops support for `:`-prefixed keys.

```diff
-$qb->setParameter(':foo', $bar);
+$qb->setParameter('foo', $bar);
```

**3. `models` key in bundle `Config/config.php` `services`** — removed; register models by class name, autowiring resolves them.

> Split out of the original batch-6; the GrapesJS assets endpoint removal moved to #17070.

UPGRADE-8.0.md updated.