### PR TITLE
[phpstan] Prefer class service references, drop redundant aliases and setter calls

### DIFF
--- a/app/bundles/CacheBundle/Cache/CacheProvider.php
+++ b/app/bundles/CacheBundle/Cache/CacheProvider.php
@@ -6,7 +6,7 @@ namespace Mautic\CacheBundle\Cache;
 
 use Symfony\Component\Cache\Adapter\AdapterInterface;
 
-final class CacheProvider extends AbstractCacheProvider
+class CacheProvider extends AbstractCacheProvider
 {
     public function getCacheAdapter(): AdapterInterface
     {

--- a/app/bundles/CacheBundle/Config/services.php
+++ b/app/bundles/CacheBundle/Config/services.php
@@ -28,9 +28,8 @@ return function (ContainerConfigurator $configurator): void {
         ->arg('$namespace', param('mautic.cache_prefix'))
         ->arg('$lifetime', param('mautic.cache_lifetime'))
         ->tag('mautic.cache.adapter');
-    $services->alias('mautic.cache.adapter.memcached', Mautic\CacheBundle\Cache\Adapter\MemcachedTagAwareAdapter::class);
+
     $services->set(Mautic\CacheBundle\EventListener\CacheClearSubscriber::class)
-        ->arg('$cacheProvider', service(Mautic\CacheBundle\Cache\CacheProvider::class))
         ->arg('$logger', service('monolog.logger.mautic'))
         ->tag('kernel.cache_clearer');
 

--- a/app/bundles/CacheBundle/Config/services.php
+++ b/app/bundles/CacheBundle/Config/services.php
@@ -30,12 +30,11 @@ return function (ContainerConfigurator $configurator): void {
         ->tag('mautic.cache.adapter');
     $services->alias('mautic.cache.adapter.memcached', Mautic\CacheBundle\Cache\Adapter\MemcachedTagAwareAdapter::class);
     $services->set(Mautic\CacheBundle\EventListener\CacheClearSubscriber::class)
-        ->arg('$cacheProvider', service('mautic.cache.provider'))
+        ->arg('$cacheProvider', service(Mautic\CacheBundle\Cache\CacheProvider::class))
         ->arg('$logger', service('monolog.logger.mautic'))
         ->tag('kernel.cache_clearer');
 
     $services->alias(Mautic\CacheBundle\Cache\CacheProviderInterface::class, Mautic\CacheBundle\Cache\CacheProvider::class);
-    $services->alias('mautic.cache.provider', Mautic\CacheBundle\Cache\CacheProvider::class);
     $services->alias('mautic.cache.adapter.redis', Mautic\CacheBundle\Cache\Adapter\RedisAdapter::class);
     $services->alias('mautic.cache.adapter.redis_tag_aware', Mautic\CacheBundle\Cache\Adapter\RedisTagAwareAdapter::class);
 

--- a/app/bundles/CacheBundle/EventListener/CacheClearSubscriber.php
+++ b/app/bundles/CacheBundle/EventListener/CacheClearSubscriber.php
@@ -6,16 +6,12 @@ namespace Mautic\CacheBundle\EventListener;
 
 use Mautic\CacheBundle\Cache\CacheProvider;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\HttpKernel\CacheClearer\CacheClearerInterface;
 
 final readonly class CacheClearSubscriber implements CacheClearerInterface
 {
-    /**
-     * @param CacheProvider $cacheProvider
-     */
     public function __construct(
-        private AdapterInterface $cacheProvider,
+        private CacheProvider $cacheProvider,
         private LoggerInterface $logger,
     ) {
     }

--- a/app/bundles/CacheBundle/Tests/EventListener/CacheClearSubscriberTest.php
+++ b/app/bundles/CacheBundle/Tests/EventListener/CacheClearSubscriberTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\CacheBundle\Tests\EventListener;
 
-use Mautic\CacheBundle\Cache\AbstractCacheProvider;
+use Mautic\CacheBundle\Cache\CacheProvider;
 use Mautic\CacheBundle\EventListener\CacheClearSubscriber;
 use Monolog\Logger;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -13,14 +13,14 @@ use Symfony\Component\Cache\Adapter\AdapterInterface;
 final class CacheClearSubscriberTest extends \PHPUnit\Framework\TestCase
 {
     /**
-     * @var MockObject&AbstractCacheProvider
+     * @var MockObject&CacheProvider
      */
     private MockObject $adapter;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->adapter = $this->getMockBuilder(AbstractCacheProvider::class)
+        $this->adapter = $this->getMockBuilder(CacheProvider::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['clear', 'commit', 'getCacheAdapter'])
             ->getMock();

--- a/app/bundles/CoreBundle/Config/services.php
+++ b/app/bundles/CoreBundle/Config/services.php
@@ -52,10 +52,8 @@ return function (ContainerConfigurator $configurator): void {
 
     $services->load('Mautic\\CoreBundle\\Entity\\', '../Entity/*Repository.php');
 
-    $services->alias('mautic.helper.core_parameters', Mautic\CoreBundle\Helper\CoreParametersHelper::class);
-
     $services->set(Mautic\CoreBundle\IpLookup\AbstractLookup::class)
-        ->factory([service('mautic.ip_lookup.factory'), 'getService'])
+        ->factory([service(Mautic\CoreBundle\Factory\IpLookupFactory::class), 'getService'])
         ->args([param('mautic.ip_lookup_service'), param('mautic.ip_lookup_auth'), param('mautic.ip_lookup_config'), service('mautic.http.client')]);
     $services->set(Symfony\Contracts\HttpClient\HttpClientInterface::class)
         ->factory(Symfony\Component\HttpClient\HttpClient::create(...));
@@ -96,7 +94,6 @@ return function (ContainerConfigurator $configurator): void {
     $services->set(Mautic\CoreBundle\Factory\IpLookupFactory::class)
         ->arg('$lookupServices', param('mautic.ip_lookup_services'))
         ->arg('$cacheDir', param('kernel.cache_dir'));
-    $services->alias('mautic.ip_lookup.factory', Mautic\CoreBundle\Factory\IpLookupFactory::class);
     $services->set('mautic.schema.helper.column', Mautic\CoreBundle\Doctrine\Helper\ColumnSchemaHelper::class)
         ->arg('$prefix', param('mautic.db_table_prefix'));
     $services->alias(Mautic\CoreBundle\Doctrine\Helper\ColumnSchemaHelper::class, 'mautic.schema.helper.column');
@@ -126,7 +123,6 @@ return function (ContainerConfigurator $configurator): void {
     $services->set('mautic.configurator', Mautic\CoreBundle\Configurator\Configurator::class);
     $services->alias(Mautic\CoreBundle\Configurator\Configurator::class, 'mautic.configurator');
     $services->set(Mautic\CoreBundle\Security\Cryptography\Cipher\Symmetric\OpenSSLCipher::class);
-    $services->alias('mautic.cipher.openssl', Mautic\CoreBundle\Security\Cryptography\Cipher\Symmetric\OpenSSLCipher::class);
     $services->set('mautic.security', Mautic\CoreBundle\Security\Permissions\CorePermissions::class)
         ->arg('$bundles', param('mautic.bundles'))
         ->arg('$pluginBundles', param('mautic.plugin.bundles'));
@@ -143,8 +139,8 @@ return function (ContainerConfigurator $configurator): void {
 
     $services->set(Mautic\CoreBundle\Helper\EncryptionHelper::class)
         ->args([
-            service('mautic.helper.core_parameters'),
-            service('mautic.cipher.openssl'),
+            service(Mautic\CoreBundle\Helper\CoreParametersHelper::class),
+            service(Mautic\CoreBundle\Security\Cryptography\Cipher\Symmetric\OpenSSLCipher::class),
         ]);
 
     $services->set(Symfony\Component\Filesystem\Filesystem::class);

--- a/app/bundles/CoreBundle/Config/services.php
+++ b/app/bundles/CoreBundle/Config/services.php
@@ -102,8 +102,6 @@ return function (ContainerConfigurator $configurator): void {
     $services->alias(Mautic\CoreBundle\Doctrine\Helper\IndexSchemaHelper::class, 'mautic.schema.helper.index');
     $services->set(Mautic\CoreBundle\Doctrine\Helper\TableSchemaHelper::class)
         ->arg('$prefix', param('mautic.db_table_prefix'));
-    $services->set(Mautic\CoreBundle\Form\Type\DynamicContentFilterEntryFiltersType::class)
-        ->call('setConnection', [service('database_connection')]);
 
     $services->set(Mautic\CoreBundle\EventListener\RouterSubscriber::class)
         ->arg('$scheme', param('router.request_context.scheme'))

--- a/app/bundles/CoreBundle/Tests/Functional/DependencyInjection/AbstractContainerSmokeTestCase.php
+++ b/app/bundles/CoreBundle/Tests/Functional/DependencyInjection/AbstractContainerSmokeTestCase.php
@@ -46,7 +46,6 @@ abstract class AbstractContainerSmokeTestCase extends TestCase
         MemcachedTagAwareAdapter::class,
         RedisAdapter::class,
         RedisTagAwareAdapter::class,
-        'mautic.cache.adapter.memcached',
         'mautic.cache.adapter.redis',
         'mautic.cache.adapter.redis_tag_aware',
         'doctrine.uuid_generator',

--- a/app/bundles/DynamicContentBundle/Config/services.php
+++ b/app/bundles/DynamicContentBundle/Config/services.php
@@ -5,17 +5,12 @@ declare(strict_types=1);
 use Mautic\CoreBundle\DependencyInjection\MauticCoreExtension;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
-
 return function (ContainerConfigurator $configurator): void {
     $services = $configurator->services()
         ->defaults()
         ->autowire()
         ->autoconfigure()
         ->public();
-
-    $services->set(Mautic\DynamicContentBundle\Form\Type\DwcEntryFiltersType::class)
-        ->call('setConnection', [service('database_connection')]);
 
     $services->load('Mautic\\DynamicContentBundle\\', '../')
         ->exclude('../{'.implode(',', MauticCoreExtension::DEFAULT_EXCLUDES).'}');

--- a/app/bundles/FormBundle/Config/services.php
+++ b/app/bundles/FormBundle/Config/services.php
@@ -27,14 +27,14 @@ return function (ContainerConfigurator $configurator): void {
     $services->load('Mautic\\FormBundle\\Entity\\', '../Entity/*Repository.php')
         ->tag(Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass::REPOSITORY_SERVICE_TAG);
     $services->set(Mautic\FormBundle\Form\Type\FieldType::class)
-        ->call('setFieldModel', [service('mautic.form.model.field')])
-        ->call('setFormModel', [service('mautic.form.model.form')]);
+        ->call('setFieldModel', [service(Mautic\FormBundle\Model\FieldModel::class)])
+        ->call('setFormModel', [service(Mautic\FormBundle\Model\FormModel::class)]);
     $services->set(Mautic\FormBundle\Form\Type\SubmitActionEmailType::class)
-        ->call('setFieldModel', [service('mautic.form.model.field')])
-        ->call('setFormModel', [service('mautic.form.model.form')]);
+        ->call('setFieldModel', [service(Mautic\FormBundle\Model\FieldModel::class)])
+        ->call('setFormModel', [service(Mautic\FormBundle\Model\FormModel::class)]);
     $services->set(Mautic\FormBundle\Form\Type\SubmitActionRepostType::class)
-        ->call('setFieldModel', [service('mautic.form.model.field')])
-        ->call('setFormModel', [service('mautic.form.model.form')]);
+        ->call('setFieldModel', [service(Mautic\FormBundle\Model\FieldModel::class)])
+        ->call('setFormModel', [service(Mautic\FormBundle\Model\FormModel::class)]);
 
     $services->set(Mautic\FormBundle\Validator\Constraint\FileExtensionConstraintValidator::class)
         ->tag('validator.constraint_validator', ['alias' => 'file_extension_constraint_validator']);

--- a/app/bundles/FormBundle/Config/services.php
+++ b/app/bundles/FormBundle/Config/services.php
@@ -25,10 +25,6 @@ return function (ContainerConfigurator $configurator): void {
     $services->load('Mautic\\FormBundle\\Entity\\', '../Entity/*Repository.php')
         ->tag(Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass::REPOSITORY_SERVICE_TAG);
 
-    $services->set(Mautic\FormBundle\Form\Type\FieldType::class);
-    $services->set(Mautic\FormBundle\Form\Type\SubmitActionEmailType::class);
-    $services->set(Mautic\FormBundle\Form\Type\SubmitActionRepostType::class);
-
     $services->set(Mautic\FormBundle\Validator\Constraint\FileExtensionConstraintValidator::class)
         ->tag('validator.constraint_validator', ['alias' => 'file_extension_constraint_validator']);
 

--- a/app/bundles/FormBundle/Config/services.php
+++ b/app/bundles/FormBundle/Config/services.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 use Mautic\CoreBundle\DependencyInjection\MauticCoreExtension;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
-use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
-
 return function (ContainerConfigurator $configurator): void {
     $services = $configurator->services()
         ->defaults()
@@ -26,15 +24,10 @@ return function (ContainerConfigurator $configurator): void {
 
     $services->load('Mautic\\FormBundle\\Entity\\', '../Entity/*Repository.php')
         ->tag(Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass::REPOSITORY_SERVICE_TAG);
-    $services->set(Mautic\FormBundle\Form\Type\FieldType::class)
-        ->call('setFieldModel', [service(Mautic\FormBundle\Model\FieldModel::class)])
-        ->call('setFormModel', [service(Mautic\FormBundle\Model\FormModel::class)]);
-    $services->set(Mautic\FormBundle\Form\Type\SubmitActionEmailType::class)
-        ->call('setFieldModel', [service(Mautic\FormBundle\Model\FieldModel::class)])
-        ->call('setFormModel', [service(Mautic\FormBundle\Model\FormModel::class)]);
-    $services->set(Mautic\FormBundle\Form\Type\SubmitActionRepostType::class)
-        ->call('setFieldModel', [service(Mautic\FormBundle\Model\FieldModel::class)])
-        ->call('setFormModel', [service(Mautic\FormBundle\Model\FormModel::class)]);
+
+    $services->set(Mautic\FormBundle\Form\Type\FieldType::class);
+    $services->set(Mautic\FormBundle\Form\Type\SubmitActionEmailType::class);
+    $services->set(Mautic\FormBundle\Form\Type\SubmitActionRepostType::class);
 
     $services->set(Mautic\FormBundle\Validator\Constraint\FileExtensionConstraintValidator::class)
         ->tag('validator.constraint_validator', ['alias' => 'file_extension_constraint_validator']);

--- a/app/bundles/FormBundle/Form/Type/FormFieldTrait.php
+++ b/app/bundles/FormBundle/Form/Type/FormFieldTrait.php
@@ -4,26 +4,20 @@ namespace Mautic\FormBundle\Form\Type;
 
 use Mautic\FormBundle\Model\FieldModel;
 use Mautic\FormBundle\Model\FormModel;
+use Symfony\Contracts\Service\Attribute\Required;
 
 trait FormFieldTrait
 {
-    /**
-     * @var FieldModel
-     */
-    protected $fieldModel;
+    protected FieldModel $fieldModel;
 
-    /**
-     * @var FormModel
-     */
-    protected $formModel;
+    protected FormModel $formModel;
 
-    public function setFieldModel(FieldModel $fieldModel): void
-    {
+    #[Required]
+    public function autowireFormFieldTrait(
+        FieldModel $fieldModel,
+        FormModel $formModel,
+    ): void {
         $this->fieldModel = $fieldModel;
-    }
-
-    public function setFormModel(FormModel $formModel): void
-    {
         $this->formModel = $formModel;
     }
 

--- a/app/bundles/LeadBundle/Config/services.php
+++ b/app/bundles/LeadBundle/Config/services.php
@@ -81,7 +81,7 @@ return function (ContainerConfigurator $configurator): void {
         ->call('setUniqueIdentifiersOperator', ['%mautic.company_unique_identifiers_operator%']);
     $services->get(Mautic\LeadBundle\Entity\LeadRepository::class)
         ->call('setUniqueIdentifiersOperator', ['%mautic.contact_unique_identifiers_operator%'])
-        ->call('setListLeadRepository', [\Symfony\Component\DependencyInjection\Loader\Configurator\service('mautic.lead.repository.list_lead')]);
+        ->call('setListLeadRepository', [\Symfony\Component\DependencyInjection\Loader\Configurator\service(Mautic\LeadBundle\Entity\ListLeadRepository::class)]);
 
     $services->alias('mautic.lead.model.field', Mautic\LeadBundle\Model\FieldModel::class);
     $services->alias('mautic.lead.model.list', Mautic\LeadBundle\Model\ListModel::class);
@@ -94,6 +94,5 @@ return function (ContainerConfigurator $configurator): void {
     $services->alias('mautic.lead.model.dnc', Mautic\LeadBundle\Model\DoNotContact::class);
     $services->alias('mautic.lead.model.ipaddress', Mautic\LeadBundle\Model\IpAddressModel::class);
     $services->alias('mautic.lead.model.export_scheduler', Mautic\LeadBundle\Model\ContactExportSchedulerModel::class);
-    $services->alias('mautic.lead.repository.list_lead', Mautic\LeadBundle\Entity\ListLeadRepository::class);
     $services->set(Mautic\LeadBundle\Security\Permissions\LeadPermissions::class);
 };

--- a/app/bundles/LeadBundle/Config/services.php
+++ b/app/bundles/LeadBundle/Config/services.php
@@ -80,8 +80,7 @@ return function (ContainerConfigurator $configurator): void {
     $services->get(Mautic\LeadBundle\Entity\CompanyRepository::class)
         ->call('setUniqueIdentifiersOperator', ['%mautic.company_unique_identifiers_operator%']);
     $services->get(Mautic\LeadBundle\Entity\LeadRepository::class)
-        ->call('setUniqueIdentifiersOperator', ['%mautic.contact_unique_identifiers_operator%'])
-        ->call('setListLeadRepository', [\Symfony\Component\DependencyInjection\Loader\Configurator\service(Mautic\LeadBundle\Entity\ListLeadRepository::class)]);
+        ->call('setUniqueIdentifiersOperator', ['%mautic.contact_unique_identifiers_operator%']);
 
     $services->alias('mautic.lead.model.field', Mautic\LeadBundle\Model\FieldModel::class);
     $services->alias('mautic.lead.model.list', Mautic\LeadBundle\Model\ListModel::class);

--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -102,9 +102,8 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
 
     #[Required]
     public function setListLeadRepository(
-        ListLeadRepository $listLeadRepository
-    ): void
-    {
+        ListLeadRepository $listLeadRepository,
+    ): void {
         $this->listLeadRepository = $listLeadRepository;
     }
 

--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -100,7 +100,10 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
         $this->dispatcher = $dispatcher;
     }
 
-    public function setListLeadRepository(ListLeadRepository $listLeadRepository): void
+    #[Required]
+    public function setListLeadRepository(
+        ListLeadRepository $listLeadRepository
+    ): void
     {
         $this->listLeadRepository = $listLeadRepository;
     }

--- a/app/bundles/LeadBundle/Form/Type/FilterTrait.php
+++ b/app/bundles/LeadBundle/Form/Type/FilterTrait.php
@@ -17,25 +17,16 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Contracts\Service\Attribute\Required;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-/**
- * This trait is consumed dynamically by multiple form types at runtime.
- *
- * @phpstan-ignore-next-line trait.unused
- */
 trait FilterTrait
 {
     use RegexTrait;
 
-    /**
-     * @var Connection
-     */
-    protected $connection;
+    protected Connection $connection;
 
     #[Required]
-    public function setConnection(
-        Connection $connection
-    ): void
-    {
+    public function autowireFilterTrait(
+        Connection $connection,
+    ): void {
         $this->connection = $connection;
     }
 
@@ -317,7 +308,7 @@ trait FilterTrait
                 message: 'mautic.core.value.required'
             );
 
-            if (in_array($operator, ['regexp', '!regexp']) && $this->connection) {
+            if (in_array($operator, ['regexp', '!regexp'])) {
                 // Let's add a custom valdiator to test the regex
                 $customOptions['constraints'][] =
                     new Callback(

--- a/app/bundles/LeadBundle/Form/Type/FilterTrait.php
+++ b/app/bundles/LeadBundle/Form/Type/FilterTrait.php
@@ -14,6 +14,7 @@ use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Validator\Constraints\Callback;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Contracts\Service\Attribute\Required;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -30,7 +31,10 @@ trait FilterTrait
      */
     protected $connection;
 
-    public function setConnection(Connection $connection): void
+    #[Required]
+    public function setConnection(
+        Connection $connection
+    ): void
     {
         $this->connection = $connection;
     }

--- a/app/bundles/NotificationBundle/Config/services.php
+++ b/app/bundles/NotificationBundle/Config/services.php
@@ -21,10 +21,11 @@ return function (ContainerConfigurator $configurator): void {
 
     $services->load('Mautic\\NotificationBundle\\Entity\\', '../Entity/*Repository.php')
         ->tag(Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass::REPOSITORY_SERVICE_TAG);
+
     $services->set(Mautic\NotificationBundle\EventListener\CampaignSubscriber::class)
         ->arg('$notificationApi', service(Mautic\NotificationBundle\Api\OneSignalApi::class));
-    $services->alias('mautic.integration.onesignal', Mautic\NotificationBundle\Integration\OneSignalIntegration::class);
 
+    $services->alias('mautic.integration.onesignal', Mautic\NotificationBundle\Integration\OneSignalIntegration::class);
     $services->alias('mautic.notification.model.notification', Mautic\NotificationBundle\Model\NotificationModel::class);
 
     $services->set(Mautic\NotificationBundle\Security\Permissions\NotificationPermissions::class);

--- a/app/bundles/NotificationBundle/Config/services.php
+++ b/app/bundles/NotificationBundle/Config/services.php
@@ -22,11 +22,10 @@ return function (ContainerConfigurator $configurator): void {
     $services->load('Mautic\\NotificationBundle\\Entity\\', '../Entity/*Repository.php')
         ->tag(Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\ServiceRepositoryCompilerPass::REPOSITORY_SERVICE_TAG);
     $services->set(Mautic\NotificationBundle\EventListener\CampaignSubscriber::class)
-        ->arg('$notificationApi', service('mautic.notification.api'));
+        ->arg('$notificationApi', service(Mautic\NotificationBundle\Api\OneSignalApi::class));
     $services->alias('mautic.integration.onesignal', Mautic\NotificationBundle\Integration\OneSignalIntegration::class);
 
     $services->alias('mautic.notification.model.notification', Mautic\NotificationBundle\Model\NotificationModel::class);
 
-    $services->alias('mautic.notification.api', Mautic\NotificationBundle\Api\OneSignalApi::class);
     $services->set(Mautic\NotificationBundle\Security\Permissions\NotificationPermissions::class);
 };

--- a/app/bundles/PluginBundle/Config/services.php
+++ b/app/bundles/PluginBundle/Config/services.php
@@ -26,14 +26,13 @@ return function (ContainerConfigurator $configurator): void {
         ->exclude('../{'.implode(',', array_merge(MauticCoreExtension::DEFAULT_EXCLUDES, $excludes)).'}');
 
     $services->load('Mautic\\PluginBundle\\Entity\\', '../Entity/*Repository.php');
-    $services->alias('mautic.helper.integration', Mautic\PluginBundle\Helper\IntegrationHelper::class);
 
     $services->alias('mautic.plugin.model.plugin', Mautic\PluginBundle\Model\PluginModel::class);
     $services->alias('mautic.plugin.model.integration_entity', Mautic\PluginBundle\Model\IntegrationEntityModel::class);
 
     $services->set(FormSubscriber::class)
-        ->call('setIntegrationHelper', [service('mautic.helper.integration')]);
+        ->call('setIntegrationHelper', [service(Mautic\PluginBundle\Helper\IntegrationHelper::class)]);
     $services->set(CampaignSubscriber::class)
-        ->call('setIntegrationHelper', [service('mautic.helper.integration')]);
+        ->call('setIntegrationHelper', [service(Mautic\PluginBundle\Helper\IntegrationHelper::class)]);
     $services->set(Mautic\PluginBundle\Security\Permissions\PluginPermissions::class);
 };

--- a/app/bundles/PluginBundle/Config/services.php
+++ b/app/bundles/PluginBundle/Config/services.php
@@ -3,11 +3,7 @@
 declare(strict_types=1);
 
 use Mautic\CoreBundle\DependencyInjection\MauticCoreExtension;
-use Mautic\PluginBundle\EventListener\CampaignSubscriber;
-use Mautic\PluginBundle\EventListener\FormSubscriber;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-
-use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return function (ContainerConfigurator $configurator): void {
     $services = $configurator->services()
@@ -30,9 +26,5 @@ return function (ContainerConfigurator $configurator): void {
     $services->alias('mautic.plugin.model.plugin', Mautic\PluginBundle\Model\PluginModel::class);
     $services->alias('mautic.plugin.model.integration_entity', Mautic\PluginBundle\Model\IntegrationEntityModel::class);
 
-    $services->set(FormSubscriber::class)
-        ->call('setIntegrationHelper', [service(Mautic\PluginBundle\Helper\IntegrationHelper::class)]);
-    $services->set(CampaignSubscriber::class)
-        ->call('setIntegrationHelper', [service(Mautic\PluginBundle\Helper\IntegrationHelper::class)]);
     $services->set(Mautic\PluginBundle\Security\Permissions\PluginPermissions::class);
 };

--- a/app/bundles/PluginBundle/EventListener/FormSubscriber.php
+++ b/app/bundles/PluginBundle/EventListener/FormSubscriber.php
@@ -6,7 +6,6 @@ use Mautic\FormBundle\Event\FormBuilderEvent;
 use Mautic\FormBundle\Event\SubmissionEvent;
 use Mautic\FormBundle\FormEvents;
 use Mautic\PluginBundle\Form\Type\IntegrationsListType;
-use Mautic\PluginBundle\Helper\IntegrationHelper;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final class FormSubscriber implements EventSubscriberInterface

--- a/app/bundles/PluginBundle/EventListener/FormSubscriber.php
+++ b/app/bundles/PluginBundle/EventListener/FormSubscriber.php
@@ -6,6 +6,7 @@ use Mautic\FormBundle\Event\FormBuilderEvent;
 use Mautic\FormBundle\Event\SubmissionEvent;
 use Mautic\FormBundle\FormEvents;
 use Mautic\PluginBundle\Form\Type\IntegrationsListType;
+use Mautic\PluginBundle\Helper\IntegrationHelper;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final class FormSubscriber implements EventSubscriberInterface

--- a/app/bundles/PluginBundle/EventListener/PushToIntegrationTrait.php
+++ b/app/bundles/PluginBundle/EventListener/PushToIntegrationTrait.php
@@ -5,6 +5,7 @@ namespace Mautic\PluginBundle\EventListener;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\PluginBundle\Helper\IntegrationHelper;
 use Mautic\PluginBundle\Integration\AbstractIntegration;
+use Symfony\Contracts\Service\Attribute\Required;
 
 /**
  * Static methods must be used due to the Point triggers not being converted to Events yet
@@ -20,7 +21,10 @@ trait PushToIntegrationTrait
     /**
      * Used by methodCalls to event subscribers.
      */
-    public function setIntegrationHelper(IntegrationHelper $integrationHelper): void
+    #[Required]
+    public function setIntegrationHelper(
+        IntegrationHelper $integrationHelper
+    ): void
     {
         static::setStaticIntegrationHelper($integrationHelper);
     }

--- a/app/bundles/PluginBundle/EventListener/PushToIntegrationTrait.php
+++ b/app/bundles/PluginBundle/EventListener/PushToIntegrationTrait.php
@@ -23,9 +23,8 @@ trait PushToIntegrationTrait
      */
     #[Required]
     public function setIntegrationHelper(
-        IntegrationHelper $integrationHelper
-    ): void
-    {
+        IntegrationHelper $integrationHelper,
+    ): void {
         static::setStaticIntegrationHelper($integrationHelper);
     }
 

--- a/app/bundles/SmsBundle/Config/services.php
+++ b/app/bundles/SmsBundle/Config/services.php
@@ -29,9 +29,10 @@ return function (ContainerConfigurator $configurator): void {
 
     $services->alias('mautic.sms.twilio.transport', Mautic\SmsBundle\Integration\Twilio\TwilioTransport::class);
     $services->set(Mautic\SmsBundle\Helper\SmsHelper::class)->tag('twig.helper', ['alias' => 'sms_helper']);
-    $services->set('mautic.sms.transport_chain', Mautic\SmsBundle\Sms\TransportChain::class)
+
+    $services->set(Mautic\SmsBundle\Sms\TransportChain::class)
         ->arg('$primaryTransport', param('mautic.sms_transport'));
-    $services->alias(Mautic\SmsBundle\Sms\TransportChain::class, 'mautic.sms.transport_chain');
+
     $services->set(Mautic\SmsBundle\Integration\Twilio\TwilioCallback::class)->tag('mautic.sms_callback_handler');
     $services->set('mautic.integration.twilio', Mautic\SmsBundle\Integration\TwilioIntegration::class);
 

--- a/app/bundles/SmsBundle/DependencyInjection/Compiler/SmsTransportPass.php
+++ b/app/bundles/SmsBundle/DependencyInjection/Compiler/SmsTransportPass.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\SmsBundle\DependencyInjection\Compiler;
 
+use Mautic\SmsBundle\Sms\TransportChain;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -12,11 +13,7 @@ final class SmsTransportPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {
-        if (!$container->has('mautic.sms.transport_chain')) {
-            return;
-        }
-
-        $definition     = $container->getDefinition('mautic.sms.transport_chain');
+        $definition     = $container->getDefinition(TransportChain::class);
         $taggedServices = $container->findTaggedServiceIds('mautic.sms_transport');
         foreach ($taggedServices as $id => $tags) {
             $definition->addMethodCall('addTransport', [

--- a/app/bundles/SmsBundle/Tests/DependencyInjection/Compiler/SmsTransportPassTest.php
+++ b/app/bundles/SmsBundle/Tests/DependencyInjection/Compiler/SmsTransportPassTest.php
@@ -39,7 +39,7 @@ final class SmsTransportPassTest extends TestCase
             ->getMock();
 
         $container
-            ->register('mautic.sms.transport_chain')
+            ->register(TransportChain::class)
             ->setClass($transport::class)
             ->setArguments(['foo', $this->createStub(IntegrationHelper::class)])
             ->setShared(false)
@@ -51,7 +51,7 @@ final class SmsTransportPassTest extends TestCase
 
         $this->assertCount(2, $container->findTaggedServiceIds('mautic.sms_transport'));
 
-        $methodCalls = $container->getDefinition('mautic.sms.transport_chain')->getMethodCalls();
+        $methodCalls = $container->getDefinition(TransportChain::class)->getMethodCalls();
         $this->assertCount(count($methodCalls), $container->findTaggedServiceIds('mautic.sms_transport'));
 
         // Translation string

--- a/app/bundles/SmsBundle/Tests/Functional/SmsModelFunctionalTest.php
+++ b/app/bundles/SmsBundle/Tests/Functional/SmsModelFunctionalTest.php
@@ -53,7 +53,7 @@ final class SmsModelFunctionalTest extends MauticMysqlTestCase
             )
             ->willReturn(new RecipientCollection($sms));
 
-        $this->getContainer()->set('mautic.sms.transport_chain', $transportMock);
+        $this->getContainer()->set(TransportChain::class, $transportMock);
 
         /** @var SmsModel $smsModel */
         $smsModel = $this->getContainer()->get(SmsModel::class);
@@ -155,7 +155,7 @@ final class SmsModelFunctionalTest extends MauticMysqlTestCase
                 return $collection;
             });
 
-        $this->getContainer()->set('mautic.sms.transport_chain', $transportMock);
+        $this->getContainer()->set(TransportChain::class, $transportMock);
 
         /** @var SmsModel $smsModel */
         $smsModel = $this->getContainer()->get(SmsModel::class);

--- a/app/bundles/UserBundle/Config/services.php
+++ b/app/bundles/UserBundle/Config/services.php
@@ -121,7 +121,7 @@ return function (ContainerConfigurator $configurator): void {
         ->decorate('security.authenticator.form_login.main')
         ->args([
             service('.inner'),
-            service('mautic.user.provider'),
+            service(UserProvider::class),
             service('security.password_hasher_factory'),
             [], // This will be replaced by the compiler pass
         ]);

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -270,6 +270,7 @@ rules:
     - Utils\PHPStan\Rule\NoAlreadyLoadedServiceSetRule
     - Utils\PHPStan\Rule\NoAutoconfiguredServiceTagRule
     - Utils\PHPStan\Rule\PreferClassServiceReferenceRule
+    - Utils\PHPStan\Rule\NoRedundantAutowiredServiceArgumentRule
 
 services:
     - Utils\PHPStan\ServiceNameUsageResolver

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -269,6 +269,7 @@ rules:
     - Utils\PHPStan\Rule\NoClassNameServiceAliasRule
     - Utils\PHPStan\Rule\NoAlreadyLoadedServiceSetRule
     - Utils\PHPStan\Rule\NoAutoconfiguredServiceTagRule
+    - Utils\PHPStan\Rule\PreferClassServiceReferenceRule
 
 services:
     - Utils\PHPStan\ServiceNameUsageResolver
@@ -290,5 +291,13 @@ services:
             - phpstan.collector
     -
         class: Utils\PHPStan\Collector\ServiceNameUsageCollector
+        tags:
+            - phpstan.collector
+    -
+        class: Utils\PHPStan\Collector\ClassTargetServiceAliasCollector
+        tags:
+            - phpstan.collector
+    -
+        class: Utils\PHPStan\Collector\ServiceStringReferenceCollector
         tags:
             - phpstan.collector

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -271,6 +271,7 @@ rules:
     - Utils\PHPStan\Rule\NoAutoconfiguredServiceTagRule
     - Utils\PHPStan\Rule\PreferClassServiceReferenceRule
     - Utils\PHPStan\Rule\NoRedundantAutowiredServiceArgumentRule
+    - Utils\PHPStan\Rule\NoServiceSetterCallRule
 
 services:
     - Utils\PHPStan\ServiceNameUsageResolver

--- a/utils/phpstan/src/Collector/ClassTargetServiceAliasCollector.php
+++ b/utils/phpstan/src/Collector/ClassTargetServiceAliasCollector.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Collector;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Collectors\Collector;
+
+/**
+ * Collects the aliases of bundle Config/services.php files that point a string service id at a class,
+ * e.g. $services->alias('mautic.helper.core_parameters', CoreParametersHelper::class).
+ *
+ * Such an id names the very same service its class name does, so a reference by the class name says the same
+ * without the loose string. The alias the other way around, e.g. $services->alias(SomeHelper::class, 'id'),
+ * is left to ClassNameServiceAliasCollector.
+ *
+ * @implements Collector<MethodCall, array{string, string, int}>
+ */
+final class ClassTargetServiceAliasCollector implements Collector
+{
+    /**
+     * @var string
+     */
+    private const SERVICES_FILE_NAME = 'services.php';
+
+    public function getNodeType(): string
+    {
+        return MethodCall::class;
+    }
+
+    /**
+     * @return array{string, string, int}|null the string service id, the class name it points at and the
+     *                                          line of the alias() call
+     */
+    public function processNode(Node $node, Scope $scope): ?array
+    {
+        if (self::SERVICES_FILE_NAME !== basename($scope->getFile())) {
+            return null;
+        }
+
+        if (!$node->name instanceof Identifier || 'alias' !== $node->name->toString()) {
+            return null;
+        }
+
+        $args = $node->getArgs();
+        if (2 !== count($args)) {
+            return null;
+        }
+
+        if (!$args[0]->value instanceof String_) {
+            return null;
+        }
+
+        $className = $this->matchClassName($args[1]->value);
+        if (null === $className) {
+            return null;
+        }
+
+        return [$args[0]->value->value, $className, $node->getStartLine()];
+    }
+
+    private function matchClassName(Node $aliasValue): ?string
+    {
+        if (!$aliasValue instanceof ClassConstFetch || !$aliasValue->class instanceof Name) {
+            return null;
+        }
+
+        if (!$aliasValue->name instanceof Identifier || 'class' !== $aliasValue->name->toLowerString()) {
+            return null;
+        }
+
+        return $aliasValue->class->toString();
+    }
+}

--- a/utils/phpstan/src/Collector/ClassTargetServiceAliasCollector.php
+++ b/utils/phpstan/src/Collector/ClassTargetServiceAliasCollector.php
@@ -37,7 +37,7 @@ final class ClassTargetServiceAliasCollector implements Collector
 
     /**
      * @return array{string, string, int}|null the string service id, the class name it points at and the
-     *                                          line of the alias() call
+     *                                         line of the alias() call
      */
     public function processNode(Node $node, Scope $scope): ?array
     {

--- a/utils/phpstan/src/Collector/DefinitionFetchByStringCollector.php
+++ b/utils/phpstan/src/Collector/DefinitionFetchByStringCollector.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Collector;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Collectors\Collector;
+
+/**
+ * Collects the definition fetches that name a service by a string id, e.g. the compiler pass call
+ * $container->getDefinition('mautic.schema.helper.column').
+ *
+ * Unlike ServiceDefinitionFetchCollector, which keeps only the id, this one keeps the line as well so the
+ * rule can point at the very call.
+ *
+ * @implements Collector<MethodCall, array{string, int}>
+ */
+final class DefinitionFetchByStringCollector implements Collector
+{
+    /**
+     * @var list<string>
+     */
+    private const DEFINITION_METHOD_NAMES = ['getDefinition', 'hasDefinition', 'findDefinition', 'removeDefinition'];
+
+    public function getNodeType(): string
+    {
+        return MethodCall::class;
+    }
+
+    /**
+     * @return array{string, int}|null the service id fetched with the line the call is on
+     */
+    public function processNode(Node $node, Scope $scope): ?array
+    {
+        if (!$node->name instanceof Identifier || !in_array($node->name->toString(), self::DEFINITION_METHOD_NAMES, true)) {
+            return null;
+        }
+
+        $firstArg = $node->getArgs()[0] ?? null;
+        if (!$firstArg instanceof Node\Arg || !$firstArg->value instanceof String_) {
+            return null;
+        }
+
+        return [$firstArg->value->value, $node->getStartLine()];
+    }
+}

--- a/utils/phpstan/src/Collector/ServiceStringReferenceCollector.php
+++ b/utils/phpstan/src/Collector/ServiceStringReferenceCollector.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Collector;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Collectors\Collector;
+
+/**
+ * Collects the service() references of bundle Config/services.php files that ask for a service by a string id,
+ * e.g. service('mautic.helper.core_parameters').
+ *
+ * A service(SomeHelper::class) reference is left out, that one already names the service by its class.
+ *
+ * @implements Collector<FuncCall, array{string, int}>
+ */
+final class ServiceStringReferenceCollector implements Collector
+{
+    /**
+     * @var string
+     */
+    private const SERVICES_FILE_NAME = 'services.php';
+
+    /**
+     * @var string
+     */
+    private const SERVICE_FUNCTION = 'Symfony\Component\DependencyInjection\Loader\Configurator\service';
+
+    public function getNodeType(): string
+    {
+        return FuncCall::class;
+    }
+
+    /**
+     * @return array{string, int}|null the string service id with the line the reference is on
+     */
+    public function processNode(Node $node, Scope $scope): ?array
+    {
+        if (self::SERVICES_FILE_NAME !== basename($scope->getFile())) {
+            return null;
+        }
+
+        if (!$node->name instanceof Name) {
+            return null;
+        }
+
+        $functionName = $node->name->toString();
+        if ('service' !== $functionName && self::SERVICE_FUNCTION !== $functionName) {
+            return null;
+        }
+
+        $firstArg = $node->getArgs()[0] ?? null;
+        if (!$firstArg instanceof Node\Arg || !$firstArg->value instanceof String_) {
+            return null;
+        }
+
+        return [$firstArg->value->value, $node->getStartLine()];
+    }
+}

--- a/utils/phpstan/src/Rule/NoRedundantAutowiredServiceArgumentRule.php
+++ b/utils/phpstan/src/Rule/NoRedundantAutowiredServiceArgumentRule.php
@@ -1,0 +1,275 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Rule;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ParameterReflection;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\ObjectType;
+
+/**
+ * Reports the service() arguments of Config/services.php that only repeat the type autowiring resolves anyway,
+ * e.g. a service that passes the very class its constructor type hints:
+ *
+ *     final class MenuHelper
+ *     {
+ *         public function __construct(private RequestStack $requestStack) {}
+ *     }
+ *
+ *     $services->set(MenuHelper::class)
+ *         ->args([service(RequestStack::class)]);
+ *
+ *     $services->set(MenuHelper::class);
+ *
+ * With autowiring on, the container injects the RequestStack by its type, so the explicit argument brings
+ * nothing. Only the safe shapes are reported, the ones a plain removal keeps working:
+ *
+ *   - a whole args([...]) call in which every argument is a service(Type::class) matching the constructor
+ *     parameter of the same position - the call goes and every parameter is autowired instead;
+ *   - a named arg('$name', service(Type::class)) call matching the type of its parameter - it goes on its own.
+ *
+ * A positional argument only some of which are redundant is left alone: dropping one would shift the rest,
+ * and an argument passing another type than the parameter, e.g. a func_get_args() extra, is no autowiring
+ * duplicate at all. A parameter type hinting an interface a concrete service is passed for is left alone too,
+ * autowiring the interface needs a binding the argument stands in for.
+ *
+ * @implements Rule<MethodCall>
+ */
+final class NoRedundantAutowiredServiceArgumentRule implements Rule
+{
+    /**
+     * @var string
+     */
+    private const SERVICES_FILE_NAME = 'services.php';
+
+    /**
+     * @var string
+     */
+    private const SERVICE_FUNCTION = 'Symfony\Component\DependencyInjection\Loader\Configurator\service';
+
+    public function __construct(
+        private readonly ReflectionProvider $reflectionProvider,
+    ) {
+    }
+
+    public function getNodeType(): string
+    {
+        return MethodCall::class;
+    }
+
+    /**
+     * @param MethodCall $node
+     *
+     * @return list<\PHPStan\Rules\IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (self::SERVICES_FILE_NAME !== basename($scope->getFile())) {
+            return [];
+        }
+
+        if (!$node->name instanceof Identifier) {
+            return [];
+        }
+
+        $methodName = $node->name->toString();
+        if ('args' !== $methodName && 'arg' !== $methodName) {
+            return [];
+        }
+
+        $parameters = $this->resolveConstructorParameters($node);
+        if (null === $parameters) {
+            return [];
+        }
+
+        if ('arg' === $methodName) {
+            return $this->processNamedArgument($node, $parameters);
+        }
+
+        return $this->processArgumentList($node, $parameters);
+    }
+
+    /**
+     * @param list<ParameterReflection> $parameters
+     *
+     * @return list<\PHPStan\Rules\IdentifierRuleError>
+     */
+    private function processArgumentList(MethodCall $node, array $parameters): array
+    {
+        $args = $node->getArgs();
+        if (1 !== count($args) || !$args[0]->value instanceof Array_) {
+            return [];
+        }
+
+        $items = $args[0]->value->items;
+        if ([] === $items || count($items) > count($parameters)) {
+            return [];
+        }
+
+        foreach ($items as $position => $item) {
+            // a keyed element is a named argument, not the plain positional list this rule reasons about
+            if (null !== $item->key) {
+                return [];
+            }
+
+            $serviceClass = $this->matchServiceClass($item->value);
+            if (null === $serviceClass || !$this->isSameType($parameters[$position], $serviceClass)) {
+                return [];
+            }
+        }
+
+        return [
+            RuleErrorBuilder::message('Every argument only repeats the type autowiring injects, remove the args() call and let autowiring resolve the constructor.')
+                ->identifier('mautic.noRedundantAutowiredServiceArgument')
+                ->line($node->getStartLine())
+                ->build(),
+        ];
+    }
+
+    /**
+     * @param list<ParameterReflection> $parameters
+     *
+     * @return list<\PHPStan\Rules\IdentifierRuleError>
+     */
+    private function processNamedArgument(MethodCall $node, array $parameters): array
+    {
+        $args = $node->getArgs();
+        if (2 !== count($args) || !$args[0]->value instanceof String_) {
+            return [];
+        }
+
+        $parameterName = ltrim($args[0]->value->value, '$');
+
+        $serviceClass = $this->matchServiceClass($args[1]->value);
+        if (null === $serviceClass) {
+            return [];
+        }
+
+        foreach ($parameters as $parameter) {
+            if ($parameter->getName() !== $parameterName) {
+                continue;
+            }
+
+            if (!$this->isSameType($parameter, $serviceClass)) {
+                return [];
+            }
+
+            return [
+                RuleErrorBuilder::message(sprintf(
+                    'Argument "$%s" only repeats the type autowiring injects, remove the arg() call and let autowiring resolve "%s".',
+                    $parameterName,
+                    $serviceClass
+                ))
+                    ->identifier('mautic.noRedundantAutowiredServiceArgument')
+                    ->line($node->getStartLine())
+                    ->build(),
+            ];
+        }
+
+        return [];
+    }
+
+    /**
+     * The constructor parameters of the class the set() call up the chain registers, null when there is no
+     * such class, no constructor or an autowire() call switching autowiring off.
+     *
+     * @return list<ParameterReflection>|null
+     */
+    private function resolveConstructorParameters(MethodCall $node): ?array
+    {
+        $className = null;
+
+        for ($cursor = $node->var; $cursor instanceof MethodCall; $cursor = $cursor->var) {
+            if (!$cursor->name instanceof Identifier) {
+                continue;
+            }
+
+            // a per-service autowire() call may switch autowiring off, then the argument is not redundant
+            if ('autowire' === $cursor->name->toString()) {
+                return null;
+            }
+
+            if ('set' === $cursor->name->toString()) {
+                $className = $this->matchSetClassName($cursor);
+            }
+        }
+
+        if (null === $className || !$this->reflectionProvider->hasClass($className)) {
+            return null;
+        }
+
+        $classReflection = $this->reflectionProvider->getClass($className);
+        if (!$classReflection->hasConstructor()) {
+            return null;
+        }
+
+        return $classReflection->getConstructor()->getVariants()[0]->getParameters();
+    }
+
+    private function matchSetClassName(MethodCall $node): ?string
+    {
+        $args = $node->getArgs();
+
+        // set(Foo::class) names the class first, set('mautic.some.id', Foo::class) names it second
+        if (1 === count($args)) {
+            return $this->matchClassName($args[0]->value);
+        }
+
+        if (2 === count($args)) {
+            return $this->matchClassName($args[1]->value);
+        }
+
+        return null;
+    }
+
+    private function matchServiceClass(Node $node): ?string
+    {
+        if (!$node instanceof FuncCall || !$node->name instanceof Name) {
+            return null;
+        }
+
+        $functionName = $node->name->toString();
+        if ('service' !== $functionName && self::SERVICE_FUNCTION !== $functionName) {
+            return null;
+        }
+
+        $firstArg = $node->getArgs()[0] ?? null;
+        if (null === $firstArg) {
+            return null;
+        }
+
+        return $this->matchClassName($firstArg->value);
+    }
+
+    private function matchClassName(Node $node): ?string
+    {
+        if (!$node instanceof ClassConstFetch || !$node->class instanceof Name) {
+            return null;
+        }
+
+        if (!$node->name instanceof Identifier || 'class' !== $node->name->toLowerString()) {
+            return null;
+        }
+
+        return $node->class->toString();
+    }
+
+    private function isSameType(ParameterReflection $parameter, string $serviceClass): bool
+    {
+        $parameterType = $parameter->getType();
+
+        return $parameterType instanceof ObjectType && $parameterType->getClassName() === $serviceClass;
+    }
+}

--- a/utils/phpstan/src/Rule/NoRedundantAutowiredServiceArgumentRule.php
+++ b/utils/phpstan/src/Rule/NoRedundantAutowiredServiceArgumentRule.php
@@ -17,7 +17,6 @@ use PHPStan\Reflection\ParameterReflection;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
-use PHPStan\Type\ObjectType;
 
 /**
  * Reports the service() arguments of Config/services.php that only repeat the type autowiring resolves anyway,
@@ -270,6 +269,6 @@ final class NoRedundantAutowiredServiceArgumentRule implements Rule
     {
         $parameterType = $parameter->getType();
 
-        return $parameterType instanceof ObjectType && $parameterType->getClassName() === $serviceClass;
+        return $parameterType->isObject()->yes() && [$serviceClass] === $parameterType->getObjectClassNames();
     }
 }

--- a/utils/phpstan/src/Rule/NoServiceSetterCallRule.php
+++ b/utils/phpstan/src/Rule/NoServiceSetterCallRule.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace Utils\PHPStan\Rule;
 
 use PhpParser\Node;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\String_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
@@ -77,6 +80,12 @@ final class NoServiceSetterCallRule implements Rule
             return [];
         }
 
+        // only a setter fed a service() can move to #[Required]; a container parameter, e.g. '%mautic.theme%',
+        // is not resolved by type, so its setter call stays
+        if (!$this->hasServiceArgument($node)) {
+            return [];
+        }
+
         return [
             RuleErrorBuilder::message(sprintf(
                 'Setter call() to "%s()" wires the dependency by hand, mark the method #[Required] and let autowiring call it instead.',
@@ -86,5 +95,36 @@ final class NoServiceSetterCallRule implements Rule
                 ->line($node->getStartLine())
                 ->build(),
         ];
+    }
+
+    /**
+     * The arguments of a call() travel in an array, e.g. ->call('setFieldModel', [service(FieldModel::class)]).
+     * A service() reference among them is the dependency #[Required] autowiring resolves by type.
+     */
+    private function hasServiceArgument(MethodCall $node): bool
+    {
+        $secondArg = $node->getArgs()[1] ?? null;
+        if (null === $secondArg || !$secondArg->value instanceof Array_) {
+            return false;
+        }
+
+        foreach ($secondArg->value->items as $item) {
+            if ($item->value instanceof FuncCall && $this->isServiceFunction($item->value)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function isServiceFunction(FuncCall $funcCall): bool
+    {
+        if (!$funcCall->name instanceof Name) {
+            return false;
+        }
+
+        $functionName = $funcCall->name->toString();
+
+        return 'service' === $functionName || self::SERVICE_FUNCTION === $functionName;
     }
 }

--- a/utils/phpstan/src/Rule/NoServiceSetterCallRule.php
+++ b/utils/phpstan/src/Rule/NoServiceSetterCallRule.php
@@ -31,8 +31,9 @@ use PHPStan\Rules\RuleErrorBuilder;
  *         $this->listLeadRepository = $listLeadRepository;
  *     }
  *
- * Only a call() naming a setXxx() method is reported. A call() to another method, e.g. ->call('configure', ...),
- * runs logic the container cannot infer, so it stays a manual call.
+ * Only a call() naming a setXxx() method a service() feeds is reported. A call() to another method, e.g.
+ * ->call('configure', ...), runs logic the container cannot infer, and a setter fed a container parameter,
+ * e.g. ->call('setDefaultTheme', [param('mautic.theme')]), has no type to autowire, so both stay a manual call.
  *
  * @implements Rule<MethodCall>
  */
@@ -49,6 +50,11 @@ final class NoServiceSetterCallRule implements Rule
      * @var string
      */
     private const SETTER_METHOD_PATTERN = '#^set\p{Lu}#u';
+
+    /**
+     * @var string
+     */
+    private const SERVICE_FUNCTION = 'Symfony\Component\DependencyInjection\Loader\Configurator\service';
 
     public function getNodeType(): string
     {

--- a/utils/phpstan/src/Rule/NoServiceSetterCallRule.php
+++ b/utils/phpstan/src/Rule/NoServiceSetterCallRule.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Rule;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Reports the setter injection wired by hand in Config/services.php, e.g.:
+ *
+ *     $services->get(LeadRepository::class)
+ *         ->call('setUniqueIdentifiersOperator', ['%mautic.contact_unique_identifiers_operator%'])
+ *         ->call('setListLeadRepository', [service(ListLeadRepository::class)]);
+ *
+ * A #[Required] attribute on the setter says the same next to the method it feeds, and lets autowiring call
+ * it, so the config no longer names the method by a loose string:
+ *
+ *     #[Required]
+ *     public function setListLeadRepository(ListLeadRepository $listLeadRepository): void
+ *     {
+ *         $this->listLeadRepository = $listLeadRepository;
+ *     }
+ *
+ * Only a call() naming a setXxx() method is reported. A call() to another method, e.g. ->call('configure', ...),
+ * runs logic the container cannot infer, so it stays a manual call.
+ *
+ * @implements Rule<MethodCall>
+ */
+final class NoServiceSetterCallRule implements Rule
+{
+    /**
+     * @var string
+     */
+    private const SERVICES_FILE_NAME = 'services.php';
+
+    /**
+     * A setter is a setXxx() method, e.g. setListLeadRepository(). A "setup" or "settle" method is no setter.
+     *
+     * @var string
+     */
+    private const SETTER_METHOD_PATTERN = '#^set\p{Lu}#u';
+
+    public function getNodeType(): string
+    {
+        return MethodCall::class;
+    }
+
+    /**
+     * @param MethodCall $node
+     *
+     * @return list<\PHPStan\Rules\IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (self::SERVICES_FILE_NAME !== basename($scope->getFile())) {
+            return [];
+        }
+
+        if (!$node->name instanceof Identifier || 'call' !== $node->name->toString()) {
+            return [];
+        }
+
+        $firstArg = $node->getArgs()[0] ?? null;
+        if (null === $firstArg || !$firstArg->value instanceof String_) {
+            return [];
+        }
+
+        $methodName = $firstArg->value->value;
+        if (1 !== preg_match(self::SETTER_METHOD_PATTERN, $methodName)) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(sprintf(
+                'Setter call() to "%s()" wires the dependency by hand, mark the method #[Required] and let autowiring call it instead.',
+                $methodName
+            ))
+                ->identifier('mautic.noServiceSetterCall')
+                ->line($node->getStartLine())
+                ->build(),
+        ];
+    }
+}

--- a/utils/phpstan/src/Rule/PreferClassInDefinitionFetchRule.php
+++ b/utils/phpstan/src/Rule/PreferClassInDefinitionFetchRule.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Rule;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\CollectedDataNode;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use Utils\PHPStan\Collector\ClassNameServiceAliasCollector;
+use Utils\PHPStan\Collector\ClassTargetServiceAliasCollector;
+use Utils\PHPStan\Collector\DefinitionFetchByStringCollector;
+use Utils\PHPStan\Collector\ServiceDefinitionNameCollector;
+
+/**
+ * Reports the definition fetches of compiler passes that name a service by a string id a class is known for,
+ * e.g. $container->getDefinition('mautic.schema.helper.column') while the service carries the
+ * ColumnSchemaHelper class in its registration.
+ *
+ * The class name says the same without the loose string:
+ *
+ *     $container->getDefinition('mautic.schema.helper.column')->setArgument('$prefix', $prefix);
+ *
+ *     $container->getDefinition(ColumnSchemaHelper::class)->setArgument('$prefix', $prefix);
+ *
+ * A class is known for an id registered by set('id', Class::class) or bridged by an alias either way, i.e.
+ * alias('id', Class::class) or alias(Class::class, 'id').
+ *
+ * The fix is safe only where the class name is the definition getDefinition() reaches, a string-primary
+ * service keeps the string until the registration is flipped to the class - getDefinition() does not resolve
+ * an alias. An id nothing registers with a class, e.g. a legacy 'mautic.tblprefix_subscriber', is left alone,
+ * there is no type to name it by.
+ *
+ * @implements Rule<CollectedDataNode>
+ */
+final class PreferClassInDefinitionFetchRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return CollectedDataNode::class;
+    }
+
+    /**
+     * @param CollectedDataNode $node
+     *
+     * @return list<\PHPStan\Rules\IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $classNamesByServiceId = $this->resolveClassNamesByServiceId($node);
+
+        /** @var array<string, list<array{string, int}>> $fetchesByFilePath */
+        $fetchesByFilePath = $node->get(DefinitionFetchByStringCollector::class);
+
+        $ruleErrors = [];
+
+        foreach ($fetchesByFilePath as $filePath => $fetches) {
+            foreach ($fetches as [$serviceId, $line]) {
+                $className = $classNamesByServiceId[$serviceId] ?? null;
+                if (null === $className) {
+                    continue;
+                }
+
+                $ruleErrors[] = RuleErrorBuilder::message(sprintf(
+                    'Fetch the definition by its class, getDefinition(%s::class), rather than by the string id "%s" the service is registered with.',
+                    $className,
+                    $serviceId
+                ))
+                    ->identifier('mautic.preferClassInDefinitionFetch')
+                    ->file($filePath)
+                    ->line($line)
+                    ->build();
+            }
+        }
+
+        return $ruleErrors;
+    }
+
+    /**
+     * @return array<string, string> the class name known for every string service id
+     */
+    private function resolveClassNamesByServiceId(CollectedDataNode $collectedDataNode): array
+    {
+        $classNamesByServiceId = [];
+
+        /** @var array<string, list<array{string, string, int, int}>> $definitionsByFilePath */
+        $definitionsByFilePath = $collectedDataNode->get(ServiceDefinitionNameCollector::class);
+        foreach ($definitionsByFilePath as $definitions) {
+            foreach ($definitions as [$serviceId, $className]) {
+                $classNamesByServiceId[$serviceId] = $className;
+            }
+        }
+
+        /** @var array<string, list<array{string, string, int}>> $targetAliasesByFilePath */
+        $targetAliasesByFilePath = $collectedDataNode->get(ClassTargetServiceAliasCollector::class);
+        foreach ($targetAliasesByFilePath as $aliases) {
+            foreach ($aliases as [$serviceId, $className]) {
+                $classNamesByServiceId[$serviceId] = $className;
+            }
+        }
+
+        /** @var array<string, list<array{string, string, int}>> $nameAliasesByFilePath */
+        $nameAliasesByFilePath = $collectedDataNode->get(ClassNameServiceAliasCollector::class);
+        foreach ($nameAliasesByFilePath as $aliases) {
+            foreach ($aliases as [$className, $serviceId]) {
+                $classNamesByServiceId[$serviceId] = $className;
+            }
+        }
+
+        return $classNamesByServiceId;
+    }
+}

--- a/utils/phpstan/src/Rule/PreferClassServiceReferenceRule.php
+++ b/utils/phpstan/src/Rule/PreferClassServiceReferenceRule.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Rule;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\CollectedDataNode;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use Utils\PHPStan\Collector\ClassTargetServiceAliasCollector;
+use Utils\PHPStan\Collector\ServiceStringReferenceCollector;
+
+/**
+ * Reports the service() references of Config/services.php files that ask for a service by a string id an
+ * alias already points at the very class of, e.g. service('mautic.helper.core_parameters') while
+ * $services->alias('mautic.helper.core_parameters', CoreParametersHelper::class) is registered.
+ *
+ * The class name names the very same service, so the reference says the same by the type instead:
+ *
+ *     $services->alias('mautic.helper.core_parameters', CoreParametersHelper::class);
+ *     ...
+ *     ->args([service('mautic.helper.core_parameters')]);
+ *
+ *     ->args([service(CoreParametersHelper::class)]);
+ *
+ * Once every reference names the class, the string alias nothing else asks for falls to NoUnusedServiceAliasRule.
+ *
+ * @implements Rule<CollectedDataNode>
+ */
+final class PreferClassServiceReferenceRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return CollectedDataNode::class;
+    }
+
+    /**
+     * @param CollectedDataNode $node
+     *
+     * @return list<\PHPStan\Rules\IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $classNamesByServiceId = $this->resolveClassNamesByServiceId($node);
+
+        /** @var array<string, list<array{string, int}>> $referencesByFilePath */
+        $referencesByFilePath = $node->get(ServiceStringReferenceCollector::class);
+
+        $ruleErrors = [];
+
+        foreach ($referencesByFilePath as $filePath => $references) {
+            foreach ($references as [$serviceId, $line]) {
+                $className = $classNamesByServiceId[$serviceId] ?? null;
+                if (null === $className) {
+                    continue;
+                }
+
+                $ruleErrors[] = RuleErrorBuilder::message(sprintf(
+                    'Reference the service by its class, service(%s::class), rather than by the string id "%s" a class name alias already covers.',
+                    $className,
+                    $serviceId
+                ))
+                    ->identifier('mautic.preferClassServiceReference')
+                    ->file($filePath)
+                    ->line($line)
+                    ->build();
+            }
+        }
+
+        return $ruleErrors;
+    }
+
+    /**
+     * @return array<string, string> the class name every string service id is aliased to
+     */
+    private function resolveClassNamesByServiceId(CollectedDataNode $collectedDataNode): array
+    {
+        /** @var array<string, list<array{string, string, int}>> $aliasesByFilePath */
+        $aliasesByFilePath = $collectedDataNode->get(ClassTargetServiceAliasCollector::class);
+
+        $classNamesByServiceId = [];
+
+        foreach ($aliasesByFilePath as $aliases) {
+            foreach ($aliases as [$serviceId, $className]) {
+                $classNamesByServiceId[$serviceId] = $className;
+            }
+        }
+
+        return $classNamesByServiceId;
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/AutowiredArgumentBundle/Bar.php
+++ b/utils/phpstan/tests/Rule/Fixture/AutowiredArgumentBundle/Bar.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture\AutowiredArgumentBundle;
+
+final class Bar
+{
+}

--- a/utils/phpstan/tests/Rule/Fixture/AutowiredArgumentBundle/BarInterface.php
+++ b/utils/phpstan/tests/Rule/Fixture/AutowiredArgumentBundle/BarInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture\AutowiredArgumentBundle;
+
+interface BarInterface
+{
+}

--- a/utils/phpstan/tests/Rule/Fixture/AutowiredArgumentBundle/Baz.php
+++ b/utils/phpstan/tests/Rule/Fixture/AutowiredArgumentBundle/Baz.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture\AutowiredArgumentBundle;
+
+final class Baz
+{
+}

--- a/utils/phpstan/tests/Rule/Fixture/AutowiredArgumentBundle/Config/services.php
+++ b/utils/phpstan/tests/Rule/Fixture/AutowiredArgumentBundle/Config/services.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
+use Utils\PHPStan\Tests\Rule\Fixture\AutowiredArgumentBundle\Bar;
+use Utils\PHPStan\Tests\Rule\Fixture\AutowiredArgumentBundle\Baz;
+use Utils\PHPStan\Tests\Rule\Fixture\AutowiredArgumentBundle\Foo;
+use Utils\PHPStan\Tests\Rule\Fixture\AutowiredArgumentBundle\NamedArgumentService;
+use Utils\PHPStan\Tests\Rule\Fixture\AutowiredArgumentBundle\NeedsInterface;
+use Utils\PHPStan\Tests\Rule\Fixture\AutowiredArgumentBundle\TwoArg;
+
+return function (ContainerConfigurator $configurator): void {
+    $services = $configurator->services();
+
+    // flagged: the single argument only repeats the autowired constructor type
+    $services->set(Foo::class)
+        ->args([service(Bar::class)]);
+
+    // flagged: every argument repeats its autowired constructor type
+    $services->set(TwoArg::class)
+        ->args([service(Bar::class), service(Baz::class)]);
+
+    // flagged: the named argument repeats its autowired constructor type
+    $services->set(NamedArgumentService::class)
+        ->arg('$bar', service(Bar::class));
+
+    // allowed: only the first argument is autowired, the extra one shifts if removed
+    $services->set(Foo::class)
+        ->args([service(Bar::class), service(Baz::class)]);
+
+    // allowed: the constructor type hints an interface, the concrete service stands in for its binding
+    $services->set(NeedsInterface::class)
+        ->args([service(Bar::class)]);
+
+    // allowed: autowiring is switched off, the argument is not redundant
+    $services->set(Foo::class)
+        ->autowire(false)
+        ->args([service(Bar::class)]);
+};

--- a/utils/phpstan/tests/Rule/Fixture/AutowiredArgumentBundle/Foo.php
+++ b/utils/phpstan/tests/Rule/Fixture/AutowiredArgumentBundle/Foo.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture\AutowiredArgumentBundle;
+
+final class Foo
+{
+    public function __construct(
+        private Bar $bar,
+    ) {
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/AutowiredArgumentBundle/NamedArgumentService.php
+++ b/utils/phpstan/tests/Rule/Fixture/AutowiredArgumentBundle/NamedArgumentService.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture\AutowiredArgumentBundle;
+
+final class NamedArgumentService
+{
+    public function __construct(
+        private Bar $bar,
+    ) {
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/AutowiredArgumentBundle/NeedsInterface.php
+++ b/utils/phpstan/tests/Rule/Fixture/AutowiredArgumentBundle/NeedsInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture\AutowiredArgumentBundle;
+
+final class NeedsInterface
+{
+    public function __construct(
+        private BarInterface $bar,
+    ) {
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/AutowiredArgumentBundle/TwoArg.php
+++ b/utils/phpstan/tests/Rule/Fixture/AutowiredArgumentBundle/TwoArg.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture\AutowiredArgumentBundle;
+
+final class TwoArg
+{
+    public function __construct(
+        private Bar $bar,
+        private Baz $baz,
+    ) {
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/ClassServiceReferenceBundle/Config/services.php
+++ b/utils/phpstan/tests/Rule/Fixture/ClassServiceReferenceBundle/Config/services.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Utils\PHPStan\Tests\Rule\Fixture\ClassServiceReferenceBundle\DependentService;
+use Utils\PHPStan\Tests\Rule\Fixture\ClassServiceReferenceBundle\SomeHelper;
+
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
+return function (ContainerConfigurator $configurator): void {
+    $services = $configurator->services();
+
+    $services->set(SomeHelper::class);
+    $services->alias('mautic.some.helper', SomeHelper::class);
+
+    // flagged: the string id names the very class the alias points at
+    $services->set('mautic.dependent.by_string', DependentService::class)
+        ->args([service('mautic.some.helper')]);
+
+    // allowed: already referenced by the class name
+    $services->set('mautic.dependent.by_class', DependentService::class)
+        ->args([service(SomeHelper::class)]);
+
+    // allowed: the string alias points at another string id, not a class
+    $services->alias('mautic.legacy.helper', 'mautic.some.helper');
+    $services->set('mautic.dependent.by_legacy', DependentService::class)
+        ->args([service('mautic.legacy.helper')]);
+};

--- a/utils/phpstan/tests/Rule/Fixture/ClassServiceReferenceBundle/Config/services.php
+++ b/utils/phpstan/tests/Rule/Fixture/ClassServiceReferenceBundle/Config/services.php
@@ -3,10 +3,11 @@
 declare(strict_types=1);
 
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
-use Utils\PHPStan\Tests\Rule\Fixture\ClassServiceReferenceBundle\DependentService;
-use Utils\PHPStan\Tests\Rule\Fixture\ClassServiceReferenceBundle\SomeHelper;
 
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
+use Utils\PHPStan\Tests\Rule\Fixture\ClassServiceReferenceBundle\DependentService;
+use Utils\PHPStan\Tests\Rule\Fixture\ClassServiceReferenceBundle\SomeHelper;
 
 return function (ContainerConfigurator $configurator): void {
     $services = $configurator->services();

--- a/utils/phpstan/tests/Rule/Fixture/ClassServiceReferenceBundle/DependentService.php
+++ b/utils/phpstan/tests/Rule/Fixture/ClassServiceReferenceBundle/DependentService.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture\ClassServiceReferenceBundle;
+
+final class DependentService
+{
+    public function __construct(
+        private SomeHelper $someHelper,
+    ) {
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/ClassServiceReferenceBundle/SomeHelper.php
+++ b/utils/phpstan/tests/Rule/Fixture/ClassServiceReferenceBundle/SomeHelper.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture\ClassServiceReferenceBundle;
+
+final class SomeHelper
+{
+}

--- a/utils/phpstan/tests/Rule/Fixture/DefinitionFetchBundle/AliasedHelper.php
+++ b/utils/phpstan/tests/Rule/Fixture/DefinitionFetchBundle/AliasedHelper.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture\DefinitionFetchBundle;
+
+final class AliasedHelper
+{
+}

--- a/utils/phpstan/tests/Rule/Fixture/DefinitionFetchBundle/Config/services.php
+++ b/utils/phpstan/tests/Rule/Fixture/DefinitionFetchBundle/Config/services.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Utils\PHPStan\Tests\Rule\Fixture\DefinitionFetchBundle\AliasedHelper;
+use Utils\PHPStan\Tests\Rule\Fixture\DefinitionFetchBundle\StringHelper;
+
+return function (ContainerConfigurator $configurator): void {
+    $services = $configurator->services();
+
+    // string-primary: a class is known for the id
+    $services->set('mautic.string.helper', StringHelper::class);
+
+    // class-primary with a string alias pointing at the class
+    $services->set(AliasedHelper::class);
+    $services->alias('mautic.aliased.helper', AliasedHelper::class);
+};

--- a/utils/phpstan/tests/Rule/Fixture/DefinitionFetchBundle/SomePass.php
+++ b/utils/phpstan/tests/Rule/Fixture/DefinitionFetchBundle/SomePass.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture\DefinitionFetchBundle;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class SomePass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        $container->getDefinition('mautic.string.helper')->setArgument('$prefix', 'x');
+        $container->getDefinition('mautic.aliased.helper')->setArgument('$prefix', 'y');
+        $container->getDefinition('mautic.unknown.service')->setArgument('$prefix', 'z');
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/DefinitionFetchBundle/StringHelper.php
+++ b/utils/phpstan/tests/Rule/Fixture/DefinitionFetchBundle/StringHelper.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture\DefinitionFetchBundle;
+
+final class StringHelper
+{
+}

--- a/utils/phpstan/tests/Rule/Fixture/SetterCallBundle/Config/services.php
+++ b/utils/phpstan/tests/Rule/Fixture/SetterCallBundle/Config/services.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
+use Utils\PHPStan\Tests\Rule\Fixture\SetterCallBundle\Repository;
+use Utils\PHPStan\Tests\Rule\Fixture\SetterCallBundle\SomeService;
+
+return function (ContainerConfigurator $configurator): void {
+    $services = $configurator->services();
+
+    // flagged: a setter wired by hand on a set() service
+    $services->set(SomeService::class)
+        ->call('setRepository', [service(Repository::class)]);
+
+    // flagged: a setter wired by hand on a get() service
+    $services->get(Repository::class)
+        ->call('setUniqueIdentifiersOperator', ['%mautic.contact_unique_identifiers_operator%']);
+
+    // allowed: call() to a non-setter method the container cannot infer
+    $services->set(SomeService::class)
+        ->call('configure', [service(Repository::class)]);
+};

--- a/utils/phpstan/tests/Rule/Fixture/SetterCallBundle/Config/services.php
+++ b/utils/phpstan/tests/Rule/Fixture/SetterCallBundle/Config/services.php
@@ -12,15 +12,19 @@ use Utils\PHPStan\Tests\Rule\Fixture\SetterCallBundle\SomeService;
 return function (ContainerConfigurator $configurator): void {
     $services = $configurator->services();
 
-    // flagged: a setter wired by hand on a set() service
+    // flagged: a setter fed a service() on a set() service
     $services->set(SomeService::class)
         ->call('setRepository', [service(Repository::class)]);
 
-    // flagged: a setter wired by hand on a get() service
+    // flagged: a setter fed a service() on a get() service
     $services->get(Repository::class)
+        ->call('setRepository', [service(Repository::class)]);
+
+    // allowed: the setter is fed a container parameter, not a service
+    $services->set(SomeService::class)
         ->call('setUniqueIdentifiersOperator', ['%mautic.contact_unique_identifiers_operator%']);
 
-    // allowed: call() to a non-setter method the container cannot infer
+    // allowed: call() to a non-setter method
     $services->set(SomeService::class)
         ->call('configure', [service(Repository::class)]);
 };

--- a/utils/phpstan/tests/Rule/Fixture/SetterCallBundle/Repository.php
+++ b/utils/phpstan/tests/Rule/Fixture/SetterCallBundle/Repository.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture\SetterCallBundle;
+
+final class Repository
+{
+}

--- a/utils/phpstan/tests/Rule/Fixture/SetterCallBundle/SomeService.php
+++ b/utils/phpstan/tests/Rule/Fixture/SetterCallBundle/SomeService.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture\SetterCallBundle;
+
+final class SomeService
+{
+    public function setRepository(Repository $repository): void
+    {
+    }
+
+    public function configure(Repository $repository): void
+    {
+    }
+}

--- a/utils/phpstan/tests/Rule/NoRedundantAutowiredServiceArgumentRuleTest.php
+++ b/utils/phpstan/tests/Rule/NoRedundantAutowiredServiceArgumentRuleTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use Utils\PHPStan\Rule\NoRedundantAutowiredServiceArgumentRule;
+
+/**
+ * @extends RuleTestCase<NoRedundantAutowiredServiceArgumentRule>
+ */
+final class NoRedundantAutowiredServiceArgumentRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new NoRedundantAutowiredServiceArgumentRule($this->createReflectionProvider());
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse([
+            __DIR__.'/Fixture/AutowiredArgumentBundle/Config/services.php',
+            __DIR__.'/Fixture/AutowiredArgumentBundle/Bar.php',
+            __DIR__.'/Fixture/AutowiredArgumentBundle/Baz.php',
+            __DIR__.'/Fixture/AutowiredArgumentBundle/Foo.php',
+            __DIR__.'/Fixture/AutowiredArgumentBundle/TwoArg.php',
+            __DIR__.'/Fixture/AutowiredArgumentBundle/NamedArgumentService.php',
+            __DIR__.'/Fixture/AutowiredArgumentBundle/BarInterface.php',
+            __DIR__.'/Fixture/AutowiredArgumentBundle/NeedsInterface.php',
+        ], [
+            [
+                'Every argument only repeats the type autowiring injects, remove the args() call and let autowiring resolve the constructor.',
+                19,
+            ],
+            [
+                'Every argument only repeats the type autowiring injects, remove the args() call and let autowiring resolve the constructor.',
+                23,
+            ],
+            [
+                'Argument "$bar" only repeats the type autowiring injects, remove the arg() call and let autowiring resolve "Utils\PHPStan\Tests\Rule\Fixture\AutowiredArgumentBundle\Bar".',
+                27,
+            ],
+        ]);
+    }
+}

--- a/utils/phpstan/tests/Rule/NoRedundantAutowiredServiceArgumentRuleTest.php
+++ b/utils/phpstan/tests/Rule/NoRedundantAutowiredServiceArgumentRuleTest.php
@@ -32,15 +32,15 @@ final class NoRedundantAutowiredServiceArgumentRuleTest extends RuleTestCase
         ], [
             [
                 'Every argument only repeats the type autowiring injects, remove the args() call and let autowiring resolve the constructor.',
-                19,
+                20,
             ],
             [
                 'Every argument only repeats the type autowiring injects, remove the args() call and let autowiring resolve the constructor.',
-                23,
+                24,
             ],
             [
                 'Argument "$bar" only repeats the type autowiring injects, remove the arg() call and let autowiring resolve "Utils\PHPStan\Tests\Rule\Fixture\AutowiredArgumentBundle\Bar".',
-                27,
+                28,
             ],
         ]);
     }

--- a/utils/phpstan/tests/Rule/NoServiceSetterCallRuleTest.php
+++ b/utils/phpstan/tests/Rule/NoServiceSetterCallRuleTest.php
@@ -27,11 +27,11 @@ final class NoServiceSetterCallRuleTest extends RuleTestCase
         ], [
             [
                 'Setter call() to "setRepository()" wires the dependency by hand, mark the method #[Required] and let autowiring call it instead.',
-                17,
+                16,
             ],
             [
                 'Setter call() to "setUniqueIdentifiersOperator()" wires the dependency by hand, mark the method #[Required] and let autowiring call it instead.',
-                21,
+                20,
             ],
         ]);
     }

--- a/utils/phpstan/tests/Rule/NoServiceSetterCallRuleTest.php
+++ b/utils/phpstan/tests/Rule/NoServiceSetterCallRuleTest.php
@@ -27,11 +27,11 @@ final class NoServiceSetterCallRuleTest extends RuleTestCase
         ], [
             [
                 'Setter call() to "setRepository()" wires the dependency by hand, mark the method #[Required] and let autowiring call it instead.',
-                15,
+                17,
             ],
             [
                 'Setter call() to "setUniqueIdentifiersOperator()" wires the dependency by hand, mark the method #[Required] and let autowiring call it instead.',
-                19,
+                21,
             ],
         ]);
     }

--- a/utils/phpstan/tests/Rule/NoServiceSetterCallRuleTest.php
+++ b/utils/phpstan/tests/Rule/NoServiceSetterCallRuleTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use Utils\PHPStan\Rule\NoServiceSetterCallRule;
+
+/**
+ * @extends RuleTestCase<NoServiceSetterCallRule>
+ */
+final class NoServiceSetterCallRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new NoServiceSetterCallRule();
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse([
+            __DIR__.'/Fixture/SetterCallBundle/Config/services.php',
+            __DIR__.'/Fixture/SetterCallBundle/Repository.php',
+            __DIR__.'/Fixture/SetterCallBundle/SomeService.php',
+        ], [
+            [
+                'Setter call() to "setRepository()" wires the dependency by hand, mark the method #[Required] and let autowiring call it instead.',
+                15,
+            ],
+            [
+                'Setter call() to "setUniqueIdentifiersOperator()" wires the dependency by hand, mark the method #[Required] and let autowiring call it instead.',
+                19,
+            ],
+        ]);
+    }
+}

--- a/utils/phpstan/tests/Rule/NoServiceSetterCallRuleTest.php
+++ b/utils/phpstan/tests/Rule/NoServiceSetterCallRuleTest.php
@@ -30,7 +30,7 @@ final class NoServiceSetterCallRuleTest extends RuleTestCase
                 16,
             ],
             [
-                'Setter call() to "setUniqueIdentifiersOperator()" wires the dependency by hand, mark the method #[Required] and let autowiring call it instead.',
+                'Setter call() to "setRepository()" wires the dependency by hand, mark the method #[Required] and let autowiring call it instead.',
                 20,
             ],
         ]);

--- a/utils/phpstan/tests/Rule/PreferClassInDefinitionFetchRuleTest.php
+++ b/utils/phpstan/tests/Rule/PreferClassInDefinitionFetchRuleTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule;
+
+use PHPStan\Collectors\Collector;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use Utils\PHPStan\Collector\ClassNameServiceAliasCollector;
+use Utils\PHPStan\Collector\ClassTargetServiceAliasCollector;
+use Utils\PHPStan\Collector\DefinitionFetchByStringCollector;
+use Utils\PHPStan\Collector\ServiceDefinitionNameCollector;
+use Utils\PHPStan\Rule\PreferClassInDefinitionFetchRule;
+
+/**
+ * @extends RuleTestCase<PreferClassInDefinitionFetchRule>
+ */
+final class PreferClassInDefinitionFetchRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new PreferClassInDefinitionFetchRule();
+    }
+
+    /**
+     * @return list<Collector<\PhpParser\Node, mixed>>
+     */
+    protected function getCollectors(): array
+    {
+        return [
+            new DefinitionFetchByStringCollector(),
+            new ServiceDefinitionNameCollector(),
+            new ClassTargetServiceAliasCollector(),
+            new ClassNameServiceAliasCollector(),
+        ];
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse([
+            __DIR__.'/Fixture/DefinitionFetchBundle/Config/services.php',
+            __DIR__.'/Fixture/DefinitionFetchBundle/SomePass.php',
+            __DIR__.'/Fixture/DefinitionFetchBundle/StringHelper.php',
+            __DIR__.'/Fixture/DefinitionFetchBundle/AliasedHelper.php',
+        ], [
+            [
+                'Fetch the definition by its class, getDefinition(Utils\PHPStan\Tests\Rule\Fixture\DefinitionFetchBundle\StringHelper::class), rather than by the string id "mautic.string.helper" the service is registered with.',
+                14,
+            ],
+            [
+                'Fetch the definition by its class, getDefinition(Utils\PHPStan\Tests\Rule\Fixture\DefinitionFetchBundle\AliasedHelper::class), rather than by the string id "mautic.aliased.helper" the service is registered with.',
+                15,
+            ],
+        ]);
+    }
+}

--- a/utils/phpstan/tests/Rule/PreferClassServiceReferenceRuleTest.php
+++ b/utils/phpstan/tests/Rule/PreferClassServiceReferenceRuleTest.php
@@ -41,7 +41,7 @@ final class PreferClassServiceReferenceRuleTest extends RuleTestCase
         ], [
             [
                 'Reference the service by its class, service(Utils\PHPStan\Tests\Rule\Fixture\ClassServiceReferenceBundle\SomeHelper::class), rather than by the string id "mautic.some.helper" a class name alias already covers.',
-                19,
+                20,
             ],
         ]);
     }

--- a/utils/phpstan/tests/Rule/PreferClassServiceReferenceRuleTest.php
+++ b/utils/phpstan/tests/Rule/PreferClassServiceReferenceRuleTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule;
+
+use PHPStan\Collectors\Collector;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use Utils\PHPStan\Collector\ClassTargetServiceAliasCollector;
+use Utils\PHPStan\Collector\ServiceStringReferenceCollector;
+use Utils\PHPStan\Rule\PreferClassServiceReferenceRule;
+
+/**
+ * @extends RuleTestCase<PreferClassServiceReferenceRule>
+ */
+final class PreferClassServiceReferenceRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new PreferClassServiceReferenceRule();
+    }
+
+    /**
+     * @return list<Collector<\PhpParser\Node, mixed>>
+     */
+    protected function getCollectors(): array
+    {
+        return [
+            new ClassTargetServiceAliasCollector(),
+            new ServiceStringReferenceCollector(),
+        ];
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse([
+            __DIR__.'/Fixture/ClassServiceReferenceBundle/Config/services.php',
+            __DIR__.'/Fixture/ClassServiceReferenceBundle/SomeHelper.php',
+            __DIR__.'/Fixture/ClassServiceReferenceBundle/DependentService.php',
+        ], [
+            [
+                'Reference the service by its class, service(Utils\PHPStan\Tests\Rule\Fixture\ClassServiceReferenceBundle\SomeHelper::class), rather than by the string id "mautic.some.helper" a class name alias already covers.',
+                19,
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
## Why

Service wiring in `Config/services.php` collected several habits that couple config to loose strings or repeat what autowiring already does. This branch adds four PHPStan rules that flag each habit, then applies the fixes across the bundles.

## Rules

### 1. `PreferClassServiceReferenceRule`

A service registered under its class name and *also* aliased to a hand-written string id can be referenced by either. Naming the class says the same and lets the redundant alias go.

```diff
-$services->alias('mautic.helper.core_parameters', CoreParametersHelper::class);
 ...
-service('mautic.helper.core_parameters')
+service(CoreParametersHelper::class)
```

### 2. `NoRedundantAutowiredServiceArgumentRule`

An explicit `service(Type::class)` argument that only repeats the constructor's type hint brings nothing — autowiring injects it anyway.

```diff
 $services->set(MenuHelper::class)
-    ->args([service(RequestStack::class)]);
+    ;
```

### 3. `NoServiceSetterCallRule`

Setter injection via `->call('setX', [...])` is wiring hidden in config. Prefer `#[Required]` on the class so the dependency is declared where it lives.

```diff
 // services.php
 $services->set(FieldType::class)
-    ->call('setFieldModel', [service(FieldModel::class)])
-    ->call('setFormModel', [service(FormModel::class)]);
+    ;
```

```diff
 // FieldType (via FormFieldTrait)
-public function setFieldModel(FieldModel $fieldModel): void
-{
+#[Required]
+public function autowireFormFieldTrait(
+    FieldModel $fieldModel,
+    FormModel $formModel,
+): void {
     $this->fieldModel = $fieldModel;
+    $this->formModel  = $formModel;
 }
```

### 4. `PreferClassInDefinitionFetchRule`

Same idea inside compiler passes: fetch a definition by its class, not a string id that only points back at the class.

```diff
-$container->getDefinition('mautic.helper.core_parameters');
+$container->getDefinition(CoreParametersHelper::class);
```

## Applied fixes

The rules run in `phpstan.neon`, and the flagged sites are cleaned up across CacheBundle, CoreBundle, FormBundle, LeadBundle, NotificationBundle, PluginBundle and SmsBundle: redundant aliases dropped, setter `->call()` wiring replaced with `#[Required]`, and typed properties added where the setter previously carried the type in a docblock.
