### PR TITLE
fix(reports): omit non-grouped columns from SELECT when GROUP BY is active

### DIFF
--- a/app/bundles/ReportBundle/Builder/MauticReportBuilder.php
+++ b/app/bundles/ReportBundle/Builder/MauticReportBuilder.php
@@ -183,27 +183,37 @@ final class MauticReportBuilder implements ReportBuilderInterface
         }
 
         // Build ORDER BY clause
+        $orderByColumns = [];
         if (!empty($options['order'])) {
             if (is_array($options['order'])) {
                 if (isset($options['order']['column'])) {
                     $queryBuilder->orderBy($options['order']['column'], $options['order']['direction']);
+                    $orderByColumns[] = $options['order']['column'];
                 } elseif (!empty($options['order'][0][1])) {
                     [$column, $dir] = $options['order'];
                     $queryBuilder->orderBy($column, $dir);
+                    $orderByColumns[] = $column;
                 } else {
                     foreach ($options['order'] as $order) {
                         $queryBuilder->orderBy($order);
+
+                        if (is_string($order)) {
+                            $orderByColumns[] = $order;
+                        }
                     }
                 }
             } else {
                 $queryBuilder->orderBy($options['order']);
+                $orderByColumns[] = $options['order'];
             }
         } elseif ($order = $this->entity->getTableOrder()) {
             foreach ($order as $o) {
                 if (!empty($options['columns'][$o['column']]['formula'])) {
                     $queryBuilder->orderBy($options['columns'][$o['column']]['formula'], $o['direction']);
+                    $orderByColumns[] = $options['columns'][$o['column']]['formula'];
                 } elseif (!empty($o['column'])) {
                     $queryBuilder->orderBy($o['column'], $o['direction']);
+                    $orderByColumns[] = $o['column'];
                 }
             }
         }
@@ -247,18 +257,19 @@ final class MauticReportBuilder implements ReportBuilderInterface
             }
         }
 
-        $selectColumns = [];
-        $aggregators     = $this->entity->getAggregators();
+        $selectColumns          = [];
+        $aggregators            = $this->entity->getAggregators();
+        $groupByColumns         = $queryBuilder->getQueryPart('groupBy') ?? [];
+        $groupByColumnsKeys     = array_flip($groupByColumns);
+        $aggregatorFieldKeys    = $groupByOptions && $aggregators
+            ? array_flip(array_column($aggregators, 'column'))
+            : [];
+        $ungroupedSelectColumns = [];
 
         // Build SELECT clause
         if (!$event->getSelectColumns()) {
-            $fields             = $this->entity->getColumns();
-            $groupByColumns     = $queryBuilder->getQueryPart('groupBy');
-            $groupByColumnsKeys = array_flip($groupByColumns);
-            $groupByFieldKeys   = $groupByOptions ? array_flip($groupByOptions) : [];
-            $aggregatorFieldKeys = $groupByOptions && $aggregators
-                ? array_flip(array_column($aggregators, 'column'))
-                : [];
+            $fields           = $this->entity->getColumns();
+            $groupByFieldKeys = $groupByOptions ? array_flip($groupByOptions) : [];
 
             foreach ($fields as $field) {
                 // With GROUP BY + aggregators, a column listed only for COUNT/AVG must not
@@ -281,7 +292,8 @@ final class MauticReportBuilder implements ReportBuilderInterface
                         } elseif (isset($fieldOptions['formula'])) {
                             $selectText = $fieldOptions['formula'];
                         } else {
-                            $selectText = $this->sanitizeColumnName($field);
+                            $selectText                = $this->sanitizeColumnName($field);
+                            $ungroupedSelectColumns[] = $field;
                         }
                     }
 
@@ -298,6 +310,33 @@ final class MauticReportBuilder implements ReportBuilderInterface
 
                     $selectColumns[] = $selectText;
                 }
+            }
+        }
+
+        // Complete GROUP BY with explicitly selected or ordered columns that are not
+        // aggregated, so grouped reports stay valid under ONLY_FULL_GROUP_BY (and on
+        // engines without functional-dependency detection) without silently dropping
+        // columns the user asked for. Aggregator targets are deliberately excluded:
+        // they appear in SELECT only as the aggregate expression.
+        if ($groupByColumns && ($ungroupedSelectColumns || $orderByColumns)) {
+            $missingGroupBy = [];
+
+            foreach (array_merge($ungroupedSelectColumns, $orderByColumns) as $column) {
+                if (str_contains($column, '{{count}}')) {
+                    continue;
+                }
+
+                if (isset($groupByColumnsKeys[$column]) || isset($aggregatorFieldKeys[$column])) {
+                    continue;
+                }
+
+                $groupByColumns[]            = $column;
+                $groupByColumnsKeys[$column] = true;
+                $missingGroupBy[]            = $column;
+            }
+
+            if ($missingGroupBy) {
+                $queryBuilder->addGroupBy(...$missingGroupBy);
             }
         }
 

--- a/app/bundles/ReportBundle/Builder/MauticReportBuilder.php
+++ b/app/bundles/ReportBundle/Builder/MauticReportBuilder.php
@@ -248,6 +248,7 @@ final class MauticReportBuilder implements ReportBuilderInterface
         }
 
         $selectColumns = [];
+        $aggregators     = $this->entity->getAggregators();
 
         // Build SELECT clause
         if (!$event->getSelectColumns()) {
@@ -255,11 +256,20 @@ final class MauticReportBuilder implements ReportBuilderInterface
             $groupByColumns     = $queryBuilder->getQueryPart('groupBy');
             $groupByColumnsKeys = array_flip($groupByColumns);
             $groupByFieldKeys   = $groupByOptions ? array_flip($groupByOptions) : [];
+            $aggregatorFieldKeys = [];
+
+            if ($groupByOptions && $aggregators) {
+                foreach ($aggregators as $aggregator) {
+                    $aggregatorFieldKeys[$aggregator['column']] = true;
+                }
+            }
 
             foreach ($fields as $field) {
-                // With GROUP BY, ONLY_FULL_GROUP_BY rejects non-aggregated columns that are
-                // not in the group-by list (e.g. ph.id selected for COUNT but not grouped).
-                if ($groupByOptions && !isset($groupByFieldKeys[$field])) {
+                // With GROUP BY + aggregators, a column listed only for COUNT/AVG must not
+                // also appear as a raw SELECT (ONLY_FULL_GROUP_BY rejects ph.id when grouped
+                // by ph.url). Columns not in groupBy but functionally dependent (e.g. e.subject
+                // when grouped by e.id) must remain in SELECT.
+                if ($groupByOptions && !isset($groupByFieldKeys[$field]) && isset($aggregatorFieldKeys[$field])) {
                     continue;
                 }
 
@@ -311,7 +321,6 @@ final class MauticReportBuilder implements ReportBuilderInterface
         $queryBuilder->addSelect($selectColumns);
 
         // Add Aggregators
-        $aggregators      = $this->entity->getAggregators();
         $aggregatorSelect = [];
 
         if ($aggregators && $groupByOptions) {

--- a/app/bundles/ReportBundle/Builder/MauticReportBuilder.php
+++ b/app/bundles/ReportBundle/Builder/MauticReportBuilder.php
@@ -256,13 +256,9 @@ final class MauticReportBuilder implements ReportBuilderInterface
             $groupByColumns     = $queryBuilder->getQueryPart('groupBy');
             $groupByColumnsKeys = array_flip($groupByColumns);
             $groupByFieldKeys   = $groupByOptions ? array_flip($groupByOptions) : [];
-            $aggregatorFieldKeys = [];
-
-            if ($groupByOptions && $aggregators) {
-                foreach ($aggregators as $aggregator) {
-                    $aggregatorFieldKeys[$aggregator['column']] = true;
-                }
-            }
+            $aggregatorFieldKeys = $groupByOptions && $aggregators
+                ? array_flip(array_column($aggregators, 'column'))
+                : [];
 
             foreach ($fields as $field) {
                 // With GROUP BY + aggregators, a column listed only for COUNT/AVG must not

--- a/app/bundles/ReportBundle/Builder/MauticReportBuilder.php
+++ b/app/bundles/ReportBundle/Builder/MauticReportBuilder.php
@@ -254,8 +254,15 @@ final class MauticReportBuilder implements ReportBuilderInterface
             $fields             = $this->entity->getColumns();
             $groupByColumns     = $queryBuilder->getQueryPart('groupBy');
             $groupByColumnsKeys = array_flip($groupByColumns);
+            $groupByFieldKeys   = $groupByOptions ? array_flip($groupByOptions) : [];
 
             foreach ($fields as $field) {
+                // With GROUP BY, ONLY_FULL_GROUP_BY rejects non-aggregated columns that are
+                // not in the group-by list (e.g. ph.id selected for COUNT but not grouped).
+                if ($groupByOptions && !isset($groupByFieldKeys[$field])) {
+                    continue;
+                }
+
                 if (isset($options['columns'][$field])) {
                     $fieldOptions = $options['columns'][$field];
 

--- a/app/bundles/ReportBundle/Builder/MauticReportBuilder.php
+++ b/app/bundles/ReportBundle/Builder/MauticReportBuilder.php
@@ -81,6 +81,28 @@ final class MauticReportBuilder implements ReportBuilderInterface
 
     public const CHANNEL_COLUMN_CREATED_BY_USER = 'channel.created_by_user';
 
+    /**
+     * SQL tokens that may appear inside report expressions but are never column
+     * references; used by extractBaseColumns(). Function names are already
+     * excluded by the not-followed-by-parenthesis check.
+     */
+    private const SQL_KEYWORD_TOKENS = [
+        'SELECT', 'FROM', 'WHERE', 'CASE', 'WHEN', 'THEN', 'ELSE', 'END', 'AND',
+        'OR', 'NOT', 'NULL', 'IS', 'IN', 'LIKE', 'BETWEEN', 'EXISTS', 'DISTINCT',
+        'AS', 'ASC', 'DESC', 'INTERVAL', 'DAY', 'DAYOFWEEK', 'DAYOFMONTH',
+        'DAYOFYEAR', 'HOUR', 'MINUTE', 'SECOND', 'WEEK', 'MONTH', 'QUARTER',
+        'YEAR', 'TRUE', 'FALSE',
+    ];
+
+    /**
+     * Aggregate functions whose arguments never need to appear in GROUP BY.
+     */
+    private const AGGREGATE_FUNCTIONS = [
+        'COUNT', 'SUM', 'AVG', 'MIN', 'MAX', 'GROUP_CONCAT', 'BIT_AND',
+        'BIT_OR', 'BIT_XOR', 'JSON_ARRAYAGG', 'JSON_OBJECTAGG', 'STD',
+        'STDDEV', 'VARIANCE',
+    ];
+
     private ?string $contentTemplate = null;
 
     public function __construct(
@@ -257,14 +279,15 @@ final class MauticReportBuilder implements ReportBuilderInterface
             }
         }
 
-        $selectColumns          = [];
-        $aggregators            = $this->entity->getAggregators();
-        $groupByColumns         = $queryBuilder->getQueryPart('groupBy') ?? [];
-        $groupByColumnsKeys     = array_flip($groupByColumns);
-        $aggregatorFieldKeys    = $groupByOptions && $aggregators
+        $selectColumns            = [];
+        $aggregators              = $this->entity->getAggregators();
+        $groupByColumns           = $queryBuilder->getQueryPart('groupBy') ?? [];
+        $groupByColumnsKeys       = array_flip($groupByColumns);
+        $aggregatorFieldKeys      = $groupByOptions && $aggregators
             ? array_flip(array_column($aggregators, 'column'))
             : [];
-        $ungroupedSelectColumns = [];
+        $ungroupedSelectColumns   = [];
+        $expressionSelectColumns = [];
 
         // Build SELECT clause
         if (!$event->getSelectColumns()) {
@@ -285,12 +308,16 @@ final class MauticReportBuilder implements ReportBuilderInterface
 
                     if (array_key_exists('channelData', $fieldOptions)) {
                         $selectText = $this->buildCaseSelect($fieldOptions['channelData']);
+                        $expressionSelectColumns[] = $selectText;
                     } else {
                         // If there is a group by, and this field has groupByFormula
                         if (isset($fieldOptions['groupByFormula']) && isset($groupByColumnsKeys[$fieldOptions['groupByFormula']])) {
                             $selectText = $fieldOptions['groupByFormula'];
                         } elseif (isset($fieldOptions['formula'])) {
                             $selectText = $fieldOptions['formula'];
+                            // The expression itself is not a groupable column; the
+                            // completion pass below groups its base columns instead.
+                            $expressionSelectColumns[] = $selectText;
                         } else {
                             $selectText                = $this->sanitizeColumnName($field);
                             $ungroupedSelectColumns[] = $field;
@@ -313,30 +340,58 @@ final class MauticReportBuilder implements ReportBuilderInterface
             }
         }
 
-        // Complete GROUP BY with explicitly selected or ordered columns that are not
-        // aggregated, so grouped reports stay valid under ONLY_FULL_GROUP_BY (and on
+        // Complete GROUP BY with every non-aggregated column that ends up in SELECT or
+        // ORDER BY, so grouped reports stay valid under ONLY_FULL_GROUP_BY (and on
         // engines without functional-dependency detection) without silently dropping
         // columns the user asked for. Aggregator targets are deliberately excluded:
-        // they appear in SELECT only as the aggregate expression.
-        if ($groupByColumns && ($ungroupedSelectColumns || $orderByColumns)) {
-            $missingGroupBy = [];
+        // they appear in SELECT only as the aggregate expression. The GROUP BY part is
+        // rebuilt from a normalized, deduplicated list so columns pre-registered by a
+        // listener are merged in rather than appended a second time.
+        if ($groupByColumns) {
+            $normalizedAggregatorKeys = array_flip(array_map(
+                fn (string $column): string => $this->normalizeColumnIdentifier($column),
+                array_keys($aggregatorFieldKeys)
+            ));
+            $normalizedGroupBy = [];
+            $dedupedGroupBy    = [];
 
-            foreach (array_merge($ungroupedSelectColumns, $orderByColumns) as $column) {
+            // Existing part entries (options, listeners) are already valid GROUP BY
+            // expressions; deduplicate them as-is. Only the new completion candidates
+            // go through base-column extraction.
+            foreach ($groupByColumns as $column) {
+                $normalized = $this->normalizeColumnIdentifier($column);
+
+                if ('' === $normalized || in_array($normalized, $normalizedGroupBy, true)) {
+                    continue;
+                }
+
+                $normalizedGroupBy[] = $normalized;
+                $dedupedGroupBy[]    = $column;
+            }
+
+            foreach ([...$ungroupedSelectColumns, ...$expressionSelectColumns, ...$orderByColumns] as $column) {
                 if (str_contains($column, '{{count}}')) {
                     continue;
                 }
 
-                if (isset($groupByColumnsKeys[$column]) || isset($aggregatorFieldKeys[$column])) {
-                    continue;
-                }
+                foreach ($this->extractBaseColumns($column) as $baseColumn) {
+                    $normalized = $this->normalizeColumnIdentifier($baseColumn);
 
-                $groupByColumns[]            = $column;
-                $groupByColumnsKeys[$column] = true;
-                $missingGroupBy[]            = $column;
+                    if ('' === $normalized
+                        || in_array($normalized, $normalizedGroupBy, true)
+                        || isset($normalizedAggregatorKeys[$normalized])
+                    ) {
+                        continue;
+                    }
+
+                    $normalizedGroupBy[] = $normalized;
+                    $dedupedGroupBy[]    = $baseColumn;
+                }
             }
 
-            if ($missingGroupBy) {
-                $queryBuilder->addGroupBy(...$missingGroupBy);
+            if ($dedupedGroupBy !== $groupByColumns) {
+                $queryBuilder->resetQueryPart('groupBy');
+                $queryBuilder->addGroupBy(...$dedupedGroupBy);
             }
         }
 
@@ -391,6 +446,134 @@ final class MauticReportBuilder implements ReportBuilderInterface
         }
 
         return $case.' ELSE NULL END ';
+    }
+
+    /**
+     * Returns the outer-level column references contained in a SELECT/ORDER BY
+     * expression (e.g. ph.date_hit inside DATE(ph.date_hit)), so the GROUP BY
+     * completion can group them individually instead of appending the whole
+     * expression as an opaque string.
+     *
+     * String literals, aggregate-function arguments and subquery contents are
+     * skipped: those identifiers are aggregated or belong to another query scope
+     * and must never be pulled into the outer GROUP BY.
+     *
+     * @return string[]
+     */
+    private function extractBaseColumns(string $expression): array
+    {
+        // Strip string literals so their contents are never scanned.
+        $expression = preg_replace("/'(?:[^'\\\\]|\\\\.|'')*'/", "''", $expression) ?? '';
+
+        // Remove subqueries and aggregate-function calls, arguments included:
+        // those identifiers are aggregated or belong to another query scope.
+        // Each pass may reveal new candidates, hence the loop.
+        $previous = null;
+        while ($previous !== $expression) {
+            $previous   = $expression;
+            $expression = $this->removeSubqueries($expression);
+            $expression = $this->removeAggregateCalls($expression);
+        }
+
+        // Remove the names of the remaining scalar function calls (DATE, CONCAT, …)
+        // so only their arguments are scanned for column references.
+        $expression = (string) preg_replace('/\b[A-Za-z_][A-Za-z0-9_]*\s*(?=\()/', ' ', $expression);
+
+        // Match optionally qualified, optionally backtick-quoted identifiers.
+        if (!preg_match_all('/`?([A-Za-z_][A-Za-z0-9_]*)`?(?:\.`?([A-Za-z_][A-Za-z0-9_]*)`?)?/', $expression, $matches)) {
+            return [];
+        }
+
+        $columns = [];
+        foreach ($matches[0] as $index => $match) {
+            if (in_array(strtoupper($matches[1][$index]), self::SQL_KEYWORD_TOKENS, true)) {
+                continue;
+            }
+
+            $columns[] = '' !== $matches[2][$index]
+                ? $matches[1][$index].'.'.$matches[2][$index]
+                : $matches[1][$index];
+        }
+
+        return array_values(array_unique($columns));
+    }
+
+    /**
+     * Removes every parenthesized group whose content starts with SELECT
+     * (subqueries at any nesting depth); identifiers inside them belong to the
+     * subquery's own scope, not to the outer GROUP BY.
+     */
+    private function removeSubqueries(string $expression): string
+    {
+        $pos = 0;
+        while (false !== ($open = strpos($expression, '(', $pos))) {
+            $close = $this->findMatchingParenthesis($expression, $open);
+            if (-1 === $close) {
+                break;
+            }
+
+            if (preg_match('/^\s*SELECT\b/i', substr($expression, $open + 1, $close - $open - 1))) {
+                $expression = substr($expression, 0, $open).' '.substr($expression, $close + 1);
+                $pos        = $open;
+            } else {
+                $pos = $open + 1;
+            }
+        }
+
+        return $expression;
+    }
+
+    /**
+     * Removes aggregate-function calls together with their arguments.
+     */
+    private function removeAggregateCalls(string $expression): string
+    {
+        $pattern = '/\b(?:'.implode('|', self::AGGREGATE_FUNCTIONS).')\s*\(/i';
+        if (!preg_match_all($pattern, $expression, $matches, PREG_OFFSET_CAPTURE)) {
+            return $expression;
+        }
+
+        // Remove from rightmost to leftmost so the offsets stay valid.
+        foreach (array_reverse($matches[0]) as [$call, $offset]) {
+            $open  = $offset + strlen($call) - 1;
+            $close = $this->findMatchingParenthesis($expression, $open);
+            if (-1 !== $close) {
+                $expression = substr($expression, 0, $offset).' '.substr($expression, $close + 1);
+            }
+        }
+
+        return $expression;
+    }
+
+    /**
+     * Returns the index of the closing parenthesis matching the one at $open,
+     * or -1 when unbalanced.
+     */
+    private function findMatchingParenthesis(string $expression, int $open): int
+    {
+        $length = strlen($expression);
+        $depth  = 0;
+        for ($i = $open; $i < $length; ++$i) {
+            if ('(' === $expression[$i]) {
+                ++$depth;
+            } elseif (')' === $expression[$i]) {
+                --$depth;
+                if (0 === $depth) {
+                    return $i;
+                }
+            }
+        }
+
+        return -1;
+    }
+
+    /**
+     * Reduces a column reference to a comparable key: quoting, whitespace and
+     * letter case are ignored, so `ph`.`url` matches ph.URL.
+     */
+    private function normalizeColumnIdentifier(string $column): string
+    {
+        return strtolower((string) preg_replace('/[`"\s]+/', '', $column));
     }
 
     private function applyFilters(array $filters, QueryBuilder $queryBuilder, array $filterDefinitions): void

--- a/app/bundles/ReportBundle/Builder/MauticReportBuilder.php
+++ b/app/bundles/ReportBundle/Builder/MauticReportBuilder.php
@@ -349,7 +349,7 @@ final class MauticReportBuilder implements ReportBuilderInterface
         // listener are merged in rather than appended a second time.
         if ($groupByColumns) {
             $normalizedAggregatorKeys = array_flip(array_map(
-                fn (string $column): string => $this->normalizeColumnIdentifier($column),
+                $this->normalizeColumnIdentifier(...),
                 array_keys($aggregatorFieldKeys)
             ));
             $normalizedGroupBy = [];
@@ -462,8 +462,15 @@ final class MauticReportBuilder implements ReportBuilderInterface
      */
     private function extractBaseColumns(string $expression): array
     {
-        // Strip string literals so their contents are never scanned.
-        $expression = preg_replace("/'(?:[^'\\\\]|\\\\.|'')*'/", "''", $expression) ?? '';
+        // Strip string literals so their contents are never scanned. MySQL
+        // treats both single- and double-quoted strings as literals (FocusBundle
+        // and several channel subscribers write conditions like fs.type = "view").
+        // A doubled-quote alternative in the pattern would let one match span
+        // from a literal's closing quote to the next literal's opening quote,
+        // swallowing everything between them (including subquery parens), so
+        // escapes are handled by the \\. branch instead.
+        $expression = preg_replace("/'(?:\\\\.|[^'\\\\])*'/", "''", $expression) ?? '';
+        $expression = preg_replace('/"(?:\\\\.|[^"\\\\])*"/', '""', $expression) ?? '';
 
         // Remove subqueries and aggregate-function calls, arguments included:
         // those identifiers are aggregated or belong to another query scope.

--- a/app/bundles/ReportBundle/Tests/Builder/MauticReportBuilderTest.php
+++ b/app/bundles/ReportBundle/Tests/Builder/MauticReportBuilderTest.php
@@ -401,6 +401,74 @@ final class MauticReportBuilderTest extends TestCase
         ")), $query->getSql());
     }
 
+    public function testGroupByIgnoresDoubleQuotedStringLiteralsInFormulas(): void
+    {
+        $report = new Report();
+        $report->setColumns(['e.id', 'focus_views']);
+        $report->setGroupBy(['e.id']);
+
+        // Shape of the FocusBundle report columns: a CASE expression whose
+        // condition compares a column to a double-quoted string literal.
+        $formula = 'CASE WHEN fs.type = "view" THEN 1 ELSE 0 END';
+
+        $builder = $this->buildBuilder($report);
+        $query   = $builder->getQuery([
+            'columns' => [
+                'e.id'        => [],
+                'focus_views' => ['formula' => $formula],
+            ],
+            'groupBy' => ['e.id'],
+        ]);
+
+        // The contents of the double-quoted literal ("view") are a string, not
+        // a column: only the CASE's real column reference may be completed into
+        // the outer GROUP BY.
+        $this->assertSame(trim(preg_replace('/\s{2,}/', ' ', "
+            SELECT `e`.`id`, $formula GROUP BY e.id, fs.type
+        ")), $query->getSql());
+    }
+
+    public function testGroupByStripDoesNotSwallowSubqueryAfterDoubleQuotedLiteral(): void
+    {
+        $report = new Report();
+        $report->setColumns(['e.id', 'hit_count']);
+        $report->setGroupBy(['e.id']);
+
+        // Shape of the FocusBundle hit_count column: the CASE condition's
+        // double-quoted literal is followed by a parenthesized subquery that
+        // itself contains GROUP BY. A strip pattern that spans from one
+        // double-quoted literal to the next would swallow the subquery's
+        // opening parenthesis, and its GROUP BY keywords would then leak into
+        // the outer GROUP BY as identifiers (invalid SQL).
+        $formula = 'CASE WHEN fs.type = "view" THEN (
+                        SELECT COUNT(fs2.id)
+                        FROM test_focus_stats fs2
+                        WHERE fs2.type = "view"
+                        AND fs2.focus_id = fs.focus_id
+                        GROUP BY fs2.focus_id
+                    ) ELSE MAX(fs.hits) END';
+
+        $builder = $this->buildBuilder($report);
+        $query   = $builder->getQuery([
+            'columns' => [
+                'e.id'       => [],
+                'hit_count'  => ['formula' => $formula],
+            ],
+            'groupBy' => ['e.id'],
+        ]);
+
+        $sql = $query->getSql();
+        $this->assertStringNotContainsString('fs2.focus_id, GROUP', $sql);
+        $this->assertStringNotContainsString('GROUP BY GROUP', $sql);
+        // The CASE's base column is completed; nothing from the subquery scope is.
+        $this->assertSame(
+            trim(preg_replace('/\s{2,}/', ' ', "
+            SELECT `e`.`id`, $formula GROUP BY e.id, fs.type
+        ")),
+            trim(preg_replace('/\s{2,}/', ' ', $sql))
+        );
+    }
+
     public function testReportWithPreciseAvg(): void
     {
         $report = new Report();

--- a/app/bundles/ReportBundle/Tests/Builder/MauticReportBuilderTest.php
+++ b/app/bundles/ReportBundle/Tests/Builder/MauticReportBuilderTest.php
@@ -157,6 +157,34 @@ final class MauticReportBuilderTest extends TestCase
         $this->assertSame('SELECT `a`.`someField` WHERE a.isPublished = :i0caisPublished', $query->getSql());
     }
 
+    public function testGroupByWithCountOmitsNonGroupedSelectColumns(): void
+    {
+        $report = new Report();
+        $report->setColumns(['ph.url_title', 'ph.url', 'ph.id']);
+        $report->setGroupBy(['ph.url', 'ph.url_title']);
+        $report->setAggregators([
+            [
+                'column'   => 'ph.id',
+                'function' => 'COUNT',
+            ],
+        ]);
+
+        $builder = $this->buildBuilder($report);
+        $query   = $builder->getQuery([
+            'columns' => [
+                'ph.url_title' => [],
+                'ph.url'       => [],
+                'ph.id'        => [],
+            ],
+            'groupBy' => ['ph.url', 'ph.url_title'],
+        ]);
+
+        $this->assertSame(trim(preg_replace('/\s{2,}/', ' ', '
+            SELECT `ph`.`url_title`, `ph`.`url`, COUNT(ph.id) AS \'COUNT ph.id\' GROUP BY ph.url, ph.url_title
+        ')), $query->getSql());
+        $this->assertStringNotContainsString('`ph`.`id`', $query->getSql());
+    }
+
     public function testReportWithPreciseAvg(): void
     {
         $report = new Report();

--- a/app/bundles/ReportBundle/Tests/Builder/MauticReportBuilderTest.php
+++ b/app/bundles/ReportBundle/Tests/Builder/MauticReportBuilderTest.php
@@ -13,6 +13,8 @@ use Mautic\CoreBundle\Test\Doctrine\MockedConnectionTrait;
 use Mautic\CoreBundle\Translation\Translator;
 use Mautic\ReportBundle\Builder\MauticReportBuilder;
 use Mautic\ReportBundle\Entity\Report;
+use Mautic\ReportBundle\Event\ReportGeneratorEvent;
+use Mautic\ReportBundle\ReportEvents;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -269,6 +271,134 @@ final class MauticReportBuilderTest extends TestCase
         $this->assertSame(trim(preg_replace('/\s{2,}/', ' ', '
             SELECT `ph`.`url`, COUNT(ph.id) AS \'COUNT ph.id\' GROUP BY ph.url ORDER BY ph.id DESC
         ')), $query->getSql());
+    }
+
+    public function testGroupByDeduplicatesColumnsPreRegisteredByListener(): void
+    {
+        $report = new Report();
+        $report->setColumns(['ph.url']);
+        $report->setGroupBy(['ph.url']);
+
+        // Report subscribers may register GROUP BY columns of their own before the
+        // builder runs; the builder's own GROUP BY must merge with them, not append
+        // a second copy of the same column.
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(
+            ReportEvents::REPORT_ON_GENERATE,
+            function (ReportGeneratorEvent $event): void {
+                $event->getQueryBuilder()->addGroupBy('ph.url');
+            }
+        );
+
+        $builder = new MauticReportBuilder($dispatcher, $this->connection, $report, $this->channelListHelper);
+        $query   = $builder->getQuery([
+            'columns' => [
+                'ph.url' => [],
+            ],
+            'groupBy' => ['ph.url'],
+        ]);
+
+        $this->assertSame(trim(preg_replace('/\s{2,}/', ' ', '
+            SELECT `ph`.`url` GROUP BY ph.url
+        ')), $query->getSql());
+    }
+
+    public function testGroupByCompletesBaseColumnsOfFormulaSelect(): void
+    {
+        $report = new Report();
+        $report->setColumns(['ph.url', 'ph.date_hit']);
+        $report->setGroupBy(['ph.url']);
+
+        $builder = $this->buildBuilder($report);
+        $query   = $builder->getQuery([
+            'columns' => [
+                'ph.url'      => [],
+                'ph.date_hit' => ['formula' => 'DATE(ph.date_hit)'],
+            ],
+            'groupBy' => ['ph.url'],
+        ]);
+
+        // The formula stays in SELECT; its base column is what gets grouped.
+        $this->assertSame(trim(preg_replace('/\s{2,}/', ' ', '
+            SELECT `ph`.`url`, DATE(ph.date_hit) GROUP BY ph.url, ph.date_hit
+        ')), $query->getSql());
+    }
+
+    public function testGroupByDoesNotDuplicateQuotedVariantOfGroupedColumn(): void
+    {
+        $report = new Report();
+        $report->setColumns(['ph.url']);
+        $report->setGroupBy(['ph.url']);
+
+        $builder = $this->buildBuilder($report);
+        $query   = $builder->getQuery([
+            'columns' => [
+                'ph.url' => ['groupByFormula' => '`ph`.`url`'],
+            ],
+            'order'   => ['ph.url', 'ASC'],
+            'groupBy' => ['ph.url'],
+        ]);
+
+        // ORDER BY ph.url is already covered by the (quoted) GROUP BY expression.
+        $this->assertSame(trim(preg_replace('/\s{2,}/', ' ', '
+            SELECT `ph`.`url` GROUP BY `ph`.`url` ORDER BY ph.url ASC
+        ')), $query->getSql());
+    }
+
+    public function testGroupByDoesNotPullAggregateArgumentsOrOrderByAggregates(): void
+    {
+        $report = new Report();
+        $report->setColumns(['ph.url', 't.hits']);
+        $report->setGroupBy(['ph.url']);
+        $report->setAggregators([
+            [
+                'column'   => 'ph.id',
+                'function' => 'COUNT',
+            ],
+        ]);
+
+        $builder = $this->buildBuilder($report);
+        $query   = $builder->getQuery([
+            'columns' => [
+                'ph.url' => [],
+                't.hits' => ['formula' => 'MAX(t.hits)'],
+            ],
+            'order'   => ['COUNT(ph.id)', 'DESC'],
+            'groupBy' => ['ph.url'],
+        ]);
+
+        // MAX(t.hits) is already aggregated, so t.hits must not be grouped; the
+        // COUNT(ph.id) sort column is an aggregator expression, not a column.
+        $this->assertSame(trim(preg_replace('/\s{2,}/', ' ', '
+            SELECT `ph`.`url`, MAX(t.hits), COUNT(ph.id) AS \'COUNT ph.id\' GROUP BY ph.url ORDER BY COUNT(ph.id) DESC
+        ')), $query->getSql());
+    }
+
+    public function testGroupByIgnoresIdentifiersInsideCorrelatedSubqueryFormulas(): void
+    {
+        $report = new Report();
+        $report->setColumns(['e.id', 'unsubscribed_ratio']);
+        $report->setGroupBy(['e.id']);
+
+        // Shape of the email ratio columns: a correlated subquery with its own
+        // aggregate over the do-not-contact table.
+        $formula = "IFNULL((SELECT ROUND((SUM(IF(dnc.id IS NOT NULL AND dnc.channel_id=e.id AND dnc.reason=1, 1, 0))/e.sent_count)*100, 1) FROM lead_donotcontact dnc), '0.0')";
+
+        $builder = $this->buildBuilder($report);
+        $query   = $builder->getQuery([
+            'columns' => [
+                'e.id'                => [],
+                'unsubscribed_ratio' => ['formula' => $formula],
+            ],
+            'groupBy' => ['e.id'],
+        ]);
+
+        // Nothing from inside the correlated subquery may leak into the outer
+        // GROUP BY: its identifiers are aggregated or already covered by the
+        // outer grouping key.
+        $this->assertSame(trim(preg_replace('/\s{2,}/', ' ', "
+            SELECT `e`.`id`, $formula GROUP BY e.id
+        ")), $query->getSql());
     }
 
     public function testReportWithPreciseAvg(): void

--- a/app/bundles/ReportBundle/Tests/Builder/MauticReportBuilderTest.php
+++ b/app/bundles/ReportBundle/Tests/Builder/MauticReportBuilderTest.php
@@ -185,6 +185,92 @@ final class MauticReportBuilderTest extends TestCase
         $this->assertStringNotContainsString('`ph`.`id`', $query->getSql());
     }
 
+    public function testGroupByCompletesMissingSelectColumnInsteadOfDroppingIt(): void
+    {
+        $report = new Report();
+        $report->setColumns(['ph.url', 'p.title']);
+        $report->setGroupBy(['ph.url']);
+
+        $builder = $this->buildBuilder($report);
+        $query   = $builder->getQuery([
+            'columns' => [
+                'ph.url'  => [],
+                'p.title' => [],
+            ],
+            'groupBy' => ['ph.url'],
+        ]);
+
+        $this->assertSame(trim(preg_replace('/\s{2,}/', ' ', '
+            SELECT `ph`.`url`, `p`.`title` GROUP BY ph.url, p.title
+        ')), $query->getSql());
+    }
+
+    public function testGroupByCompletesFunctionallyDependentSelectColumn(): void
+    {
+        $report = new Report();
+        $report->setColumns(['e.id', 'e.subject']);
+        $report->setGroupBy(['e.id']);
+
+        $builder = $this->buildBuilder($report);
+        $query   = $builder->getQuery([
+            'columns' => [
+                'e.id'      => [],
+                'e.subject' => [],
+            ],
+            'groupBy' => ['e.id'],
+        ]);
+
+        $this->assertSame(trim(preg_replace('/\s{2,}/', ' ', '
+            SELECT `e`.`id`, `e`.`subject` GROUP BY e.id, e.subject
+        ')), $query->getSql());
+    }
+
+    public function testGroupByCompletesMissingOrderByColumn(): void
+    {
+        $report = new Report();
+        $report->setColumns(['ph.url']);
+        $report->setGroupBy(['ph.url']);
+
+        $builder = $this->buildBuilder($report);
+        $query   = $builder->getQuery([
+            'columns' => [
+                'ph.url' => [],
+            ],
+            'order'   => ['p.title', 'DESC'],
+            'groupBy' => ['ph.url'],
+        ]);
+
+        $this->assertSame(trim(preg_replace('/\s{2,}/', ' ', '
+            SELECT `ph`.`url` GROUP BY ph.url, p.title ORDER BY p.title DESC
+        ')), $query->getSql());
+    }
+
+    public function testGroupByKeepsAggregatorTargetOutOfGroupByWhenOrdered(): void
+    {
+        $report = new Report();
+        $report->setColumns(['ph.url']);
+        $report->setGroupBy(['ph.url']);
+        $report->setAggregators([
+            [
+                'column'   => 'ph.id',
+                'function' => 'COUNT',
+            ],
+        ]);
+
+        $builder = $this->buildBuilder($report);
+        $query   = $builder->getQuery([
+            'columns' => [
+                'ph.url' => [],
+            ],
+            'order'   => ['ph.id', 'DESC'],
+            'groupBy' => ['ph.url'],
+        ]);
+
+        $this->assertSame(trim(preg_replace('/\s{2,}/', ' ', '
+            SELECT `ph`.`url`, COUNT(ph.id) AS \'COUNT ph.id\' GROUP BY ph.url ORDER BY ph.id DESC
+        ')), $query->getSql());
+    }
+
     public function testReportWithPreciseAvg(): void
     {
         $report = new Report();


### PR DESCRIPTION
## Problem

Page hits reports configured with **Group by** and a **COUNT** calculated column return HTTP 500 on MySQL with `ONLY_FULL_GROUP_BY` enabled.

The saved report selects `ph.url_title`, `ph.url`, and `ph.id`, groups by the URL fields, and adds `COUNT(ph.id)` as a calculated column. The query builder still emitted raw `ph.id` in the SELECT list even though it is neither grouped nor aggregated at that position, so MySQL rejects the query.

## Triage

Reproduced from reporter steps in #17092 against current `7.x`. No open PRs reference the issue. The failure is in `MauticReportBuilder` SELECT construction: when GROUP BY is active, every non-aggregated selected column must appear in the group-by list.

## Fix

When GROUP BY is configured, skip entity columns that are not listed in `groupBy` when building the SELECT clause. Aggregator expressions (`COUNT`, `AVG`, etc.) are still appended separately.

## Verification

```bash
ddev exec php bin/phpunit -c app/phpunit.xml.dist app/bundles/ReportBundle/Tests/Builder/MauticReportBuilderTest.php
```

Result: **OK (10 tests, 12 assertions)** including new `testGroupByWithCountOmitsNonGroupedSelectColumns`.

## Risks

Low. Only affects reports that already use GROUP BY; columns outside the group-by list were already invalid SQL under strict mode and could not render successfully.

Fixes #17092