### PR TITLE
Fix: manually removing a manually-added lead deletes segment membership row instead of flagging it

### DIFF
--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -816,16 +816,22 @@ class ListModel extends FormModel implements GlobalSearchInterface
                 continue;
             }
 
-            if (($manuallyRemoved && $listLead->wasManuallyAdded()) || (!$manuallyRemoved && !$listLead->wasManuallyAdded())) {
-                // lead was manually added and now manually removed or was not manually added and now being removed
+            if (!$manuallyRemoved && !$listLead->wasManuallyAdded()) {
+                // Filter-based removal of a filter-added lead. There is nothing to protect against
+                // re-addition here, so it is safe to delete the membership record outright.
                 $deleteLists[]    = $listLead;
                 $dispatchEvents[] = $listId;
-            } elseif ($manuallyRemoved && !$listLead->wasManuallyAdded()) {
+            } elseif ($manuallyRemoved) {
+                // Manual removal must be persisted (regardless of whether the lead was originally
+                // added manually or by filter) so that a future segment rebuild does not silently
+                // re-add this lead if/when they start matching the segment's filters again.
                 $listLead->setManuallyRemoved(true);
 
                 $persistLists[]   = $listLead;
                 $dispatchEvents[] = $listId;
             }
+            // The remaining case (a filter-based removal attempt on a manually-added lead) is a
+            // no-op: automated segment rebuilds must never override a manual add.
 
             if ($this->coreParametersHelper->get('update_segment_contact_count_in_background', false)) {
                 $this->segmentCountCacheHelper->invalidateSegmentContactCount($listId);

--- a/app/bundles/LeadBundle/Tests/Model/ListModelFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/ListModelFunctionalTest.php
@@ -141,6 +141,58 @@ final class ListModelFunctionalTest extends MauticMysqlTestCase
         $this->assertSame(0, (int) end($data['datasets'][2]['data'])); // Total for today.
     }
 
+    /**
+     * Manually removing a lead that was manually added must keep the lead_lists_leads row
+     * (with manually_removed = 1) instead of deleting it outright. Otherwise a later segment
+     * rebuild could silently re-add the lead if/when they start matching the segment's filters,
+     * silently overriding the user's explicit removal.
+     */
+    public function testManuallyRemovingManuallyAddedLeadPersistsMembershipRecord(): void
+    {
+        /** @var ListModel $segmentModel */
+        $segmentModel = self::getContainer()->get(ListModel::class);
+
+        /** @var LeadRepository $contactRepository */
+        $contactRepository = $this->em->getRepository(Lead::class);
+
+        $segment = new LeadList();
+        $segment->setName('Segment Manual Removal');
+
+        $segmentModel->saveEntity($segment);
+
+        $contact = new Lead();
+        $contactRepository->saveEntities([$contact]);
+
+        // Manually add the contact to the segment (i.e. not because it matched a filter).
+        $segmentModel->addLead($contact, $segment, true);
+
+        $this->assertSame(
+            ['manually_added' => '1', 'manually_removed' => '0'],
+            $this->fetchListLeadRow($contact->getId(), $segment->getId()),
+            'Sanity check: the contact should be recorded as a current, manually-added member.'
+        );
+
+        // Manually remove the contact from the segment.
+        $segmentModel->removeLead($contact, $segment, true);
+
+        $this->assertSame(
+            ['manually_added' => '1', 'manually_removed' => '1'],
+            $this->fetchListLeadRow($contact->getId(), $segment->getId()),
+            'A manually removed lead\'s membership row must be kept and flagged manually_removed = 1, not deleted, so a future segment rebuild cannot silently re-add the lead.'
+        );
+    }
+
+    /**
+     * @return array<string, string>|false
+     */
+    private function fetchListLeadRow(int $leadId, int $segmentId)
+    {
+        return $this->connection->fetchAssociative(
+            'SELECT manually_added, manually_removed FROM '.MAUTIC_TABLE_PREFIX.'lead_lists_leads WHERE lead_id = :leadId AND leadlist_id = :segmentId',
+            ['leadId' => $leadId, 'segmentId' => $segmentId]
+        );
+    }
+
     private function createLeadList(User $user, string $name, bool $isGlobal): LeadList
     {
         $leadList = new LeadList();


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | Fixes #16087

## Description

When a lead is **manually added** to a segment and then **manually removed**, `ListModel::removeLead()` deletes the `lead_lists_leads` row outright instead of keeping it with `manually_removed = 1`.

That's inconsistent with how the exact same method already treats a lead who was *auto-added by filters* and then manually removed: in that case the row is kept with `manually_removed = 1` so that a later `mautic:segments:update` run does not silently re-add the lead (`ContactSegmentQueryBuilder::addNewContactsRestrictions()` excludes any lead who already has *any* row in `lead_lists_leads` for that segment, regardless of its `manually_removed` value - that's the actual mechanism this protection relies on).

For a manually-added lead, deleting the row removes that protection. If the lead's data later changes such that they start matching the segment's filter criteria, the next segment rebuild will silently re-add them - even though a user explicitly removed them - because there is no trace left that they were ever removed.

This also matches the intent stated when `manually_removed` was first introduced (#7436): "Manually removed contacts are soft-deleted so Mautic would know that manually removed contact should not be added to the segment via filters again" - stated as a general rule, not limited to leads that were originally auto-added.

### Fix

In `ListModel::removeLead()`, any **manual** removal (regardless of whether the lead was originally added manually or by filter) now persists the row with `manually_removed = 1`, instead of only doing so for filter-added leads. A filter-based removal of a filter-added lead still deletes the row (nothing to protect there), and a filter-based removal attempt on a manually-added lead remains a no-op, exactly as before.

### How I verified this

- Read `ListModel::addLead()` / `removeLead()` and `ContactSegmentQueryBuilder::addNewContactsRestrictions()` / `getOrphanedLeadListLeadsQueryBuilder()` to confirm the "row exists ⇒ excluded from resegmentation" mechanism that the fix relies on.
- Added `ListModelFunctionalTest::testManuallyRemovingManuallyAddedLeadPersistsMembershipRecord()`, a functional test (real MySQL/MariaDB, `MauticMysqlTestCase`) that manually adds then manually removes a contact and asserts the `lead_lists_leads` row is kept with `manually_added = 1, manually_removed = 1` rather than deleted.
  - Ran it against the unpatched code first: it fails (`fetchAssociative` returns `false`, i.e. no row).
  - Ran it against the patched code: it passes.
- Ran the full existing `ListModelFunctionalTest`, `ListModelTest`, `LeadListRepositoryFunctionalTest`, and `LeadListRepositoryTest` suites afterward: all 34 tests still pass, so this doesn't change behavior for the cases those tests cover (adding, removing-by-filter, chart data, etc).
- `composer cs` (php-cs-fixer, dry-run) on the changed files: clean.

### 📋 Steps to test this PR:

1. Create a segment (e.g. with no filters, so nothing auto-matches it).
2. Manually add a contact to it (Contacts → segment → Add).
3. Manually remove that same contact from the segment.
4. Check the `lead_lists_leads` table: the row for that contact/segment should still exist, with `manually_removed = 1`, instead of being gone.
5. (Optional, closer to the original report) Give the segment a filter that the contact now matches, run `bin/console mautic:segments:update <id>`, and confirm the contact is *not* re-added.
