### PR TITLE
[removal] remove deprecated Form::formType (unused since 7.1)

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -6,6 +6,7 @@
 
 ## Removed code
 
+- Deprecated form type removed from `Mautic\FormBundle\Entity\Form`. Form types were no longer used, so the `$formType` property, the `getFormType()` method, the `form_type` ORM mapping and the `formType` API field are gone. The `form_type` database column is dropped by a migration. The `formType`/`form_type` key is no longer read from or written to the API, and is dropped from form export payloads.
 - Deprecated Mautic v1 theme fallback removed from `Mautic\PageBundle\Controller\PublicController::indexAction()`. Public pages are now rendered solely from `Page::getCustomHtml()`; the legacy path that rendered `Page::getContent()` through a `@themes/<template>/html/page.html.twig` theme template (used when `customHtml` was empty) is gone. The unused `ThemeHelper` argument was dropped from `indexAction()`.
 - Deprecated method `Mautic\LeadBundle\Model\LeadModel::isContactable()` removed. Use `Mautic\LeadBundle\Model\DoNotContact::isContactable()` instead.
 - Deprecated method `Mautic\CampaignBundle\EventCollector\Builder\ConnectionBuilder::addDeprecatedAnchorRestrictions()` removed. With it, the campaign event keys `associatedActions`, `associatedDecisions` and `anchorRestrictions` are no longer read. Use the `connectionRestrictions` key instead:

--- a/app/bundles/FormBundle/Entity/Form.php
+++ b/app/bundles/FormBundle/Entity/Form.php
@@ -168,14 +168,6 @@ class Form extends FormEntity implements UuidInterface
     public int $submission_count = 0;
 
     /**
-     * @var string|null
-     *
-     * @deprecated since Mautic 7.1, will be removed in 8.0. Form types are no longer used.
-     */
-    #[Groups(['form:read', 'form:write', 'download:read', 'campaign:read', 'email:read'])]
-    private $formType = 'standalone';
-
-    /**
      * @var bool|null
      */
     #[Groups(['form:read', 'form:write', 'download:read', 'campaign:read', 'email:read'])]
@@ -300,8 +292,6 @@ class Form extends FormEntity implements UuidInterface
             ->columnName('submission_count')
             ->build();
 
-        $builder->addNullableField('formType', 'string', 'form_type');
-
         $builder->createField('noIndex', 'boolean')
             ->columnName('no_index')
             ->nullable()
@@ -360,7 +350,6 @@ class Form extends FormEntity implements UuidInterface
                     'template',
                     'inKioskMode',
                     'renderStyle',
-                    'formType',
                     'postAction',
                     'postActionProperty',
                     'noIndex',
@@ -762,18 +751,6 @@ class Form extends FormEntity implements UuidInterface
     public function isInKioskMode()
     {
         return $this->inKioskMode;
-    }
-
-    /**
-     * @deprecated since Mautic 7.1, will be removed in 8.0. Form types are no longer used.
-     *
-     * @return string|null
-     */
-    public function getFormType()
-    {
-        trigger_deprecation('mautic/mautic', '7.1', 'Form::getFormType() is deprecated and will be removed in 8.0.');
-
-        return $this->formType;
     }
 
     /**

--- a/app/bundles/FormBundle/EventListener/FormImportExportSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/FormImportExportSubscriber.php
@@ -69,7 +69,6 @@ final class FormImportExportSubscriber implements EventSubscriberInterface
             'cached_html'          => $form->getCachedHtml(),
             'post_action'          => $form->getPostAction(),
             'template'             => $form->getTemplate(),
-            'form_type'            => $form->getFormType(), // @phpstan-ignore-line
             'render_style'         => $form->getRenderStyle(),
             'post_action_property' => $form->getPostActionProperty(),
             'form_attr'            => $form->getFormAttributes(),

--- a/app/bundles/FormBundle/Tests/Controller/Api/FormApiControllerFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/Api/FormApiControllerFunctionalTest.php
@@ -107,7 +107,6 @@ final class FormApiControllerFunctionalTest extends MauticMysqlTestCase
         $formId = $response['form']['id'];
         $this->assertGreaterThan(0, $formId);
         $this->assertEquals($payload['name'], $response['form']['name']);
-        $this->assertEquals($payload['formType'], $response['form']['formType']);
         $this->assertEquals($payload['isPublished'], $response['form']['isPublished']);
         $this->assertEquals($payload['description'], $response['form']['description']);
         $this->assertIsArray($response['form']['fields']);
@@ -129,7 +128,6 @@ final class FormApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertResponseIsSuccessful();
         $this->assertSame($formId, $responsePatch['form']['id'], 'ID of the created form does not match with the edited one.');
         $this->assertEquals($expectedResponse['newName'], $responsePatch['form']['name']);
-        $this->assertEquals($payload['formType'], $responsePatch['form']['formType']);
         $this->assertEquals($payload['isPublished'], $responsePatch['form']['isPublished']);
         $this->assertEquals($payload['description'], $responsePatch['form']['description']);
         $this->assertIsArray($responsePatch['form']['fields']);
@@ -280,7 +278,6 @@ final class FormApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertGreaterThan(0, $formId);
         $this->assertEquals($payload['name'], $response['form']['name']);
         $this->assertEquals($payload['description'], $response['form']['description']);
-        $this->assertEquals($payload['formType'], $response['form']['formType']);
         $this->assertNotEmpty($response['form']['cachedHtml']);
         $this->assertCount($fieldCount, $response['form']['fields']);
         $this->assertEquals($payload['fields'][0]['label'], $response['form']['fields'][0]['label']);
@@ -353,7 +350,6 @@ final class FormApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertEquals('API form renamed', $response['form']['name']);
         $this->assertEquals($payload['description'], $response['form']['description']);
         $this->assertCount($fieldCount, $response['form']['fields']);
-        $this->assertEquals($payload['formType'], $response['form']['formType']);
         $this->assertNotEmpty($response['form']['cachedHtml']);
 
         // Edit PUT:
@@ -368,7 +364,6 @@ final class FormApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertEquals($payload['name'], $response['form']['name']);
         $this->assertEquals('Form created via API test renamed', $response['form']['description']);
         $this->assertCount($fieldCount, $response['form']['fields']);
-        $this->assertEquals($payload['formType'], $response['form']['formType']);
         $this->assertNotEmpty($response['form']['cachedHtml']);
 
         // Get:
@@ -381,7 +376,6 @@ final class FormApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertEquals($payload['name'], $response['form']['name']);
         $this->assertEquals($payload['description'], $response['form']['description']);
         $this->assertCount($fieldCount, $response['form']['fields']);
-        $this->assertEquals($payload['formType'], $response['form']['formType']);
         $this->assertNotEmpty($response['form']['cachedHtml']);
 
         // Submit the form:
@@ -450,7 +444,6 @@ final class FormApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertEquals($payload['name'], $response['form']['name']);
         $this->assertEquals($payload['description'], $response['form']['description']);
         $this->assertCount($fieldCount, $response['form']['fields']);
-        $this->assertEquals($payload['formType'], $response['form']['formType']);
         $this->assertNotEmpty($response['form']['cachedHtml']);
 
         // Get (ensure that the form is gone):
@@ -519,7 +512,6 @@ final class FormApiControllerFunctionalTest extends MauticMysqlTestCase
         $formId = $response['form']['id'];
         $this->assertGreaterThan(0, $formId);
         $this->assertEquals($payload['name'], $response['form']['name']);
-        $this->assertEquals($payload['formType'], $response['form']['formType']);
         $this->assertEquals($payload['isPublished'], $response['form']['isPublished']);
         $this->assertEquals($payload['description'], $response['form']['description']);
         $this->assertIsArray($response['form']['fields']);

--- a/app/migrations/Version20260814141635.php
+++ b/app/migrations/Version20260814141635.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\Exception\SkipMigration;
+use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+
+final class Version20260814141635 extends AbstractMauticMigration
+{
+    protected const TABLE_NAME = 'forms';
+    private string $columnName  = 'form_type';
+
+    public function preUp(Schema $schema): void
+    {
+        if (!$schema->getTable($this->getPrefixedTableName())->hasColumn($this->columnName)) {
+            throw new SkipMigration('Column already removed');
+        }
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE `{$this->getPrefixedTableName()}` DROP COLUMN `{$this->columnName}`");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE `{$this->getPrefixedTableName()}` ADD COLUMN `{$this->columnName}` VARCHAR(255) DEFAULT NULL");
+    }
+}


### PR DESCRIPTION
## Description

Removes the long-deprecated **form type** from `Mautic\FormBundle\Entity\Form`.

It was deprecated in 7.1 (`@deprecated since Mautic 7.1, will be removed in 8.0. Form types are no longer used.`) and is due for removal in 8.0. Nothing in core reads it any more — the only remaining caller was the export subscriber, which carried a `@phpstan-ignore-line`.

## Notes

- The API writes went through `allow_extra_fields => true`, so clients still sending `formType` are silently ignored - no hard break. The field simply disappears from `form:read` responses.
- Migration drops `form_type` with a `preUp` guard (skips if the column is already gone) and a `down()` that re-adds it.
