### PR TITLE
Add type declarations across plugins

### DIFF
--- a/plugins/MauticCrmBundle/Api/SalesforceApi.php
+++ b/plugins/MauticCrmBundle/Api/SalesforceApi.php
@@ -546,12 +546,10 @@ final class SalesforceApi extends CrmApi
     }
 
     /**
-     * @return string|false
-     *
      * @throws ApiErrorException
      * @throws RetryRequestException
      */
-    private function processError(array $error, bool $isRetry)
+    private function processError(array $error, bool $isRetry): string|false
     {
         switch ($error['errorCode']) {
             case 'INVALID_SESSION_ID':

--- a/plugins/MauticCrmBundle/Integration/ConnectwiseIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/ConnectwiseIntegration.php
@@ -100,7 +100,7 @@ class ConnectwiseIntegration extends CrmAbstractIntegration
         return $this->router->generate('mautic_integration_auth_callback', ['integration' => $this->getName()]);
     }
 
-    public function authCallback(array $settings = [], $parameters = []): string|false
+    public function authCallback(array $settings = [], array $parameters = []): string|false
     {
         $url   = $this->getApiUrl();
         $error = false;

--- a/plugins/MauticCrmBundle/Integration/DynamicsIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/DynamicsIntegration.php
@@ -146,10 +146,7 @@ final class DynamicsIntegration extends CrmAbstractIntegration
         return $url.('&resource='.urlencode($this->keys['resource']));
     }
 
-    /**
-     * @param bool $inAuthorization
-     */
-    public function getBearerToken($inAuthorization = false)
+    public function getBearerToken(bool $inAuthorization = false): false|string
     {
         if (!$inAuthorization && isset($this->keys[$this->getAuthTokenKey()])) {
             return $this->keys[$this->getAuthTokenKey()];

--- a/plugins/MauticCrmBundle/Integration/HubspotIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/HubspotIntegration.php
@@ -82,16 +82,11 @@ class HubspotIntegration extends CrmAbstractIntegration
         return ['push_lead', 'get_leads'];
     }
 
-    /**
-     * @param bool $inAuthorization
-     *
-     * @return mixed|string|null
-     */
-    public function getBearerToken($inAuthorization = false)
+    public function getBearerToken(bool $inAuthorization = false): false|string
     {
         $tokenData = $this->getKeys();
 
-        return $tokenData[self::ACCESS_KEY] ?? null;
+        return $tokenData[self::ACCESS_KEY] ?? false;
     }
 
     /**
@@ -477,7 +472,7 @@ class HubspotIntegration extends CrmAbstractIntegration
             if (isset($stageName)) {
                 $stage = $this->stageRepository->getStageByName($stageName);
 
-                if (empty($stage)) {
+                if (null === $stage) {
                     $stage = new Stage();
                     $stage->setName($stageName);
                     $stages[$stageName] = $stage;

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -162,10 +162,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
         return sprintf('%s/services/data/v38.0', $this->keys['instance_url']);
     }
 
-    /**
-     * @param bool $inAuthorization
-     */
-    public function getBearerToken($inAuthorization = false)
+    public function getBearerToken(bool $inAuthorization = false): false|string
     {
         if (!$inAuthorization && isset($this->keys[$this->getAuthTokenKey()])) {
             return $this->keys[$this->getAuthTokenKey()];
@@ -2318,10 +2315,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
         return $limit - count($currentContactList);
     }
 
-    /**
-     * @return array|bool
-     */
-    protected function checkLeadIsContact(array &$trackedContacts, $email, $contactId, $leadFields)
+    protected function checkLeadIsContact(array &$trackedContacts, $email, $contactId, $leadFields): array|bool|null
     {
         if (empty($trackedContacts[$email])) {
             // Check if there's an existing entry

--- a/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
@@ -54,7 +54,7 @@ final class SugarcrmIntegration extends CrmAbstractIntegration
      */
     private array $sugarDncKeys = ['email_opt_out', 'invalid_email'];
 
-    private $authorizationError;
+    private bool|string|array|null $authorizationError = null;
 
     /**
      * Returns the name of the social integration that must match the name of the file.
@@ -128,11 +128,9 @@ final class SugarcrmIntegration extends CrmAbstractIntegration
     /**
      * Retrieves and stores tokens returned from oAuthLogin.
      *
-     * @param array $parameters
-     *
      * @return array
      */
-    public function authCallback(array $settings = [], $parameters = [])
+    public function authCallback(array $settings = [], array $parameters = []): array|false
     {
         if (isset($this->keys['version']) && '6' == $this->keys['version']) {
             $success = $this->isAuthorized();
@@ -589,10 +587,7 @@ final class SugarcrmIntegration extends CrmAbstractIntegration
         return parent::prepareRequest($url, $parameters, $method, $settings, $authType);
     }
 
-    /**
-     * @return bool
-     */
-    public function isAuthorized()
+    public function isAuthorized(): bool
     {
         if (!$this->isConfigured()) {
             return false;

--- a/plugins/MauticCrmBundle/Integration/VtigerIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/VtigerIntegration.php
@@ -67,7 +67,7 @@ class VtigerIntegration extends CrmAbstractIntegration
     /**
      * @return bool|array<mixed>|string
      */
-    public function isAuthorized()
+    public function isAuthorized(): bool|string|array
     {
         if (!isset($this->keys['url'])) {
             return false;
@@ -117,10 +117,8 @@ class VtigerIntegration extends CrmAbstractIntegration
 
     /**
      * Retrieves and stores tokens returned from oAuthLogin.
-     *
-     * @param array $parameters
      */
-    public function authCallback(array $settings = [], $parameters = []): string|bool
+    public function authCallback(array $settings = [], array $parameters = []): string|false
     {
         $success = $this->isAuthorized();
         if (!$success) {

--- a/plugins/MauticCrmBundle/Tests/Integration/HubspotIntegrationTest.php
+++ b/plugins/MauticCrmBundle/Tests/Integration/HubspotIntegrationTest.php
@@ -60,7 +60,7 @@ final class HubspotIntegrationTest extends AbstractIntegrationTestCase
             ->willReturn($event);
 
         $this->integration->encryptAndSetApiKeys([HubspotIntegration::ACCESS_KEY], $this->createStub(Integration::class));
-        $this->assertNull($this->integration->getBearerToken());
+        $this->assertFalse($this->integration->getBearerToken());
     }
 
     public function testGetBearerTokenSet(): void

--- a/plugins/MauticEmailMarketingBundle/Integration/ConstantContactIntegration.php
+++ b/plugins/MauticEmailMarketingBundle/Integration/ConstantContactIntegration.php
@@ -39,12 +39,8 @@ final class ConstantContactIntegration extends EmailAbstractIntegration
 
     /**
      * Retrieves and stores tokens returned from oAuthLogin.
-     *
-     * @param array $parameters
-     *
-     * @return bool|string false if no error; otherwise the error string
      */
-    public function authCallback(array $settings = [], $parameters = [])
+    public function authCallback(array $settings = [], array $parameters = []): string|false
     {
         // Constanct Contact doesn't like POST
         $settings['method'] = 'GET';

--- a/plugins/MauticEmailMarketingBundle/Integration/IcontactIntegration.php
+++ b/plugins/MauticEmailMarketingBundle/Integration/IcontactIntegration.php
@@ -50,7 +50,7 @@ final class IcontactIntegration extends EmailAbstractIntegration
     /**
      * Get account ID and client folder ID.
      */
-    public function authCallback(array $settings = [], $parameters = [])
+    public function authCallback(array $settings = [], array $parameters = []): false|string
     {
         $url = $this->getApiUrl();
 

--- a/plugins/MauticEmailMarketingBundle/Integration/MailchimpIntegration.php
+++ b/plugins/MauticEmailMarketingBundle/Integration/MailchimpIntegration.php
@@ -50,12 +50,7 @@ final class MailchimpIntegration extends EmailAbstractIntegration
             ];
     }
 
-    /**
-     * @param array $parameters
-     *
-     * @return bool|string
-     */
-    public function authCallback(array $settings = [], $parameters = [])
+    public function authCallback(array $settings = [], array $parameters = []): string|false
     {
         $error = parent::authCallback($settings, $parameters);
 

--- a/plugins/MauticSocialBundle/Command/MonitorTwitterBaseCommand.php
+++ b/plugins/MauticSocialBundle/Command/MonitorTwitterBaseCommand.php
@@ -109,12 +109,8 @@ abstract class MonitorTwitterBaseCommand extends Command
 
     /**
      * Search for tweets by creating your own search criteria.
-     *
-     * @param Monitoring $monitor
-     *
-     * @return array The results of makeRequest
      */
-    abstract protected function getTweets($monitor);
+    abstract protected function getTweets(Monitoring $monitor): array|false;
 
     /**
      * Main execution method. Gets the integration settings, processes the search criteria.
@@ -177,12 +173,8 @@ abstract class MonitorTwitterBaseCommand extends Command
      *
      * @Note: Keeping this method here instead of in the twitterCommandHelper
      *        so that the hashtag and mention commands can easily extend it.
-     *
-     * @param Monitoring $monitor
-     *
-     * @return bool
      */
-    protected function processMonitor($monitor)
+    protected function processMonitor(Monitoring $monitor): bool
     {
         $results = $this->getTweets($monitor);
 

--- a/plugins/MauticSocialBundle/Command/MonitorTwitterHashtagsCommand.php
+++ b/plugins/MauticSocialBundle/Command/MonitorTwitterHashtagsCommand.php
@@ -13,12 +13,8 @@ final class MonitorTwitterHashtagsCommand extends MonitorTwitterBaseCommand
 {
     /**
      * Search for tweets by hashtag.
-     *
-     * @param Monitoring $monitor
-     *
-     * @return bool|array False if missing the hashtag, otherwise the array response from Twitter
      */
-    protected function getTweets($monitor)
+    protected function getTweets(Monitoring $monitor): array|false
     {
         $params = $monitor->getProperties();
         $stats  = $monitor->getStats();

--- a/plugins/MauticSocialBundle/Command/MonitorTwitterMentionsCommand.php
+++ b/plugins/MauticSocialBundle/Command/MonitorTwitterMentionsCommand.php
@@ -13,12 +13,8 @@ final class MonitorTwitterMentionsCommand extends MonitorTwitterBaseCommand
 {
     /**
      * Search for tweets by mention.
-     *
-     * @param Monitoring $monitor
-     *
-     * @return bool|array False if missing the twitter handle, otherwise the array response from Twitter
      */
-    protected function getTweets($monitor)
+    protected function getTweets(Monitoring $monitor): array|false
     {
         $params = $monitor->getProperties();
         $stats  = $monitor->getStats();

--- a/plugins/MauticSocialBundle/Integration/FoursquareIntegration.php
+++ b/plugins/MauticSocialBundle/Integration/FoursquareIntegration.php
@@ -247,10 +247,8 @@ final class FoursquareIntegration extends SocialIntegration
 
     /**
      * @param array<string, mixed> $socialCache
-     *
-     * @return bool
      */
-    private function getContactUserId(array|string &$identifier, array &$socialCache)
+    private function getContactUserId(array|string &$identifier, array &$socialCache): false|string
     {
         if (!empty($socialCache['id'])) {
             return $socialCache['id'];

--- a/plugins/MauticSocialBundle/Integration/InstagramIntegration.php
+++ b/plugins/MauticSocialBundle/Integration/InstagramIntegration.php
@@ -113,7 +113,7 @@ final class InstagramIntegration extends SocialIntegration
     /**
      * @param array<string, mixed> $socialCache
      */
-    private function getContactUserId(&$identifier, array &$socialCache)
+    private function getContactUserId(&$identifier, array &$socialCache): false|string
     {
         if (!empty($socialCache['id'])) {
             return $socialCache['id'];


### PR DESCRIPTION
Adds missing `param` and `return` type declarations across `plugins` (MauticCrm, MauticEmailMarketing, MauticSocial). Pure type-safety improvement, no behaviour change — native types replace docblock annotations.

Part of a 3-PR type-coverage series; this one covers plugins.
