### PR TITLE
Apply IssetOnPropertyObjectToPropertyExistsRector on DoctrineEventsSubscriber

### DIFF
--- a/app/bundles/CoreBundle/EventListener/DoctrineEventsSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/DoctrineEventsSubscriber.php
@@ -88,7 +88,7 @@ final class DoctrineEventsSubscriber
 
                 $classMetadata->setSequenceGeneratorDefinition($newDefinition);
                 $em = $args->getEntityManager();
-                if (isset($classMetadata->idGenerator)) {
+                if (property_exists($classMetadata, 'idGenerator') && null !== $classMetadata->idGenerator) {
                     $sequenceGenerator = new SequenceGenerator(
                         $em->getConfiguration()->getQuoteStrategy()->getSequenceName(
                             $newDefinition,

--- a/rector.php
+++ b/rector.php
@@ -58,11 +58,6 @@ return RectorConfig::configure()
         // preference to compare null over object
         Rector\CodeQuality\Rector\Identical\FlipTypeControlToUseExclusiveTypeRector::class,
 
-        Rector\CodeQuality\Rector\Isset_\IssetOnPropertyObjectToPropertyExistsRector::class => [
-            // doctrine magic
-            __DIR__.'/app/bundles/CoreBundle/EventListener/DoctrineEventsSubscriber.php',
-        ],
-
         // test fixtures
         __DIR__.'/plugins/*/node_modules/*',
         __DIR__.'/app/bundles/CoreBundle/Tests/Unit/Helper/resource/',


### PR DESCRIPTION
Removes the last skip for `IssetOnPropertyObjectToPropertyExistsRector` and applies the rule, so it can run repo-wide.

The rule rewrites `isset()` on an object property to an explicit `property_exists()` + null check:

```diff
-if (isset($classMetadata->idGenerator)) {
+if (property_exists($classMetadata, 'idGenerator') && null !== $classMetadata->idGenerator) {
```

Semantics are preserved: `isset()` on an object property is true only when the property both exists and is not null, which is exactly what the expanded form checks.