### PR TITLE
[di] Inject DateTimeHelper into DateHelper via constructor for testability

### DIFF
--- a/app/bundles/CoreBundle/Helper/DateTimeHelper.php
+++ b/app/bundles/CoreBundle/Helper/DateTimeHelper.php
@@ -6,11 +6,11 @@ use Mautic\CoreBundle\Loader\ParameterLoader;
 
 class DateTimeHelper
 {
-    public const FORMAT_DB = 'Y-m-d H:i:s';
+    public const string FORMAT_DB = 'Y-m-d H:i:s';
+
+    public const string FORMAT_DB_DATE_ONLY = 'Y-m-d';
 
     private static ?string $defaultLocalTimezone = null;
-
-    public const FORMAT_DB_DATE_ONLY = 'Y-m-d';
 
     /**
      * @var string

--- a/app/bundles/CoreBundle/Tests/Unit/Twig/Helper/DateHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Twig/Helper/DateHelperTest.php
@@ -119,9 +119,9 @@ final class DateHelperTest extends \PHPUnit\Framework\TestCase
             ->willReturn($now);
 
         // Inject the mock DateTimeHelper into DateHelper
-        ReflectionHelper::setValue($this->helper, 'helper', $dateTimeHelperMock);
+        $helper = $this->createDateHelperWithDateTimeHelper($dateTimeHelperMock);
 
-        $result = $this->helper->toText($now);
+        $result = $helper->toText($now);
 
         // Assertions
         $this->assertSame('Today', $result);
@@ -177,10 +177,10 @@ final class DateHelperTest extends \PHPUnit\Framework\TestCase
             ->willReturn('today');
 
         // Inject the mock DateTimeHelper into DateHelper
-        ReflectionHelper::setValue($this->helper, 'helper', $dateTimeHelperMock);
+        $helper = $this->createDateHelperWithDateTimeHelper($dateTimeHelperMock);
 
         $now    = new \DateTime('now', new \DateTimeZone('UTC'));
-        $result = $this->helper->toTextShort($now);
+        $result = $helper->toTextShort($now);
 
         $this->assertSame('Today', $result);
     }
@@ -199,10 +199,10 @@ final class DateHelperTest extends \PHPUnit\Framework\TestCase
             ->willReturn('December 31, 2023');
 
         // Inject the mock DateTimeHelper into DateHelper
-        ReflectionHelper::setValue($this->helper, 'helper', $dateTimeHelperMock);
+        $helper = $this->createDateHelperWithDateTimeHelper($dateTimeHelperMock);
 
         $olderDate = '2023-12-31 23:59:59';
-        $result    = $this->helper->toTextShort($olderDate, 'UTC', 'Y-m-d H:i:s');
+        $result    = $helper->toTextShort($olderDate, 'UTC', 'Y-m-d H:i:s');
 
         // Should return formatted date
         $this->assertStringContainsString('2023', $result);
@@ -213,6 +213,19 @@ final class DateHelperTest extends \PHPUnit\Framework\TestCase
     {
         $result = $this->helper->toTextShort('');
         $this->assertSame('', $result);
+    }
+
+    private function createDateHelperWithDateTimeHelper(DateTimeHelper $dateTimeHelper): DateHelper
+    {
+        return new DateHelper(
+            'F j, Y g:i a T',
+            'D, M d',
+            'F j, Y',
+            'g:i a',
+            $this->translator,
+            $this->coreParametersHelper,
+            $dateTimeHelper,
+        );
     }
 
     private function setDefaultLocalTimezone(string $timezone): void

--- a/app/bundles/CoreBundle/Twig/Helper/DateHelper.php
+++ b/app/bundles/CoreBundle/Twig/Helper/DateHelper.php
@@ -13,10 +13,7 @@ final class DateHelper
      */
     private readonly array $formats;
 
-    /**
-     * @api cannot be readonly, as changed in tests via reflection
-     */
-    private DateTimeHelper $helper;
+    private readonly DateTimeHelper $helper;
 
     public function __construct(
         string $dateFullFormat,
@@ -25,6 +22,7 @@ final class DateHelper
         string $timeOnlyFormat,
         private readonly TranslatorInterface $translator,
         private readonly CoreParametersHelper $coreParametersHelper,
+        ?DateTimeHelper $helper = null,
     ) {
         $this->formats = [
             'datetime' => $dateFullFormat,
@@ -33,7 +31,7 @@ final class DateHelper
             'time'     => $timeOnlyFormat,
         ];
 
-        $this->helper               = new DateTimeHelper('', 'Y-m-d H:i:s', 'local');
+        $this->helper = $helper ?? new DateTimeHelper('', 'Y-m-d H:i:s', 'local');
     }
 
     /**

--- a/app/bundles/CoreBundle/Twig/Helper/DateHelper.php
+++ b/app/bundles/CoreBundle/Twig/Helper/DateHelper.php
@@ -6,22 +6,22 @@ use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-final class DateHelper
+final readonly class DateHelper
 {
     /**
      * @var string[]
      */
-    private readonly array $formats;
+    private array $formats;
 
-    private readonly DateTimeHelper $helper;
+    private DateTimeHelper $helper;
 
     public function __construct(
         string $dateFullFormat,
         string $dateShortFormat,
         string $dateOnlyFormat,
         string $timeOnlyFormat,
-        private readonly TranslatorInterface $translator,
-        private readonly CoreParametersHelper $coreParametersHelper,
+        private TranslatorInterface $translator,
+        private CoreParametersHelper $coreParametersHelper,
         ?DateTimeHelper $helper = null,
     ) {
         $this->formats = [


### PR DESCRIPTION
Tiny improvement to allow clear testing via __cosntruct()

`DateHelper` built its `DateTimeHelper` collaborator internally with `new`, so tests could only swap in a mock via reflection (`ReflectionHelper::setValue($helper, 'helper', $mock)`). That reflection also blocks marking the property `readonly`.
