### PR TITLE
[types] add return type to getTweets() in Twitter monitor commands

### DIFF
--- a/plugins/MauticSocialBundle/Command/MonitorTwitterBaseCommand.php
+++ b/plugins/MauticSocialBundle/Command/MonitorTwitterBaseCommand.php
@@ -109,12 +109,8 @@ abstract class MonitorTwitterBaseCommand extends Command
 
     /**
      * Search for tweets by creating your own search criteria.
-     *
-     * @param Monitoring $monitor
-     *
-     * @return array The results of makeRequest
      */
-    abstract protected function getTweets($monitor);
+    abstract protected function getTweets(Monitoring $monitor): array|false;
 
     /**
      * Main execution method. Gets the integration settings, processes the search criteria.

--- a/plugins/MauticSocialBundle/Command/MonitorTwitterHashtagsCommand.php
+++ b/plugins/MauticSocialBundle/Command/MonitorTwitterHashtagsCommand.php
@@ -13,12 +13,8 @@ final class MonitorTwitterHashtagsCommand extends MonitorTwitterBaseCommand
 {
     /**
      * Search for tweets by hashtag.
-     *
-     * @param Monitoring $monitor
-     *
-     * @return bool|array False if missing the hashtag, otherwise the array response from Twitter
      */
-    protected function getTweets($monitor)
+    protected function getTweets(Monitoring $monitor): array|false
     {
         $params = $monitor->getProperties();
         $stats  = $monitor->getStats();

--- a/plugins/MauticSocialBundle/Command/MonitorTwitterMentionsCommand.php
+++ b/plugins/MauticSocialBundle/Command/MonitorTwitterMentionsCommand.php
@@ -13,12 +13,8 @@ final class MonitorTwitterMentionsCommand extends MonitorTwitterBaseCommand
 {
     /**
      * Search for tweets by mention.
-     *
-     * @param Monitoring $monitor
-     *
-     * @return bool|array False if missing the twitter handle, otherwise the array response from Twitter
      */
-    protected function getTweets($monitor)
+    protected function getTweets(Monitoring $monitor): array|false
     {
         $params = $monitor->getProperties();
         $stats  = $monitor->getStats();


### PR DESCRIPTION
Adds native return types to `getTweets()` in the Twitter monitor commands.

Split out of the larger `tv-type-perfect` branch — one of **8 focused PRs** grouped by method / bundle so each is small to review. No behaviour change, type declarations only.

### Example
```diff
-    protected function getTweets($monitor)
+    protected function getTweets(Monitoring $monitor): array|false
```
