### PR TITLE
[removal] remove deprecated LeadEvents::ON_CAMPAIGN_TRIGGER_ACTION

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -119,6 +119,32 @@
 
 - Deprecated support for `:`-prefixed parameter keys removed from `Mautic\LeadBundle\Segment\Query\QueryBuilder::setParameter()`. Pass the key without the colon — `setParameter('foo', $bar)`, not `setParameter(':foo', $bar)`. The `:foo` placeholder in the query string itself is unchanged.
 - Deprecated `models` key in bundle `Config/config.php` `services` removed. Services listed under it are no longer registered with the `mautic.model` tag; register models by their class name and let autowiring resolve them.
+<<<<<<< HEAD
 - Deprecated method `Mautic\FormBundle\Entity\Form::setFormType()` removed with no replacement. Form types are no longer used; the `form_type` column and its getter are unchanged.
 - Deprecated method `Mautic\FormBundle\Entity\Form::isStandalone()` removed with no replacement. All forms can now be used in campaigns, so the standalone/campaign distinction no longer exists.
 - Deprecated class `Mautic\CampaignBundle\Event\CampaignScheduledEvent` removed. Its only subclass `Mautic\CampaignBundle\Event\ScheduledEvent` absorbed all of its properties and getters, so the dispatched event keeps the same public API. Code type-hinting or `instanceof`-checking `CampaignScheduledEvent` must target `ScheduledEvent` instead.
+=======
+- Deprecated constant `Mautic\LeadBundle\LeadEvents::ON_CAMPAIGN_TRIGGER_ACTION` (`mautic.lead.on_campaign_trigger_action`) removed. The eight built-in lead campaign actions (change points, change segments, modify tags, add to company, change company score, change owner, update contact, update primary company) and the internal set-manipulator listener now run on the batch event `LeadEvents::ON_CAMPAIGN_BATCH_ACTION` with a `Mautic\CampaignBundle\Event\PendingEvent` instead of the per-contact, also-deprecated `CampaignExecutionEvent`. Plugins that registered an action with `'eventName' => LeadEvents::ON_CAMPAIGN_TRIGGER_ACTION`, or added a listener on that event, must switch to `'batchEventName' => LeadEvents::ON_CAMPAIGN_BATCH_ACTION` and a `PendingEvent` listener — iterate `getPending()` and call `pass()`/`fail()` per log:
+
+```diff
+-'eventName' => LeadEvents::ON_CAMPAIGN_TRIGGER_ACTION,
++'batchEventName' => LeadEvents::ON_CAMPAIGN_BATCH_ACTION,
+```
+
+```diff
+-public function onAction(CampaignExecutionEvent $event): void
+-{
+-    $lead = $event->getLead();
+-    // ...
+-    $event->setResult(true);
+-}
++public function onAction(PendingEvent $event): void
++{
++    foreach ($event->getPending() as $log) {
++        $lead = $log->getLead();
++        // ...
++        $event->pass($log);
++    }
++}
+```
+>>>>>>> 7e1aa6a30c ([removal] remove deprecated LeadEvents::ON_CAMPAIGN_TRIGGER_ACTION)

--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -119,11 +119,9 @@
 
 - Deprecated support for `:`-prefixed parameter keys removed from `Mautic\LeadBundle\Segment\Query\QueryBuilder::setParameter()`. Pass the key without the colon — `setParameter('foo', $bar)`, not `setParameter(':foo', $bar)`. The `:foo` placeholder in the query string itself is unchanged.
 - Deprecated `models` key in bundle `Config/config.php` `services` removed. Services listed under it are no longer registered with the `mautic.model` tag; register models by their class name and let autowiring resolve them.
-<<<<<<< HEAD
 - Deprecated method `Mautic\FormBundle\Entity\Form::setFormType()` removed with no replacement. Form types are no longer used; the `form_type` column and its getter are unchanged.
 - Deprecated method `Mautic\FormBundle\Entity\Form::isStandalone()` removed with no replacement. All forms can now be used in campaigns, so the standalone/campaign distinction no longer exists.
 - Deprecated class `Mautic\CampaignBundle\Event\CampaignScheduledEvent` removed. Its only subclass `Mautic\CampaignBundle\Event\ScheduledEvent` absorbed all of its properties and getters, so the dispatched event keeps the same public API. Code type-hinting or `instanceof`-checking `CampaignScheduledEvent` must target `ScheduledEvent` instead.
-=======
 - Deprecated constant `Mautic\LeadBundle\LeadEvents::ON_CAMPAIGN_TRIGGER_ACTION` (`mautic.lead.on_campaign_trigger_action`) removed. The eight built-in lead campaign actions (change points, change segments, modify tags, add to company, change company score, change owner, update contact, update primary company) and the internal set-manipulator listener now run on the batch event `LeadEvents::ON_CAMPAIGN_BATCH_ACTION` with a `Mautic\CampaignBundle\Event\PendingEvent` instead of the per-contact, also-deprecated `CampaignExecutionEvent`. Plugins that registered an action with `'eventName' => LeadEvents::ON_CAMPAIGN_TRIGGER_ACTION`, or added a listener on that event, must switch to `'batchEventName' => LeadEvents::ON_CAMPAIGN_BATCH_ACTION` and a `PendingEvent` listener — iterate `getPending()` and call `pass()`/`fail()` per log:
 
 ```diff
@@ -147,4 +145,3 @@
 +    }
 +}
 ```
->>>>>>> 7e1aa6a30c ([removal] remove deprecated LeadEvents::ON_CAMPAIGN_TRIGGER_ACTION)

--- a/app/bundles/CampaignBundle/Tests/Executioner/EventExecutionerLockTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/EventExecutionerLockTest.php
@@ -8,7 +8,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Mautic\CampaignBundle\Entity\Campaign;
 use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CampaignBundle\Entity\LeadEventLog;
-use Mautic\CampaignBundle\Event\CampaignExecutionEvent;
+use Mautic\CampaignBundle\Event\PendingEvent;
 use Mautic\CampaignBundle\Executioner\EventExecutioner;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\CoreBundle\Tests\Traits\LoggerTrait;
@@ -124,17 +124,17 @@ final class EventExecutionerLockTest extends MauticMysqlTestCase
 
     private function makeEventExecutionFail(): callable
     {
-        $listener = function (CampaignExecutionEvent $event): void { // @phpstan-ignore parameter.deprecatedClass
-            $event->setResult(false);
+        $listener = function (PendingEvent $event): void {
+            $event->failAll('Forced failure for test.');
             $event->stopPropagation();
         };
-        $this->eventDispatcher->addListener(LeadEvents::ON_CAMPAIGN_TRIGGER_ACTION, $listener, 9999); // @phpstan-ignore classConstant.deprecated
+        $this->eventDispatcher->addListener(LeadEvents::ON_CAMPAIGN_BATCH_ACTION, $listener, 9999);
 
         return $listener;
     }
 
     private function makeEventExecutionPass(callable $listener): void
     {
-        $this->eventDispatcher->removeListener(LeadEvents::ON_CAMPAIGN_TRIGGER_ACTION, $listener); // @phpstan-ignore classConstant.deprecated
+        $this->eventDispatcher->removeListener(LeadEvents::ON_CAMPAIGN_BATCH_ACTION, $listener);
     }
 }

--- a/app/bundles/LeadBundle/EventListener/CampaignActionDeleteContactSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/CampaignActionDeleteContactSubscriber.php
@@ -33,8 +33,6 @@ final readonly class CampaignActionDeleteContactSubscriber implements EventSubsc
             [
                 'label'                  => 'mautic.lead.lead.events.delete',
                 'description'            => 'mautic.lead.lead.events.delete_descr',
-                // Kept for BC in case plugins are listening to the shared trigger
-                'eventName'              => LeadEvents::ON_CAMPAIGN_TRIGGER_ACTION,
                 'batchEventName'         => LeadEvents::ON_CAMPAIGN_ACTION_DELETE_CONTACT,
                 'connectionRestrictions' => [
                     'target' => [

--- a/app/bundles/LeadBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/CampaignSubscriber.php
@@ -77,7 +77,8 @@ final class CampaignSubscriber implements EventSubscriberInterface
     {
         return [
             CampaignEvents::CAMPAIGN_ON_BUILD      => ['onCampaignBuild', 0],
-            LeadEvents::ON_CAMPAIGN_TRIGGER_ACTION => [
+            LeadEvents::ON_CAMPAIGN_BATCH_ACTION => [
+                ['onCampaignTriggerActionUpdateLead', 0],
                 ['onCampaignTriggerActionChangePoints', 0],
                 ['onCampaignTriggerActionChangeLists', 1],
                 ['onCampaignTriggerActionUpdateTags', 3],
@@ -86,9 +87,6 @@ final class CampaignSubscriber implements EventSubscriberInterface
                 ['onCampaignTriggerActionChangeOwner', 7],
                 ['onCampaignTriggerActionUpdateCompany', 8],
                 ['onCampaignTriggerActionSetManipulator', 100],
-            ],
-            LeadEvents::ON_CAMPAIGN_BATCH_ACTION => [
-                ['onCampaignTriggerActionUpdateLead', 0],
             ],
             LeadEvents::ON_CAMPAIGN_TRIGGER_CONDITION => [
                 ['onCampaignTriggerCondition', 0],
@@ -106,7 +104,7 @@ final class CampaignSubscriber implements EventSubscriberInterface
             'label'       => 'mautic.lead.lead.events.changepoints',
             'description' => 'mautic.lead.lead.events.changepoints_descr',
             'formType'    => PointActionType::class,
-            'eventName'   => LeadEvents::ON_CAMPAIGN_TRIGGER_ACTION,
+            'batchEventName' => LeadEvents::ON_CAMPAIGN_BATCH_ACTION,
         ];
         $event->addAction('lead.changepoints', $action);
 
@@ -114,7 +112,7 @@ final class CampaignSubscriber implements EventSubscriberInterface
             'label'       => 'mautic.lead.lead.events.changelist',
             'description' => 'mautic.lead.lead.events.changelist_descr',
             'formType'    => ListActionType::class,
-            'eventName'   => LeadEvents::ON_CAMPAIGN_TRIGGER_ACTION,
+            'batchEventName' => LeadEvents::ON_CAMPAIGN_BATCH_ACTION,
         ];
         $event->addAction('lead.changelist', $action);
 
@@ -132,7 +130,7 @@ final class CampaignSubscriber implements EventSubscriberInterface
             'description' => 'mautic.lead.lead.events.updatecompany_descr',
             'formType'    => UpdateCompanyActionType::class,
             'formTheme'   => '@MauticLead/FormTheme/ActionUpdateCompany/_updatecompany_action_widget.html.twig',
-            'eventName'   => LeadEvents::ON_CAMPAIGN_TRIGGER_ACTION,
+            'batchEventName' => LeadEvents::ON_CAMPAIGN_BATCH_ACTION,
         ];
         $event->addAction('lead.updatecompany', $action);
 
@@ -140,7 +138,7 @@ final class CampaignSubscriber implements EventSubscriberInterface
             'label'       => 'mautic.lead.lead.events.changetags',
             'description' => 'mautic.lead.lead.events.changetags_descr',
             'formType'    => ModifyLeadTagsType::class,
-            'eventName'   => LeadEvents::ON_CAMPAIGN_TRIGGER_ACTION,
+            'batchEventName' => LeadEvents::ON_CAMPAIGN_BATCH_ACTION,
         ];
         $event->addAction('lead.changetags', $action);
 
@@ -148,7 +146,7 @@ final class CampaignSubscriber implements EventSubscriberInterface
             'label'       => 'mautic.lead.lead.events.addtocompany',
             'description' => 'mautic.lead.lead.events.addtocompany_descr',
             'formType'    => AddToCompanyActionType::class,
-            'eventName'   => LeadEvents::ON_CAMPAIGN_TRIGGER_ACTION,
+            'batchEventName' => LeadEvents::ON_CAMPAIGN_BATCH_ACTION,
         ];
         $event->addAction('lead.addtocompany', $action);
 
@@ -156,7 +154,7 @@ final class CampaignSubscriber implements EventSubscriberInterface
             'label'       => 'mautic.lead.lead.events.changeowner',
             'description' => 'mautic.lead.lead.events.changeowner_descr',
             'formType'    => ChangeOwnerType::class,
-            'eventName'   => LeadEvents::ON_CAMPAIGN_TRIGGER_ACTION,
+            'batchEventName' => LeadEvents::ON_CAMPAIGN_BATCH_ACTION,
         ];
         $event->addAction(self::ACTION_LEAD_CHANGE_OWNER, $action);
 
@@ -164,7 +162,7 @@ final class CampaignSubscriber implements EventSubscriberInterface
             'label'       => 'mautic.lead.lead.events.changecompanyscore',
             'description' => 'mautic.lead.lead.events.changecompanyscore_descr',
             'formType'    => CompanyChangeScoreActionType::class,
-            'eventName'   => LeadEvents::ON_CAMPAIGN_TRIGGER_ACTION,
+            'batchEventName' => LeadEvents::ON_CAMPAIGN_BATCH_ACTION,
         ];
         $event->addAction('lead.scorecontactscompanies', $action);
 
@@ -269,72 +267,74 @@ final class CampaignSubscriber implements EventSubscriberInterface
         $event->addCondition('lead.points', $trigger);
     }
 
-    public function onCampaignTriggerActionChangePoints(CampaignExecutionEvent $event): void
+    public function onCampaignTriggerActionChangePoints(PendingEvent $event): void
     {
         if (!$event->checkContext('lead.changepoints')) {
             return;
         }
 
-        $lead              = $event->getLead();
-        $points            = $event->getConfig()['points'];
-        $somethingHappened = false;
+        $campaignEvent       = $event->getEvent();
+        $config              = $campaignEvent->getProperties();
+        $points              = $config['points'];
+        $pointGroupId        = $config['group'] ?? null;
+        $pointGroup          = $pointGroupId ? $this->groupModel->getEntity($pointGroupId) : null;
+        $pointsLogActionName = "{$campaignEvent->getId()}: {$campaignEvent->getName()}";
+        $pointsLogEventName  = "{$campaignEvent->getCampaign()->getId()}: {$campaignEvent->getCampaign()->getName()}";
 
-        if (null !== $lead && !empty($points)) {
-            $pointsLogActionName      = "{$event->getEvent()['id']}: {$event->getEvent()['name']}";
-            $pointsLogEventName       = "{$event->getEvent()['campaign']['id']}: {$event->getEvent()['campaign']['name']}";
-            $pointGroupId             = $event->getConfig()['group'] ?? null;
-            $pointGroup               = $pointGroupId ? $this->groupModel->getEntity($pointGroupId) : null;
+        foreach ($event->getPending() as $log) {
+            $lead = $log->getLead();
 
-            if ($pointGroup instanceof \Mautic\PointBundle\Entity\Group) {
-                $this->groupModel->adjustPoints($lead, $pointGroup, $points);
-            } else {
-                $lead->adjustPoints($points);
+            if (null !== $lead && !empty($points)) {
+                if ($pointGroup instanceof \Mautic\PointBundle\Entity\Group) {
+                    $this->groupModel->adjustPoints($lead, $pointGroup, $points);
+                } else {
+                    $lead->adjustPoints($points);
+                }
+
+                // add a lead point change log
+                $pointsChangeLog = new PointsChangeLog();
+                $pointsChangeLog->setDelta($points);
+                $pointsChangeLog->setLead($lead);
+                $pointsChangeLog->setType('campaign');
+                $pointsChangeLog->setEventName($pointsLogEventName);
+                $pointsChangeLog->setActionName($pointsLogActionName);
+                $pointsChangeLog->setIpAddress($this->ipLookupHelper->getIpAddress());
+                $pointsChangeLog->setDateAdded(new \DateTime());
+                if ($pointGroup) {
+                    $pointsChangeLog->setGroup($pointGroup);
+                }
+                $lead->addPointsChangeLog($pointsChangeLog);
+
+                $this->leadModel->saveEntity($lead);
             }
 
-            // add a lead point change log
-            $log = new PointsChangeLog();
-            $log->setDelta($points);
-            $log->setLead($lead);
-            $log->setType('campaign');
-            $log->setEventName($pointsLogEventName);
-            $log->setActionName($pointsLogActionName);
-            $log->setIpAddress($this->ipLookupHelper->getIpAddress());
-            $log->setDateAdded(new \DateTime());
-            if ($pointGroup) {
-                $log->setGroup($pointGroup);
-            }
-            $lead->addPointsChangeLog($log);
-
-            $this->leadModel->saveEntity($lead);
-            $somethingHappened = true;
+            $event->pass($log);
         }
-
-        $event->setResult($somethingHappened);
     }
 
-    public function onCampaignTriggerActionChangeLists(CampaignExecutionEvent $event): void
+    public function onCampaignTriggerActionChangeLists(PendingEvent $event): void
     {
         if (!$event->checkContext('lead.changelist')) {
             return;
         }
 
-        $addTo      = $event->getConfig()['addToLists'];
-        $removeFrom = $event->getConfig()['removeFromLists'];
+        $config     = $event->getEvent()->getProperties();
+        $addTo      = $config['addToLists'];
+        $removeFrom = $config['removeFromLists'];
 
-        $lead              = $event->getLead();
-        $somethingHappened = false;
+        foreach ($event->getPending() as $log) {
+            $lead = $log->getLead();
 
-        if (!empty($addTo)) {
-            $this->leadModel->addToLists($lead, $addTo);
-            $somethingHappened = true;
+            if (!empty($addTo)) {
+                $this->leadModel->addToLists($lead, $addTo);
+            }
+
+            if (!empty($removeFrom)) {
+                $this->leadModel->removeFromLists($lead, $removeFrom);
+            }
+
+            $event->pass($log);
         }
-
-        if (!empty($removeFrom)) {
-            $this->leadModel->removeFromLists($lead, $removeFrom);
-            $somethingHappened = true;
-        }
-
-        $event->setResult($somethingHappened);
     }
 
     public function onCampaignTriggerActionUpdateLead(PendingEvent $event): void
@@ -390,113 +390,123 @@ final class CampaignSubscriber implements EventSubscriberInterface
         $event->pass($log);
     }
 
-    public function onCampaignTriggerActionChangeOwner(CampaignExecutionEvent $event): void
+    public function onCampaignTriggerActionChangeOwner(PendingEvent $event): void
     {
         if (!$event->checkContext(self::ACTION_LEAD_CHANGE_OWNER)) {
             return;
         }
 
-        $lead = $event->getLead();
-        $data = $event->getConfig();
+        $data = $event->getEvent()->getProperties();
         if (empty($data['owner'])) {
+            $event->passAll();
+
             return;
         }
 
-        $this->leadModel->updateLeadOwner($lead, $data['owner']);
-
-        $event->setResult(true);
+        foreach ($event->getPending() as $log) {
+            $this->leadModel->updateLeadOwner($log->getLead(), $data['owner']);
+            $event->pass($log);
+        }
     }
 
-    public function onCampaignTriggerActionUpdateTags(CampaignExecutionEvent $event): void
+    public function onCampaignTriggerActionUpdateTags(PendingEvent $event): void
     {
         if (!$event->checkContext('lead.changetags')) {
             return;
         }
 
-        $config = $event->getConfig();
-        $lead   = $event->getLead();
-
+        $config     = $event->getEvent()->getProperties();
         $addTags    = (!empty($config['add_tags'])) ? $config['add_tags'] : [];
         $removeTags = (!empty($config['remove_tags'])) ? $config['remove_tags'] : [];
 
-        $this->leadModel->modifyTags($lead, $addTags, $removeTags);
-
-        $event->setResult(true);
+        foreach ($event->getPending() as $log) {
+            $this->leadModel->modifyTags($log->getLead(), $addTags, $removeTags);
+            $event->pass($log);
+        }
     }
 
-    public function onCampaignTriggerActionAddToCompany(CampaignExecutionEvent $event): void
+    public function onCampaignTriggerActionAddToCompany(PendingEvent $event): void
     {
         if (!$event->checkContext('lead.addtocompany')) {
             return;
         }
 
-        $company = $event->getConfig()['company'];
-        $lead    = $event->getLead();
+        $company = $event->getEvent()->getProperties()['company'];
 
-        if (!empty($company)) {
-            $this->leadModel->addToCompany($lead, $company);
+        foreach ($event->getPending() as $log) {
+            if (!empty($company)) {
+                $this->leadModel->addToCompany($log->getLead(), $company);
+            }
+
+            $event->pass($log);
         }
     }
 
-    public function onCampaignTriggerActionChangeCompanyScore(CampaignExecutionEvent $event): void
+    public function onCampaignTriggerActionChangeCompanyScore(PendingEvent $event): void
     {
         if (!$event->checkContext('lead.scorecontactscompanies')) {
             return;
         }
 
-        $score = $event->getConfig()['score'];
-        $lead  = $event->getLead();
+        $score = $event->getEvent()->getProperties()['score'];
 
-        if (!$this->leadModel->scoreContactsCompany($lead, $score)) {
-            $event->setFailed('mautic.lead.no_company');
+        foreach ($event->getPending() as $log) {
+            if (!$this->leadModel->scoreContactsCompany($log->getLead(), $score)) {
+                $event->fail($log, 'mautic.lead.no_company');
 
-            return;
+                continue;
+            }
+
+            $event->pass($log);
         }
-
-        $event->setResult(true);
     }
 
-    public function onCampaignTriggerActionUpdateCompany(CampaignExecutionEvent $event): void
+    public function onCampaignTriggerActionUpdateCompany(PendingEvent $event): void
     {
         if (!$event->checkContext('lead.updatecompany')) {
             return;
         }
 
-        $lead    = $event->getLead();
-        $company = $lead->getPrimaryCompany();
-        $config  = $event->getConfig();
+        $config = $event->getEvent()->getProperties();
 
-        if (empty($company['id'])) {
-            return;
+        foreach ($event->getPending() as $log) {
+            $lead    = $log->getLead();
+            $company = $lead->getPrimaryCompany();
+
+            if (empty($company['id'])) {
+                $event->pass($log);
+
+                continue;
+            }
+
+            $primaryCompany = $this->companyModel->getEntity($company['id']);
+
+            if (isset($config['companyname']) && $primaryCompany->getName() != $config['companyname']) {
+                [$company, $leadAdded, $companyEntity] = IdentifyCompanyHelper::identifyLeadsCompany($config, $lead, $this->companyModel);
+                $companyChangeLog                      = null;
+                if ($leadAdded) {
+                    $companyChangeLog = $lead->addCompanyChangeLogEntry('form', 'Identify Company', 'Lead added to the company, '.$company['companyname'], $company['id']);
+                } elseif ($companyEntity instanceof Company) {
+                    $this->companyModel->setFieldValues($companyEntity, $config);
+                    $this->companyModel->saveEntity($companyEntity);
+                }
+
+                if (!empty($company)) {
+                    // Save after the lead in for new leads created
+                    $this->companyModel->addLeadToCompany($companyEntity, $lead);
+                    $this->leadModel->setPrimaryCompany($companyEntity->getId(), $lead->getId());
+                }
+
+                if (null !== $companyChangeLog) {
+                    $this->companyModel->getCompanyLeadRepository()->detachEntity($companyChangeLog);
+                }
+            } else {
+                $this->companyModel->setFieldValues($primaryCompany, $config, false);
+                $this->companyModel->saveEntity($primaryCompany);
+            }
+
+            $event->pass($log);
         }
-
-        $primaryCompany =  $this->companyModel->getEntity($company['id']);
-
-        if (isset($config['companyname']) && $primaryCompany->getName() != $config['companyname']) {
-            [$company, $leadAdded, $companyEntity] = IdentifyCompanyHelper::identifyLeadsCompany($config, $lead, $this->companyModel);
-            $companyChangeLog                      = null;
-            if ($leadAdded) {
-                $companyChangeLog = $lead->addCompanyChangeLogEntry('form', 'Identify Company', 'Lead added to the company, '.$company['companyname'], $company['id']);
-            } elseif ($companyEntity instanceof Company) {
-                $this->companyModel->setFieldValues($companyEntity, $config);
-                $this->companyModel->saveEntity($companyEntity);
-            }
-
-            if (!empty($company)) {
-                // Save after the lead in for new leads created
-                $this->companyModel->addLeadToCompany($companyEntity, $lead);
-                $this->leadModel->setPrimaryCompany($companyEntity->getId(), $lead->getId());
-            }
-
-            if (null !== $companyChangeLog) {
-                $this->companyModel->getCompanyLeadRepository()->detachEntity($companyChangeLog);
-            }
-        } else {
-            $this->companyModel->setFieldValues($primaryCompany, $config, false);
-            $this->companyModel->saveEntity($primaryCompany);
-        }
-
-        $event->setResult(true);
     }
 
     public function onCampaignTriggerCondition(CampaignExecutionEvent $event): void
@@ -761,25 +771,29 @@ final class CampaignSubscriber implements EventSubscriberInterface
         return $now > $objEffectiveDate;
     }
 
-    public function onCampaignTriggerActionSetManipulator(CampaignExecutionEvent $event): void
+    public function onCampaignTriggerActionSetManipulator(PendingEvent $event): void
     {
-        $lead = $event->getLead();
+        // Cross-cutting listener: runs first (priority 100) and only mutates the leads.
+        // It intentionally does not pass()/fail() any log, leaving that to the matching action handler.
+        $campaignEvent = $event->getEvent();
+        $campaign      = $campaignEvent->getCampaign();
 
-        if (!$lead instanceof Lead) {
-            return;
+        foreach ($event->getPending() as $log) {
+            $lead = $log->getLead();
+
+            if (!$lead instanceof Lead) {
+                continue;
+            }
+
+            $lead->setManipulator(
+                new LeadManipulator(
+                    'campaign',
+                    'trigger-action',
+                    $campaignEvent->getId(),
+                    sprintf('%s (%s)', $campaignEvent->getName(), $campaign->getName())
+                )
+            );
         }
-
-        $campaign      = $event->getLogEntry()->getCampaign();
-        $campaignEvent = $event->getLogEntry()->getEvent();
-
-        $lead->setManipulator(
-            new LeadManipulator(
-                'campaign',
-                'trigger-action',
-                $campaignEvent->getId(),
-                sprintf('%s (%s)', $campaignEvent->getName(), $campaign->getName())
-            )
-        );
     }
 
     /**

--- a/app/bundles/LeadBundle/LeadEvents.php
+++ b/app/bundles/LeadBundle/LeadEvents.php
@@ -427,16 +427,6 @@ final class LeadEvents
     public const string FILTER_CHOICE_FIELDS = 'mautic.filter_choice_fields';
 
     /**
-     * @deprecated Listen to ON_CAMPAIGN_BATCH_ACTION instead.
-     *
-     * The mautic.lead.on_campaign_trigger_action event is fired when the campaign action triggers.
-     *
-     * The event listener receives a
-     * Mautic\CampaignBundle\Event\CampaignExecutionEvent
-     */
-    public const string ON_CAMPAIGN_TRIGGER_ACTION = 'mautic.lead.on_campaign_trigger_action';
-
-    /**
      * The mautic.lead.on_campaign_batch_action event is dispatched when the campaign action triggers.
      *
      * The event listener receives a

--- a/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\LeadBundle\Tests\EventListener;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\OptimisticLockException;
 use Mautic\CampaignBundle\Entity\Campaign;
@@ -11,6 +12,8 @@ use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CampaignBundle\Entity\Lead as CampaignLead;
 use Mautic\CampaignBundle\Entity\LeadEventLog;
 use Mautic\CampaignBundle\Event\CampaignExecutionEvent;
+use Mautic\CampaignBundle\Event\PendingEvent;
+use Mautic\CampaignBundle\EventCollector\Accessor\Event\ActionAccessor;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\DataObject\LeadManipulator;
 use Mautic\LeadBundle\Entity\Lead;
@@ -1044,18 +1047,12 @@ final class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
         $lead = new Lead();
         $log  = new LeadEventLog();
         $log->setEvent($campaignEvent);
+        $log->setLead($lead);
 
-        $args = [
-            'lead'            => $lead,
-            'event'           => $campaignEvent,
-            'eventDetails'    => null,
-            'systemTriggered' => false,
-            'eventSettings'   => [],
-        ];
-
-        $event           = new CampaignExecutionEvent($args, false, $log);
+        $eventAccessor   = new ActionAccessor([]);
+        $event           = new PendingEvent($eventAccessor, $campaignEvent, new ArrayCollection([$log]));
         $eventDispatcher = self::getContainer()->get(EventDispatcherInterface::class);
-        $eventDispatcher->dispatch($event, 'mautic.lead.on_campaign_trigger_action');
+        $eventDispatcher->dispatch($event, LeadEvents::ON_CAMPAIGN_BATCH_ACTION);
 
         $leadManipulator = $lead->getManipulator();
         $this->assertInstanceOf(LeadManipulator::class, $leadManipulator);

--- a/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberTest.php
@@ -224,20 +224,19 @@ final class CampaignSubscriberTest extends \PHPUnit\Framework\TestCase
                 }
             );
 
-        $args = [
-            'lead'  => $lead,
-            'event' => [
-                'type'       => 'lead.updatecompany',
-                'properties' => $this->configTo,
-            ],
-            'eventDetails'    => [],
-            'systemTriggered' => true,
-            'eventSettings'   => [],
-        ];
+        $campaignEvent = new Event();
+        $campaignEvent->setType('lead.updatecompany');
+        $campaignEvent->setProperties($this->configTo);
 
-        $event = new CampaignExecutionEvent($args, true);
-        $this->subscriber->onCampaignTriggerActionUpdateCompany($event);
-        $this->assertTrue($event->getResult());
+        $leadEventLog = $this->createMock(LeadEventLog::class);
+        $leadEventLog->method('getLead')->willReturn($lead);
+        $leadEventLog->method('getId')->willReturn(1);
+
+        $pendingEvent = new PendingEvent($this->createStub(ActionAccessor::class), $campaignEvent, new ArrayCollection([$leadEventLog]));
+        $this->subscriber->onCampaignTriggerActionUpdateCompany($pendingEvent);
+
+        $this->assertCount(1, $pendingEvent->getSuccessful());
+        $this->assertCount(0, $pendingEvent->getFailures());
 
         $primaryCompany = $lead->getPrimaryCompany();
         $this->assertSame($this->configTo['companyname'], $primaryCompany['companyname']);


### PR DESCRIPTION
> **Draft** — this migrates core campaign-execution behavior. I could not run the DB-backed campaign functional tests locally; relying on CI. Please review the behavioral notes below.

Removes the deprecated constant `LeadEvents::ON_CAMPAIGN_TRIGGER_ACTION` (`mautic.lead.on_campaign_trigger_action`).

### Why it's more than a constant delete
The constant was the **live** `eventName` for 8 built-in lead actions, each with a per-contact handler on the (also-deprecated) `CampaignExecutionEvent`. The framework direction is batch execution (`ON_CAMPAIGN_BATCH_ACTION` + `PendingEvent`) — `lead.updatelead` already ran there. This PR moves the remaining 7 actions **and** the cross-cutting set-manipulator listener onto the batch event, keeping the existing `checkContext()`-gated, shared-event architecture.

### What changed
- **Registration** (`onCampaignBuild`): the 7 actions flip `'eventName' => ON_CAMPAIGN_TRIGGER_ACTION` → `'batchEventName' => ON_CAMPAIGN_BATCH_ACTION`.
- **Handlers**: converted from `CampaignExecutionEvent` (single contact) to `PendingEvent` (loop `getPending()`, `pass()`/`fail()` per log). Config now read via `$event->getEvent()->getProperties()`; event id/name/campaign via the `Event` entity getters instead of array access.
- **set-manipulator**: stays a priority-100 listener but on the batch event; it only mutates the leads and intentionally does **not** `pass()`/`fail()` (so it can't drain the batch before the matching action handler runs).
- **`CampaignActionDeleteContactSubscriber`**: dropped the BC `eventName => ON_CAMPAIGN_TRIGGER_ACTION` line; its real handler already used a dedicated batch event.
- Tests updated to the batch event/`PendingEvent`.

```php
// before
public function onCampaignTriggerActionChangePoints(CampaignExecutionEvent $event): void
{
    $lead = $event->getLead();
    // ...
    $event->setResult($somethingHappened);
}
// after
public function onCampaignTriggerActionChangePoints(PendingEvent $event): void
{
    foreach ($event->getPending() as $log) {
        $lead = $log->getLead();
        // ...
        $event->pass($log);
    }
}
```

### Behavioral notes for reviewers (the forks)
1. **`setResult(false)` → `pass()`**: the old handlers used `setResult(false)` for no-op cases (e.g. empty config). A no-op is treated as a **pass** (action executed, no failure), matching how `lead.updatelead` already behaved. Only `changeCompanyScore`'s `setFailed('mautic.lead.no_company')` maps to `fail($log, ...)`.
2. **set-manipulator now also covers `lead.updatelead`**: previously it lived on `ON_CAMPAIGN_TRIGGER_ACTION` while `updatelead` was on the batch event, so update-contact never got a campaign manipulator. Now all lead actions share the batch event, so it does. Arguably a fix; flagging as a behavior change.
