### PR TITLE
[misc] import fqns, improve void types, remove dead-comments and remove just-variable property assigns

### DIFF
--- a/app/bundles/ApiBundle/Tests/Functional/Controller/CommonApiControllerTest.php
+++ b/app/bundles/ApiBundle/Tests/Functional/Controller/CommonApiControllerTest.php
@@ -10,6 +10,7 @@ use Mautic\CoreBundle\Tests\Functional\CreateTestEntitiesTrait;
 use Mautic\UserBundle\Entity\Role;
 use Mautic\UserBundle\Entity\User;
 use Mautic\UserBundle\Security\UserTokenSetter;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -28,7 +29,7 @@ final class CommonApiControllerTest extends MauticMysqlTestCase
         $this->assertInstanceOf(\DateTimeInterface::class, $email->getCheckedOut());
         $this->assertEquals('Admin User', $email->getCheckedOutByUser());
 
-        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_PATCH, '/api/emails/'.$email->getId().'/edit', [
+        $this->client->request(Request::METHOD_PATCH, '/api/emails/'.$email->getId().'/edit', [
             'name' => 'Updated Email',
         ]);
         $response = $this->client->getResponse();
@@ -67,7 +68,7 @@ final class CommonApiControllerTest extends MauticMysqlTestCase
 
         $this->createAndAuthenticateApiUser('api_lead_user', 'api-lead@example.com');
 
-        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_PATCH, '/api/contacts/'.$lead->getId().'/edit', [
+        $this->client->request(Request::METHOD_PATCH, '/api/contacts/'.$lead->getId().'/edit', [
             'firstname' => 'Updated Firstname',
         ]);
         $response = $this->client->getResponse();
@@ -94,7 +95,7 @@ final class CommonApiControllerTest extends MauticMysqlTestCase
         ];
 
         $this->client->request(
-            \Symfony\Component\HttpFoundation\Request::METHOD_PATCH,
+            Request::METHOD_PATCH,
             '/api/emails/batch/edit',
             [],
             [],

--- a/app/bundles/CampaignBundle/Controller/EventController.php
+++ b/app/bundles/CampaignBundle/Controller/EventController.php
@@ -13,6 +13,7 @@ use Mautic\CoreBundle\Twig\Helper\DateHelper;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\Service\Attribute\Required;
 
 final class EventController extends CommonFormController
@@ -60,7 +61,7 @@ final class EventController extends CommonFormController
     /**
      * Generates new form and processes post data.
      */
-    public function newAction(Request $request): JsonResponse|\Symfony\Component\HttpFoundation\Response
+    public function newAction(Request $request): JsonResponse|Response
     {
         $success = 0;
         $valid   = $cancelled   = false;
@@ -197,7 +198,7 @@ final class EventController extends CommonFormController
     /**
      * Generates edit form and processes post data.
      */
-    public function editAction(Request $request, string $objectId): JsonResponse|\Symfony\Component\HttpFoundation\Response
+    public function editAction(Request $request, string $objectId): JsonResponse|Response
     {
         $valid         = $cancelled = false;
         $method        = $request->getMethod();
@@ -526,7 +527,7 @@ final class EventController extends CommonFormController
         if (empty($event)) {
             return new JsonResponse([
                 'error' => $this->translator->trans('mautic.campaign.event.clone.request.missing'),
-            ], \Symfony\Component\HttpFoundation\Response::HTTP_BAD_REQUEST);
+            ], Response::HTTP_BAD_REQUEST);
         }
         $session->remove('mautic.campaign.events.clone.storage');
 

--- a/app/bundles/CampaignBundle/Controller/EventController.php
+++ b/app/bundles/CampaignBundle/Controller/EventController.php
@@ -409,7 +409,6 @@ final class EventController extends CommonFormController
     {
         $campaignId     = $request->query->get('campaignId');
         $this->setCampaignElements($request->request);
-        $modifiedEvents = $this->modifiedEvents;
         $deletedEvents  = $this->deletedEvents;
 
         // ajax only for form fields
@@ -425,7 +424,7 @@ final class EventController extends CommonFormController
             $this->throwAccessDenied();
         }
 
-        $event = $modifiedEvents[$objectId] ?? null;
+        $event = $this->modifiedEvents[$objectId] ?? null;
 
         if ('POST' === $request->getMethod() && null !== $event) {
             $events = $this->eventCollector->getEventsArray();
@@ -476,7 +475,6 @@ final class EventController extends CommonFormController
         $campaignId     = $request->query->get('campaignId');
         $session        = $request->getSession();
         $this->setCampaignElements($request->request);
-        $modifiedEvents = $this->modifiedEvents;
         $campaign       = $this->campaignModel->getEntity($campaignId);
 
         // ajax only for form fields
@@ -492,7 +490,7 @@ final class EventController extends CommonFormController
             $this->throwAccessDenied();
         }
 
-        $event = $modifiedEvents[$objectId] ?? null;
+        $event = $this->modifiedEvents[$objectId] ?? null;
 
         if ('POST' === $request->getMethod() && null !== $event) {
             $keyId          = 'new'.hash('sha1', uniqid((string) mt_rand()));

--- a/app/bundles/CampaignBundle/Entity/LeadEventLog.php
+++ b/app/bundles/CampaignBundle/Entity/LeadEventLog.php
@@ -509,9 +509,7 @@ class LeadEventLog implements ChannelInterface, OptimisticLockInterface
 
     public function isFailed(): bool
     {
-        $log = $this->failedLog;
-
-        return !empty($log);
+        return !empty($this->failedLog);
     }
 
     public function isSuccess(): bool

--- a/app/bundles/CoreBundle/Controller/AbstractStandardFormController.php
+++ b/app/bundles/CoreBundle/Controller/AbstractStandardFormController.php
@@ -88,14 +88,14 @@ abstract class AbstractStandardFormController extends AbstractFormController
     /**
      * Called after the entity has been persisted allowing for custom preperation of $entity prior to viewAction.
      */
-    protected function afterEntitySave($entity, Form $form, $action, $pass = null)
+    protected function afterEntitySave($entity, Form $form, $action, $pass = null): void
     {
     }
 
     /**
      * Called after the form is validated on POST.
      */
-    protected function afterFormProcessed($isValid, $entity, Form $form, $action, $isClone = false)
+    protected function afterFormProcessed($isValid, $entity, Form $form, $action, $isClone = false): void
     {
     }
 
@@ -183,7 +183,7 @@ abstract class AbstractStandardFormController extends AbstractFormController
     /**
      * Do anything necessary before the form is checked for POST and processed.
      */
-    protected function beforeFormProcessed($entity, Form $form, $action, $isPost, $objectId = null, $isClone = false)
+    protected function beforeFormProcessed($entity, Form $form, $action, $isPost, $objectId = null, $isClone = false): void
     {
     }
 

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -1319,10 +1319,9 @@ class MailHelper
             - if 'Disable unsubscribe link in header' setting is true in email configuration
         */
 
-        $email               = $this->email;
         $unsubscribeBodyText = $this->coreParametersHelper->get('unsubscribe_text') ?? '';
-        if (!$email
-            || $email->getSendToDnc()
+        if (!$this->email
+            || $this->email->getSendToDnc()
             || $this->coreParametersHelper->get('disable_unsubscribe_link_header')
             || !self::isUnsubscribeHeadersRequired($this->getBody(), $unsubscribeBodyText)) {
             return $headers;
@@ -1940,22 +1939,20 @@ class MailHelper
 
     private function setFromForSingleMessage(): void
     {
-        $email = $this->email;
-
-        if ($this->lead && $email && $email->getUseOwnerAsMailer()) {
+        if ($this->lead && $this->email && $this->email->getUseOwnerAsMailer()) {
             if (!isset($this->lead['owner_id'])) {
                 $this->lead['owner_id'] = 0;
             }
 
-            $from = $this->fromEmailHelper->getFromAddressConsideringOwner($this->getFrom(), $this->lead, $email);
+            $from = $this->fromEmailHelper->getFromAddressConsideringOwner($this->getFrom(), $this->lead, $this->email);
             $this->setMessageFrom($from);
 
             return;
         }
 
-        if ($email) {
-            $fromEmail = $email->getFromAddress();
-            $fromName  = $email->getFromName();
+        if ($this->email) {
+            $fromEmail = $this->email->getFromAddress();
+            $fromName  = $this->email->getFromName();
             if (!empty($fromEmail) || !empty($fromName)) {
                 if (empty($fromName)) {
                     $fromName = $this->getFrom()->getName();
@@ -1967,7 +1964,7 @@ class MailHelper
             }
         }
 
-        $from = $this->fromEmailHelper->getFromAddressDto($this->getFrom(), $this->lead, $email);
+        $from = $this->fromEmailHelper->getFromAddressDto($this->getFrom(), $this->lead, $this->email);
 
         $this->setMessageFrom($from);
     }

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -640,7 +640,6 @@ class MailHelper
     }
 
     /**
-     * Search and replace tokens
      * Adapted from \Swift_Plugins_DecoratorPlugin.
      *
      * @param array $search

--- a/app/bundles/LeadBundle/Entity/Lead.php
+++ b/app/bundles/LeadBundle/Entity/Lead.php
@@ -695,18 +695,15 @@ class Lead extends FormEntity implements CustomFieldEntityInterface, IdentifierF
      */
     public function getName($lastFirst = false)
     {
-        $firstName = $this->firstname;
-        $lastName  = $this->lastname;
-
         $fullName = '';
-        if ($lastFirst && $firstName && $lastName) {
-            $fullName = $lastName.', '.$firstName;
-        } elseif ($firstName && $lastName) {
-            $fullName = $firstName.' '.$lastName;
-        } elseif ($firstName) {
-            $fullName = $firstName;
-        } elseif ($lastName) {
-            $fullName = $lastName;
+        if ($lastFirst && $this->firstname && $this->lastname) {
+            $fullName = $this->lastname.', '.$this->firstname;
+        } elseif ($this->firstname && $this->lastname) {
+            $fullName = $this->firstname.' '.$this->lastname;
+        } elseif ($this->firstname) {
+            $fullName = $this->firstname;
+        } elseif ($this->lastname) {
+            $fullName = $this->lastname;
         }
 
         return $fullName;

--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -128,10 +128,6 @@ class ListModel extends FormModel implements GlobalSearchInterface
         $alias = $this->cleanAlias($alias, '', 0, '-');
 
         // make sure alias is not already taken
-<<<<<<< HEAD
-        $repo      = $this->getRepository();
-=======
->>>>>>> bba3ffabf5 ([php] remove just variable assigns)
         $testAlias = $alias;
 
         $existing  = $this->leadListRepository->getLists(null, $testAlias, $entity->getId(), false);

--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -128,15 +128,19 @@ class ListModel extends FormModel implements GlobalSearchInterface
         $alias = $this->cleanAlias($alias, '', 0, '-');
 
         // make sure alias is not already taken
+<<<<<<< HEAD
         $repo      = $this->getRepository();
+=======
+>>>>>>> bba3ffabf5 ([php] remove just variable assigns)
         $testAlias = $alias;
-        $existing  = $repo->getLists(null, $testAlias, $entity->getId(), false);
+
+        $existing  = $this->leadListRepository->getLists(null, $testAlias, $entity->getId(), false);
         $count     = count($existing);
         $aliasTag  = $count;
 
         while ($count) {
             $testAlias = $alias.$aliasTag;
-            $existing  = $repo->getLists(null, $testAlias, $entity->getId(), false);
+            $existing  = $this->leadListRepository->getLists(null, $testAlias, $entity->getId(), false);
             $count     = count($existing);
             ++$aliasTag;
         }
@@ -151,7 +155,7 @@ class ListModel extends FormModel implements GlobalSearchInterface
         }
 
         $event = $this->dispatchEvent('pre_save', $entity, $isNew);
-        $repo->saveEntity($entity);
+        $this->leadListRepository->saveEntity($entity);
         $this->dispatchEvent('post_save', $entity, $isNew, $event);
     }
 

--- a/app/bundles/LeadBundle/Tests/Controller/Api/TagApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/TagApiControllerFunctionalTest.php
@@ -7,6 +7,7 @@ namespace Mautic\LeadBundle\Tests\Controller\Api;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Tag;
 use Mautic\LeadBundle\Entity\TagRepository;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 final class TagApiControllerFunctionalTest extends MauticMysqlTestCase
@@ -16,7 +17,7 @@ final class TagApiControllerFunctionalTest extends MauticMysqlTestCase
         $tag1Payload = ['tag' => 'test_tag'];
 
         // Create new tag
-        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_POST, '/api/tags/new', $tag1Payload);
+        $this->client->request(Request::METHOD_POST, '/api/tags/new', $tag1Payload);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
         $tagId          = $response['tag']['id'];
@@ -26,7 +27,7 @@ final class TagApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertEquals($tag1Payload['tag'], $response['tag']['tag']);
 
         // Try to create tag with same name
-        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_POST, '/api/tags/new', $tag1Payload);
+        $this->client->request(Request::METHOD_POST, '/api/tags/new', $tag1Payload);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
         $this->assertResponseIsSuccessful('Return code must be 200.');
@@ -36,7 +37,7 @@ final class TagApiControllerFunctionalTest extends MauticMysqlTestCase
 
         // Edit tag name
         $tag1RenamePayload = ['tag' => 'tag_renamed'];
-        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_PATCH, "/api/tags/{$tagId}/edit", $tag1RenamePayload);
+        $this->client->request(Request::METHOD_PATCH, "/api/tags/{$tagId}/edit", $tag1RenamePayload);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
         $this->assertResponseIsSuccessful('Return code must be 200.');
@@ -44,7 +45,7 @@ final class TagApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertEquals($tag1RenamePayload['tag'], $response['tag']['tag']);
 
         // Get tag
-        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, "/api/tags/{$tagId}");
+        $this->client->request(Request::METHOD_GET, "/api/tags/{$tagId}");
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
         $this->assertResponseIsSuccessful();
@@ -52,12 +53,12 @@ final class TagApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertEquals($tag1RenamePayload['tag'], $response['tag']['tag']);
 
         // Delete:
-        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_DELETE, "/api/tags/{$tagId}/delete");
+        $this->client->request(Request::METHOD_DELETE, "/api/tags/{$tagId}/delete");
         $clientResponse = $this->client->getResponse();
         $this->assertResponseIsSuccessful($clientResponse->getContent());
 
         // Get (ensure it's deleted):
-        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, "/api/tags/{$tagId}");
+        $this->client->request(Request::METHOD_GET, "/api/tags/{$tagId}");
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 
@@ -74,7 +75,7 @@ final class TagApiControllerFunctionalTest extends MauticMysqlTestCase
         $whitespaceTestPayload = ['test', 'test ', ' test', "test\t", "\ttest"];
         $tagId                 = null;
         foreach ($whitespaceTestPayload as $payload) {
-            $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_POST, '/api/tags/new', ['tag' => $payload]);
+            $this->client->request(Request::METHOD_POST, '/api/tags/new', ['tag' => $payload]);
             $clientResponse = $this->client->getResponse();
             $response       = json_decode($clientResponse->getContent(), true);
 
@@ -95,7 +96,7 @@ final class TagApiControllerFunctionalTest extends MauticMysqlTestCase
     {
         $tagInputName    = 'hello" world';
 
-        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_POST, '/api/tags/new', ['tag' => $tagInputName]);
+        $this->client->request(Request::METHOD_POST, '/api/tags/new', ['tag' => $tagInputName]);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
         $tagId          = $response['tag']['id'];
@@ -103,7 +104,7 @@ final class TagApiControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertEquals($tagInputName, $response['tag']['tag']);
 
         // Try to create duplicate
-        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_POST, '/api/tags/new', ['tag' => $tagInputName]);
+        $this->client->request(Request::METHOD_POST, '/api/tags/new', ['tag' => $tagInputName]);
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
         $this->assertSame($tagId, $response['tag']['id'], 'ID of created tag does not match. Possible duplicates.');
@@ -113,7 +114,7 @@ final class TagApiControllerFunctionalTest extends MauticMysqlTestCase
     {
         // Sending an empty payload should return a 500 server error
         // TODO ensure that the server sends back a 400 status code instead
-        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_POST, '/api/tags/new', []);
+        $this->client->request(Request::METHOD_POST, '/api/tags/new', []);
 
         $this->assertResponseStatusCodeSame(500);
     }
@@ -129,7 +130,7 @@ final class TagApiControllerFunctionalTest extends MauticMysqlTestCase
         $tagRepository->saveEntity($matchingTag, false);
         $tagRepository->saveEntity($otherTag);
 
-        $this->client->request(\Symfony\Component\HttpFoundation\Request::METHOD_GET, '/api/tags?limit=1&search=test');
+        $this->client->request(Request::METHOD_GET, '/api/tags?limit=1&search=test');
         $clientResponse = $this->client->getResponse();
         $response       = json_decode($clientResponse->getContent(), true);
 

--- a/app/bundles/MessengerBundle/Message/EmailHitNotification.php
+++ b/app/bundles/MessengerBundle/Message/EmailHitNotification.php
@@ -12,7 +12,11 @@ final class EmailHitNotification
     use MessageRequestTrait;
 
     public function __construct(
+<<<<<<< HEAD
         private string $statId,
+=======
+        private readonly string $statId,
+>>>>>>> 1ebbe49a7c (avoid trait override)
         private Request $request,
         ?\DateTimeInterface $eventTime = null,
     ) {

--- a/app/bundles/MessengerBundle/Message/EmailHitNotification.php
+++ b/app/bundles/MessengerBundle/Message/EmailHitNotification.php
@@ -12,11 +12,7 @@ final class EmailHitNotification
     use MessageRequestTrait;
 
     public function __construct(
-<<<<<<< HEAD
-        private string $statId,
-=======
         private readonly string $statId,
->>>>>>> 1ebbe49a7c (avoid trait override)
         private Request $request,
         ?\DateTimeInterface $eventTime = null,
     ) {

--- a/app/bundles/MessengerBundle/Message/PageHitNotification.php
+++ b/app/bundles/MessengerBundle/Message/PageHitNotification.php
@@ -12,12 +12,21 @@ final class PageHitNotification
     use MessageRequestTrait;
 
     public function __construct(
+<<<<<<< HEAD
         private int $hitId,
         private Request $request,
         private bool $isNew,
         private bool $isRedirect,
         private ?int $pageId = null,
         private ?int $leadId = null,
+=======
+        private readonly int $hitId,
+        private Request $request,
+        private readonly bool $isNew,
+        private readonly bool $isRedirect,
+        private readonly ?int $pageId = null,
+        private readonly ?int $leadId = null,
+>>>>>>> 1ebbe49a7c (avoid trait override)
         ?\DateTimeInterface $eventTime = null,
     ) {
         $this->setEventTime($eventTime ?? new \DateTimeImmutable());

--- a/app/bundles/MessengerBundle/Message/PageHitNotification.php
+++ b/app/bundles/MessengerBundle/Message/PageHitNotification.php
@@ -12,21 +12,12 @@ final class PageHitNotification
     use MessageRequestTrait;
 
     public function __construct(
-<<<<<<< HEAD
-        private int $hitId,
-        private Request $request,
-        private bool $isNew,
-        private bool $isRedirect,
-        private ?int $pageId = null,
-        private ?int $leadId = null,
-=======
         private readonly int $hitId,
         private Request $request,
         private readonly bool $isNew,
         private readonly bool $isRedirect,
         private readonly ?int $pageId = null,
         private readonly ?int $leadId = null,
->>>>>>> 1ebbe49a7c (avoid trait override)
         ?\DateTimeInterface $eventTime = null,
     ) {
         $this->setEventTime($eventTime ?? new \DateTimeImmutable());

--- a/app/bundles/ReportBundle/Controller/ReportController.php
+++ b/app/bundles/ReportBundle/Controller/ReportController.php
@@ -526,7 +526,6 @@ final class ReportController extends FormController
     public function viewAction(Request $request, $objectId, $reportPage = 1): Response
     {
         $entity   = $this->reportModel->getEntity($objectId);
-        $security = $this->security;
 
         if (null === $entity) {
             $page = $request->getSession()->get('mautic.report.page', 1);
@@ -550,7 +549,7 @@ final class ReportController extends FormController
                 ]
             );
         }
-        if (!$security->hasEntityAccess('report:reports:viewown', 'report:reports:viewother', $entity->getCreatedBy())) {
+        if (!$this->security->hasEntityAccess('report:reports:viewown', 'report:reports:viewother', $entity->getCreatedBy())) {
             $this->throwAccessDenied();
         }
 
@@ -676,7 +675,7 @@ final class ReportController extends FormController
                     'reportDataResult' => $reportDataResult,
                     'tmpl'             => $request->isXmlHttpRequest() ? $request->get('tmpl', 'index') : 'index',
                     'limit'            => $reportData['limit'],
-                    'permissions'      => $security->isGranted(
+                    'permissions'      => $this->security->isGranted(
                         [
                             'report:reports:viewown',
                             'report:reports:viewother',
@@ -758,7 +757,6 @@ final class ReportController extends FormController
     public function exportAction(Request $request, $objectId, $format = 'csv'): Response
     {
         $entity   = $this->reportModel->getEntity($objectId);
-        $security = $this->security;
 
         if (null === $entity) {
             $page = $request->getSession()->get('mautic.report.page', 1);
@@ -782,7 +780,7 @@ final class ReportController extends FormController
                 ]
             );
         }
-        if (!$security->hasEntityAccess('report:reports:viewown', 'report:reports:viewother', $entity->getCreatedBy())) {
+        if (!$this->security->hasEntityAccess('report:reports:viewown', 'report:reports:viewother', $entity->getCreatedBy())) {
             $this->throwAccessDenied();
         } elseif (!$this->security->isAdmin() && !$this->security->isGranted('report:export:enable', 'MATCH_ONE')) {
             $this->throwAccessDenied();
@@ -864,13 +862,11 @@ final class ReportController extends FormController
         /** @var Report $report */
         $report = $this->reportModel->getEntity($reportId);
 
-        $security = $this->security;
-
         if (empty($report)) {
             return $this->notFound($this->translator->trans('mautic.report.notfound', ['%id%' => $reportId]));
         }
 
-        if (!$security->hasEntityAccess('report:reports:viewown', 'report:reports:viewother', $report->getCreatedBy())) {
+        if (!$this->security->hasEntityAccess('report:reports:viewown', 'report:reports:viewother', $report->getCreatedBy())) {
             $this->throwAccessDenied();
         }
 

--- a/app/bundles/UserBundle/Tests/Model/UserModelTest.php
+++ b/app/bundles/UserBundle/Tests/Model/UserModelTest.php
@@ -23,6 +23,7 @@ use Mautic\UserBundle\Entity\UserToken;
 use Mautic\UserBundle\Exception\PasswordResetTokenCreationFailedException;
 use Mautic\UserBundle\Model\UserModel;
 use Mautic\UserBundle\Model\UserToken\UserTokenServiceInterface;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -32,7 +33,7 @@ use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Twig\Environment;
 
-#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
+#[AllowMockObjectsWithoutExpectations]
 final class UserModelTest extends TestCase
 {
     private UserModel $userModel;

--- a/app/bundles/UserBundle/Tests/Security/SAML/Store/CredentialsStoreTest.php
+++ b/app/bundles/UserBundle/Tests/Security/SAML/Store/CredentialsStoreTest.php
@@ -8,10 +8,11 @@ use Composer\Autoload\ClassLoader;
 use LightSaml\Credential\X509Credential;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\UserBundle\Security\SAML\Store\CredentialsStore;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
+#[AllowMockObjectsWithoutExpectations]
 final class CredentialsStoreTest extends TestCase
 {
     private string $cacheDir;

--- a/app/bundles/WebhookBundle/Tests/Unit/Controller/WebhookControllerTest.php
+++ b/app/bundles/WebhookBundle/Tests/Unit/Controller/WebhookControllerTest.php
@@ -32,6 +32,7 @@ use Mautic\WebhookBundle\Http\Client;
 use Mautic\WebhookBundle\Model\WebhookModel;
 use Mautic\WebhookBundle\Service\WebhookService;
 use Mautic\WebhookBundle\WebhookEvents;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\StreamInterface;
@@ -44,7 +45,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
-#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
+#[AllowMockObjectsWithoutExpectations]
 final class WebhookControllerTest extends TestCase
 {
     #[DataProvider('provideNewOrUpdate')]

--- a/tests/_support/Helper/DbHelper.php
+++ b/tests/_support/Helper/DbHelper.php
@@ -99,7 +99,7 @@ final class DbHelper extends Module
         $this->runCommand($command, 'Populating database from dump.sql');
     }
 
-    private function runCommand($command, $description): void
+    private function runCommand($command, string $description): void
     {
         $process = Process::fromShellCommandline($command);
         $process->run();

--- a/tests/_support/Helper/EnvHelper.php
+++ b/tests/_support/Helper/EnvHelper.php
@@ -13,7 +13,7 @@ final class EnvHelper extends Module
     private string $envLocalBackupPath = '.env.local.e2e.backup';
     private bool $envLocalOverridden   = false;
 
-    public function _beforeSuite($settings = [])
+    public function _beforeSuite($settings = []): void
     {
         if ($this->isTestEnvironment()) {
             return;

--- a/utils/phpstan/src/Rule/NoNullableServiceInConstructorRule.php
+++ b/utils/phpstan/src/Rule/NoNullableServiceInConstructorRule.php
@@ -43,7 +43,7 @@ final class NoNullableServiceInConstructorRule implements Rule
     /**
      * @var string[]
      */
-    private const SKIPPED_EXACT_CLASSES = ['Mautic\\CoreBundle\\IpLookup\\AbstractLookup'];
+    private const SKIPPED_EXACT_CLASSES = [\Mautic\CoreBundle\IpLookup\AbstractLookup::class];
 
     public function __construct(
         private readonly ReflectionProvider $reflectionProvider,

--- a/utils/phpstan/src/Rule/NoParentConstructorForwardingRule.php
+++ b/utils/phpstan/src/Rule/NoParentConstructorForwardingRule.php
@@ -65,7 +65,7 @@ final class NoParentConstructorForwardingRule implements Rule
      * @var string[]
      */
     private const SKIPPED_CLASSES = [
-        'Mautic\ApiBundle\Controller\CommonApiController',
+        \Mautic\ApiBundle\Controller\CommonApiController::class,
     ];
 
     public function getNodeType(): string

--- a/utils/phpstan/src/Rule/NoServiceInMethodParameterRule.php
+++ b/utils/phpstan/src/Rule/NoServiceInMethodParameterRule.php
@@ -67,7 +67,7 @@ final class NoServiceInMethodParameterRule implements Rule
      */
     private const SKIPPED_TYPES = [
         'Symfony\\Component\\DependencyInjection\\ContainerBuilder',
-        'Mautic\\CoreBundle\\Translation\\Translator',
+        \Mautic\CoreBundle\Translation\Translator::class,
     ];
 
     /**
@@ -76,7 +76,7 @@ final class NoServiceInMethodParameterRule implements Rule
      *
      * @var array<string, string>
      */
-    private const SKIPPED_PARENT_CLASS_METHODS = ['Mautic\\CoreBundle\\Model\\FormModel' => 'createform'];
+    private const SKIPPED_PARENT_CLASS_METHODS = [\Mautic\CoreBundle\Model\FormModel::class => 'createform'];
 
     /**
      * A test case has no container to inject from - it fetches services itself and hands them to its own data
@@ -97,7 +97,7 @@ final class NoServiceInMethodParameterRule implements Rule
     private const SKIPPED_CLASS_TYPES = [
         'Symfony\\Contracts\\EventDispatcher\\Event',
         'Symfony\\Component\\EventDispatcher\\Event',
-        'Mautic\\CoreBundle\\Entity\\CommonEntity',
+        \Mautic\CoreBundle\Entity\CommonEntity::class,
         'Twig\\Extension\\AbstractExtension',
         'FOS\\OAuthServerBundle\\Controller\\AuthorizeController',
     ];

--- a/utils/rector/src/ModelGetRepositoryToRepositoryServiceRector.php
+++ b/utils/rector/src/ModelGetRepositoryToRepositoryServiceRector.php
@@ -56,7 +56,7 @@ final class ModelGetRepositoryToRepositoryServiceRector extends AbstractRector
      */
     private const TEST_CASE = 'PHPUnit\Framework\TestCase';
 
-    private const ABSTRACT_COMMON_MODEL = 'Mautic\CoreBundle\Model\AbstractCommonModel';
+    private const ABSTRACT_COMMON_MODEL = \Mautic\CoreBundle\Model\AbstractCommonModel::class;
 
     /**
      * Generic repository bases - a model that does not override getRepository() resolves to one of these,
@@ -64,7 +64,7 @@ final class ModelGetRepositoryToRepositoryServiceRector extends AbstractRector
      */
     private const GENERIC_REPOSITORIES = [
         'Doctrine\ORM\EntityRepository',
-        'Mautic\CoreBundle\Entity\CommonRepository',
+        \Mautic\CoreBundle\Entity\CommonRepository::class,
     ];
 
     public function __construct(


### PR DESCRIPTION
Small cleanup batch, no behavior change:

- Import fully-qualified names into `use` statements
- Improve `void` return types on `AbstractStandardFormController` and builder types
- Use class-constant `::class` type references
- Remove dead comments and dead initial assignments
- Inline single-use property-fetch variables, replace getter call with direct property fetch
- Mark a private property `readonly`
- Remove just-variable property assignments
