### PR TITLE
[removal] remove deprecated Mautic v1 theme fallback from PublicController

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -6,6 +6,7 @@
 
 ## Removed code
 
+- Deprecated Mautic v1 theme fallback removed from `Mautic\PageBundle\Controller\PublicController::indexAction()`. Public pages are now rendered solely from `Page::getCustomHtml()`; the legacy path that rendered `Page::getContent()` through a `@themes/<template>/html/page.html.twig` theme template (used when `customHtml` was empty) is gone. The unused `ThemeHelper` argument was dropped from `indexAction()`.
 - Deprecated method `Mautic\LeadBundle\Model\LeadModel::isContactable()` removed. Use `Mautic\LeadBundle\Model\DoNotContact::isContactable()` instead.
 - Deprecated method `Mautic\CampaignBundle\EventCollector\Builder\ConnectionBuilder::addDeprecatedAnchorRestrictions()` removed. With it, the campaign event keys `associatedActions`, `associatedDecisions` and `anchorRestrictions` are no longer read. Use the `connectionRestrictions` key instead:
 

--- a/app/bundles/PageBundle/Controller/PublicController.php
+++ b/app/bundles/PageBundle/Controller/PublicController.php
@@ -53,7 +53,6 @@ final class PublicController extends AbstractFormController
         CookieHelper $cookieHelper,
         AnalyticsHelper $analyticsHelper,
         AssetsHelper $assetsHelper,
-        ThemeHelper $themeHelper,
         Tracking404Model $tracking404Model,
         RouterInterface $router,
         DeviceTrackingServiceInterface $deviceTrackingService,
@@ -245,40 +244,13 @@ final class PublicController extends AbstractFormController
             // Generate contents
             $analytics = $analyticsHelper->getCode();
 
-            $BCcontent = $entity->getContent();
-            $content   = $entity->getCustomHtml();
-            // This condition remains so the Mautic v1 themes would display the content
-            if (empty($content) && !empty($BCcontent)) {
-                /**
-                 * @deprecated  BC support to be removed in 3.0
-                 */
-                $template = $entity->getTemplate();
-                // all the checks pass so display the content
-                $content = $entity->getContent();
+            $content = $entity->getCustomHtml();
 
-                // Add the GA code to the template assets
-                if (!empty($analytics)) {
-                    $assetsHelper->addCustomDeclaration($analytics);
-                }
-
-                $logicalName = $themeHelper->checkForTwigTemplate('@themes/'.$template.'/html/page.html.twig');
-
-                $content = $themeHelper->renderThemeTemplate(
-                    $logicalName,
-                    [
-                        'content'  => $content,
-                        'page'     => $entity,
-                        'template' => $template,
-                        'public'   => true,
-                    ]
-                );
-            } else {
-                if (!empty($analytics)) {
-                    $content = str_replace('</head>', $analytics."\n</head>", $content);
-                }
-                if ($entity->getNoIndex()) {
-                    $content = str_replace('</head>', "<meta name=\"robots\" content=\"noindex\">\n</head>", $content);
-                }
+            if (!empty($analytics)) {
+                $content = str_replace('</head>', $analytics."\n</head>", $content);
+            }
+            if ($entity->getNoIndex()) {
+                $content = str_replace('</head>', "<meta name=\"robots\" content=\"noindex\">\n</head>", $content);
             }
 
             $assetsHelper->addScript(

--- a/app/bundles/PageBundle/Tests/Controller/PublicControllerTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PublicControllerTest.php
@@ -11,7 +11,6 @@ use Mautic\CoreBundle\Factory\ModelFactory;
 use Mautic\CoreBundle\Helper\CookieHelper;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\IpLookupHelper;
-use Mautic\CoreBundle\Helper\ThemeHelper;
 use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\CoreBundle\Service\FlashBag;
@@ -207,9 +206,6 @@ final class PublicControllerTest extends TestCase
             ->willReturn(new Lead());
 
         $this->request->attributes->set('ignore_mismatch', true);
-        $themeHelper = $this->createMock(ThemeHelper::class);
-        $themeHelper->expects($this->never())
-            ->method('checkForTwigTemplate');
 
         $controller = new PublicController(
             $this->createStub(ManagerRegistry::class),
@@ -230,7 +226,6 @@ final class PublicControllerTest extends TestCase
             $this->createStub(CookieHelper::class),
             $analyticsHelper,
             $assetHelper,
-            $themeHelper,
             $this->createStub(Tracking404Model::class),
             $this->router,
             $this->createStub(DeviceTrackingServiceInterface::class),


### PR DESCRIPTION
## Removal

Removes the deprecated **Mautic v1 theme fallback** in `PublicController::indexAction()`.
It was marked `@deprecated BC support to be removed in 3.0`; we are on 8.x.

The branch rendered `Page::getContent()` through a `@themes/<template>/html/page.html.twig`
theme template whenever `customHtml` was empty. Public pages are now rendered solely from
`Page::getCustomHtml()`. The now-unused `ThemeHelper` argument was dropped from `indexAction()`.

```diff
-            $BCcontent = $entity->getContent();
-            $content   = $entity->getCustomHtml();
-            // This condition remains so the Mautic v1 themes would display the content
-            if (empty($content) && !empty($BCcontent)) {
-                /**
-                 * @deprecated  BC support to be removed in 3.0
-                 */
-                $template = $entity->getTemplate();
-                // all the checks pass so display the content
-                $content = $entity->getContent();
-
-                if (!empty($analytics)) {
-                    $assetsHelper->addCustomDeclaration($analytics);
-                }
-
-                $logicalName = $themeHelper->checkForTwigTemplate('@themes/'.$template.'/html/page.html.twig');
-                $content = $themeHelper->renderThemeTemplate($logicalName, [...]);
-            } else {
-                if (!empty($analytics)) {
-                    $content = str_replace('</head>', $analytics."\n</head>", $content);
-                }
-                if ($entity->getNoIndex()) {
-                    $content = str_replace('</head>', "<meta name=\"robots\" content=\"noindex\">\n</head>", $content);
-                }
-            }
+            $content = $entity->getCustomHtml();
+
+            if (!empty($analytics)) {
+                $content = str_replace('</head>', $analytics."\n</head>", $content);
+            }
+            if ($entity->getNoIndex()) {
+                $content = str_replace('</head>', "<meta name=\"robots\" content=\"noindex\">\n</head>", $content);
+            }
```

`UPGRADE-8.0.md` updated under **Removed code**.

> Note: `previewAction()` still carries the same (untagged) legacy pattern; left untouched to keep this PR scoped to the `@deprecated` site.
