### PR TITLE
[symfony] Dispatch CoreBundle events by class name (Symfony 4.3 style)

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -176,6 +176,7 @@
 ## Changed code
 
 - IntegrationsBundle events are now dispatched by the event object alone, so the event name is the event class (Symfony 4.3+) instead of the `Mautic\IntegrationsBundle\IntegrationEvents` string constants. Update any subscriber or listener that keys on one of the converted `IntegrationEvents::*` constants to key on the event class instead:
+- CoreBundle events are now dispatched by the event object alone, so the event name is the event class (Symfony 4.3+) instead of the `Mautic\CoreBundle\CoreEvents` string constants. Update any subscriber or listener that keys on a `CoreEvents::*` constant (or the raw string name such as `mautic.build_menu`) to key on the event class instead:
 
     ```diff
      public static function getSubscribedEvents(): array
@@ -183,6 +184,8 @@
          return [
     -        IntegrationEvents::INTEGRATION_COLLECT_INTERNAL_OBJECTS => ['collectInternalObjects', 0],
     +        InternalObjectEvent::class => ['collectInternalObjects', 0],
+    -        CoreEvents::BUILD_MENU => ['onBuildMenu', 9999],
+    +        MenuEvent::class => ['onBuildMenu', 9999],
          ];
      }
     ```
@@ -206,6 +209,25 @@
     | `IntegrationEvents::INTEGRATION_FIND_INTERNAL_RECORD` | `InternalObjectFindByIdEvent` |
     | `IntegrationEvents::INTEGRATION_BUILD_INTERNAL_OBJECT_ROUTE` | `InternalObjectRouteEvent` |
     | `IntegrationEvents::INTEGRATION_OBJECT_TOKEN_EVENT` | `MappedIntegrationObjectTokenEvent` |
+    Dispatching drops the redundant second argument, e.g. `$dispatcher->dispatch($event, CoreEvents::BUILD_MENU)` becomes `$dispatcher->dispatch($event)`. The `Mautic\CoreBundle\CoreEvents` constants are kept for backwards compatibility but are no longer used internally. Note that listeners for the icon event (`Mautic\CoreBundle\Event\IconEvent`) must now be keyed on `IconEvent::class`, as that event was already dispatched by object.
+
+    Full mapping of old event name to new event class (all in the `Mautic\CoreBundle\Event` namespace):
+
+    | Old event name | `CoreEvents` constant | New event class |
+    | --- | --- | --- |
+    | `mautic.build_menu` | `CoreEvents::BUILD_MENU` | `MenuEvent` |
+    | `mautic.build_route` | `CoreEvents::BUILD_ROUTE` | `RouteEvent` |
+    | `mautic.global_search` | `CoreEvents::GLOBAL_SEARCH` | `GlobalSearchEvent` |
+    | `mautic.list_stats` | `CoreEvents::LIST_STATS` | `StatsEvent` |
+    | `mautic.build_command_list` | `CoreEvents::BUILD_COMMAND_LIST` | `CommandListEvent` |
+    | `mautic.on_fetch_icons` | `CoreEvents::FETCH_ICONS` | `IconEvent` |
+    | `mautic.build_embeddable_js` | `CoreEvents::BUILD_MAUTIC_JS` | `BuildJsEvent` |
+    | `mautic.maintenance_cleanup_data` | `CoreEvents::MAINTENANCE_CLEANUP_DATA` | `MaintenanceEvent` |
+    | `mautic.view_inject_custom_buttons` | `CoreEvents::VIEW_INJECT_CUSTOM_BUTTONS` | `CustomButtonEvent` |
+    | `mautic.view_inject_custom_content` | `CoreEvents::VIEW_INJECT_CUSTOM_CONTENT` | `CustomContentEvent` |
+    | `mautic.view_inject_custom_template` | `CoreEvents::VIEW_INJECT_CUSTOM_TEMPLATE` | `CustomTemplateEvent` |
+    | `mautic.view_inject_custom_assets` | `CoreEvents::VIEW_INJECT_CUSTOM_ASSETS` | `CustomAssetsEvent` |
+    | `mautic.on_generated_columns_build` | `CoreEvents::ON_GENERATED_COLUMNS_BUILD` | `GeneratedColumnsEvent` |
 
 - `Mautic\CoreBundle\Factory\ModelFactory` now builds its service locator from a `defaultIndexMethod` on the `mautic.model` tag, replacing the removed `Mautic\CoreBundle\DependencyInjection\Compiler\ModelPass`. Every model (a service implementing `Mautic\CoreBundle\Model\MauticModelInterface`) declares its `ModelFactory::getModel()` lookup key via a static `getName()` method:
 

--- a/app/bundles/ApiBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/ApiBundle/EventListener/SearchSubscriber.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Mautic\ApiBundle\EventListener;
 
 use Mautic\ApiBundle\Model\ClientModel;
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\DTO\GlobalSearchFilterDTO;
 use Mautic\CoreBundle\Event as MauticEvents;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
@@ -24,8 +23,8 @@ final readonly class SearchSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            CoreEvents::GLOBAL_SEARCH      => ['onGlobalSearch', 0],
-            CoreEvents::BUILD_COMMAND_LIST => ['onBuildCommandList', 0],
+            MauticEvents\GlobalSearchEvent::class => ['onGlobalSearch', 0],
+            MauticEvents\CommandListEvent::class  => ['onBuildCommandList', 0],
         ];
     }
 

--- a/app/bundles/AssetBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/SearchSubscriber.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Mautic\AssetBundle\EventListener;
 
 use Mautic\AssetBundle\Model\AssetModel;
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\DTO\GlobalSearchFilterDTO;
 use Mautic\CoreBundle\Event as MauticEvents;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
@@ -24,8 +23,8 @@ final readonly class SearchSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            CoreEvents::GLOBAL_SEARCH      => ['onGlobalSearch', 0],
-            CoreEvents::BUILD_COMMAND_LIST => ['onBuildCommandList', 0],
+            MauticEvents\GlobalSearchEvent::class => ['onGlobalSearch', 0],
+            MauticEvents\CommandListEvent::class  => ['onBuildCommandList', 0],
         ];
     }
 

--- a/app/bundles/CampaignBundle/EventListener/ButtonSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/ButtonSubscriber.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\CampaignBundle\EventListener;
 
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Event\CustomButtonEvent;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\CoreBundle\Twig\Helper\ButtonHelper;
@@ -24,7 +23,7 @@ final readonly class ButtonSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            CoreEvents::VIEW_INJECT_CUSTOM_BUTTONS => ['injectViewButtons', 0],
+            CustomButtonEvent::class => ['injectViewButtons', 0],
         ];
     }
 

--- a/app/bundles/CampaignBundle/EventListener/CampaignInjectCustomContentSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/CampaignInjectCustomContentSubscriber.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Mautic\CampaignBundle\EventListener;
 
 use Mautic\CampaignBundle\Entity\Campaign;
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Event\CustomContentEvent;
 use Mautic\CoreBundle\Model\AuditLogModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -25,7 +24,7 @@ final readonly class CampaignInjectCustomContentSubscriber implements EventSubsc
     public static function getSubscribedEvents(): array
     {
         return [
-            CoreEvents::VIEW_INJECT_CUSTOM_CONTENT => ['injectViewCustomContent', 0],
+            CustomContentEvent::class => ['injectViewCustomContent', 0],
         ];
     }
 

--- a/app/bundles/CampaignBundle/EventListener/GeneratedColumnSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/GeneratedColumnSubscriber.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\CampaignBundle\EventListener;
 
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Doctrine\GeneratedColumn\GeneratedColumn;
 use Mautic\CoreBundle\Doctrine\Provider\VersionProviderInterface;
 use Mautic\CoreBundle\Event\GeneratedColumnsEvent;
@@ -20,7 +19,7 @@ final readonly class GeneratedColumnSubscriber implements EventSubscriberInterfa
     public static function getSubscribedEvents(): array
     {
         return [
-            CoreEvents::ON_GENERATED_COLUMNS_BUILD => ['onGeneratedColumnsBuild', 0],
+            GeneratedColumnsEvent::class => ['onGeneratedColumnsBuild', 0],
         ];
     }
 

--- a/app/bundles/CampaignBundle/EventListener/PublishToggleSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/PublishToggleSubscriber.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Mautic\CampaignBundle\EventListener;
 
 use Mautic\CampaignBundle\Entity\Campaign;
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Event\CustomTemplateEvent;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -22,7 +21,7 @@ final readonly class PublishToggleSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            CoreEvents::VIEW_INJECT_CUSTOM_TEMPLATE => ['onTemplateRender', 0],
+            CustomTemplateEvent::class => ['onTemplateRender', 0],
         ];
     }
 

--- a/app/bundles/CampaignBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/SearchSubscriber.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Mautic\CampaignBundle\EventListener;
 
 use Mautic\CampaignBundle\Model\CampaignModel;
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\DTO\GlobalSearchFilterDTO;
 use Mautic\CoreBundle\Event as MauticEvents;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
@@ -24,8 +23,8 @@ final readonly class SearchSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            CoreEvents::GLOBAL_SEARCH      => ['onGlobalSearch', 0],
-            CoreEvents::BUILD_COMMAND_LIST => ['onBuildCommandList', 0],
+            MauticEvents\GlobalSearchEvent::class => ['onGlobalSearch', 0],
+            MauticEvents\CommandListEvent::class  => ['onBuildCommandList', 0],
         ];
     }
 

--- a/app/bundles/CampaignBundle/Tests/EventListener/GeneratedColumnSubscriberTest.php
+++ b/app/bundles/CampaignBundle/Tests/EventListener/GeneratedColumnSubscriberTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Mautic\CampaignBundle\Tests\EventListener;
 
 use Mautic\CampaignBundle\EventListener\GeneratedColumnSubscriber;
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Doctrine\GeneratedColumn\GeneratedColumnInterface;
 use Mautic\CoreBundle\Doctrine\GeneratedColumn\GeneratedColumns;
 use Mautic\CoreBundle\Doctrine\Provider\VersionProviderInterface;
@@ -17,7 +16,7 @@ final class GeneratedColumnSubscriberTest extends TestCase
     public function testGetSubscribedEvents(): void
     {
         $subscribedEvents = [
-            CoreEvents::ON_GENERATED_COLUMNS_BUILD => ['onGeneratedColumnsBuild', 0],
+            GeneratedColumnsEvent::class => ['onGeneratedColumnsBuild', 0],
         ];
 
         $this->assertSame($subscribedEvents, GeneratedColumnSubscriber::getSubscribedEvents());

--- a/app/bundles/CategoryBundle/EventListener/ButtonSubscriber.php
+++ b/app/bundles/CategoryBundle/EventListener/ButtonSubscriber.php
@@ -2,7 +2,6 @@
 
 namespace Mautic\CategoryBundle\EventListener;
 
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Event\CustomButtonEvent;
 use Mautic\CoreBundle\Twig\Helper\ButtonHelper;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -20,7 +19,7 @@ final readonly class ButtonSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            CoreEvents::VIEW_INJECT_CUSTOM_BUTTONS => ['injectContactBulkButtons', 0],
+            CustomButtonEvent::class => ['injectContactBulkButtons', 0],
         ];
     }
 

--- a/app/bundles/ChannelBundle/EventListener/ButtonSubscriber.php
+++ b/app/bundles/ChannelBundle/EventListener/ButtonSubscriber.php
@@ -2,7 +2,6 @@
 
 namespace Mautic\ChannelBundle\EventListener;
 
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Event\CustomButtonEvent;
 use Mautic\CoreBundle\Twig\Helper\ButtonHelper;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -20,7 +19,7 @@ final readonly class ButtonSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            CoreEvents::VIEW_INJECT_CUSTOM_BUTTONS => ['injectContactBulkButtons', 0],
+            CustomButtonEvent::class => ['injectContactBulkButtons', 0],
         ];
     }
 

--- a/app/bundles/ChannelBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/ChannelBundle/EventListener/SearchSubscriber.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Mautic\ChannelBundle\EventListener;
 
 use Mautic\ChannelBundle\Model\MessageModel;
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\DTO\GlobalSearchFilterDTO;
 use Mautic\CoreBundle\Event\GlobalSearchEvent;
 use Mautic\CoreBundle\Service\GlobalSearch;
@@ -22,7 +21,7 @@ final readonly class SearchSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            CoreEvents::GLOBAL_SEARCH => ['onGlobalSearch', 0],
+            GlobalSearchEvent::class => ['onGlobalSearch', 0],
         ];
     }
 

--- a/app/bundles/CoreBundle/Command/CleanupMaintenanceCommand.php
+++ b/app/bundles/CoreBundle/Command/CleanupMaintenanceCommand.php
@@ -2,7 +2,6 @@
 
 namespace Mautic\CoreBundle\Command;
 
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Event\MaintenanceEvent;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\IpLookupHelper;
@@ -50,7 +49,7 @@ Deletes records of anonymous <options=bold>and inactive identified</> contacts o
 <info>php %command.full_name% --dry-run</info>
 Shows you how many records of anonymous contacts <info>%command.name%</info> will purge.
 
-The <info>%command.name%</info> command dispatches the <info>CoreEvents::MAINTENANCE_CLEANUP_DATA</info> event in order to purge old data (data must be supported by event listeners, as not all data is applicable to be purged).
+The <info>%command.name%</info> command dispatches the <info>MaintenanceEvent</info> event in order to purge old data (data must be supported by event listeners, as not all data is applicable to be purged).
 TXT
 )]
 final class CleanupMaintenanceCommand extends ModeratedCommand
@@ -122,7 +121,7 @@ final class CleanupMaintenanceCommand extends ModeratedCommand
         }
 
         $event = new MaintenanceEvent($daysOld, !empty($dryRun), !empty($gdpr));
-        $this->dispatcher->dispatch($event, CoreEvents::MAINTENANCE_CLEANUP_DATA);
+        $this->dispatcher->dispatch($event);
         $stats = $event->getStats();
 
         $rows = [];

--- a/app/bundles/CoreBundle/Controller/AjaxController.php
+++ b/app/bundles/CoreBundle/Controller/AjaxController.php
@@ -2,7 +2,6 @@
 
 namespace Mautic\CoreBundle\Controller;
 
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Event\CustomTemplateEvent;
 use Mautic\CoreBundle\Event\GlobalSearchEvent;
 use Mautic\CoreBundle\Exception\RecordCanNotUnpublishException;
@@ -141,7 +140,7 @@ class AjaxController extends CommonController
         $request->getSession()->set('mautic.global_search', $searchStr);
 
         $event = new GlobalSearchEvent($searchStr, $this->translator);
-        $this->dispatcher->dispatch($event, CoreEvents::GLOBAL_SEARCH);
+        $this->dispatcher->dispatch($event);
 
         $dataArray['newContent'] = $this->renderView(
             '@MauticCore/GlobalSearch/results.html.twig',
@@ -443,10 +442,7 @@ class AjaxController extends CommonController
      */
     protected function renderView(string $view, array $parameters = []): string
     {
-        $event = $this->dispatcher->dispatch(
-            new CustomTemplateEvent($this->getCurrentRequest(), $view, $parameters),
-            CoreEvents::VIEW_INJECT_CUSTOM_TEMPLATE
-        );
+        $event = $this->dispatcher->dispatch(new CustomTemplateEvent($this->getCurrentRequest(), $view, $parameters));
 
         return parent::renderView($event->getTemplate(), $event->getVars());
     }

--- a/app/bundles/CoreBundle/Controller/Api/StatsApiController.php
+++ b/app/bundles/CoreBundle/Controller/Api/StatsApiController.php
@@ -3,7 +3,6 @@
 namespace Mautic\CoreBundle\Controller\Api;
 
 use Mautic\ApiBundle\Controller\CommonApiController;
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Event\StatsEvent;
 use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\CoreBundle\Helper\UserHelper;
@@ -36,7 +35,7 @@ final class StatsApiController extends CommonApiController
 
         try {
             $event = new StatsEvent($table, $start, $limit, $order, $where, $userHelper->getUser());
-            $this->dispatcher->dispatch($event, CoreEvents::LIST_STATS);
+            $this->dispatcher->dispatch($event);
 
             // Return available tables if no result was set
             if (!$event->hasResults()) {

--- a/app/bundles/CoreBundle/Controller/CommonController.php
+++ b/app/bundles/CoreBundle/Controller/CommonController.php
@@ -3,7 +3,6 @@
 namespace Mautic\CoreBundle\Controller;
 
 use Doctrine\Persistence\ManagerRegistry;
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Event\CustomTemplateEvent;
 use Mautic\CoreBundle\Factory\ModelFactory;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
@@ -137,11 +136,8 @@ class CommonController extends AbstractController implements MauticController
      */
     public function eventAwareRenderView(string &$contentTemplate, array &$parameters, ?Request $request = null): string
     {
-        if ($this->dispatcher->hasListeners(CoreEvents::VIEW_INJECT_CUSTOM_TEMPLATE)) {
-            $event = $this->dispatcher->dispatch(
-                new CustomTemplateEvent($request, $contentTemplate, $parameters),
-                CoreEvents::VIEW_INJECT_CUSTOM_TEMPLATE
-            );
+        if ($this->dispatcher->hasListeners(CustomTemplateEvent::class)) {
+            $event = $this->dispatcher->dispatch(new CustomTemplateEvent($request, $contentTemplate, $parameters));
 
             $contentTemplate   = $event->getTemplate();
             $parameters        = $event->getVars(); // @phpstan-ignore parameterByRef.type
@@ -201,11 +197,8 @@ class CommonController extends AbstractController implements MauticController
         $code     = $args['responseCode'] ?? 200;
         $response = new Response('', $code);
 
-        if ($this->dispatcher->hasListeners(CoreEvents::VIEW_INJECT_CUSTOM_TEMPLATE)) {
-            $event = $this->dispatcher->dispatch(
-                new CustomTemplateEvent($request, $template, $parameters),
-                CoreEvents::VIEW_INJECT_CUSTOM_TEMPLATE
-            );
+        if ($this->dispatcher->hasListeners(CustomTemplateEvent::class)) {
+            $event = $this->dispatcher->dispatch(new CustomTemplateEvent($request, $template, $parameters));
 
             $template   = $event->getTemplate();
             $parameters = $event->getVars();

--- a/app/bundles/CoreBundle/Controller/DefaultController.php
+++ b/app/bundles/CoreBundle/Controller/DefaultController.php
@@ -2,7 +2,6 @@
 
 namespace Mautic\CoreBundle\Controller;
 
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Event\GlobalSearchEvent;
 use Mautic\CoreBundle\Model\NotificationModel;
 use Mautic\PageBundle\Model\PageModel;
@@ -55,7 +54,7 @@ final class DefaultController extends CommonController
 
         if (!empty($searchStr)) {
             $event = new GlobalSearchEvent($searchStr, $this->translator);
-            $this->dispatcher->dispatch($event, CoreEvents::GLOBAL_SEARCH);
+            $this->dispatcher->dispatch($event);
             $results = $event->getResults();
         } else {
             $results = [];

--- a/app/bundles/CoreBundle/Controller/JsController.php
+++ b/app/bundles/CoreBundle/Controller/JsController.php
@@ -2,7 +2,6 @@
 
 namespace Mautic\CoreBundle\Controller;
 
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Event\BuildJsEvent;
 use Mautic\CoreBundle\Event\BuildJsScope;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -45,8 +44,8 @@ final class JsController extends CommonController
 
         $event = new BuildJsEvent($this->getJsHeader(), $kernelDebug, $acceptedScopes);
 
-        if ($this->dispatcher->hasListeners(CoreEvents::BUILD_MAUTIC_JS)) {
-            $this->dispatcher->dispatch($event, CoreEvents::BUILD_MAUTIC_JS);
+        if ($this->dispatcher->hasListeners(BuildJsEvent::class)) {
+            $this->dispatcher->dispatch($event);
         }
 
         return new Response($event->getJs(), Response::HTTP_OK, ['Content-Type' => 'application/javascript']);

--- a/app/bundles/CoreBundle/Doctrine/Provider/GeneratedColumnsProvider.php
+++ b/app/bundles/CoreBundle/Doctrine/Provider/GeneratedColumnsProvider.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\Doctrine\Provider;
 
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Doctrine\GeneratedColumn\GeneratedColumns;
 use Mautic\CoreBundle\Event\GeneratedColumnsEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -34,9 +33,9 @@ final class GeneratedColumnsProvider implements GeneratedColumnsProviderInterfac
     {
         if ($this->generatedColumnsAreSupported()
             && 0 === $this->generatedColumns->count()
-            && $this->dispatcher->hasListeners(CoreEvents::ON_GENERATED_COLUMNS_BUILD)
+            && $this->dispatcher->hasListeners(GeneratedColumnsEvent::class)
         ) {
-            $event                  = $this->dispatcher->dispatch(new GeneratedColumnsEvent(), CoreEvents::ON_GENERATED_COLUMNS_BUILD);
+            $event                  = $this->dispatcher->dispatch(new GeneratedColumnsEvent());
             $this->generatedColumns = $event->getGeneratedColumns();
         }
 

--- a/app/bundles/CoreBundle/EventListener/AssetsSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/AssetsSubscriber.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\EventListener;
 
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Event\CustomAssetsEvent;
 use Mautic\CoreBundle\Twig\Helper\AssetsHelper;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -29,11 +28,8 @@ final readonly class AssetsSubscriber implements EventSubscriberInterface
 
     public function fetchCustomAssets(RequestEvent $event): void
     {
-        if ($event->isMainRequest() && $this->dispatcher->hasListeners(CoreEvents::VIEW_INJECT_CUSTOM_ASSETS)) {
-            $this->dispatcher->dispatch(
-                new CustomAssetsEvent($this->assetsHelper),
-                CoreEvents::VIEW_INJECT_CUSTOM_ASSETS
-            );
+        if ($event->isMainRequest() && $this->dispatcher->hasListeners(CustomAssetsEvent::class)) {
+            $this->dispatcher->dispatch(new CustomAssetsEvent($this->assetsHelper));
         }
     }
 }

--- a/app/bundles/CoreBundle/EventListener/BuildJsSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/BuildJsSubscriber.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\EventListener;
 
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Event\BuildJsEvent;
 use Mautic\CoreBundle\Event\BuildJsScope;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -14,7 +13,7 @@ final class BuildJsSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            CoreEvents::BUILD_MAUTIC_JS => ['onBuildJs', 1000],
+            BuildJsEvent::class => ['onBuildJs', 1000],
         ];
     }
 

--- a/app/bundles/CoreBundle/EventListener/CommonStatsSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/CommonStatsSubscriber.php
@@ -3,7 +3,6 @@
 namespace Mautic\CoreBundle\EventListener;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Entity\CommonRepository;
 use Mautic\CoreBundle\Event\StatsEvent;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
@@ -36,7 +35,7 @@ abstract class CommonStatsSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            CoreEvents::LIST_STATS => ['onStatsFetch', 0],
+            StatsEvent::class => ['onStatsFetch', 0],
         ];
     }
 

--- a/app/bundles/CoreBundle/EventListener/CoreSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/CoreSubscriber.php
@@ -2,7 +2,6 @@
 
 namespace Mautic\CoreBundle\EventListener;
 
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Event\IconEvent;
 use Mautic\CoreBundle\Event\MenuEvent;
 use Mautic\CoreBundle\Event\RouteEvent;
@@ -40,9 +39,9 @@ final readonly class CoreSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            CoreEvents::BUILD_MENU            => ['onBuildMenu', 9999],
-            CoreEvents::BUILD_ROUTE           => ['onBuildRoute', 0],
-            CoreEvents::FETCH_ICONS           => ['onFetchIcons', 9999],
+            MenuEvent::class                  => ['onBuildMenu', 9999],
+            RouteEvent::class                 => ['onBuildRoute', 0],
+            IconEvent::class                  => ['onFetchIcons', 9999],
             SecurityEvents::INTERACTIVE_LOGIN => ['onSecurityInteractiveLogin', 0],
         ];
     }

--- a/app/bundles/CoreBundle/EventListener/EditorFontsSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/EditorFontsSubscriber.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\EventListener;
 
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Event\CustomAssetsEvent;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -21,7 +20,7 @@ final readonly class EditorFontsSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            CoreEvents::VIEW_INJECT_CUSTOM_ASSETS => ['addGlobalAssets', 0],
+            CustomAssetsEvent::class => ['addGlobalAssets', 0],
         ];
     }
 

--- a/app/bundles/CoreBundle/EventListener/MaintenanceSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/MaintenanceSubscriber.php
@@ -4,7 +4,6 @@ namespace Mautic\CoreBundle\EventListener;
 
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Event\MaintenanceEvent;
 use Mautic\UserBundle\Entity\UserTokenRepositoryInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -22,7 +21,7 @@ final readonly class MaintenanceSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            CoreEvents::MAINTENANCE_CLEANUP_DATA => ['onDataCleanup', -50],
+            MaintenanceEvent::class => ['onDataCleanup', -50],
         ];
     }
 

--- a/app/bundles/CoreBundle/Loader/RouteLoader.php
+++ b/app/bundles/CoreBundle/Loader/RouteLoader.php
@@ -2,7 +2,6 @@
 
 namespace Mautic\CoreBundle\Loader;
 
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Event\RouteEvent;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Symfony\Component\Config\Loader\Loader;
@@ -28,7 +27,7 @@ final class RouteLoader extends Loader
     {
         // Public
         $event = new RouteEvent($this, 'public');
-        $this->dispatcher->dispatch($event, CoreEvents::BUILD_ROUTE);
+        $this->dispatcher->dispatch($event);
         $collection = $event->getCollection();
 
         // Force all links to be SSL if the site_url parameter is SSL
@@ -45,7 +44,7 @@ final class RouteLoader extends Loader
 
         // Secured area - Default
         $event = new RouteEvent($this);
-        $this->dispatcher->dispatch($event, CoreEvents::BUILD_ROUTE);
+        $this->dispatcher->dispatch($event);
         $secureCollection = $event->getCollection();
 
         // OneupUploader (added behind our secure /s)
@@ -56,7 +55,7 @@ final class RouteLoader extends Loader
 
         // API
         $event = new RouteEvent($this, 'api');
-        $this->dispatcher->dispatch($event, CoreEvents::BUILD_ROUTE);
+        $this->dispatcher->dispatch($event);
         $apiCollection = $event->getCollection();
         $apiCollection->addPrefix('/api');
 
@@ -74,7 +73,7 @@ final class RouteLoader extends Loader
 
         // Catch all
         $event = new RouteEvent($this, 'catchall');
-        $this->dispatcher->dispatch($event, CoreEvents::BUILD_ROUTE);
+        $this->dispatcher->dispatch($event);
         $lastCollection = $event->getCollection();
 
         if ($forceSSL) {

--- a/app/bundles/CoreBundle/Menu/MenuBuilder.php
+++ b/app/bundles/CoreBundle/Menu/MenuBuilder.php
@@ -5,7 +5,6 @@ namespace Mautic\CoreBundle\Menu;
 use Knp\Menu\FactoryInterface;
 use Knp\Menu\Loader\ArrayLoader;
 use Knp\Menu\Matcher\MatcherInterface;
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Event\MenuEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -81,7 +80,7 @@ final readonly class MenuBuilder
 
             // dispatch the MENU_BUILD event to retrieve bundle menu items
             $event = new MenuEvent($this->menuHelper, $name);
-            $this->dispatcher->dispatch($event, CoreEvents::BUILD_MENU);
+            $this->dispatcher->dispatch($event);
 
             $menuItems    = $event->getMenuItems();
 

--- a/app/bundles/CoreBundle/Service/SearchCommandList.php
+++ b/app/bundles/CoreBundle/Service/SearchCommandList.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\Service;
 
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Event\CommandListEvent;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
@@ -27,7 +26,7 @@ final class SearchCommandList implements SearchCommandListInterface
         }
 
         $event = new CommandListEvent();
-        $this->dispatcher->dispatch($event, CoreEvents::BUILD_COMMAND_LIST);
+        $this->dispatcher->dispatch($event);
 
         return $this->searchCommands = $event->getCommands();
     }

--- a/app/bundles/CoreBundle/Test/EventListener/MaintenanceSubscriberTest.php
+++ b/app/bundles/CoreBundle/Test/EventListener/MaintenanceSubscriberTest.php
@@ -8,7 +8,6 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\Expression\ExpressionBuilder;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Result;
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Event\MaintenanceEvent;
 use Mautic\CoreBundle\EventListener\MaintenanceSubscriber;
 use Mautic\UserBundle\Entity\UserTokenRepositoryInterface;
@@ -26,7 +25,7 @@ final class MaintenanceSubscriberTest extends \PHPUnit\Framework\TestCase
     public function testGetSubscribedEvents(): void
     {
         $this->assertSame(
-            [CoreEvents::MAINTENANCE_CLEANUP_DATA => ['onDataCleanup', -50]],
+            [MaintenanceEvent::class => ['onDataCleanup', -50]],
             $this->subscriber->getSubscribedEvents()
         );
     }

--- a/app/bundles/CoreBundle/Tests/EventListener/CoreSubscriberTest.php
+++ b/app/bundles/CoreBundle/Tests/EventListener/CoreSubscriberTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\Tests\EventListener;
 
-use Mautic\CoreBundle\CoreEvents;
+use Mautic\CoreBundle\Event\IconEvent;
+use Mautic\CoreBundle\Event\MenuEvent;
+use Mautic\CoreBundle\Event\RouteEvent;
 use Mautic\CoreBundle\EventListener\CoreSubscriber;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Http\SecurityEvents;
@@ -14,9 +16,9 @@ final class CoreSubscriberTest extends TestCase
     public function testGetSubscribedEvents(): void
     {
         $this->assertSame([
-            CoreEvents::BUILD_MENU            => ['onBuildMenu', 9999],
-            CoreEvents::BUILD_ROUTE           => ['onBuildRoute', 0],
-            CoreEvents::FETCH_ICONS           => ['onFetchIcons', 9999],
+            MenuEvent::class                  => ['onBuildMenu', 9999],
+            RouteEvent::class                 => ['onBuildRoute', 0],
+            IconEvent::class                  => ['onFetchIcons', 9999],
             SecurityEvents::INTERACTIVE_LOGIN => ['onSecurityInteractiveLogin', 0],
         ], CoreSubscriber::getSubscribedEvents());
     }

--- a/app/bundles/CoreBundle/Tests/Functional/EventListener/MaintenanceSubscriberTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/EventListener/MaintenanceSubscriberTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\Tests\Functional\EventListener;
 
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Event\MaintenanceEvent;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -52,7 +51,7 @@ final class MaintenanceSubscriberTest extends MauticMysqlTestCase
         /** @var EventDispatcherInterface $dispatcher */
         $dispatcher = self::getContainer()->get(EventDispatcherInterface::class);
 
-        $event = $dispatcher->dispatch(new MaintenanceEvent(2, false, false), CoreEvents::MAINTENANCE_CLEANUP_DATA);
+        $event = $dispatcher->dispatch(new MaintenanceEvent(2, false, false));
         $stats = $event->getStats();
 
         $this->assertArrayHasKey($translator->trans('mautic.maintenance.audit_log'), $stats);

--- a/app/bundles/CoreBundle/Tests/Functional/EventListener/MigrationCommandSubscriberTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/EventListener/MigrationCommandSubscriberTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\Tests\Functional\EventListener;
 
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Doctrine\GeneratedColumn\GeneratedColumn;
 use Mautic\CoreBundle\Event\GeneratedColumnsEvent;
 use Mautic\CoreBundle\Helper\ExitCode;
@@ -41,13 +40,13 @@ final class MigrationCommandSubscriberTest extends MauticMysqlTestCase
     {
         $this->createTables();
 
-        $this->eventDispatcher->addListener(CoreEvents::ON_GENERATED_COLUMNS_BUILD, function (GeneratedColumnsEvent $event): void {
+        $this->eventDispatcher->addListener(GeneratedColumnsEvent::class, function (GeneratedColumnsEvent $event): void {
             $event->addGeneratedColumn(new GeneratedColumn('test_first', 'generated_name_one', 'CHAR(2)', 'SUBSTRING(name, 1, 2)'));
             $event->addGeneratedColumn(new GeneratedColumn('test_first', 'generated_name_two', 'CHAR(2)', 'SUBSTRING(name, 3, 2)'));
             $event->addGeneratedColumn(new GeneratedColumn('test_first', 'generated_name_three', 'CHAR(2)', 'SUBSTRING(name, 5, 2)'));
         });
 
-        $this->eventDispatcher->addListener(CoreEvents::ON_GENERATED_COLUMNS_BUILD, function (GeneratedColumnsEvent $event): void {
+        $this->eventDispatcher->addListener(GeneratedColumnsEvent::class, function (GeneratedColumnsEvent $event): void {
             $generatedColumn = new GeneratedColumn('test_second', 'generated_date_year', 'YEAR', 'YEAR(date_added)');
             $generatedColumn->prependIndexColumn('campaign_id');
             $generatedColumn->addIndexColumn('id');

--- a/app/bundles/CoreBundle/Twig/Extension/OverrideIncludeExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/OverrideIncludeExtension.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\Twig\Extension;
 
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Event\CustomTemplateEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -84,9 +83,6 @@ final class OverrideIncludeExtension extends AbstractExtension
      */
     private function dispatchCustomTemplateEvent(string $template, array $variables): CustomTemplateEvent
     {
-        return $this->eventDispatcher->dispatch(
-            new CustomTemplateEvent($this->requestStack->getCurrentRequest(), $template, $variables),
-            CoreEvents::VIEW_INJECT_CUSTOM_TEMPLATE
-        );
+        return $this->eventDispatcher->dispatch(new CustomTemplateEvent($this->requestStack->getCurrentRequest(), $template, $variables));
     }
 }

--- a/app/bundles/CoreBundle/Twig/Helper/ButtonHelper.php
+++ b/app/bundles/CoreBundle/Twig/Helper/ButtonHelper.php
@@ -2,7 +2,6 @@
 
 namespace Mautic\CoreBundle\Twig\Helper;
 
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Event\CustomButtonEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -310,11 +309,8 @@ final class ButtonHelper
 
     private function fetchCustomButtons(): self
     {
-        if (!$this->buttonsFetched && $this->dispatcher->hasListeners(CoreEvents::VIEW_INJECT_CUSTOM_BUTTONS)) {
-            $event = $this->dispatcher->dispatch(
-                new CustomButtonEvent($this->location, $this->request, $this->buttons, $this->item),
-                CoreEvents::VIEW_INJECT_CUSTOM_BUTTONS
-            );
+        if (!$this->buttonsFetched && $this->dispatcher->hasListeners(CustomButtonEvent::class)) {
+            $event = $this->dispatcher->dispatch(new CustomButtonEvent($this->location, $this->request, $this->buttons, $this->item));
             $this->buttonsFetched = true;
             $this->buttons        = $event->getButtons();
             $this->buttonCount    = count($this->buttons);

--- a/app/bundles/CoreBundle/Twig/Helper/ContentHelper.php
+++ b/app/bundles/CoreBundle/Twig/Helper/ContentHelper.php
@@ -2,7 +2,6 @@
 
 namespace Mautic\CoreBundle\Twig\Helper;
 
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Event\CustomContentEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Twig\Environment;
@@ -30,10 +29,7 @@ final readonly class ContentHelper
         }
 
         /** @var CustomContentEvent $event */
-        $event = $this->dispatcher->dispatch(
-            new CustomContentEvent($viewName, $context, $vars),
-            CoreEvents::VIEW_INJECT_CUSTOM_CONTENT
-        );
+        $event = $this->dispatcher->dispatch(new CustomContentEvent($viewName, $context, $vars));
 
         $content = $event->getContent();
 

--- a/app/bundles/DynamicContentBundle/EventListener/BuildJsSubscriber.php
+++ b/app/bundles/DynamicContentBundle/EventListener/BuildJsSubscriber.php
@@ -2,7 +2,6 @@
 
 namespace Mautic\DynamicContentBundle\EventListener;
 
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Event\BuildJsEvent;
 use Mautic\CoreBundle\Event\BuildJsScope;
 use Mautic\CoreBundle\Twig\Helper\AssetsHelper;
@@ -25,7 +24,7 @@ final readonly class BuildJsSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            CoreEvents::BUILD_MAUTIC_JS => ['onBuildJs', 200],
+            BuildJsEvent::class => ['onBuildJs', 200],
         ];
     }
 

--- a/app/bundles/DynamicContentBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/DynamicContentBundle/EventListener/SearchSubscriber.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\DynamicContentBundle\EventListener;
 
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\DTO\GlobalSearchFilterDTO;
 use Mautic\CoreBundle\Event\GlobalSearchEvent;
 use Mautic\CoreBundle\Service\GlobalSearch;
@@ -22,7 +21,7 @@ final readonly class SearchSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            CoreEvents::GLOBAL_SEARCH  => ['onGlobalSearch', 0],
+            GlobalSearchEvent::class => ['onGlobalSearch', 0],
         ];
     }
 

--- a/app/bundles/EmailBundle/EventListener/EmailDetailsRightColumnSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/EmailDetailsRightColumnSubscriber.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\EmailBundle\EventListener;
 
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Event\CustomContentEvent;
 use Mautic\EmailBundle\Model\AbTest\EmailStatus;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -17,7 +16,7 @@ final class EmailDetailsRightColumnSubscriber implements EventSubscriberInterfac
     public static function getSubscribedEvents(): array
     {
         return [
-            CoreEvents::VIEW_INJECT_CUSTOM_CONTENT => ['injectContent', 0],
+            CustomContentEvent::class => ['injectContent', 0],
         ];
     }
 

--- a/app/bundles/EmailBundle/EventListener/GeneratedColumnSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/GeneratedColumnSubscriber.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\EmailBundle\EventListener;
 
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Doctrine\GeneratedColumn\GeneratedColumn;
 use Mautic\CoreBundle\Event\GeneratedColumnsEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -14,7 +13,7 @@ final class GeneratedColumnSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            CoreEvents::ON_GENERATED_COLUMNS_BUILD => ['onGeneratedColumnsBuild', 0],
+            GeneratedColumnsEvent::class => ['onGeneratedColumnsBuild', 0],
         ];
     }
 

--- a/app/bundles/EmailBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/SearchSubscriber.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\EmailBundle\EventListener;
 
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\DTO\GlobalSearchFilterDTO;
 use Mautic\CoreBundle\Event as MauticEvents;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
@@ -24,8 +23,8 @@ final readonly class SearchSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            CoreEvents::GLOBAL_SEARCH      => ['onGlobalSearch', 0],
-            CoreEvents::BUILD_COMMAND_LIST => ['onBuildCommandList', 0],
+            MauticEvents\GlobalSearchEvent::class => ['onGlobalSearch', 0],
+            MauticEvents\CommandListEvent::class  => ['onBuildCommandList', 0],
         ];
     }
 

--- a/app/bundles/FormBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/SearchSubscriber.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\FormBundle\EventListener;
 
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\DTO\GlobalSearchFilterDTO;
 use Mautic\CoreBundle\Event as MauticEvents;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
@@ -24,8 +23,8 @@ final readonly class SearchSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            CoreEvents::GLOBAL_SEARCH      => ['onGlobalSearch', 0],
-            CoreEvents::BUILD_COMMAND_LIST => ['onBuildCommandList', 0],
+            MauticEvents\GlobalSearchEvent::class => ['onGlobalSearch', 0],
+            MauticEvents\CommandListEvent::class  => ['onBuildCommandList', 0],
         ];
     }
 

--- a/app/bundles/IntegrationsBundle/EventListener/UIContactIntegrationsTabSubscriber.php
+++ b/app/bundles/IntegrationsBundle/EventListener/UIContactIntegrationsTabSubscriber.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\IntegrationsBundle\EventListener;
 
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Event\CustomTemplateEvent;
 use Mautic\IntegrationsBundle\Entity\ObjectMappingRepository;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\Object\Contact;
@@ -21,7 +20,7 @@ final readonly class UIContactIntegrationsTabSubscriber implements EventSubscrib
     public static function getSubscribedEvents(): array
     {
         return [
-            CoreEvents::VIEW_INJECT_CUSTOM_TEMPLATE => ['onTemplateRender', 0],
+            CustomTemplateEvent::class => ['onTemplateRender', 0],
         ];
     }
 

--- a/app/bundles/LeadBundle/EventListener/ButtonSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/ButtonSubscriber.php
@@ -2,7 +2,6 @@
 
 namespace Mautic\LeadBundle\EventListener;
 
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Event\CustomButtonEvent;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\CoreBundle\Twig\Helper\ButtonHelper;
@@ -22,7 +21,7 @@ final readonly class ButtonSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            CoreEvents::VIEW_INJECT_CUSTOM_BUTTONS => ['injectViewButtons', 0],
+            CustomButtonEvent::class => ['injectViewButtons', 0],
         ];
     }
 

--- a/app/bundles/LeadBundle/EventListener/GeneratedColumnSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/GeneratedColumnSubscriber.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\LeadBundle\EventListener;
 
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Doctrine\GeneratedColumn\GeneratedColumn;
 use Mautic\CoreBundle\Event\GeneratedColumnsEvent;
 use Mautic\LeadBundle\Event\LeadListFiltersChoicesEvent;
@@ -27,7 +26,7 @@ final readonly class GeneratedColumnSubscriber implements EventSubscriberInterfa
     public static function getSubscribedEvents(): array
     {
         return [
-            CoreEvents::ON_GENERATED_COLUMNS_BUILD       => ['onGeneratedColumnsBuild', 0],
+            GeneratedColumnsEvent::class                 => ['onGeneratedColumnsBuild', 0],
             LeadEvents::LIST_FILTERS_CHOICES_ON_GENERATE => ['onGenerateSegmentFilters', 0],
         ];
     }

--- a/app/bundles/LeadBundle/EventListener/MaintenanceSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/MaintenanceSubscriber.php
@@ -3,7 +3,6 @@
 namespace Mautic\LeadBundle\EventListener;
 
 use Doctrine\DBAL\Connection;
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Event\MaintenanceEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -19,7 +18,7 @@ final readonly class MaintenanceSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            CoreEvents::MAINTENANCE_CLEANUP_DATA => ['onDataCleanup', 0],
+            MaintenanceEvent::class => ['onDataCleanup', 0],
         ];
     }
 

--- a/app/bundles/LeadBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/SearchSubscriber.php
@@ -4,7 +4,6 @@ namespace Mautic\LeadBundle\EventListener;
 
 use Doctrine\DBAL\Query\QueryBuilder;
 use Mautic\ChannelBundle\Entity\MessageQueue;
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\DTO\GlobalSearchFilterDTO;
 use Mautic\CoreBundle\Event\CommandListEvent;
 use Mautic\CoreBundle\Event\GlobalSearchEvent;
@@ -43,12 +42,12 @@ final readonly class SearchSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            CoreEvents::GLOBAL_SEARCH  => [
+            GlobalSearchEvent::class               => [
                 ['onGlobalSearchForContacts', 0],
                 ['onGlobalSearchForCompanies', 0],
                 ['onGlobalSearchForSegments', 0],
             ],
-            CoreEvents::BUILD_COMMAND_LIST         => ['onBuildCommandList', 0],
+            CommandListEvent::class                => ['onBuildCommandList', 0],
             LeadEvents::LEAD_BUILD_SEARCH_COMMANDS => ['onBuildSearchCommands', 0],
         ];
     }

--- a/app/bundles/MarketplaceBundle/EventListener/MenuSubscriber.php
+++ b/app/bundles/MarketplaceBundle/EventListener/MenuSubscriber.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\MarketplaceBundle\EventListener;
 
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Event\MenuEvent;
 use Mautic\MarketplaceBundle\Security\Permissions\MarketplacePermissions;
 use Mautic\MarketplaceBundle\Service\Config;
@@ -21,7 +20,7 @@ final readonly class MenuSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            CoreEvents::BUILD_MENU => ['onBuildMenu', 9999],
+            MenuEvent::class => ['onBuildMenu', 9999],
         ];
     }
 

--- a/app/bundles/NotificationBundle/EventListener/BuildJsSubscriber.php
+++ b/app/bundles/NotificationBundle/EventListener/BuildJsSubscriber.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\NotificationBundle\EventListener;
 
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Event\BuildJsEvent;
 use Mautic\CoreBundle\Event\BuildJsScope;
 use Mautic\NotificationBundle\Helper\NotificationHelper;
@@ -25,7 +24,7 @@ final readonly class BuildJsSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            CoreEvents::BUILD_MAUTIC_JS => ['onBuildJs', 254],
+            BuildJsEvent::class => ['onBuildJs', 254],
         ];
     }
 

--- a/app/bundles/NotificationBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/NotificationBundle/EventListener/SearchSubscriber.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\NotificationBundle\EventListener;
 
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\DTO\GlobalSearchFilterDTO;
 use Mautic\CoreBundle\Event as MauticEvents;
 use Mautic\CoreBundle\Service\GlobalSearch;
@@ -22,7 +21,7 @@ final readonly class SearchSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            CoreEvents::GLOBAL_SEARCH => [
+            MauticEvents\GlobalSearchEvent::class => [
                 ['onGlobalSearchWebNotification', 0],
                 ['onGlobalSearchMobileNotification', 0],
             ],

--- a/app/bundles/PageBundle/EventListener/BuildJsSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/BuildJsSubscriber.php
@@ -2,7 +2,6 @@
 
 namespace Mautic\PageBundle\EventListener;
 
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Event\BuildJsEvent;
 use Mautic\CoreBundle\Event\BuildJsScope;
 use Mautic\PageBundle\Helper\TrackingHelper;
@@ -21,7 +20,7 @@ final readonly class BuildJsSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            CoreEvents::BUILD_MAUTIC_JS => [
+            BuildJsEvent::class => [
                 // onBuildJs must always needs to be last to ensure setup before delivering the event
                 ['onBuildJs', -255],
                 ['onBuildJsForTrackingEvent', 256],

--- a/app/bundles/PageBundle/EventListener/MaintenanceSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/MaintenanceSubscriber.php
@@ -4,7 +4,6 @@ namespace Mautic\PageBundle\EventListener;
 
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Event\MaintenanceEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -20,7 +19,7 @@ final readonly class MaintenanceSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            CoreEvents::MAINTENANCE_CLEANUP_DATA => ['onDataCleanup', 10], // Cleanup before visitors are processed
+            MaintenanceEvent::class => ['onDataCleanup', 10], // Cleanup before visitors are processed
         ];
     }
 

--- a/app/bundles/PageBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/SearchSubscriber.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\PageBundle\EventListener;
 
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\DTO\GlobalSearchFilterDTO;
 use Mautic\CoreBundle\Event as MauticEvents;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
@@ -24,8 +23,8 @@ final readonly class SearchSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            CoreEvents::GLOBAL_SEARCH      => ['onGlobalSearch', 0],
-            CoreEvents::BUILD_COMMAND_LIST => ['onBuildCommandList', 0],
+            MauticEvents\GlobalSearchEvent::class => ['onGlobalSearch', 0],
+            MauticEvents\CommandListEvent::class  => ['onBuildCommandList', 0],
         ];
     }
 

--- a/app/bundles/PointBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/PointBundle/EventListener/SearchSubscriber.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\PointBundle\EventListener;
 
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\DTO\GlobalSearchFilterDTO;
 use Mautic\CoreBundle\Event as MauticEvents;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
@@ -28,12 +27,12 @@ final readonly class SearchSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            CoreEvents::GLOBAL_SEARCH => [
+            MauticEvents\GlobalSearchEvent::class => [
                 ['onGlobalSearchPointActions', 0],
                 ['onGlobalSearchPointTriggers', 0],
                 ['onGlobalSearchPointGroup', 0],
             ],
-            CoreEvents::BUILD_COMMAND_LIST => ['onBuildCommandList', 0],
+            MauticEvents\CommandListEvent::class  => ['onBuildCommandList', 0],
         ];
     }
 

--- a/app/bundles/ReportBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/ReportBundle/EventListener/SearchSubscriber.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\ReportBundle\EventListener;
 
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\DTO\GlobalSearchFilterDTO;
 use Mautic\CoreBundle\Event as MauticEvents;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
@@ -24,8 +23,8 @@ final readonly class SearchSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            CoreEvents::GLOBAL_SEARCH      => ['onGlobalSearch', 0],
-            CoreEvents::BUILD_COMMAND_LIST => ['onBuildCommandList', 0],
+            MauticEvents\GlobalSearchEvent::class => ['onGlobalSearch', 0],
+            MauticEvents\CommandListEvent::class  => ['onBuildCommandList', 0],
         ];
     }
 

--- a/app/bundles/SmsBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/SmsBundle/EventListener/SearchSubscriber.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\SmsBundle\EventListener;
 
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\DTO\GlobalSearchFilterDTO;
 use Mautic\CoreBundle\Event as MauticEvents;
 use Mautic\CoreBundle\Service\GlobalSearch;
@@ -22,7 +21,7 @@ final readonly class SearchSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            CoreEvents::GLOBAL_SEARCH => ['onGlobalSearch', 0],
+            MauticEvents\GlobalSearchEvent::class => ['onGlobalSearch', 0],
         ];
     }
 

--- a/app/bundles/StageBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/StageBundle/EventListener/SearchSubscriber.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\StageBundle\EventListener;
 
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\DTO\GlobalSearchFilterDTO;
 use Mautic\CoreBundle\Event as MauticEvents;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
@@ -24,8 +23,8 @@ final readonly class SearchSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            CoreEvents::GLOBAL_SEARCH      => ['onGlobalSearch', 0],
-            CoreEvents::BUILD_COMMAND_LIST => ['onBuildCommandList', 0],
+            MauticEvents\GlobalSearchEvent::class => ['onGlobalSearch', 0],
+            MauticEvents\CommandListEvent::class  => ['onBuildCommandList', 0],
         ];
     }
 

--- a/app/bundles/UserBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/UserBundle/EventListener/SearchSubscriber.php
@@ -2,7 +2,6 @@
 
 namespace Mautic\UserBundle\EventListener;
 
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\DTO\GlobalSearchFilterDTO;
 use Mautic\CoreBundle\Event as MauticEvents;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
@@ -24,11 +23,11 @@ final readonly class SearchSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            CoreEvents::GLOBAL_SEARCH => [
+            MauticEvents\GlobalSearchEvent::class => [
                 ['onGlobalSearchUser', 0],
                 ['onGlobalSearchRoles', 0],
             ],
-            CoreEvents::BUILD_COMMAND_LIST => ['onBuildCommandList', 0],
+            MauticEvents\CommandListEvent::class  => ['onBuildCommandList', 0],
         ];
     }
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -273,6 +273,7 @@ rules:
     - Utils\PHPStan\Rule\PreferClassServiceReferenceRule
     - Utils\PHPStan\Rule\NoRedundantAutowiredServiceArgumentRule
     - Utils\PHPStan\Rule\NoServiceSetterCallRule
+    - Utils\PHPStan\Rule\SingleArgumentDispatchRule
 
 services:
     - Utils\PHPStan\ServiceNameUsageResolver

--- a/plugins/GrapesJsBuilderBundle/EventSubscriber/AssetsSubscriber.php
+++ b/plugins/GrapesJsBuilderBundle/EventSubscriber/AssetsSubscriber.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace MauticPlugin\GrapesJsBuilderBundle\EventSubscriber;
 
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Event\CustomAssetsEvent;
 use Mautic\InstallBundle\Install\InstallService;
 use MauticPlugin\GrapesJsBuilderBundle\Integration\Config;
@@ -28,7 +27,7 @@ final readonly class AssetsSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            CoreEvents::VIEW_INJECT_CUSTOM_ASSETS => ['injectAssets', 0],
+            CustomAssetsEvent::class => ['injectAssets', 0],
         ];
     }
 

--- a/plugins/GrapesJsBuilderBundle/EventSubscriber/InjectCustomContentSubscriber.php
+++ b/plugins/GrapesJsBuilderBundle/EventSubscriber/InjectCustomContentSubscriber.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace MauticPlugin\GrapesJsBuilderBundle\EventSubscriber;
 
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Event\CustomContentEvent;
 use Mautic\EmailBundle\Entity\Email;
 use MauticPlugin\GrapesJsBuilderBundle\Entity\GrapesJsBuilder;
@@ -32,7 +31,7 @@ final readonly class InjectCustomContentSubscriber implements EventSubscriberInt
     public static function getSubscribedEvents(): array
     {
         return [
-            CoreEvents::VIEW_INJECT_CUSTOM_CONTENT => ['injectViewCustomContent', 0],
+            CustomContentEvent::class => ['injectViewCustomContent', 0],
         ];
     }
 

--- a/plugins/MauticClearbitBundle/EventListener/ButtonSubscriber.php
+++ b/plugins/MauticClearbitBundle/EventListener/ButtonSubscriber.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace MauticPlugin\MauticClearbitBundle\EventListener;
 
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Event\CustomButtonEvent;
 use Mautic\CoreBundle\Twig\Helper\ButtonHelper;
 use Mautic\IntegrationsBundle\Exception\IntegrationNotFoundException;
@@ -25,7 +24,7 @@ final readonly class ButtonSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            CoreEvents::VIEW_INJECT_CUSTOM_BUTTONS => ['injectViewButtons', 0],
+            CustomButtonEvent::class => ['injectViewButtons', 0],
         ];
     }
 

--- a/plugins/MauticClearbitBundle/Tests/Unit/EventListener/ButtonSubscriberTest.php
+++ b/plugins/MauticClearbitBundle/Tests/Unit/EventListener/ButtonSubscriberTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace MauticPlugin\MauticClearbitBundle\Tests\Unit\EventListener;
 
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Event\CustomButtonEvent;
 use Mautic\CoreBundle\Twig\Helper\ButtonHelper;
 use Mautic\IntegrationsBundle\Exception\IntegrationNotFoundException;
@@ -44,7 +43,7 @@ final class ButtonSubscriberTest extends TestCase
     public function testGetSubscribedEvents(): void
     {
         $this->assertSame(
-            [CoreEvents::VIEW_INJECT_CUSTOM_BUTTONS => ['injectViewButtons', 0]],
+            [CustomButtonEvent::class => ['injectViewButtons', 0]],
             ButtonSubscriber::getSubscribedEvents()
         );
     }

--- a/plugins/MauticFocusBundle/EventListener/SearchSubscriber.php
+++ b/plugins/MauticFocusBundle/EventListener/SearchSubscriber.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace MauticPlugin\MauticFocusBundle\EventListener;
 
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\DTO\GlobalSearchFilterDTO;
 use Mautic\CoreBundle\Event\GlobalSearchEvent;
 use Mautic\CoreBundle\Service\GlobalSearch;
@@ -22,7 +21,7 @@ final readonly class SearchSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            CoreEvents::GLOBAL_SEARCH => ['onGlobalSearch', 0],
+            GlobalSearchEvent::class => ['onGlobalSearch', 0],
         ];
     }
 

--- a/plugins/MauticFullContactBundle/EventListener/ButtonSubscriber.php
+++ b/plugins/MauticFullContactBundle/EventListener/ButtonSubscriber.php
@@ -2,7 +2,6 @@
 
 namespace MauticPlugin\MauticFullContactBundle\EventListener;
 
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\Event\CustomButtonEvent;
 use Mautic\CoreBundle\Twig\Helper\ButtonHelper;
 use Mautic\PluginBundle\Helper\IntegrationHelper;
@@ -23,7 +22,7 @@ final readonly class ButtonSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            CoreEvents::VIEW_INJECT_CUSTOM_BUTTONS => ['injectViewButtons', 0],
+            CustomButtonEvent::class => ['injectViewButtons', 0],
         ];
     }
 

--- a/plugins/MauticTagManagerBundle/EventListener/SearchSubscriber.php
+++ b/plugins/MauticTagManagerBundle/EventListener/SearchSubscriber.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace MauticPlugin\MauticTagManagerBundle\EventListener;
 
-use Mautic\CoreBundle\CoreEvents;
 use Mautic\CoreBundle\DTO\GlobalSearchFilterDTO;
 use Mautic\CoreBundle\Event\GlobalSearchEvent;
 use Mautic\CoreBundle\Service\GlobalSearch;
@@ -22,7 +21,7 @@ final readonly class SearchSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            CoreEvents::GLOBAL_SEARCH => ['onGlobalSearch', 0],
+            GlobalSearchEvent::class => ['onGlobalSearch', 0],
         ];
     }
 

--- a/utils/phpstan/src/Rule/SingleArgumentDispatchRule.php
+++ b/utils/phpstan/src/Rule/SingleArgumentDispatchRule.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Rule;
+
+use Mautic\CoreBundle\CoreEvents;
+use PhpParser\Node;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Dispatch CoreBundle events by the event object alone: $dispatcher->dispatch($event).
+ *
+ * Since Symfony 4.3 the event class name is the event name, so the string event name passed as the
+ * second argument is redundant. Passing it also keeps the legacy CoreEvents:: constants alive. Every
+ * CoreBundle event class maps to exactly one event name, so dropping the second argument is safe.
+ *
+ * @see https://symfony.com/blog/new-in-symfony-4-3-simpler-event-dispatching
+ *
+ * @implements Rule<MethodCall>
+ */
+final class SingleArgumentDispatchRule implements Rule
+{
+    /**
+     * @var string
+     */
+    private const DISPATCH_METHOD = 'dispatch';
+
+    /**
+     * @var string
+     */
+    private const ERROR_MESSAGE = 'Dispatch the event object alone: ->dispatch($event). The event class is the event name (Symfony 4.3+), so drop the CoreEvents::%s second argument.';
+
+    public function getNodeType(): string
+    {
+        return MethodCall::class;
+    }
+
+    /**
+     * @param MethodCall $node
+     *
+     * @return list<\PHPStan\Rules\IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node->name instanceof Identifier) {
+            return [];
+        }
+
+        if (self::DISPATCH_METHOD !== $node->name->toString()) {
+            return [];
+        }
+
+        $args = $node->getArgs();
+        if (count($args) < 2) {
+            return [];
+        }
+
+        $secondArg = $args[1]->value;
+        if (!$secondArg instanceof ClassConstFetch) {
+            return [];
+        }
+
+        if (!$secondArg->class instanceof Name) {
+            return [];
+        }
+
+        if (CoreEvents::class !== $secondArg->class->toString()) {
+            return [];
+        }
+
+        $constantName = $secondArg->name instanceof Identifier ? $secondArg->name->toString() : '';
+
+        $ruleError = RuleErrorBuilder::message(sprintf(self::ERROR_MESSAGE, $constantName))
+            ->identifier('mautic.singleArgumentDispatch')
+            ->build();
+
+        return [$ruleError];
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/DispatchEventService.php
+++ b/utils/phpstan/tests/Rule/Fixture/DispatchEventService.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+use Mautic\CoreBundle\CoreEvents;
+use Mautic\CoreBundle\Event\MenuEvent;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class DispatchEventService
+{
+    public function __construct(
+        private EventDispatcherInterface $dispatcher,
+    ) {
+    }
+
+    public function withRedundantEventName(MenuEvent $event): void
+    {
+        // the CoreEvents:: second argument is redundant and must be reported
+        $this->dispatcher->dispatch($event, CoreEvents::BUILD_MENU);
+    }
+
+    public function withEventObjectOnly(MenuEvent $event): void
+    {
+        $this->dispatcher->dispatch($event);
+    }
+
+    public function withNonCoreEventName(MenuEvent $event): void
+    {
+        // a non-CoreEvents name is out of scope for this rule
+        $this->dispatcher->dispatch($event, 'some.custom.event');
+    }
+}

--- a/utils/phpstan/tests/Rule/SingleArgumentDispatchRuleTest.php
+++ b/utils/phpstan/tests/Rule/SingleArgumentDispatchRuleTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use Utils\PHPStan\Rule\SingleArgumentDispatchRule;
+
+/**
+ * @extends RuleTestCase<SingleArgumentDispatchRule>
+ */
+final class SingleArgumentDispatchRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new SingleArgumentDispatchRule();
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/DispatchEventService.php'], [
+            [
+                'Dispatch the event object alone: ->dispatch($event). The event class is the event name (Symfony 4.3+), so drop the CoreEvents::BUILD_MENU second argument.',
+                21,
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
This is standard since Symfony 4.3, dispatch and event class and it will find all subscriber that listen to the event `:class` :+1: 

Also added custom PHPStan rule to require only 1 arg in `dispatch()` event dispatcher call.

---

Since [Symfony 4.3](https://symfony.com/blog/new-in-symfony-4-3-simpler-event-dispatching) the event object alone identifies the event — its **class name is the event name**. This PR replaces every `Mautic\CoreBundle\CoreEvents::*` string-constant usage with the corresponding event class.

Three shapes are converted:

```diff
-$this->dispatcher->dispatch($event, CoreEvents::BUILD_MENU);
+$this->dispatcher->dispatch($event);
```
```diff
-if ($this->dispatcher->hasListeners(CoreEvents::VIEW_INJECT_CUSTOM_BUTTONS)) {
+if ($this->dispatcher->hasListeners(CustomButtonEvent::class)) {
```
```diff
 public static function getSubscribedEvents(): array
 {
     return [
-        CoreEvents::BUILD_MENU => ['onBuildMenu', 9999],
+        MenuEvent::class => ['onBuildMenu', 9999],
     ];
 }
```
