### PR TITLE
[types] add type declarations across plugins and remaining bundles

### DIFF
--- a/app/bundles/CampaignBundle/Entity/Campaign.php
+++ b/app/bundles/CampaignBundle/Entity/Campaign.php
@@ -559,7 +559,7 @@ class Campaign extends FormEntity implements OptimisticLockInterface, UuidInterf
     }
 
     /**
-     * @return ArrayCollection<int, LeadList>
+     * @return Collection<int, LeadList>
      */
     public function getLists(): Collection
     {

--- a/app/bundles/CampaignBundle/Executioner/Dispatcher/LegacyEventDispatcher.php
+++ b/app/bundles/CampaignBundle/Executioner/Dispatcher/LegacyEventDispatcher.php
@@ -127,10 +127,7 @@ class LegacyEventDispatcher
         return $campaignEvent;
     }
 
-    /**
-     * @return mixed
-     */
-    private function dispatchCallback(array $settings, LeadEventLog $log)
+    private function dispatchCallback(array $settings, LeadEventLog $log): mixed
     {
         @trigger_error('callback is deprecated. Convert to using batchEventName.', E_USER_DEPRECATED);
 

--- a/app/bundles/ChannelBundle/Tests/Model/ChannelActionModelTest.php
+++ b/app/bundles/ChannelBundle/Tests/Model/ChannelActionModelTest.php
@@ -188,7 +188,7 @@ final class ChannelActionModelTest extends \PHPUnit\Framework\TestCase
         $matcher = $this->exactly(2);
 
         $this->doNotContactMock->expects($matcher)
-            ->method('addDncForContact')->willReturnCallback(function (...$parameters) use ($matcher): void {
+            ->method('addDncForContact')->willReturnCallback(function (...$parameters) use ($matcher): false {
                 if (1 === $matcher->numberOfInvocations()) {
                     $this->assertSame(5, $parameters[0]);
                     $this->assertSame('email', $parameters[1]);
@@ -199,6 +199,8 @@ final class ChannelActionModelTest extends \PHPUnit\Framework\TestCase
                     $this->assertSame('sms', $parameters[1]);
                     $this->assertSame(DNC::MANUAL, $parameters[2]);
                 }
+
+                return false;
             });
 
         $this->actionModel->update($contacts, $subscribedChannels);

--- a/app/bundles/CoreBundle/Model/AbstractCommonModel.php
+++ b/app/bundles/CoreBundle/Model/AbstractCommonModel.php
@@ -202,7 +202,7 @@ abstract class AbstractCommonModel implements MauticModelInterface
         }
 
         if ($lang && !isset($locales[$lang])) {
-            // Language doesn't exist so return false
+            // Language doesn't exist so return null
 
             return null;
         }

--- a/app/bundles/DynamicContentBundle/Tests/Unit/Validator/Constraints/NoNestingValidatorTest.php
+++ b/app/bundles/DynamicContentBundle/Tests/Unit/Validator/Constraints/NoNestingValidatorTest.php
@@ -67,7 +67,7 @@ final class NoNestingValidatorTest extends TestCase
         $this->assertSame(self::TRANSLATED_MESSAGE, $this->context->getViolations()->get(0)->getMessage());
     }
 
-    private function createContext(): ExecutionContextInterface
+    private function createContext(): ExecutionContext
     {
         $locale     = 'en_US';
         $translator = new Translator($locale);

--- a/app/bundles/IntegrationsBundle/Auth/Provider/ApiKey/HttpFactory.php
+++ b/app/bundles/IntegrationsBundle/Auth/Provider/ApiKey/HttpFactory.php
@@ -84,16 +84,14 @@ final class HttpFactory implements AuthProviderInterface
         return !empty($credentials->getApiKey());
     }
 
-    private function getHeaderClient(): ClientInterface
+    private function getHeaderClient(): Client
     {
-        return new Client(
-            [
-                'headers' => [$this->credentials->getKeyName() => $this->credentials->getApiKey()],
-            ]
-        );
+        return new Client([
+            'headers' => [$this->credentials->getKeyName() => $this->credentials->getApiKey()],
+        ]);
     }
 
-    private function getParameterClient(): ClientInterface
+    private function getParameterClient(): Client
     {
         $handler = new HandlerStack();
         $handler->setHandler(new CurlHandler());
@@ -106,10 +104,8 @@ final class HttpFactory implements AuthProviderInterface
             )
         );
 
-        return new Client(
-            [
-                'handler' => $handler,
-            ]
-        );
+        return new Client([
+            'handler' => $handler,
+        ]);
     }
 }

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -1385,7 +1385,7 @@ class LeadModel extends FormModel
                 // Set stage for contact
                 $stage = $this->stageRepository->getStageByName($stageName);
 
-                if (empty($stage)) {
+                if (null === $stage) {
                     $stage = new Stage();
                     $stage->setName($stageName);
                     $stages[$stageName] = $stage;

--- a/app/bundles/PageBundle/Helper/TrackingHelper.php
+++ b/app/bundles/PageBundle/Helper/TrackingHelper.php
@@ -86,10 +86,7 @@ class TrackingHelper
         return (array) $cacheValue;
     }
 
-    /**
-     * @return bool|mixed
-     */
-    public function displayInitCode($service)
+    public function displayInitCode($service): mixed
     {
         $pixelId = $this->coreParametersHelper->get($service.'_id');
 

--- a/app/bundles/PluginBundle/Entity/IntegrationEntityRepository.php
+++ b/app/bundles/PluginBundle/Entity/IntegrationEntityRepository.php
@@ -102,10 +102,7 @@ class IntegrationEntityRepository extends CommonRepository
         return $q->executeQuery()->fetchAllAssociative();
     }
 
-    /**
-     * @return array
-     */
-    public function getIntegrationEntity($integration, $integrationEntity, $internalEntity, $internalEntityId, $leadFields = null)
+    public function getIntegrationEntity($integration, $integrationEntity, $internalEntity, $internalEntityId, $leadFields = null): ?array
     {
         $q = $this->_em->getConnection()->createQueryBuilder()
             ->from(MAUTIC_TABLE_PREFIX.'integration_entity', 'i')

--- a/app/bundles/PluginBundle/Event/PluginIntegrationKeyEvent.php
+++ b/app/bundles/PluginBundle/Event/PluginIntegrationKeyEvent.php
@@ -18,7 +18,7 @@ class PluginIntegrationKeyEvent extends AbstractPluginIntegrationEvent
     /**
      * Get the keys array.
      *
-     * @return mixed[]|null
+     * @return array<string, mixed>|null
      */
     public function getKeys(): ?array
     {
@@ -26,7 +26,7 @@ class PluginIntegrationKeyEvent extends AbstractPluginIntegrationEvent
     }
 
     /**
-     * Set new keys array.
+     * @param array<string, mixed> $keys
      */
     public function setKeys(array $keys): void
     {

--- a/app/bundles/PluginBundle/Integration/AbstractIntegration.php
+++ b/app/bundles/PluginBundle/Integration/AbstractIntegration.php
@@ -72,6 +72,9 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
 
     protected ?Integration $settings = null;
 
+    /**
+     * @var array<string, string>
+     */
     protected array $keys = [];
 
     protected CacheInterface $cache;
@@ -403,9 +406,9 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
     /**
      * Returns already decrypted keys.
      *
-     * @return mixed
+     * @return array<string, string>
      */
-    public function getKeys()
+    public function getKeys(): array
     {
         return $this->keys;
     }
@@ -1114,10 +1117,8 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
 
     /**
      * Extacts the auth keys from response and saves entity.
-     *
-     * @return bool|string false if no error; otherwise the error string
      */
-    public function extractAuthKeys($data, $tokenOverride = null)
+    public function extractAuthKeys($data, $tokenOverride = null): bool|string|array
     {
         // check to see if an entity exists
         $entity = $this->getIntegrationSettings();
@@ -2143,11 +2144,9 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
     }
 
     /**
-     * @param array $keys
-     *
-     * @return array
+     * @return array<string, mixed>
      */
-    protected function dispatchIntegrationKeyEvent(?string $eventName, $keys = [])
+    protected function dispatchIntegrationKeyEvent(?string $eventName, array $keys = [])
     {
         /** @var PluginIntegrationKeyEvent $event */
         $event = $this->dispatcher->dispatch(

--- a/app/bundles/PluginBundle/Integration/AbstractSsoServiceIntegration.php
+++ b/app/bundles/PluginBundle/Integration/AbstractSsoServiceIntegration.php
@@ -78,10 +78,8 @@ abstract class AbstractSsoServiceIntegration extends AbstractIntegration
 
     /**
      * Don't save the keys as they are only used to validate user login.
-     *
-     * @return array
      */
-    public function extractAuthKeys($data, $tokenOverride = null)
+    public function extractAuthKeys($data, $tokenOverride = null): bool|array
     {
         // Prepare the keys for extraction such as renaming, setting expiry, etc
         $data = $this->prepareResponseForExtraction($data);

--- a/app/bundles/PointBundle/Entity/PointInsight.php
+++ b/app/bundles/PointBundle/Entity/PointInsight.php
@@ -259,12 +259,7 @@ class PointInsight extends FormEntity
         return $this->isActive();
     }
 
-    /**
-     * @param bool $active
-     *
-     * @return PointInsight
-     */
-    public function setActive($active): FormEntity
+    public function setActive(bool $active): self
     {
         return $this->setIsPublished($active);
     }

--- a/app/bundles/PointBundle/Model/TriggerModel.php
+++ b/app/bundles/PointBundle/Model/TriggerModel.php
@@ -307,7 +307,7 @@ class TriggerModel extends CommonFormModel implements GlobalSearchInterface
      *
      * @return bool Was event triggered
      */
-    public function triggerEvent(array $event, ?Lead $lead = null, $force = false)
+    public function triggerEvent(array $event, ?Lead $lead = null, $force = false): bool
     {
         // only trigger events for anonymous users
         if (!$force && !$this->security->isAnonymous()) {

--- a/app/bundles/SmsBundle/Helper/SmsHelper.php
+++ b/app/bundles/SmsBundle/Helper/SmsHelper.php
@@ -2,7 +2,6 @@
 
 namespace Mautic\SmsBundle\Helper;
 
-use libphonenumber\PhoneNumberFormat;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\PhoneNumberHelper;
 use Mautic\LeadBundle\Entity\DoNotContact as DoNotContactEntity;
@@ -27,9 +26,9 @@ class SmsHelper
     ) {
     }
 
-    public function unsubscribe($number)
+    public function unsubscribe($number): false|DoNotContactEntity
     {
-        $number = $this->phoneNumberHelper->format($number, PhoneNumberFormat::E164);
+        $number = $this->phoneNumberHelper->format($number);
 
         $args = [
             'filter' => [

--- a/app/bundles/StageBundle/Entity/StageRepository.php
+++ b/app/bundles/StageBundle/Entity/StageRepository.php
@@ -158,15 +158,10 @@ class StageRepository extends CommonRepository
         return $q->getQuery()->getArrayResult();
     }
 
-    /**
-     * Get a list of stages.
-     *
-     * @return array
-     */
-    public function getStageByName($stageName)
+    public function getStageByName(string $stageName): ?Stage
     {
         if (!$stageName) {
-            return false;
+            return null;
         }
 
         $q = $this->_em->createQueryBuilder()

--- a/app/bundles/UserBundle/Event/AuthenticationEvent.php
+++ b/app/bundles/UserBundle/Event/AuthenticationEvent.php
@@ -129,12 +129,7 @@ class AuthenticationEvent extends Event
         return $this->token->getUserIdentifier();
     }
 
-    /**
-     * Get user provider to find and/or create new users.
-     *
-     * @return UserProvider
-     */
-    public function getUserProvider(): UserProviderInterface
+    public function getUserProvider(): UserProvider
     {
         return $this->userProvider;
     }

--- a/app/bundles/UserBundle/Tests/Security/Authenticator/PluginAuthenticatorTest.php
+++ b/app/bundles/UserBundle/Tests/Security/Authenticator/PluginAuthenticatorTest.php
@@ -201,7 +201,7 @@ final class PluginAuthenticatorTest extends TestCase
         $passportUser->method('getPassword')->willReturn($encodedPassword);
         $passportUser->method('getRoles')->willReturn($roles);
 
-        $userBadge = new UserBadge('', fn (): UserInterface => $passportUser);
+        $userBadge = new UserBadge('user', fn (): UserInterface => $passportUser);
 
         $pluginBadge = new PluginBadge(null, $pluginResponse, $authenticatingService);
 

--- a/plugins/MauticCrmBundle/Api/SalesforceApi.php
+++ b/plugins/MauticCrmBundle/Api/SalesforceApi.php
@@ -546,12 +546,10 @@ final class SalesforceApi extends CrmApi
     }
 
     /**
-     * @return string|false
-     *
      * @throws ApiErrorException
      * @throws RetryRequestException
      */
-    private function processError(array $error, bool $isRetry)
+    private function processError(array $error, bool $isRetry): string|false
     {
         switch ($error['errorCode']) {
             case 'INVALID_SESSION_ID':

--- a/plugins/MauticCrmBundle/Integration/DynamicsIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/DynamicsIntegration.php
@@ -149,7 +149,7 @@ final class DynamicsIntegration extends CrmAbstractIntegration
     /**
      * @param bool $inAuthorization
      */
-    public function getBearerToken($inAuthorization = false)
+    public function getBearerToken($inAuthorization = false): string|false
     {
         if (!$inAuthorization && isset($this->keys[$this->getAuthTokenKey()])) {
             return $this->keys[$this->getAuthTokenKey()];

--- a/plugins/MauticCrmBundle/Integration/HubspotIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/HubspotIntegration.php
@@ -477,7 +477,7 @@ class HubspotIntegration extends CrmAbstractIntegration
             if (isset($stageName)) {
                 $stage = $this->stageRepository->getStageByName($stageName);
 
-                if (empty($stage)) {
+                if (null === $stage) {
                     $stage = new Stage();
                     $stage->setName($stageName);
                     $stages[$stageName] = $stage;

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -165,7 +165,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
     /**
      * @param bool $inAuthorization
      */
-    public function getBearerToken($inAuthorization = false)
+    public function getBearerToken($inAuthorization = false): string|false
     {
         if (!$inAuthorization && isset($this->keys[$this->getAuthTokenKey()])) {
             return $this->keys[$this->getAuthTokenKey()];
@@ -2318,10 +2318,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
         return $limit - count($currentContactList);
     }
 
-    /**
-     * @return array|bool
-     */
-    protected function checkLeadIsContact(array &$trackedContacts, $email, $contactId, $leadFields)
+    protected function checkLeadIsContact(array &$trackedContacts, $email, $contactId, $leadFields): array|bool|null
     {
         if (empty($trackedContacts[$email])) {
             // Check if there's an existing entry

--- a/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
@@ -54,7 +54,7 @@ final class SugarcrmIntegration extends CrmAbstractIntegration
      */
     private array $sugarDncKeys = ['email_opt_out', 'invalid_email'];
 
-    private $authorizationError;
+    private bool|string|array|null $authorizationError = null;
 
     /**
      * Returns the name of the social integration that must match the name of the file.

--- a/plugins/MauticSocialBundle/Command/MonitorTwitterBaseCommand.php
+++ b/plugins/MauticSocialBundle/Command/MonitorTwitterBaseCommand.php
@@ -173,12 +173,8 @@ abstract class MonitorTwitterBaseCommand extends Command
      *
      * @Note: Keeping this method here instead of in the twitterCommandHelper
      *        so that the hashtag and mention commands can easily extend it.
-     *
-     * @param Monitoring $monitor
-     *
-     * @return bool
      */
-    protected function processMonitor($monitor)
+    protected function processMonitor(Monitoring $monitor): bool
     {
         $results = $this->getTweets($monitor);
 

--- a/plugins/MauticSocialBundle/Integration/FoursquareIntegration.php
+++ b/plugins/MauticSocialBundle/Integration/FoursquareIntegration.php
@@ -247,10 +247,8 @@ final class FoursquareIntegration extends SocialIntegration
 
     /**
      * @param array<string, mixed> $socialCache
-     *
-     * @return bool
      */
-    private function getContactUserId(array|string &$identifier, array &$socialCache)
+    private function getContactUserId(array|string &$identifier, array &$socialCache): false|string
     {
         if (!empty($socialCache['id'])) {
             return $socialCache['id'];

--- a/plugins/MauticSocialBundle/Integration/InstagramIntegration.php
+++ b/plugins/MauticSocialBundle/Integration/InstagramIntegration.php
@@ -113,7 +113,7 @@ final class InstagramIntegration extends SocialIntegration
     /**
      * @param array<string, mixed> $socialCache
      */
-    private function getContactUserId(&$identifier, array &$socialCache)
+    private function getContactUserId(&$identifier, array &$socialCache): false|string
     {
         if (!empty($socialCache['id'])) {
             return $socialCache['id'];


### PR DESCRIPTION
Adds param/return/property type declarations across the plugins (Crm, Social, EmailMarketing), PluginBundle, IntegrationsBundle and remaining small bundles.

Split out of the larger `tv-type-perfect` branch — one of **8 focused PRs** grouped by method / bundle so each is small to review. No behaviour change, type declarations only.

### Example
```diff
-    public function getKeys()
+    public function getKeys(): array
```
