### PR TITLE
Fix: Tags page ajax list refresh (sort/paginate) duplicates the search/filter toolbar

### DIFF
--- a/plugins/MauticTagManagerBundle/Resources/views/Tag/list.html.twig
+++ b/plugins/MauticTagManagerBundle/Resources/views/Tag/list.html.twig
@@ -13,6 +13,7 @@
 {% set listCommand = 'mautic.tagmanager.tag.searchcommand.list'|trans %}
 
 {% block content %}
+{% if isIndex %}
     <div id="page-list-wrapper" class="{% if items|length > 0 or searchValue is not empty %}panel {% endif %}panel-default">
         {{- include('@MauticCore/Helper/list_toolbar.html.twig', {
             'searchValue': searchValue,
@@ -33,139 +34,146 @@
             },
         }) -}}
         <div class="page-list">
-            {% if items is defined and items is not empty %}
-                <div class="table-responsive">
-                    <table class="table table-hover" id="tagsTable">
-                        <thead>
-                        <tr>
-                            {{ include('@MauticCore/Helper/tableheader.html.twig', {
-                                'checkall': 'true',
-                                'target': '#tagsTable',
-                            }) }}
-                            {{ include(
-                                '@MauticCore/Helper/tableheader.html.twig',
-                                {
-                                    'sessionVar': 'tags',
-                                    'orderBy'   : 'lt.tag',
-                                    'text'      : 'mautic.core.name',
-                                    'class'     : 'col-tag-name',
-                                }
-                            ) }}
-
-                            {{ include(
-                                '@MauticCore/Helper/tableheader.html.twig',
-                                {
-                                    'sessionVar' : 'tags',
-                                    'text'       : 'mautic.lead.list.thead.leadcount',
-                                    'class'      : 'visible-md visible-lg col-tag-leadcount',
-                                }
-                            ) }}
-
-                            {{ include(
-                                '@MauticCore/Helper/tableheader.html.twig',
-                                {
-                                    'sessionVar' : 'tags',
-                                    'orderBy'    : 'lt.id',
-                                    'text'       : 'mautic.core.id',
-                                    'class'      : 'visible-md visible-lg col-tag-id',
-                                }
-                            ) }}
-                        </tr>
-                        </thead>
-                        <tbody>
-                        {% for item in items %}
-                            <tr>
-                                <td>
-                                    {{- include('@MauticCore/Helper/list_actions.html.twig', {
-                                        item: item,
-                                        templateButtons: {
-                                            edit: permissions['tagManager:tagManager:edit'],
-                                            delete: permissions['tagManager:tagManager:delete'],
-                                        },
-                                        routeBase: 'tagmanager',
-                                        langVar: 'tagmanager.tag',
-                                        nameGetter: nameGetter,
-                                        custom: {
-                                            0: {
-                                                attr : {
-                                                    'data-toggle': 'ajax',
-                                                    href: '',
-                                                },
-                                                icon: 'ri-team-line',
-                                                label: 'mautic.lead.list.view_contacts'
-                                            }
-                                        }
-                                    }) -}}
-                                </td>
-                                <td>
-                                    <div>
-                                        {% if permissions['tagManager:tagManager:edit'] %}
-                                            <a href="{{ path('mautic_tagmanager_action', {
-                                                objectAction: 'view',
-                                                objectId: item.getId()
-                                            }) }}" data-toggle="ajax">
-                                                {{ item.getTag() }}
-                                            </a>
-                                        {% else %}
-                                            {{ item.getTag() }}
-                                        {% endif %}
-                                        {{ customContent('tag.name', _context) }}
-                                    </div>
-                                    {% set description = item.getDescription() %}
-                                    {% if description %}
-                                        {{ include('@MauticCore/Helper/description--inline.html.twig', {
-                                            'description': description
-                                        }) }}
-                                    {% endif %}
-                                </td>
-                                <td class="visible-md visible-lg">
-                                    <a size="sm" class="label label-gray" href="{{-  path('mautic_contact_index', {
-                                        'search' : "#{'mautic.tagmanager.lead.searchcommand.list'|trans}:\"#{item.getTag()}\"",
-                                    }) -}}" data-toggle="ajax" {{- 0 == tagsCount[item.getId()] ? 'disabled=disabled' : '' -}}>
-                                    {{- 'mautic.lead.list.viewleads_count'|trans({'%count%': tagsCount[item.getId()]}) -}}
-                                    </a>
-                                </td>
-                                <td class="visible-md visible-lg">{{ item.getId() }}</td>
-                            </tr>
-                        {% endfor %}
-                        </tbody>
-                    </table>
-                    <div class="panel-footer">
-                        {{- include('@MauticCore/Helper/pagination.html.twig', {
-                            'totalItems' : items|length,
-                            'page'       : page,
-                            'limit'      : limit,
-                            'baseUrl'    : path('mautic_tagmanager_index'),
-                            'sessionVar' : 'tagmanager',
-                        }) -}}
-                    </div>
-                </div>
-            {% else %}
-                {% if searchValue is not empty %}
-                    {{- include('@MauticCore/Helper/noresults.html.twig') -}}
-                {% else %}
-                    <div class="mt-80 col-md-offset-2 col-lg-offset-3 col-md-8 col-lg-5 height-auto">
-                        {% set childContainer %}
-                            <div class="mt-32 mb-md">
-                                {% include '@MauticCore/Components/pictogram.html.twig' with {
-                                    'pictogram': 'tags',
-                                    'size': '80'
-                                } %}
-                            </div>
-                        {% endset %}
-            
-                        {{ include('@MauticCore/Components/content-block.html.twig', {
-                            heading: 'mautic.tagmanager.contentblock.heading',
-                            subheading: 'mautic.tagmanager.contentblock.subheading',
-                            copy: 'mautic.tagmanager.contentblock.copy',
-                            childContainer: childContainer,
-                        }) }}
-                    </div>
-                {% endif %}
-            {% endif %}
+            {{ block('listResults') }}
         </div>
     </div>
     {{ include('@MauticCore/Modules/protip.html.twig', {
         tip: random(['mautic.protip.tags.segmentation', 'mautic.protip.tags.multivalue', 'mautic.protip.tags.creation'])
     }) }}
+{% else %}
+    {{ block('listResults') }}
+{% endif %}
+{% endblock %}
+
+{% block listResults %}
+    {% if items is defined and items is not empty %}
+        <div class="table-responsive">
+            <table class="table table-hover" id="tagsTable">
+                <thead>
+                <tr>
+                    {{ include('@MauticCore/Helper/tableheader.html.twig', {
+                        'checkall': 'true',
+                        'target': '#tagsTable',
+                    }) }}
+                    {{ include(
+                        '@MauticCore/Helper/tableheader.html.twig',
+                        {
+                            'sessionVar': 'tags',
+                            'orderBy'   : 'lt.tag',
+                            'text'      : 'mautic.core.name',
+                            'class'     : 'col-tag-name',
+                        }
+                    ) }}
+
+                    {{ include(
+                        '@MauticCore/Helper/tableheader.html.twig',
+                        {
+                            'sessionVar' : 'tags',
+                            'text'       : 'mautic.lead.list.thead.leadcount',
+                            'class'      : 'visible-md visible-lg col-tag-leadcount',
+                        }
+                    ) }}
+
+                    {{ include(
+                        '@MauticCore/Helper/tableheader.html.twig',
+                        {
+                            'sessionVar' : 'tags',
+                            'orderBy'    : 'lt.id',
+                            'text'       : 'mautic.core.id',
+                            'class'      : 'visible-md visible-lg col-tag-id',
+                        }
+                    ) }}
+                </tr>
+                </thead>
+                <tbody>
+                {% for item in items %}
+                    <tr>
+                        <td>
+                            {{- include('@MauticCore/Helper/list_actions.html.twig', {
+                                item: item,
+                                templateButtons: {
+                                    edit: permissions['tagManager:tagManager:edit'],
+                                    delete: permissions['tagManager:tagManager:delete'],
+                                },
+                                routeBase: 'tagmanager',
+                                langVar: 'tagmanager.tag',
+                                nameGetter: nameGetter,
+                                custom: {
+                                    0: {
+                                        attr : {
+                                            'data-toggle': 'ajax',
+                                            href: '',
+                                        },
+                                        icon: 'ri-team-line',
+                                        label: 'mautic.lead.list.view_contacts'
+                                    }
+                                }
+                            }) -}}
+                        </td>
+                        <td>
+                            <div>
+                                {% if permissions['tagManager:tagManager:edit'] %}
+                                    <a href="{{ path('mautic_tagmanager_action', {
+                                        objectAction: 'view',
+                                        objectId: item.getId()
+                                    }) }}" data-toggle="ajax">
+                                        {{ item.getTag() }}
+                                    </a>
+                                {% else %}
+                                    {{ item.getTag() }}
+                                {% endif %}
+                                {{ customContent('tag.name', _context) }}
+                            </div>
+                            {% set description = item.getDescription() %}
+                            {% if description %}
+                                {{ include('@MauticCore/Helper/description--inline.html.twig', {
+                                    'description': description
+                                }) }}
+                            {% endif %}
+                        </td>
+                        <td class="visible-md visible-lg">
+                            <a size="sm" class="label label-gray" href="{{-  path('mautic_contact_index', {
+                                'search' : "#{'mautic.tagmanager.lead.searchcommand.list'|trans}:\"#{item.getTag()}\"",
+                            }) -}}" data-toggle="ajax" {{- 0 == tagsCount[item.getId()] ? 'disabled=disabled' : '' -}}>
+                            {{- 'mautic.lead.list.viewleads_count'|trans({'%count%': tagsCount[item.getId()]}) -}}
+                            </a>
+                        </td>
+                        <td class="visible-md visible-lg">{{ item.getId() }}</td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+            <div class="panel-footer">
+                {{- include('@MauticCore/Helper/pagination.html.twig', {
+                    'totalItems' : items|length,
+                    'page'       : page,
+                    'limit'      : limit,
+                    'baseUrl'    : path('mautic_tagmanager_index'),
+                    'sessionVar' : 'tagmanager',
+                }) -}}
+            </div>
+        </div>
+    {% else %}
+        {% if searchValue is not empty %}
+            {{- include('@MauticCore/Helper/noresults.html.twig') -}}
+        {% else %}
+            <div class="mt-80 col-md-offset-2 col-lg-offset-3 col-md-8 col-lg-5 height-auto">
+                {% set childContainer %}
+                    <div class="mt-32 mb-md">
+                        {% include '@MauticCore/Components/pictogram.html.twig' with {
+                            'pictogram': 'tags',
+                            'size': '80'
+                        } %}
+                    </div>
+                {% endset %}
+
+                {{ include('@MauticCore/Components/content-block.html.twig', {
+                    heading: 'mautic.tagmanager.contentblock.heading',
+                    subheading: 'mautic.tagmanager.contentblock.subheading',
+                    copy: 'mautic.tagmanager.contentblock.copy',
+                    childContainer: childContainer,
+                }) }}
+            </div>
+        {% endif %}
+    {% endif %}
 {% endblock %}

--- a/plugins/MauticTagManagerBundle/Tests/Functional/Controller/TagControllerTest.php
+++ b/plugins/MauticTagManagerBundle/Tests/Functional/Controller/TagControllerTest.php
@@ -96,6 +96,35 @@ final class TagControllerTest extends MauticMysqlTestCase
         $this->assertStringNotContainsString('tag2', (string) $clientResponseContent, 'The return must not contain unrelated tags.');
     }
 
+    /**
+     * Regression test for https://github.com/mautic/mautic/issues/15969: clicking a sortable
+     * column header (or any other ajax list refresh - pagination, per-page limit) re-requests
+     * the index action with tmpl=list. That must return only the table/pagination fragment,
+     * the same way every other entity list in Mautic behaves, not the full page-list-wrapper
+     * with a second copy of the search/filter toolbar nested inside the ajax target.
+     */
+    public function testIndexActionAjaxReorderDoesNotDuplicateToolbar(): void
+    {
+        $this->client->request(
+            'POST',
+            '/s/tags?tmpl=list&name=tags&orderby=lt.tag',
+            [],
+            [],
+            $this->createAjaxHeaders()
+        );
+        $clientResponse = $this->client->getResponse();
+        $this->assertResponseIsSuccessful();
+
+        $json = json_decode((string) $clientResponse->getContent(), true);
+        $this->assertIsArray($json);
+        $this->assertArrayHasKey('newContent', $json, 'Response should contain the re-rendered list HTML: '.(string) $clientResponse->getContent());
+
+        $html = (string) $json['newContent'];
+        $this->assertStringContainsString('id="tagsTable"', $html, 'The ajax reorder response must still contain the tags table.');
+        $this->assertStringNotContainsString('toolbar--table-toolbar', $html, 'The ajax reorder response must not re-render the search/filter toolbar.');
+        $this->assertStringNotContainsString('page-list-wrapper', $html, 'The ajax reorder response must not re-render the index-only page wrapper.');
+    }
+
     public function testTagDeletion(): void
     {
         $tagId = $this->tagRepository->findOneBy([])->getId();


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | Fixes #15969

## Description

On the Tags page, clicking a sortable column header (or paginating, or changing the per-page limit) re-requests `TagController::indexAction` with `tmpl=list` and swaps the response HTML into the existing `.page-list` element via `Mautic.loadContent()`. That's the standard ajax-refresh pattern used by every list page in Mautic.

`Tag/list.html.twig` rendered the full `#page-list-wrapper` - including a second copy of `list_toolbar.html.twig` (the search box and bulk-action toolbar) - on *every* request, not just the initial index load. So the ajax response for a sort/paginate/filter action contains a whole extra `page-list-wrapper` + toolbar nested inside the `.page-list` div it's replacing, and a second search/filter toolbar visibly appears above the table.

I compared against every other entity list template in the codebase (Stage, Contact, Company, Campaign, Email, Page, etc.). All of them guard the toolbar with `{% if isIndex %}` (`isIndex = tmpl == 'index'`), rendering only the table/pagination fragment - typically via a separate `listResults`-style block - when the request isn't the initial full-page load. `Tag/list.html.twig` was the one list template missing that split; it rendered the same markup unconditionally regardless of `tmpl`.

## Fix

Restructured `Tag/list.html.twig` to match the established pattern: the toolbar and outer `#page-list-wrapper` now only render when `isIndex` is true, and the table + empty-state markup moved into their own `listResults` block that both the index and ajax-fragment branches call. No behavior change for a normal full-page load - same markup, just conditioned correctly for the ajax case.

## Verification

Added `testIndexActionAjaxReorderDoesNotDuplicateToolbar` to `TagControllerTest`, which sends the same ajax request `Mautic.reorderTableData()` sends (`POST /s/tags?tmpl=list&name=tags&orderby=lt.tag` with the ajax/CSRF headers `createAjaxHeaders()` sets up) and asserts the JSON response's `newContent`:
- still contains the `tagsTable` table (the fragment isn't broken), and
- does **not** contain `toolbar--table-toolbar` or `page-list-wrapper` (no duplicated toolbar/wrapper).

To confirm the test actually catches the bug rather than passing trivially, I stashed just the template change (`git stash push -- .../Tag/list.html.twig`), reran the new test against the original unpatched template, and it failed on the `toolbar--table-toolbar` assertion - the fragment really does contain a second toolbar without the fix. Restored the fix (`git stash pop`) and the test passed again.

Ran the full `TagControllerTest` (21 tests) and the full `MauticTagManagerBundle` suite (35 tests) afterward - all green, no regressions. Also ran `bin/console lint:twig`, `php-cs-fixer --dry-run`, and `phpstan analyse` against the changed files - all clean.

---
### 📋 Steps to test this PR:

1. Open this PR on GitHub Codespaces or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Go to **Settings > Tags** (or `/s/tags`) with a few tags present.
3. Open your browser's dev tools and click the "Name" or "ID" column header to sort.
4. Before this fix: a second search/filter bar appears nested above the table. After this fix: only the table re-sorts, no duplicate toolbar.
5. Optionally run `bin/phpunit --filter testIndexActionAjaxReorderDoesNotDuplicateToolbar plugins/MauticTagManagerBundle/Tests/Functional/Controller/TagControllerTest.php`
