### PR TITLE
fix: GrapesJS email builder canvas- showing paragraph spacing in email builder 

### DIFF
--- a/plugins/GrapesJsBuilderBundle/Assets/library/js/plugins/grapesjs-ckeditor/editorLifecycle.js
+++ b/plugins/GrapesJsBuilderBundle/Assets/library/js/plugins/grapesjs-ckeditor/editorLifecycle.js
@@ -274,9 +274,12 @@ export const editorLifecycleMixin = {
       return;
     }
 
+    // Zero margins only for paragraphs inside list items so canvas <p> spacing matches
+    // preview/send. Keep inline-block on top-level editable paragraphs for editor layout.
+    // See https://github.com/mautic/mautic/issues/17047
     this.inlineStyles = createHtmlElem('style', head, {
       innerHTML:
-        `.ck-editor__editable>p {display: inline-block; margin-top: 0px !important; margin-bottom: 0px !important;}`,
+        `.ck-editor__editable>p {display: inline-block;} li p{margin-top:0px !important; margin-bottom:0px !important;}`,
     });
   },
 

--- a/plugins/GrapesJsBuilderBundle/Assets/library/js/plugins/grapesjs-ckeditor/index.js
+++ b/plugins/GrapesJsBuilderBundle/Assets/library/js/plugins/grapesjs-ckeditor/index.js
@@ -155,7 +155,9 @@ class Ck5ForGrapesJs {
         'style',
         this.frameDoc.querySelector('head'),
         {
-          innerHTML: `p{margin-top:0px !important; margin-bottom: 0px !important;} .ck.ck-sticky-panel__content{ border-bottom-width: 1px !important; } ` +
+          // Keep zero margins only inside lists so top-level <p> spacing shows in the canvas
+          // (Enter vs Shift+Enter). See https://github.com/mautic/mautic/issues/17047
+          innerHTML: `li p{margin-top:0px !important; margin-bottom: 0px !important;} .ck.ck-sticky-panel__content{ border-bottom-width: 1px !important; } ` +
             `.ck-button.token-tip-active { background-color: #fff9c4 !important; border: 1px solid #ffd54f !important; margin: 5px !important; padding: 5px 10px !important; cursor: default !important; pointer-events: none !important; width: calc(100% - 10px) !important; min-height: auto !important; display: block !important; box-shadow: none !important; } ` +
             `.ck-button.token-tip-active .ck-button__label { color: #333 !important; font-weight: normal !important; white-space: normal !important; text-align: left !important; font-size: 13px !important; } ` +
             `.ck-button.token-tip-active.ck-on, .ck-button.token-tip-active.ck-on:not(.ck-disabled):hover { background: #fff9c4 !important; border: 1px solid #ffd54f !important; box-shadow: none !important; } ` +


### PR DESCRIPTION

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌
| Related user documentation PR URL      | n/a
| Related developer documentation PR URL | n/a
| Issue(s) addressed                     | Fixes #17047

## Description

In the GrapesJS email builder canvas, pressing **Enter** (new paragraph) and **Shift+Enter** (line break) looked the same because canvas CSS forced paragraph margins to `0`. Preview and sent emails already showed normal spacing; only the builder canvas was wrong.

This change:

- Scopes the zero-margin rule to `li p` (list item paragraphs), so list layout stays tight
- Stops forcing top-level editable paragraphs to `margin: 0`, so Enter vs Shift+Enter is visible in the canvas

No PHP/backend changes. Automated tests are not included because this is canvas CSS behavior best verified manually in the builder.

| Before                                 | After
| -------------------------------------- | ---
| Enter and Shift+Enter look identical in the builder canvas | Enter shows a clear paragraph gap; Shift+Enter stays tighter |

---
### 📋 Steps to test this PR:

1. Open this PR on GitHub Codespaces or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Go to **Channels → Emails → New** and open the **GrapesJS** builder
3. Add a **text** block
4. Type a line, press **Enter**, type a second line
5. Confirm there is a **visible gap** between the two lines in the canvas (similar to Preview)
6. In the same text block, use **Shift+Enter** between two lines
7. Confirm that break is **tighter** than the Enter gap
8. Add a short **bullet/numbered list** and confirm list items still look normal (no odd extra spacing)
9. Open **Preview** and confirm Enter vs Shift+Enter still looks correct there as well
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->