### PR TITLE
[config] autoconfigure mautic.update_step and mautic.update_check tags

### DIFF
--- a/app/bundles/CoreBundle/Config/services.php
+++ b/app/bundles/CoreBundle/Config/services.php
@@ -176,27 +176,15 @@ return function (ContainerConfigurator $configurator): void {
     $services->get(Mautic\CoreBundle\Helper\ComposerHelper::class)
         ->arg('$logger', \Symfony\Component\DependencyInjection\Loader\Configurator\service('monolog.logger.mautic'));
 
-    $services->get(Mautic\CoreBundle\Update\Step\DeleteCacheStep::class)->tag('mautic.update_step');
-
-    $services->get(Mautic\CoreBundle\Update\Step\FinalizeUpdateStep::class)->tag('mautic.update_step');
-
-    $services->get(Mautic\CoreBundle\Update\Step\InstallNewFilesStep::class)->tag('mautic.update_step');
-
     $services->get(Mautic\CoreBundle\Update\Step\RemoveDeletedFilesStep::class)
-        ->arg('$logger', \Symfony\Component\DependencyInjection\Loader\Configurator\service('monolog.logger.mautic'))
-        ->tag('mautic.update_step');
-
-    $services->get(Mautic\CoreBundle\Update\Step\UpdateSchemaStep::class)->tag('mautic.update_step');
+        ->arg('$logger', \Symfony\Component\DependencyInjection\Loader\Configurator\service('monolog.logger.mautic'));
 
     $services->get(Mautic\CoreBundle\Update\Step\UpdateTranslationsStep::class)
-        ->arg('$logger', \Symfony\Component\DependencyInjection\Loader\Configurator\service('monolog.logger.mautic'))
-        ->tag('mautic.update_step');
+        ->arg('$logger', \Symfony\Component\DependencyInjection\Loader\Configurator\service('monolog.logger.mautic'));
 
-    $services->get(Mautic\CoreBundle\Update\Step\PreUpdateChecksStep::class)->tag('mautic.update_step');
+    $services->set(Mautic\CoreBundle\Helper\Update\PreUpdateChecks\CheckPhpVersion::class);
 
-    $services->set(Mautic\CoreBundle\Helper\Update\PreUpdateChecks\CheckPhpVersion::class)->tag('mautic.update_check');
-
-    $services->set(Mautic\CoreBundle\Helper\Update\PreUpdateChecks\CheckDatabaseDriverAndVersion::class)->tag('mautic.update_check');
+    $services->set(Mautic\CoreBundle\Helper\Update\PreUpdateChecks\CheckDatabaseDriverAndVersion::class);
 
     $services->get(Mautic\CoreBundle\Monolog\LogProcessor::class)->tag('monolog.processor');
 

--- a/app/bundles/CoreBundle/DependencyInjection/MauticCoreExtension.php
+++ b/app/bundles/CoreBundle/DependencyInjection/MauticCoreExtension.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\DependencyInjection;
 
+use Mautic\CoreBundle\Helper\Update\PreUpdateChecks\AbstractPreUpdateCheck;
 use Mautic\CoreBundle\Security\Permissions\AbstractPermissions;
+use Mautic\CoreBundle\Update\Step\StepInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
@@ -36,6 +38,12 @@ final class MauticCoreExtension extends Extension
     {
         $container->registerForAutoconfiguration(AbstractPermissions::class)
             ->addTag('mautic.permissions');
+
+        $container->registerForAutoconfiguration(StepInterface::class)
+            ->addTag('mautic.update_step');
+
+        $container->registerForAutoconfiguration(AbstractPreUpdateCheck::class)
+            ->addTag('mautic.update_check');
 
         // For the project:
         $loader = new PhpFileLoader($container, new FileLocator(__DIR__.'/../../../config'));


### PR DESCRIPTION
## Description

`autoconfigure()` already tags any service by the interface it implements. The 7 update steps all implement `StepInterface` and both pre-update checks extend `AbstractPreUpdateCheck`, yet each service still repeated the tag by hand in `CoreBundle/Config/services.php`.

## Change

Register autoconfiguration in `MauticCoreExtension::load()`:

```diff
 $container->registerForAutoconfiguration(AbstractPermissions::class)
     ->addTag('mautic.permissions');
+
+$container->registerForAutoconfiguration(StepInterface::class)
+    ->addTag('mautic.update_step');
+
+$container->registerForAutoconfiguration(AbstractPreUpdateCheck::class)
+    ->addTag('mautic.update_check');
```
