### PR TITLE
Stabilize GrapesJS builder acceptance test startup

### DIFF
--- a/tests/acceptance/GrapesJsBuilderPageCest.php
+++ b/tests/acceptance/GrapesJsBuilderPageCest.php
@@ -65,6 +65,7 @@ final class GrapesJsBuilderPageCest
     private function openBuilder(AcceptanceTester $I): void
     {
         $I->waitForJS("return typeof Mautic.launchBuilder === 'function' && Mautic.launchBuilder.toString().includes('builder-active') && document.querySelector('#page_buttons_builder') !== null;", 30);
+        $I->waitForJS("return document.querySelector('#page_buttons_builder').disabled === false;", 30);
         $I->executeJS("document.querySelector('#page_buttons_builder').click();");
         $I->waitForElementVisible('.builder.builder-active', 30);
     }

--- a/tests/acceptance/GrapesJsBuilderPageCest.php
+++ b/tests/acceptance/GrapesJsBuilderPageCest.php
@@ -19,7 +19,7 @@ final class GrapesJsBuilderPageCest
         $I->waitForElementVisible('form[name="page"]');
         $I->fillField('input[name="page[title]"]', 'GrapesJS E2E '.date('YmdHis'));
 
-        $I->click('.btn-builder');
+        $this->openBuilder($I);
         $this->editCanvasText($I);
 
         $I->click('#btn-views-apply');
@@ -37,7 +37,7 @@ final class GrapesJsBuilderPageCest
         $I->reloadPage();
         $I->waitForElementVisible('.btn-builder');
 
-        $I->click('.btn-builder');
+        $this->openBuilder($I);
         $this->waitForCanvasContent($I);
         $I->switchToIFrame('iframe.gjs-frame');
         $I->see(self::EDITED_CONTENT);
@@ -60,6 +60,13 @@ final class GrapesJsBuilderPageCest
         $I->pressKey('[contenteditable="true"]', self::EDITED_CONTENT);
         $I->see(self::EDITED_CONTENT, '[contenteditable="true"]');
         $I->switchToIFrame();
+    }
+
+    private function openBuilder(AcceptanceTester $I): void
+    {
+        $I->waitForJS("return typeof Mautic.launchBuilder === 'function' && document.querySelector('#page_buttons_builder') !== null;", 30);
+        $I->executeJS("document.querySelector('#page_buttons_builder').click();");
+        $I->waitForElementVisible('.builder.builder-active', 30);
     }
 
     private function waitForCanvasContent(AcceptanceTester $I): void

--- a/tests/acceptance/GrapesJsBuilderPageCest.php
+++ b/tests/acceptance/GrapesJsBuilderPageCest.php
@@ -64,7 +64,7 @@ final class GrapesJsBuilderPageCest
 
     private function openBuilder(AcceptanceTester $I): void
     {
-        $I->waitForJS("return typeof Mautic.launchBuilder === 'function' && document.querySelector('#page_buttons_builder') !== null;", 30);
+        $I->waitForJS("return typeof Mautic.launchBuilder === 'function' && Mautic.launchBuilder.toString().includes('builder-active') && document.querySelector('#page_buttons_builder') !== null;", 30);
         $I->executeJS("document.querySelector('#page_buttons_builder').click();");
         $I->waitForElementVisible('.builder.builder-active', 30);
     }


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✅
| New feature/enhancement? (use the a.x branch) | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✅
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | No public issue. This fixes an intermittent acceptance-test failure.

## Description

The GrapesJS acceptance test opened the builder through the generic `.btn-builder` selector. The page contains both the canonical form button and a generated toolbar proxy, so the selector could target the wrong control.

The test now waits for the GrapesJS `Mautic.launchBuilder` implementation, targets the canonical `#page_buttons_builder` button, waits for its theme-loading request to finish and the button to become enabled, then waits for `.builder.builder-active` before interacting with the canvas. This prevents a missed click when the theme AJAX request is still disabling the builder button, which occurred consistently in the `mautic/mautic-security` CI environment under its slower timing.

Application behavior is unchanged; this only stabilizes the acceptance test.

---
### 📋 Steps to test this PR:

1. Check out this PR in a configured DDEV environment.
2. Run `ddev exec php bin/codecept run acceptance GrapesJsBuilderPageCest:landingPageContentSurvivesBuilderSaveAndReload --steps`.
3. Run the same scenario again without `--steps`.
4. Confirm the builder opens on both attempts, the GrapesJS canvas loads, edited content survives Save and reload, and the final public page contains the edited content.
