### PR TITLE
Fix: DWC/segment 'Including ALL' / 'Excluding ALL' filter operator crashes on save for leadlist and multiselect fields

### DIFF
--- a/app/bundles/LeadBundle/Form/Type/FilterTrait.php
+++ b/app/bundles/LeadBundle/Form/Type/FilterTrait.php
@@ -92,7 +92,7 @@ trait FilterTrait
                 }
 
                 $customOptions['choices']                   = $options['lists'];
-                $customOptions['multiple']                  = in_array($data['operator'], ['in', '!in']);
+                $customOptions['multiple']                  = in_array($data['operator'], ['in', '!in', 'in_all', '!in_all']);
                 $customOptions['choice_translation_domain'] = false;
                 $type                                       = ChoiceType::class;
                 break;
@@ -259,7 +259,7 @@ trait FilterTrait
                     ]
                 );
 
-                if (in_array($operator, ['in', '!in'])) {
+                if (in_array($operator, ['in', '!in', 'in_all', '!in_all'])) {
                     $customOptions['multiple'] = true;
                     if (!isset($data['filter'])) {
                         $data['filter'] = [];

--- a/app/bundles/LeadBundle/Tests/Form/Type/FilterTraitTest.php
+++ b/app/bundles/LeadBundle/Tests/Form/Type/FilterTraitTest.php
@@ -35,8 +35,9 @@ final class FilterTraitTest extends TypeTestCase
 
     public function testLeadlistFilterWithIncludingAllOperatorDoesNotCrashOnSubmit(): void
     {
-        $form = $this->factory->create(FilterTraitLeadlistStubFormType::class, null, [
-            'lists' => ['Segment A' => '1', 'Segment B' => '2'],
+        $form = $this->factory->create(FilterTraitStubFormType::class, null, [
+            'lists'  => ['Segment A' => '1', 'Segment B' => '2'],
+            'fields' => [],
         ]);
 
         $form->submit([
@@ -53,7 +54,8 @@ final class FilterTraitTest extends TypeTestCase
 
     public function testMultiselectFilterWithExcludingAllOperatorDoesNotCrashOnSubmit(): void
     {
-        $form = $this->factory->create(FilterTraitMultiselectStubFormType::class, null, [
+        $form = $this->factory->create(FilterTraitStubFormType::class, null, [
+            'lists'  => [],
             'fields' => [
                 'lead' => [
                     'custom_multiselect' => [
@@ -79,15 +81,31 @@ final class FilterTraitTest extends TypeTestCase
 }
 
 /**
+ * Minimal stand-in for the real FilterTrait consumers (e.g. DwcEntryFiltersType, FilterType):
+ * wires FilterTrait::buildFiltersForm() up to PRE_SET_DATA/PRE_SUBMIT exactly as they do, without
+ * needing their heavier constructor dependencies. The field type under test ('leadlist' vs
+ * 'multiselect') is driven entirely by the submitted data, not by this stub, so a single stub
+ * type covers both scenarios.
+ *
  * @extends AbstractType<mixed>
  */
-final class FilterTraitLeadlistStubFormType extends AbstractType
+final class FilterTraitStubFormType extends AbstractType
 {
     use FilterTrait;
 
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
-        $translator = self::createStubTranslator();
+        $translator = new class() implements TranslatorInterface {
+            public function trans(?string $id, array $parameters = [], ?string $domain = null, ?string $locale = null): string
+            {
+                return $id ?? '';
+            }
+
+            public function getLocale(): string
+            {
+                return 'en';
+            }
+        };
 
         $formModifier = function (FormEvent $event, string $eventName) use ($translator): void {
             $this->buildFiltersForm($eventName, $event, $translator);
@@ -111,71 +129,5 @@ final class FilterTraitLeadlistStubFormType extends AbstractType
             'lists'  => [],
             'fields' => [],
         ]);
-    }
-
-    private static function createStubTranslator(): TranslatorInterface
-    {
-        return new class() implements TranslatorInterface {
-            public function trans(?string $id, array $parameters = [], ?string $domain = null, ?string $locale = null): string
-            {
-                return $id ?? '';
-            }
-
-            public function getLocale(): string
-            {
-                return 'en';
-            }
-        };
-    }
-}
-
-/**
- * @extends AbstractType<mixed>
- */
-final class FilterTraitMultiselectStubFormType extends AbstractType
-{
-    use FilterTrait;
-
-    public function buildForm(FormBuilderInterface $builder, array $options): void
-    {
-        $translator = self::createStubTranslator();
-
-        $formModifier = function (FormEvent $event, string $eventName) use ($translator): void {
-            $this->buildFiltersForm($eventName, $event, $translator);
-        };
-
-        $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) use ($formModifier): void {
-            $formModifier($event, FormEvents::PRE_SET_DATA);
-        });
-        $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) use ($formModifier): void {
-            $formModifier($event, FormEvents::PRE_SUBMIT);
-        });
-
-        $builder->add('field', HiddenType::class);
-        $builder->add('object', HiddenType::class);
-        $builder->add('type', HiddenType::class);
-    }
-
-    public function configureOptions(OptionsResolver $resolver): void
-    {
-        $resolver->setDefaults([
-            'lists'  => [],
-            'fields' => [],
-        ]);
-    }
-
-    private static function createStubTranslator(): TranslatorInterface
-    {
-        return new class() implements TranslatorInterface {
-            public function trans(?string $id, array $parameters = [], ?string $domain = null, ?string $locale = null): string
-            {
-                return $id ?? '';
-            }
-
-            public function getLocale(): string
-            {
-                return 'en';
-            }
-        };
     }
 }

--- a/app/bundles/LeadBundle/Tests/Form/Type/FilterTraitTest.php
+++ b/app/bundles/LeadBundle/Tests/Form/Type/FilterTraitTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\LeadBundle\Tests\Form\Type;
+
+use Mautic\LeadBundle\Form\Type\FilterTrait;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Form\Test\TypeTestCase;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Validation;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * Reproduces https://github.com/mautic/mautic/issues/16280: saving a DWC "Segment Membership"
+ * (or any multiselect) filter with the "Including ALL" / "Excluding ALL" operator crashed,
+ * because FilterTrait always turns the submitted filter value into an array for these field
+ * types, but only flagged the underlying ChoiceType as `multiple` for the "in"/"!in" ("Including
+ * ANY" / "Excluding ANY") operators - leaving "in_all"/"!in_all" building a single-select
+ * ChoiceType fed an array value.
+ */
+final class FilterTraitTest extends TypeTestCase
+{
+    protected function getExtensions(): array
+    {
+        return [
+            new ValidatorExtension(Validation::createValidator()),
+        ];
+    }
+
+    public function testLeadlistFilterWithIncludingAllOperatorDoesNotCrashOnSubmit(): void
+    {
+        $form = $this->factory->create(FilterTraitLeadlistStubFormType::class, null, [
+            'lists' => ['Segment A' => '1', 'Segment B' => '2'],
+        ]);
+
+        $form->submit([
+            'field'    => 'leadlist',
+            'object'   => 'lead',
+            'type'     => 'leadlist',
+            'operator' => 'in_all',
+            'filter'   => ['2'],
+        ]);
+
+        $this->assertTrue($form->isSubmitted());
+        $this->assertSame(['2'], $form->get('filter')->getData());
+    }
+
+    public function testMultiselectFilterWithExcludingAllOperatorDoesNotCrashOnSubmit(): void
+    {
+        $form = $this->factory->create(FilterTraitMultiselectStubFormType::class, null, [
+            'fields' => [
+                'lead' => [
+                    'custom_multiselect' => [
+                        'properties' => [
+                            'list' => ['Option A' => 'a', 'Option B' => 'b'],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $form->submit([
+            'field'    => 'custom_multiselect',
+            'object'   => 'lead',
+            'type'     => 'multiselect',
+            'operator' => '!in_all',
+            'filter'   => ['a'],
+        ]);
+
+        $this->assertTrue($form->isSubmitted());
+        $this->assertSame(['a'], $form->get('filter')->getData());
+    }
+}
+
+/**
+ * @extends AbstractType<mixed>
+ */
+final class FilterTraitLeadlistStubFormType extends AbstractType
+{
+    use FilterTrait;
+
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $translator = self::createStubTranslator();
+
+        $formModifier = function (FormEvent $event, string $eventName) use ($translator): void {
+            $this->buildFiltersForm($eventName, $event, $translator);
+        };
+
+        $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) use ($formModifier): void {
+            $formModifier($event, FormEvents::PRE_SET_DATA);
+        });
+        $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) use ($formModifier): void {
+            $formModifier($event, FormEvents::PRE_SUBMIT);
+        });
+
+        $builder->add('field', HiddenType::class);
+        $builder->add('object', HiddenType::class);
+        $builder->add('type', HiddenType::class);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'lists'  => [],
+            'fields' => [],
+        ]);
+    }
+
+    private static function createStubTranslator(): TranslatorInterface
+    {
+        return new class() implements TranslatorInterface {
+            public function trans(?string $id, array $parameters = [], ?string $domain = null, ?string $locale = null): string
+            {
+                return $id ?? '';
+            }
+
+            public function getLocale(): string
+            {
+                return 'en';
+            }
+        };
+    }
+}
+
+/**
+ * @extends AbstractType<mixed>
+ */
+final class FilterTraitMultiselectStubFormType extends AbstractType
+{
+    use FilterTrait;
+
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $translator = self::createStubTranslator();
+
+        $formModifier = function (FormEvent $event, string $eventName) use ($translator): void {
+            $this->buildFiltersForm($eventName, $event, $translator);
+        };
+
+        $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) use ($formModifier): void {
+            $formModifier($event, FormEvents::PRE_SET_DATA);
+        });
+        $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) use ($formModifier): void {
+            $formModifier($event, FormEvents::PRE_SUBMIT);
+        });
+
+        $builder->add('field', HiddenType::class);
+        $builder->add('object', HiddenType::class);
+        $builder->add('type', HiddenType::class);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'lists'  => [],
+            'fields' => [],
+        ]);
+    }
+
+    private static function createStubTranslator(): TranslatorInterface
+    {
+        return new class() implements TranslatorInterface {
+            public function trans(?string $id, array $parameters = [], ?string $domain = null, ?string $locale = null): string
+            {
+                return $id ?? '';
+            }
+
+            public function getLocale(): string
+            {
+                return 'en';
+            }
+        };
+    }
+}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7081,6 +7081,18 @@ parameters:
 			path: app/bundles/LeadBundle/Segment/TableSchemaColumnsCache.php
 
 		-
+			message: '#^Method Mautic\\LeadBundle\\Tests\\Form\\Type\\FilterTraitStubFormType\:\:buildFiltersForm\(\) has parameter \$currentListId with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/bundles/LeadBundle/Tests/Form/Type/FilterTraitTest.php
+
+		-
+			message: '#^Method Mautic\\LeadBundle\\Tests\\Form\\Type\\FilterTraitStubFormType\:\:prepareRegex\(\) has parameter \$regex with no type specified\.$#'
+			identifier: missingType.parameter
+			count: 1
+			path: app/bundles/LeadBundle/Tests/Form/Type/FilterTraitTest.php
+
+		-
 			message: '#^Property Mautic\\LeadBundle\\Tests\\StandardImportTestHelper\:\:\$csvPath has no type specified\.$#'
 			identifier: missingType.property
 			count: 1


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | Fixes #16280

## Description

Saving a Dynamic Web Content filter (or a segment filter using the same trait) on a "Segment Membership" field - or any custom multiselect field - with the **"Including ALL"** / **"Excluding ALL"** operator throws a server error:

```
ErrorException
.../vendor/symfony/form/ChoiceList/ArrayChoiceList.php:58
  ... ChoiceToValueTransformer->transform()
  ... Form->normToView() / Form->setData() / Form->add()
.../app/bundles/LeadBundle/Form/Type/FilterTrait.php:361
```

("Including ANY" / "Excluding ANY" work fine, as the reporter's own edit on the issue noted, and so does a plain custom multiselect field with "Excluding ALL" - independently confirming the same root cause in a second field type.)

### Root cause

`OperatorOptions` defines four "collection" operators: `in` / `!in` ("Including/Excluding ANY", `OperatorOptions::INCLUDING_ANY` / `EXCLUDING_ANY`) and `in_all` / `!in_all` ("Including/Excluding ALL", `OperatorOptions::INCLUDING_ALL` / `EXCLUDING_ALL`). For a `leadlist` (Segment Membership) or `multiselect` field, all four are valid, selectable operators (see `OperatorListTrait::$typeOperators['multiselect']`, and `FilterOperatorSubscriber` wiring `leadlist` to the same `multiselect` operator set).

In `FilterTrait::buildFiltersForm()`, both the `'leadlist'` case and the `'select'/'multiselect'/'boolean'` case always coerce the submitted `filter` value into an array for these field types, regardless of operator:

```php
if (!isset($data['filter'])) {
    $data['filter'] = [];
} elseif (!is_array($data['filter'])) {
    $data['filter'] = [$data['filter']];
}
```

...but only mark the underlying `ChoiceType` as `multiple` for `in`/`!in`:

```php
$customOptions['multiple'] = in_array($data['operator'], ['in', '!in']);
```

So with `in_all`/`!in_all`, the form builds a **single-select** `ChoiceType` but feeds it an **array** value - which is exactly what crashes `ChoiceToValueTransformer` (the single-value transformer) when it tries to resolve that array against the choice list.

A sibling code path for the main Segment filter builder (`TypeOperatorSubscriber::onSegmentFilterFormHandleSelect()`) already gets this right - it computes `multiple` from `INCLUDING_ANY`, `EXCLUDING_ANY`, `INCLUDING_ALL` and `EXCLUDING_ALL` together. `FilterTrait` (used by the DWC filter form, and shared by other filter forms) just never picked up the two "ALL" operators when the `multiple` flag was originally added.

There is a third, textually-identical occurrence of the same `in_array($operator, ['in', '!in'])` check for `country`/`timezone`/`region`/`locale` fields. I left that one alone: those field types use `OperatorListTrait::$typeOperators['select']`, which does **not** include `in_all`/`!in_all` as a choice at all, so that occurrence is not reachable with these operators and there's nothing to reproduce there.

### Fix

Add `'in_all'` and `'!in_all'` to the two operator checks that are actually reachable with those operators (the `'leadlist'` case, and the `'select'/'multiselect'/'boolean'` case).

### How I verified this

- Read `OperatorOptions`, `OperatorListTrait::$typeOperators`, `FilterOperatorSubscriber`, and `TypeOperatorSubscriber::onSegmentFilterFormHandleSelect()` to confirm exactly which field types can actually reach `in_all`/`!in_all`, rather than guessing from the report alone.
- Added `FilterTraitTest`, which builds a real form around `FilterTrait` (via `Symfony\Component\Form\Test\TypeTestCase`, the same pattern already used by `ToBcBccFieldsTraitTest`) and submits `operator => in_all` (`leadlist`) / `!in_all` (`multiselect`) with a single selected value, then asserts the submission doesn't throw and the value round-trips correctly.
  - Ran it against the unpatched code first: it fails - the array value comes back as `null`, and PHPUnit captures the underlying `ArrayChoiceList.php:58` "Array to string conversion" warning, the *exact* file and line from the issue's real stack trace.
  - Ran it against the patched code: it passes (2 tests, both operators).
- Ran the pre-existing `FilterTypeTest` suite alongside it afterward: no regressions (4 tests total, all green).
- I also ran the full `DynamicContentBundle` functional test suite, but it fails independently of this change (missing compiled Sass/JS assets in my environment - `var/sass/app.output.css doesn't exist, run php bin/console sass:build`), since I did not run the frontend build. That's an environment gap on my end, not something this PR touches; I did not rely on that suite to validate the fix.
- `composer cs` (php-cs-fixer, dry-run) on the changed files: clean.

### 📋 Steps to test this PR:

1. Create two segments.
2. Create a Dynamic Web Content item, deselect "campaign based", add a filter on "Segment Membership".
3. Set the condition to "Including ALL" (or "Excluding ALL").
4. Select one (or more) segments and save.
5. Without this fix: only one segment can be picked, and saving throws a server error. With this fix: multiple segments can be selected, and saving succeeds.
6. Repeat with a custom multiselect contact field to confirm the same fix covers that field type too.
