### PR TITLE
Fix: local.php-derived values silently override .env/.env.local values (but not system env vars)

### DIFF
--- a/app/bundles/CoreBundle/Loader/ParameterLoader.php
+++ b/app/bundles/CoreBundle/Loader/ParameterLoader.php
@@ -25,6 +25,17 @@ final class ParameterLoader
      */
     private static array $defaultParameters = [];
 
+    /**
+     * Keys this loader has itself populated into the environment during this process, tracked so
+     * a later call (e.g. re-booting the kernel between tests within the same PHP process) can
+     * still refresh values it previously set. Without this, that protection would incorrectly
+     * extend to values that were never set by this method, e.g. a value from a .env/.env.local
+     * file loaded once during the application's real bootstrap.
+     *
+     * @var array<string, true>
+     */
+    private static array $selfPopulatedEnvKeys = [];
+
     public function __construct(
         private readonly string $rootPath = __DIR__.'/../../../',
     ) {
@@ -76,8 +87,26 @@ final class ParameterLoader
             if (null === $value) {
                 $envVariables->set($key, '');
             }
+
+            // Do not let a value derived from local.php override a value that has already been
+            // set in the environment - unless we are the ones who set it. This protects a value
+            // that came from a real system/OS environment variable or from a .env/.env.local file
+            // loaded earlier during the application's bootstrap. Dotenv::populate() only skips
+            // values that are *not* tracked in $_ENV['SYMFONY_DOTENV_VARS'], so a value loaded
+            // from a .env file (which *is* tracked there) would otherwise still be silently
+            // overwritten below, even though a plain system environment variable of the same name
+            // would not be. Keying the guard off our own tracking (rather than only off
+            // SYMFONY_DOTENV_VARS) also keeps a later call in the same process - e.g. a kernel
+            // reboot between tests - free to refresh values it previously computed itself.
+            if (!isset(self::$selfPopulatedEnvKeys[$key]) && isset($_ENV[$key])) {
+                $envVariables->remove($key);
+            }
         }
         $dotenv->populate($envVariables->all());
+
+        foreach ($envVariables->all() as $key => $value) {
+            self::$selfPopulatedEnvKeys[$key] = true;
+        }
     }
 
     public static function getLocalConfigFile(string $root, bool $updateDefaultParameters = true): string

--- a/app/bundles/CoreBundle/Tests/Unit/Loader/ParameterLoaderTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Loader/ParameterLoaderTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Mautic\CoreBundle\Tests\Unit\Loader;
 
 use Mautic\CoreBundle\Loader\ParameterLoader;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
 
 final class ParameterLoaderTest extends TestCase
@@ -33,5 +35,34 @@ final class ParameterLoaderTest extends TestCase
         $loader = new ParameterLoader(__DIR__.'/TestRoot/app');
         $this->assertIsArray($loader->getDefaultParameters());
         $this->assertFalse($loader->getDefaultParameters()['api_enabled']);
+    }
+
+    /**
+     * A value already present because a real .env/.env.local file set it earlier during the
+     * application's bootstrap must win over the value computed from local.php. Symfony tracks
+     * such values in $_ENV['SYMFONY_DOTENV_VARS'] so that later .env layers (.env.local,
+     * .env.$env, ...) may still override them - and Dotenv::populate() only protects values that
+     * are *not* tracked there. That is exactly how this bug slipped through: our own later
+     * populate() call was indistinguishable from just another legitimate .env cascade layer, so
+     * it was allowed to silently overwrite a real .env file's value, even though a plain system
+     * environment variable of the same name (never tracked in SYMFONY_DOTENV_VARS) would not be.
+     *
+     * Run in an isolated process: the fix only protects the first time ParameterLoader populates
+     * a given key in a process (see ParameterLoader::$selfPopulatedEnvKeys), so this needs a
+     * process where MAUTIC_MAILER_DSN has not already been touched by another test's loader call.
+     */
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function testLoadIntoEnvironmentDoesNotOverrideAnExistingEnvValue(): void
+    {
+        // The TestRoot fixture's local.php sets 'mailer_dsn' => 'foobar.com', which is mapped to
+        // the MAUTIC_MAILER_DSN environment variable.
+        $_ENV['MAUTIC_MAILER_DSN']   = 'from-dotenv-file';
+        $_ENV['SYMFONY_DOTENV_VARS'] = 'MAUTIC_MAILER_DSN';
+
+        $loader = new ParameterLoader(__DIR__.'/TestRoot/app');
+        $loader->loadIntoEnvironment();
+
+        $this->assertEquals('from-dotenv-file', $_ENV['MAUTIC_MAILER_DSN']);
     }
 }


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | Fixes #14500

## Description

`ParameterLoader::loadIntoEnvironment()` computes `MAUTIC_*` environment variables from `local.php` and calls `Dotenv::populate()` with the default `$overrideExistingVars = false`, intending not to clobber a value the environment already has.

That protection silently doesn't apply to values that came from a real `.env`/`.env.local` file, only to plain system/OS environment variables. The reason is in `Dotenv::populate()` itself:

```php
if (!isset($loadedVars[$name]) && !$overrideExistingVars && isset($_ENV[$name])) {
    continue;
}
```

`$loadedVars` comes from `$_ENV['SYMFONY_DOTENV_VARS']`, the list Symfony's Dotenv keeps of variables it loaded from `.env` files, precisely so that a later layer (`.env.local`, `.env.$env`, ...) is still allowed to override an earlier one. Since Mautic's own call is really just producing derived values from `local.php`, not another legitimate `.env` cascade layer, but it *is* calling the same `populate()` method - so once a variable exists because a real `.env` file set it, it's already tracked in `SYMFONY_DOTENV_VARS`, and this later call is treated as "just another cascade layer" entitled to override it.

Net effect: a value set via a true system/OS environment variable is protected, but the exact same value set via `.env`/`.env.local` is not - it gets silently overwritten by whatever `local.php` (or a bundle's default) says, which contradicts the "don't override an existing value" intent of passing `$overrideExistingVars = false` in the first place, and contradicts Mautic's own documented ability to configure things per `.env` file.

### Fix

Before calling `populate()`, drop any key from the computed `$envVariables` bag that is already present in `$_ENV`, unless *this same loader* is the one that put it there earlier in the same process (tracked via a small static set, `ParameterLoader::$selfPopulatedEnvKeys`). That distinction matters for keeping this safe inside a single long-lived process such as the test suite or a worker: a value this method already set on an earlier call (e.g. a kernel reboot between tests) is still refreshed normally on the next call; only a value that was never touched by this method - i.e. a real system environment variable or a value from an actual `.env` file - is left alone.

### How I verified this

- Read the installed `vendor/symfony/dotenv/Dotenv.php` `populate()` implementation directly (not just the issue's description) to confirm the `SYMFONY_DOTENV_VARS` mechanics described above against the actual Symfony 7.4 version this repo uses.
- Added `ParameterLoaderTest::testLoadIntoEnvironmentDoesNotOverrideAnExistingEnvValue()`, a unit test that pre-populates `$_ENV['MAUTIC_MAILER_DSN']` and `$_ENV['SYMFONY_DOTENV_VARS']` (simulating a value a real `.env` file already set) and asserts it survives `loadIntoEnvironment()` even though the test fixture's `local.php` sets a different value for the same key.
  - Ran it against the unpatched code first: it fails (the `.env`-sourced value gets overwritten by `local.php`'s value).
  - Ran it against the patched code: it passes.
  - The test runs `#[RunInSeparateProcess]` since the fix is intentionally scoped to "first time this key is populated in the process" - see above.
- Ran the full `app/bundles/CoreBundle/Tests/Unit` suite plus the three container smoke tests (`ControllerSmokeTest`, `CommandSmokeTest`, `EventSubscriberSmokeTest`, which boot the full container/every command/every subscriber) together with this change: no new failures. I did hit one non-obvious regression while developing this - my first version of the fix (without the self-tracking) made a pre-existing test order-dependent because it made `loadIntoEnvironment()` sticky across repeated calls in the same process; I fixed that by scoping the protection to first-touch-per-key rather than a blanket "already set" check, and confirmed the combined suite is clean with that refinement.
- `composer cs` (php-cs-fixer, dry-run) on the changed files: clean.

### 📋 Steps to test this PR:

1. Set up Mautic with a `.env.local` file (or `.env`) containing e.g. `MAUTIC_DB_HOST=some-host`.
2. Confirm Mautic picks it up (e.g. it fails to connect to `some-host`, or succeeds if that's a real reachable host you intended).
3. Without this fix: remove any `local.php` override for `db_host` so the request/console command still boots, and observe that the `.env`-provided `MAUTIC_DB_HOST` value gets silently replaced by whatever `local.php`/defaults compute instead.
4. With this fix: confirm the `.env`-provided value is respected instead.
