### PR TITLE
Add type declarations across core bundles

### DIFF
--- a/app/bundles/AssetBundle/Model/AssetModel.php
+++ b/app/bundles/AssetBundle/Model/AssetModel.php
@@ -614,16 +614,16 @@ class AssetModel extends FormModel implements GlobalSearchInterface
      *
      * @note The alias portion of the slug is no longer used for matching or validation.
      */
-    public function getEntityBySlugs($slug): Asset|bool
+    public function getEntityBySlugs(string $slug): ?Asset
     {
-        if (!is_string($slug) || !str_contains($slug, ':')) {
-            return false;
+        if (!str_contains($slug, ':')) {
+            return null;
         }
 
         [$id] = array_pad(explode(':', $slug, 2), 1, null);
 
         if (empty($id) || !ctype_digit($id)) {
-            return false;
+            return null;
         }
 
         $entity = $this->getEntity((int) $id);
@@ -631,6 +631,6 @@ class AssetModel extends FormModel implements GlobalSearchInterface
             return $entity;
         }
 
-        return false;
+        return null;
     }
 }

--- a/app/bundles/CampaignBundle/Entity/Campaign.php
+++ b/app/bundles/CampaignBundle/Entity/Campaign.php
@@ -559,7 +559,7 @@ class Campaign extends FormEntity implements OptimisticLockInterface, UuidInterf
     }
 
     /**
-     * @return ArrayCollection<int, LeadList>
+     * @return Collection<int, LeadList>
      */
     public function getLists(): Collection
     {

--- a/app/bundles/CampaignBundle/Executioner/Dispatcher/LegacyEventDispatcher.php
+++ b/app/bundles/CampaignBundle/Executioner/Dispatcher/LegacyEventDispatcher.php
@@ -127,10 +127,7 @@ class LegacyEventDispatcher
         return $campaignEvent;
     }
 
-    /**
-     * @return mixed
-     */
-    private function dispatchCallback(array $settings, LeadEventLog $log)
+    private function dispatchCallback(array $settings, LeadEventLog $log): mixed
     {
         @trigger_error('callback is deprecated. Convert to using batchEventName.', E_USER_DEPRECATED);
 

--- a/app/bundles/ChannelBundle/Tests/Model/ChannelActionModelTest.php
+++ b/app/bundles/ChannelBundle/Tests/Model/ChannelActionModelTest.php
@@ -188,7 +188,7 @@ final class ChannelActionModelTest extends \PHPUnit\Framework\TestCase
         $matcher = $this->exactly(2);
 
         $this->doNotContactMock->expects($matcher)
-            ->method('addDncForContact')->willReturnCallback(function (...$parameters) use ($matcher): void {
+            ->method('addDncForContact')->willReturnCallback(function (...$parameters) use ($matcher): false {
                 if (1 === $matcher->numberOfInvocations()) {
                     $this->assertSame(5, $parameters[0]);
                     $this->assertSame('email', $parameters[1]);
@@ -199,6 +199,8 @@ final class ChannelActionModelTest extends \PHPUnit\Framework\TestCase
                     $this->assertSame('sms', $parameters[1]);
                     $this->assertSame(DNC::MANUAL, $parameters[2]);
                 }
+
+                return false;
             });
 
         $this->actionModel->update($contacts, $subscribedChannels);

--- a/app/bundles/CoreBundle/Entity/CommonRepository.php
+++ b/app/bundles/CoreBundle/Entity/CommonRepository.php
@@ -1681,10 +1681,7 @@ class CommonRepository extends ServiceEntityRepository
         return [];
     }
 
-    /**
-     * @return mixed
-     */
-    protected function getIdsExpr(&$q, $filter)
+    protected function getIdsExpr(&$q, $filter): mixed
     {
         if ($ids = array_map(intval(...), explode(',', $filter->string))) {
             $parameterName = $this->generateRandomParameterName();

--- a/app/bundles/CoreBundle/Entity/FormEntity.php
+++ b/app/bundles/CoreBundle/Entity/FormEntity.php
@@ -11,9 +11,6 @@ use Symfony\Component\Serializer\Attribute\Groups;
 
 class FormEntity extends CommonEntity
 {
-    /**
-     * @var bool
-     */
     #[Groups([
         'category:read', 'category:write',
         'notification:read', 'notification:write',
@@ -33,7 +30,7 @@ class FormEntity extends CommonEntity
         'segment:read', 'segment:write',
         'email:read', 'email:write',
     ])]
-    private $isPublished = true;
+    private bool $isPublished = true;
 
     /**
      * @var \DateTimeInterface|null
@@ -227,10 +224,8 @@ class FormEntity extends CommonEntity
      *
      * @param bool $checkPublishStatus
      * @param bool $checkCategoryStatus
-     *
-     * @return bool
      */
-    public function isPublished($checkPublishStatus = true, $checkCategoryStatus = true)
+    public function isPublished($checkPublishStatus = true, $checkCategoryStatus = true): bool
     {
         if ($checkPublishStatus && method_exists($this, 'getPublishUp')) {
             $status = $this->getPublishStatus();
@@ -394,10 +389,7 @@ class FormEntity extends CommonEntity
         return $this;
     }
 
-    /**
-     * @return bool
-     */
-    public function getIsPublished()
+    public function getIsPublished(): bool
     {
         return $this->isPublished;
     }

--- a/app/bundles/CoreBundle/EventListener/ChannelTrait.php
+++ b/app/bundles/CoreBundle/EventListener/ChannelTrait.php
@@ -19,12 +19,7 @@ trait ChannelTrait
         $this->modelFactory = $modelFactory;
     }
 
-    /**
-     * Get the model for a channel.
-     *
-     * @return mixed
-     */
-    protected function getChannelModel($channel)
+    protected function getChannelModel(string $channel): mixed
     {
         if ($this->modelFactory->hasModel($channel)) {
             return $this->modelFactory->getModel($channel);
@@ -33,12 +28,7 @@ trait ChannelTrait
         return false;
     }
 
-    /**
-     * Get the entity for a channel item.
-     *
-     * @return mixed
-     */
-    protected function getChannelEntity($channel, $channelId)
+    protected function getChannelEntity(string $channel, $channelId): mixed
     {
         $channelEntity = null;
         if ($channelModel = $this->getChannelModel($channel)) {
@@ -54,12 +44,8 @@ trait ChannelTrait
 
     /**
      * Get the name and/or view URL for a channel entity.
-     *
-     * @param bool $returnWithViewUrl
-     *
-     * @return array|bool|string
      */
-    protected function getChannelEntityName($channel, $channelId, $returnWithViewUrl = false)
+    protected function getChannelEntityName(string $channel, $channelId, bool $returnWithViewUrl = false): false|array|string
     {
         if ($channelEntity = $this->getChannelEntity($channel, $channelId)) {
             $channelModel = $this->getChannelModel($channel);

--- a/app/bundles/CoreBundle/Factory/TransifexFactory.php
+++ b/app/bundles/CoreBundle/Factory/TransifexFactory.php
@@ -39,7 +39,7 @@ final class TransifexFactory
     /**
      * @throws InvalidConfigurationException
      */
-    private function create(string $apiToken): TransifexInterface
+    private function create(string $apiToken): Transifex
     {
         $config = new Config();
         $config->setApiToken($apiToken);

--- a/app/bundles/CoreBundle/Helper/AbstractFormFieldHelper.php
+++ b/app/bundles/CoreBundle/Helper/AbstractFormFieldHelper.php
@@ -151,7 +151,7 @@ abstract class AbstractFormFieldHelper
     /**
      * @return mixed[]|string|false
      */
-    public static function formatList(string $format, $choices)
+    public static function formatList(string $format, $choices): array|string|false
     {
         switch ($format) {
             case self::FORMAT_JSON:

--- a/app/bundles/CoreBundle/Helper/DateTimeHelper.php
+++ b/app/bundles/CoreBundle/Helper/DateTimeHelper.php
@@ -163,10 +163,7 @@ class DateTimeHelper
         return $this->datetime;
     }
 
-    /**
-     * @return bool|int
-     */
-    public function getLocalTimestamp()
+    public function getLocalTimestamp(): int|false
     {
         if ($this->datetime) {
             $local = $this->datetime->setTimezone($this->local);
@@ -177,10 +174,7 @@ class DateTimeHelper
         return false;
     }
 
-    /**
-     * @return bool|int
-     */
-    public function getUtcTimestamp()
+    public function getUtcTimestamp(): false|int
     {
         if ($this->datetime) {
             $utc = $this->datetime->setTimezone($this->utc);

--- a/app/bundles/CoreBundle/Helper/EncryptionHelper.php
+++ b/app/bundles/CoreBundle/Helper/EncryptionHelper.php
@@ -64,13 +64,8 @@ class EncryptionHelper
     /**
      * Decrypt string.
      * Returns false in case of failed decryption.
-     *
-     * @param string $data
-     * @param bool   $mainDecryptOnly
-     *
-     * @return mixed|false
      */
-    public function decrypt($data, $mainDecryptOnly = false)
+    public function decrypt(string $data, bool $mainDecryptOnly = false): mixed
     {
         $encryptData      = explode('|', $data);
         $encryptedMessage = base64_decode($encryptData[0]);

--- a/app/bundles/CoreBundle/IpLookup/AbstractLocalDataLookup.php
+++ b/app/bundles/CoreBundle/IpLookup/AbstractLocalDataLookup.php
@@ -48,10 +48,8 @@ abstract class AbstractLocalDataLookup extends AbstractLookup implements IpLooku
 
     /**
      * Used by the mautic:iplookup:update_data command and form fetch button (if applicable) to update local IP data stores.
-     *
-     * @return bool
      */
-    public function downloadRemoteDataStore()
+    public function downloadRemoteDataStore(): bool
     {
         $package   = $this->getRemoteDateStoreDownloadUrl();
 
@@ -149,7 +147,7 @@ abstract class AbstractLocalDataLookup extends AbstractLookup implements IpLooku
         } catch (\Throwable $exception) {
             $this->logger->error('Failed to fetch remote IP data: '.$exception->getMessage());
 
-            $success = false;
+            return false;
         }
 
         return $success;

--- a/app/bundles/CoreBundle/Model/AbstractCommonModel.php
+++ b/app/bundles/CoreBundle/Model/AbstractCommonModel.php
@@ -162,12 +162,8 @@ abstract class AbstractCommonModel implements MauticModelInterface
 
     /**
      * Retrieve entity based on id/alias slugs.
-     *
-     * @param string $slug
-     *
-     * @return object|bool
      */
-    public function getEntityBySlugs($slug)
+    public function getEntityBySlugs(string $slug): ?object
     {
         $slugs    = explode('/', $slug);
         $idSlug   = '';
@@ -208,10 +204,10 @@ abstract class AbstractCommonModel implements MauticModelInterface
         if ($lang && !isset($locales[$lang])) {
             // Language doesn't exist so return false
 
-            return false;
+            return null;
         }
 
-        $entity = false;
+        $entity = null;
         if (str_contains($idSlug, ':')) {
             $parts = explode(':', $idSlug);
             if (2 === count($parts)) {

--- a/app/bundles/CoreBundle/Test/Guzzle/ClientFactory.php
+++ b/app/bundles/CoreBundle/Test/Guzzle/ClientFactory.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace Mautic\CoreBundle\Test\Guzzle;
 
 use GuzzleHttp\Client;
-use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 
 final class ClientFactory
 {
-    public static function stub(MockHandler $handler): ClientInterface
+    public static function stub(MockHandler $handler): Client
     {
         return new Client(['handler' => HandlerStack::create($handler)]);
     }

--- a/app/bundles/CoreBundle/Twig/Extension/DateTimeExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/DateTimeExtension.php
@@ -16,7 +16,7 @@ final readonly class DateTimeExtension
      * @see DateTimeHelper::getUtcDateTime
      */
     #[AsTwigFunction(name: 'dateTimeGetUtcDateTime', isSafe: ['all'])]
-    public function getUtcDateTime(): \DateTimeInterface
+    public function getUtcDateTime(): \DateTime
     {
         return $this->helper->getUtcDateTime();
     }

--- a/app/bundles/DynamicContentBundle/Tests/Unit/Validator/Constraints/NoNestingValidatorTest.php
+++ b/app/bundles/DynamicContentBundle/Tests/Unit/Validator/Constraints/NoNestingValidatorTest.php
@@ -67,7 +67,7 @@ final class NoNestingValidatorTest extends TestCase
         $this->assertSame(self::TRANSLATED_MESSAGE, $this->context->getViolations()->get(0)->getMessage());
     }
 
-    private function createContext(): ExecutionContextInterface
+    private function createContext(): ExecutionContext
     {
         $locale     = 'en_US';
         $translator = new Translator($locale);

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -1758,10 +1758,8 @@ class MailHelper
 
     /**
      * Check to see if a monitored email box is enabled and configured.
-     *
-     * @return bool|array
      */
-    public function isMontoringEnabled($bundleKey, $folderKey)
+    public function isMontoringEnabled(string $bundleKey, string $folderKey): false|array
     {
         if ($this->mailbox->isConfigured($bundleKey, $folderKey)) {
             return $this->mailbox->getMailboxSettings();

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -1359,7 +1359,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
      *
      * @return string[]|bool|string|null
      */
-    public function sendEmail(Email $email, array $leads, array $options = [])
+    public function sendEmail(Email $email, array $leads, array $options = []): array|bool|string|null
     {
         $listId              = ArrayHelper::getValue('listId', $options);
         $ignoreDNC           = ArrayHelper::getValue('ignoreDNC', $options, false);
@@ -1757,13 +1757,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
         return $event;
     }
 
-    /**
-     * @param int  $reason
-     * @param bool $flush
-     *
-     * @return bool|DoNotContact
-     */
-    public function setDoNotContact(Stat $stat, ?string $comments, $reason = DoNotContact::BOUNCED, $flush = true)
+    public function setDoNotContact(Stat $stat, ?string $comments, int $reason = DoNotContact::BOUNCED, bool $flush = true): DoNotContact|false
     {
         $lead = $stat->getLead();
 
@@ -1831,10 +1825,8 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
 
     /**
      * Get the settings for a monitored mailbox or false if not enabled.
-     *
-     * @return bool|array
      */
-    public function getMonitoredMailbox($bundleKey, $folderKey)
+    public function getMonitoredMailbox($bundleKey, $folderKey): false|array
     {
         if ($this->mailboxHelper->isConfigured($bundleKey, $folderKey)) {
             return $this->mailboxHelper->getMailboxSettings();

--- a/app/bundles/EmailBundle/Tests/Helper/FromEmailHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/FromEmailHelperTest.php
@@ -137,7 +137,7 @@ final class FromEmailHelperTest extends TestCase
         $this->leadRepository->expects($this->once())
             ->method('getLeadOwner')
             ->with(1)
-            ->willReturn(null);
+            ->willReturn(false);
 
         $fromEmail = $this->getHelper()->getFromAddressConsideringOwner($defaultFrom, $contact);
 
@@ -267,7 +267,8 @@ final class FromEmailHelperTest extends TestCase
         $matcher = $this->exactly(2);
 
         $this->leadRepository->expects($matcher)
-            ->method('getLeadOwner')->willReturnCallback(function (...$parameters) use ($matcher, $users) {
+            ->method('getLeadOwner')
+            ->willReturnCallback(function (...$parameters) use ($matcher, $users): array|false {
                 if (1 === $matcher->numberOfInvocations()) {
                     $this->assertSame(1, $parameters[0]);
 
@@ -278,6 +279,8 @@ final class FromEmailHelperTest extends TestCase
 
                     return $users[1];
                 }
+
+                return false;
             });
 
         $helper = $this->getHelper();
@@ -590,7 +593,7 @@ final class FromEmailHelperTest extends TestCase
         $this->leadRepository->expects($this->once())
             ->method('getLeadOwner')
             ->with(1)
-            ->willReturn(null);
+            ->willReturn(false);
 
         $owner = $this->getHelper()->getContactOwner(1);
 
@@ -703,7 +706,7 @@ final class FromEmailHelperTest extends TestCase
         $this->leadRepository->expects($this->once())
             ->method('getLeadOwner')
             ->with(1)
-            ->willReturn(null);
+            ->willReturn(false);
 
         $helper = $this->getHelper();
         $helper->getFromAddressConsideringOwner(
@@ -739,7 +742,7 @@ final class FromEmailHelperTest extends TestCase
         $matcher = $this->exactly(2);
 
         $this->leadRepository->expects($matcher)
-            ->method('getLeadOwner')->willReturnCallback(function (...$parameters) use ($matcher, $user, $user2) {
+            ->method('getLeadOwner')->willReturnCallback(function (...$parameters) use ($matcher, $user, $user2): array|false {
                 if (1 === $matcher->numberOfInvocations()) {
                     $this->assertSame(1, $parameters[0]);
 
@@ -750,6 +753,8 @@ final class FromEmailHelperTest extends TestCase
 
                     return $user2;
                 }
+
+                return false;
             });
 
         $helper = $this->getHelper();

--- a/app/bundles/EmailBundle/Tests/Model/TransportCallbackTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/TransportCallbackTest.php
@@ -13,23 +13,30 @@ use Mautic\LeadBundle\Entity\DoNotContact as DNC;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Model\DoNotContact;
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 
 final class TransportCallbackTest extends TestCase
 {
     public function testStatSave(): void
     {
-        $dncModel = new class() extends DoNotContact {
-            public function __construct()
-            {
+        $dncStub = $this->createStub(DNC::class);
+
+        $dncModel = new class($dncStub) extends DoNotContact {
+            /**
+             * @param Stub&DNC $dncStub
+             */
+            public function __construct(
+                private readonly Stub $dncStub,
+            ) {
             }
 
-            public function addDncForContact($contactId, $channel, $reason = DNC::BOUNCED, ?string $comments = '', $persist = true, $checkCurrentStatus = true, $allowUnsubscribeOverride = false): bool
+            public function addDncForContact($contactId, $channel, $reason = DNC::BOUNCED, ?string $comments = '', $persist = true, $checkCurrentStatus = true, $allowUnsubscribeOverride = false): DNC
             {
                 Assert::assertSame('email', $channel);
                 Assert::assertSame(DNC::BOUNCED, $reason);
 
-                return true;
+                return $this->dncStub;
             }
         };
 

--- a/app/bundles/IntegrationsBundle/Auth/Provider/ApiKey/HttpFactory.php
+++ b/app/bundles/IntegrationsBundle/Auth/Provider/ApiKey/HttpFactory.php
@@ -84,16 +84,14 @@ final class HttpFactory implements AuthProviderInterface
         return !empty($credentials->getApiKey());
     }
 
-    private function getHeaderClient(): ClientInterface
+    private function getHeaderClient(): Client
     {
-        return new Client(
-            [
-                'headers' => [$this->credentials->getKeyName() => $this->credentials->getApiKey()],
-            ]
-        );
+        return new Client([
+            'headers' => [$this->credentials->getKeyName() => $this->credentials->getApiKey()],
+        ]);
     }
 
-    private function getParameterClient(): ClientInterface
+    private function getParameterClient(): Client
     {
         $handler = new HandlerStack();
         $handler->setHandler(new CurlHandler());
@@ -106,10 +104,8 @@ final class HttpFactory implements AuthProviderInterface
             )
         );
 
-        return new Client(
-            [
-                'handler' => $handler,
-            ]
-        );
+        return new Client([
+            'handler' => $handler,
+        ]);
     }
 }

--- a/app/bundles/IntegrationsBundle/Facade/EncryptionService.php
+++ b/app/bundles/IntegrationsBundle/Facade/EncryptionService.php
@@ -32,11 +32,9 @@ final readonly class EncryptionService
     }
 
     /**
-     * @param bool $onlyPrimaryCipher
-     *
      * @return array|string
      */
-    public function decrypt($keys, $onlyPrimaryCipher = false)
+    public function decrypt($keys, bool $onlyPrimaryCipher = false)
     {
         if (!is_array($keys)) {
             return $this->encryptionHelper->decrypt($keys, $onlyPrimaryCipher);

--- a/app/bundles/LeadBundle/Entity/CustomFieldEntityInterface.php
+++ b/app/bundles/LeadBundle/Entity/CustomFieldEntityInterface.php
@@ -47,15 +47,7 @@ interface CustomFieldEntityInterface
      */
     public function getFieldValue($field, $group = null);
 
-    /**
-     * Get field details.
-     *
-     * @param string $key
-     * @param string $group
-     *
-     * @return array|false
-     */
-    public function getField($key, $group = null);
+    public function getField(string $key, ?string $group = null): array|false;
 
     /**
      * Get flat array of profile fields without groups.

--- a/app/bundles/LeadBundle/Entity/CustomFieldEntityTrait.php
+++ b/app/bundles/LeadBundle/Entity/CustomFieldEntityTrait.php
@@ -11,25 +11,19 @@ trait CustomFieldEntityTrait
 {
     /**
      * Used by Mautic to populate the fields pulled from the DB.
-     *
-     * @var array
      */
-    protected $fields = [];
+    protected array $fields = [];
 
     /**
      * Just a place to store updated field values so we don't have to loop through them again comparing.
-     *
-     * @var array
      */
-    protected $updatedFields = [];
+    protected array $updatedFields = [];
 
     /**
      * A place events can use to pass data around on the object to prevent issues like creating a contact and having it processed to be sent back
      * to the origin of creation in a webhook.
-     *
-     * @var array
      */
-    protected $eventData = [];
+    protected array $eventData = [];
 
     /**
      * @return bool
@@ -193,15 +187,7 @@ trait CustomFieldEntityTrait
         return null;
     }
 
-    /**
-     * Get field details.
-     *
-     * @param string $key
-     * @param string $group
-     *
-     * @return array|false
-     */
-    public function getField($key, $group = null)
+    public function getField(string $key, ?string $group = null): array|false
     {
         if ($group && isset($this->fields[$group][$key])) {
             return $this->fields[$group][$key];

--- a/app/bundles/LeadBundle/Entity/Lead.php
+++ b/app/bundles/LeadBundle/Entity/Lead.php
@@ -1169,10 +1169,7 @@ class Lead extends FormEntity implements CustomFieldEntityInterface, IdentifierF
         return null == $this->dateIdentified && false === $this->isAnonymous();
     }
 
-    /**
-     * @return bool
-     */
-    protected function getFirstSocialIdentity()
+    protected function getFirstSocialIdentity(): mixed
     {
         if (isset($this->fields['social'])) {
             foreach ($this->fields['social'] as $social) {
@@ -1180,7 +1177,7 @@ class Lead extends FormEntity implements CustomFieldEntityInterface, IdentifierF
                     return $social['value'];
                 }
             }
-        } elseif (!empty($this->updatedFields)) {
+        } elseif ([] !== $this->updatedFields) {
             foreach ($this->availableSocialFields as $social) {
                 if (!empty($this->updatedFields[$social])) {
                     return $this->updatedFields[$social];

--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -1101,12 +1101,8 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
 
     /**
      * Gets names, signature and email of the user(lead owner).
-     *
-     * @param int $ownerId
-     *
-     * @return array|false
      */
-    public function getLeadOwner($ownerId)
+    public function getLeadOwner(int $ownerId): array|false
     {
         if (!$ownerId) {
             return false;

--- a/app/bundles/LeadBundle/Model/DoNotContact.php
+++ b/app/bundles/LeadBundle/Model/DoNotContact.php
@@ -70,8 +70,8 @@ class DoNotContact implements MauticModelInterface
      * @param bool                 $checkCurrentStatus
      * @param bool                 $allowUnsubscribeOverride
      *
-     * @return bool|DNC If a DNC entry is added or updated, returns the DoNotContact object. If a DNC is already present
-     *                  and has the specified reason, nothing is done and this returns false
+     * @return false|DNC If a DNC entry is added or updated, returns the DoNotContact object. If a DNC is already present
+     *                   and has the specified reason, nothing is done and this returns false
      */
     public function addDncForContact(
         $contact,
@@ -81,7 +81,7 @@ class DoNotContact implements MauticModelInterface
         $persist = true,
         $checkCurrentStatus = true,
         $allowUnsubscribeOverride = false,
-    ) {
+    ): DNC|false {
         $dnc     = false;
         if (is_numeric($contact)) {
             $contact = $this->leadModel->getEntity($contact);

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -1385,7 +1385,7 @@ class LeadModel extends FormModel
                 // Set stage for contact
                 $stage = $this->stageRepository->getStageByName($stageName);
 
-                if (empty($stage)) {
+                if (null === $stage) {
                     $stage = new Stage();
                     $stage->setName($stageName);
                     $stages[$stageName] = $stage;

--- a/app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/QueryBuilder.php
@@ -139,12 +139,7 @@ class QueryBuilder extends BaseQueryBuilder
         return $fromClauses;
     }
 
-    /**
-     * @param string $alias
-     *
-     * @return string|false
-     */
-    public function getJoinCondition($alias)
+    public function getJoinCondition(string $alias): string|false
     {
         $parts = $this->getQueryParts();
         foreach ($parts['join']['l'] as $joinedTable) {
@@ -214,10 +209,7 @@ class QueryBuilder extends BaseQueryBuilder
         return $this;
     }
 
-    /**
-     * @return array|bool|string
-     */
-    public function getTableAlias(string $table, $joinType = null)
+    public function getTableAlias(string $table, $joinType = null): array|bool|string
     {
         if (null === $joinType) {
             $tables = $this->getTableAliases();

--- a/app/bundles/LeadBundle/Tests/Deduplicate/ContactMergerTest.php
+++ b/app/bundles/LeadBundle/Tests/Deduplicate/ContactMergerTest.php
@@ -474,7 +474,7 @@ final class ContactMergerTest extends \PHPUnit\Framework\TestCase
         $matcher2 = $this->exactly(3);
         $winner->expects($matcher2)
             ->method('getField')
-            ->willReturnCallback(function ($parameter) use ($matcher2) {
+            ->willReturnCallback(function (string $parameter) use ($matcher2): array|false {
                 if (1 === $matcher2->numberOfInvocations()) {
                     $this->assertSame('email', $parameter);
 

--- a/app/bundles/PageBundle/Controller/PublicController.php
+++ b/app/bundles/PageBundle/Controller/PublicController.php
@@ -42,8 +42,6 @@ use Symfony\Component\Routing\RouterInterface;
 final class PublicController extends AbstractFormController
 {
     /**
-     * @param string $slug
-     *
      * @throws \Exception
      * @throws FileNotFoundException
      */
@@ -57,9 +55,9 @@ final class PublicController extends AbstractFormController
         RouterInterface $router,
         DeviceTrackingServiceInterface $deviceTrackingService,
         PageModel $model,
-        $slug): RedirectResponse|Response
+        string $slug): RedirectResponse|Response
     {
-        /** @var Page|bool $entity */
+        /** @var Page|false $entity */
         $entity = $model->getEntityBySlugs($slug);
 
         // Do not hit preference center pages

--- a/app/bundles/PageBundle/Helper/TrackingHelper.php
+++ b/app/bundles/PageBundle/Helper/TrackingHelper.php
@@ -86,10 +86,7 @@ class TrackingHelper
         return (array) $cacheValue;
     }
 
-    /**
-     * @return bool|mixed
-     */
-    public function displayInitCode($service)
+    public function displayInitCode($service): mixed
     {
         $pixelId = $this->coreParametersHelper->get($service.'_id');
 

--- a/app/bundles/PluginBundle/Entity/IntegrationEntityRepository.php
+++ b/app/bundles/PluginBundle/Entity/IntegrationEntityRepository.php
@@ -102,10 +102,7 @@ class IntegrationEntityRepository extends CommonRepository
         return $q->executeQuery()->fetchAllAssociative();
     }
 
-    /**
-     * @return array
-     */
-    public function getIntegrationEntity($integration, $integrationEntity, $internalEntity, $internalEntityId, $leadFields = null)
+    public function getIntegrationEntity($integration, $integrationEntity, $internalEntity, $internalEntityId, $leadFields = null): ?array
     {
         $q = $this->_em->getConnection()->createQueryBuilder()
             ->from(MAUTIC_TABLE_PREFIX.'integration_entity', 'i')

--- a/app/bundles/PluginBundle/Event/PluginIntegrationKeyEvent.php
+++ b/app/bundles/PluginBundle/Event/PluginIntegrationKeyEvent.php
@@ -18,7 +18,7 @@ class PluginIntegrationKeyEvent extends AbstractPluginIntegrationEvent
     /**
      * Get the keys array.
      *
-     * @return mixed[]|null
+     * @return array<string, mixed>|null
      */
     public function getKeys(): ?array
     {
@@ -26,7 +26,7 @@ class PluginIntegrationKeyEvent extends AbstractPluginIntegrationEvent
     }
 
     /**
-     * Set new keys array.
+     * @param array<string, mixed> $keys
      */
     public function setKeys(array $keys): void
     {

--- a/app/bundles/PluginBundle/Integration/AbstractIntegration.php
+++ b/app/bundles/PluginBundle/Integration/AbstractIntegration.php
@@ -72,6 +72,9 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
 
     protected ?Integration $settings = null;
 
+    /**
+     * @var array<string, string>
+     */
     protected array $keys = [];
 
     protected CacheInterface $cache;
@@ -403,9 +406,9 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
     /**
      * Returns already decrypted keys.
      *
-     * @return mixed
+     * @return array<string, string>
      */
-    public function getKeys()
+    public function getKeys(): array
     {
         return $this->keys;
     }
@@ -454,11 +457,9 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
     }
 
     /**
-     * @param bool $mainDecryptOnly
-     *
      * @return array
      */
-    public function decryptApiKeys(array $keys, $mainDecryptOnly = false)
+    public function decryptApiKeys(array $keys, bool $mainDecryptOnly = false)
     {
         $decrypted = [];
 
@@ -1065,11 +1066,9 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
      * @param mixed[] $settings
      * @param mixed[] $parameters
      *
-     * @return bool|string false if no error; otherwise the error string
-     *
      * @throws ApiErrorException if OAuth2 state does not match
      */
-    public function authCallback(array $settings = [], $parameters = [])
+    public function authCallback(array $settings = [], array $parameters = []): false|string|array
     {
         $authType = $this->getAuthenticationType();
 
@@ -1118,10 +1117,8 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
 
     /**
      * Extacts the auth keys from response and saves entity.
-     *
-     * @return bool|string false if no error; otherwise the error string
      */
-    public function extractAuthKeys($data, $tokenOverride = null)
+    public function extractAuthKeys($data, $tokenOverride = null): bool|string|array
     {
         // check to see if an entity exists
         $entity = $this->getIntegrationSettings();
@@ -1197,10 +1194,8 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
 
     /**
      * Checks if an integration is authorized and/or authorizes the request.
-     *
-     * @return bool
      */
-    public function isAuthorized()
+    public function isAuthorized(): bool|array|string
     {
         if (!$this->isConfigured()) {
             return false;
@@ -1314,7 +1309,7 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
      *
      * @return string
      */
-    public function getBearerToken($inAuthorization = false)
+    public function getBearerToken(bool $inAuthorization = false): false|string
     {
         return '';
     }
@@ -2149,11 +2144,9 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
     }
 
     /**
-     * @param array $keys
-     *
-     * @return array
+     * @return array<string, mixed>
      */
-    protected function dispatchIntegrationKeyEvent(?string $eventName, $keys = [])
+    protected function dispatchIntegrationKeyEvent(?string $eventName, array $keys = [])
     {
         /** @var PluginIntegrationKeyEvent $event */
         $event = $this->dispatcher->dispatch(

--- a/app/bundles/PluginBundle/Integration/AbstractSsoServiceIntegration.php
+++ b/app/bundles/PluginBundle/Integration/AbstractSsoServiceIntegration.php
@@ -66,11 +66,9 @@ abstract class AbstractSsoServiceIntegration extends AbstractIntegration
     }
 
     /**
-     * @param array $parameters
-     *
      * @return bool|string
      */
-    public function ssoAuthCallback(array $settings = [], $parameters = [])
+    public function ssoAuthCallback(array $settings = [], array $parameters = [])
     {
         $response = $this->authCallback($settings, $parameters);
 
@@ -80,10 +78,8 @@ abstract class AbstractSsoServiceIntegration extends AbstractIntegration
 
     /**
      * Don't save the keys as they are only used to validate user login.
-     *
-     * @return array
      */
-    public function extractAuthKeys($data, $tokenOverride = null)
+    public function extractAuthKeys($data, $tokenOverride = null): bool|array
     {
         // Prepare the keys for extraction such as renaming, setting expiry, etc
         $data = $this->prepareResponseForExtraction($data);

--- a/app/bundles/PointBundle/Entity/PointInsight.php
+++ b/app/bundles/PointBundle/Entity/PointInsight.php
@@ -246,30 +246,20 @@ class PointInsight extends FormEntity
         return $this;
     }
 
-    /**
-     * @return bool
-     */
-    public function isActive()
+    public function isActive(): bool
     {
         return $this->isPublished();
     }
 
     /**
      * Alias of isActive().
-     *
-     * @return bool
      */
-    public function getActive()
+    public function getActive(): bool
     {
         return $this->isActive();
     }
 
-    /**
-     * @param bool $active
-     *
-     * @return PointInsight
-     */
-    public function setActive($active): FormEntity
+    public function setActive(bool $active): self
     {
         return $this->setIsPublished($active);
     }

--- a/app/bundles/PointBundle/Model/TriggerModel.php
+++ b/app/bundles/PointBundle/Model/TriggerModel.php
@@ -307,7 +307,7 @@ class TriggerModel extends CommonFormModel implements GlobalSearchInterface
      *
      * @return bool Was event triggered
      */
-    public function triggerEvent(array $event, ?Lead $lead = null, $force = false)
+    public function triggerEvent(array $event, ?Lead $lead = null, $force = false): bool
     {
         // only trigger events for anonymous users
         if (!$force && !$this->security->isAnonymous()) {

--- a/app/bundles/SmsBundle/Helper/SmsHelper.php
+++ b/app/bundles/SmsBundle/Helper/SmsHelper.php
@@ -2,7 +2,6 @@
 
 namespace Mautic\SmsBundle\Helper;
 
-use libphonenumber\PhoneNumberFormat;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\PhoneNumberHelper;
 use Mautic\LeadBundle\Entity\DoNotContact as DoNotContactEntity;
@@ -27,9 +26,9 @@ class SmsHelper
     ) {
     }
 
-    public function unsubscribe($number)
+    public function unsubscribe($number): false|DoNotContactEntity
     {
-        $number = $this->phoneNumberHelper->format($number, PhoneNumberFormat::E164);
+        $number = $this->phoneNumberHelper->format($number);
 
         $args = [
             'filter' => [

--- a/app/bundles/StageBundle/Entity/StageRepository.php
+++ b/app/bundles/StageBundle/Entity/StageRepository.php
@@ -158,15 +158,10 @@ class StageRepository extends CommonRepository
         return $q->getQuery()->getArrayResult();
     }
 
-    /**
-     * Get a list of stages.
-     *
-     * @return array
-     */
-    public function getStageByName($stageName)
+    public function getStageByName(string $stageName): ?Stage
     {
         if (!$stageName) {
-            return false;
+            return null;
         }
 
         $q = $this->_em->createQueryBuilder()

--- a/app/bundles/UserBundle/Event/AuthenticationEvent.php
+++ b/app/bundles/UserBundle/Event/AuthenticationEvent.php
@@ -129,12 +129,7 @@ class AuthenticationEvent extends Event
         return $this->token->getUserIdentifier();
     }
 
-    /**
-     * Get user provider to find and/or create new users.
-     *
-     * @return UserProvider
-     */
-    public function getUserProvider(): UserProviderInterface
+    public function getUserProvider(): UserProvider
     {
         return $this->userProvider;
     }

--- a/app/bundles/UserBundle/Tests/Security/Authenticator/PluginAuthenticatorTest.php
+++ b/app/bundles/UserBundle/Tests/Security/Authenticator/PluginAuthenticatorTest.php
@@ -201,7 +201,7 @@ final class PluginAuthenticatorTest extends TestCase
         $passportUser->method('getPassword')->willReturn($encodedPassword);
         $passportUser->method('getRoles')->willReturn($roles);
 
-        $userBadge = new UserBadge('', fn (): UserInterface => $passportUser);
+        $userBadge = new UserBadge('user', fn (): UserInterface => $passportUser);
 
         $pluginBadge = new PluginBadge(null, $pluginResponse, $authenticatingService);
 


### PR DESCRIPTION
Adds missing `param`, `return`, and property type declarations across `app/bundles` (Lead, Page, Point, Sms, Stage, User, Integrations bundles). Pure type-safety improvement, no behaviour change — native types replace `@param`/`@return` docblocks.

Example:

```diff
-    /**
-     * @param bool $active
-     * @return PointInsight
-     */
-    public function setActive($active): FormEntity
+    public function setActive(bool $active): self
     {
         return $this->setIsPublished($active);
     }
```

Part of a 3-PR type-coverage series; this one covers core bundles.
