### PR TITLE
[symfony] Dispatch PluginBundle events by class name (Symfony 4.3 style)

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -207,6 +207,33 @@
     | `IntegrationEvents::INTEGRATION_BUILD_INTERNAL_OBJECT_ROUTE` | `InternalObjectRouteEvent` |
     | `IntegrationEvents::INTEGRATION_OBJECT_TOKEN_EVENT` | `MappedIntegrationObjectTokenEvent` |
 
+- PluginBundle events are now dispatched by the event object alone, so the event name is the event class (Symfony 4.3+) instead of the `Mautic\PluginBundle\PluginEvents` string constants. Update any subscriber or listener that keys on one of the converted `PluginEvents::*` constants to key on the event class instead:
+
+    ```diff
+     public static function getSubscribedEvents(): array
+     {
+         return [
+    -        PluginEvents::ON_PLUGIN_INSTALL => ['onInstall', 0],
+    +        PluginInstallEvent::class => ['onInstall', 0],
+         ];
+     }
+    ```
+
+    Dispatching drops the redundant second argument, e.g. `$dispatcher->dispatch($event, PluginEvents::ON_PLUGIN_INSTALL)` becomes `$dispatcher->dispatch($event)`. The `Mautic\PluginBundle\PluginEvents` constants are kept for backwards compatibility but are no longer used internally for the events below. Constants that share an event class (e.g. the `PLUGIN_ON_INTEGRATION_KEYS_ENCRYPT` / `_KEYS_DECRYPT` / `_KEYS_MERGE` group and the `PLUGIN_ON_INTEGRATION_REQUEST` / `_RESPONSE` pair) are unchanged.
+
+    Full mapping of the converted constants to their event class (all in the `Mautic\PluginBundle\Event` namespace):
+
+    | `PluginEvents` constant | New event class |
+    | --- | --- |
+    | `PluginEvents::PLUGIN_ON_INTEGRATION_CONFIG_SAVE` | `PluginIntegrationEvent` |
+    | `PluginEvents::PLUGIN_ON_INTEGRATION_AUTH_REDIRECT` | `PluginIntegrationAuthRedirectEvent` |
+    | `PluginEvents::PLUGIN_ON_INTEGRATION_GET_AUTH_CALLBACK_URL` | `PluginIntegrationAuthCallbackUrlEvent` |
+    | `PluginEvents::PLUGIN_ON_INTEGRATION_FORM_DISPLAY` | `PluginIntegrationFormDisplayEvent` |
+    | `PluginEvents::PLUGIN_ON_INTEGRATION_FORM_BUILD` | `PluginIntegrationFormBuildEvent` |
+    | `PluginEvents::ON_PLUGIN_UPDATE` | `PluginUpdateEvent` |
+    | `PluginEvents::ON_PLUGIN_INSTALL` | `PluginInstallEvent` |
+    | `PluginEvents::PLUGIN_IS_PUBLISHED_STATE_CHANGING` | `PluginIsPublishedEvent` |
+
 - `Mautic\CoreBundle\Factory\ModelFactory` now builds its service locator from a `defaultIndexMethod` on the `mautic.model` tag, replacing the removed `Mautic\CoreBundle\DependencyInjection\Compiler\ModelPass`. Every model (a service implementing `Mautic\CoreBundle\Model\MauticModelInterface`) declares its `ModelFactory::getModel()` lookup key via a static `getName()` method:
 
     ```php

--- a/app/bundles/PluginBundle/Controller/AuthController.php
+++ b/app/bundles/PluginBundle/Controller/AuthController.php
@@ -5,7 +5,6 @@ namespace Mautic\PluginBundle\Controller;
 use Mautic\CoreBundle\Controller\FormController;
 use Mautic\PluginBundle\Event\PluginIntegrationAuthRedirectEvent;
 use Mautic\PluginBundle\Helper\IntegrationHelper;
-use Mautic\PluginBundle\PluginEvents;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -105,8 +104,7 @@ final class AuthController extends FormController
             new PluginIntegrationAuthRedirectEvent(
                 $integrationObject,
                 $integrationObject->getAuthLoginUrl()
-            ),
-            PluginEvents::PLUGIN_ON_INTEGRATION_AUTH_REDIRECT
+            )
         );
         $oauthUrl = $event->getAuthUrl();
 

--- a/app/bundles/PluginBundle/Controller/PluginController.php
+++ b/app/bundles/PluginBundle/Controller/PluginController.php
@@ -13,7 +13,6 @@ use Mautic\PluginBundle\Form\Type\DetailsType;
 use Mautic\PluginBundle\Helper\IntegrationHelper;
 use Mautic\PluginBundle\Integration\AbstractIntegration;
 use Mautic\PluginBundle\Model\PluginModel;
-use Mautic\PluginBundle\PluginEvents;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -254,14 +253,14 @@ final class PluginController extends FormController
 
                     if ($valid || $authorize) {
                         $mauticLogger->info('Dispatching integration config save event.');
-                        if ($this->dispatcher->hasListeners(PluginEvents::PLUGIN_ON_INTEGRATION_CONFIG_SAVE)) {
+                        if ($this->dispatcher->hasListeners(PluginIntegrationEvent::class)) {
                             $mauticLogger->info('Event dispatcher has integration config save listeners.');
                             if (!$valid && !$existingPublishedState) {
                                 $integrationObject->getIntegrationSettings()->setIsPublished(false);
                             }
                             $event = new PluginIntegrationEvent($integrationObject);
 
-                            $this->dispatcher->dispatch($event, PluginEvents::PLUGIN_ON_INTEGRATION_CONFIG_SAVE);
+                            $this->dispatcher->dispatch($event);
 
                             $entity = $event->getEntity();
                         }
@@ -277,8 +276,7 @@ final class PluginController extends FormController
                             new PluginIntegrationAuthRedirectEvent(
                                 $integrationObject,
                                 $integrationObject->getAuthLoginUrl()
-                            ),
-                            PluginEvents::PLUGIN_ON_INTEGRATION_AUTH_REDIRECT
+                            )
                         );
                         $oauthUrl = $event->getAuthUrl();
 

--- a/app/bundles/PluginBundle/EventListener/PluginSubscriber.php
+++ b/app/bundles/PluginBundle/EventListener/PluginSubscriber.php
@@ -7,7 +7,6 @@ namespace Mautic\PluginBundle\EventListener;
 use Mautic\PluginBundle\Bundle\PluginDatabase;
 use Mautic\PluginBundle\Event\PluginInstallEvent;
 use Mautic\PluginBundle\Event\PluginUpdateEvent;
-use Mautic\PluginBundle\PluginEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final readonly class PluginSubscriber implements EventSubscriberInterface
@@ -42,8 +41,8 @@ final readonly class PluginSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            PluginEvents::ON_PLUGIN_INSTALL => ['onInstall', 0],
-            PluginEvents::ON_PLUGIN_UPDATE  => ['onUpdate', 0],
+            PluginInstallEvent::class => ['onInstall', 0],
+            PluginUpdateEvent::class  => ['onUpdate', 0],
         ];
     }
 }

--- a/app/bundles/PluginBundle/Form/Constraint/CanPublishValidator.php
+++ b/app/bundles/PluginBundle/Form/Constraint/CanPublishValidator.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Mautic\PluginBundle\Form\Constraint;
 
 use Mautic\PluginBundle\Event\PluginIsPublishedEvent;
-use Mautic\PluginBundle\PluginEvents;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
@@ -27,7 +26,7 @@ final class CanPublishValidator extends ConstraintValidator
             throw new UnexpectedTypeException($constraint, CanPublish::class);
         }
         $event = new PluginIsPublishedEvent($value, $constraint->integrationName);
-        $event = $this->eventDispatcher->dispatch($event, PluginEvents::PLUGIN_IS_PUBLISHED_STATE_CHANGING);
+        $event = $this->eventDispatcher->dispatch($event);
 
         if (!$event->isCanPublish()) {
             $this->context->buildViolation($event->getMessage())

--- a/app/bundles/PluginBundle/Helper/ReloadHelper.php
+++ b/app/bundles/PluginBundle/Helper/ReloadHelper.php
@@ -7,7 +7,6 @@ use Doctrine\ORM\Mapping\ClassMetadata;
 use Mautic\PluginBundle\Entity\Plugin;
 use Mautic\PluginBundle\Event\PluginInstallEvent;
 use Mautic\PluginBundle\Event\PluginUpdateEvent;
-use Mautic\PluginBundle\PluginEvents;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -82,7 +81,7 @@ final readonly class ReloadHelper
 
                     $event = new PluginUpdateEvent($plugin, $oldVersion, $metadata, $installedSchema);
 
-                    $this->eventDispatcher->dispatch($event, PluginEvents::ON_PLUGIN_UPDATE);
+                    $this->eventDispatcher->dispatch($event);
 
                     unset($metadata, $installedSchema);
 
@@ -116,7 +115,7 @@ final readonly class ReloadHelper
 
                 $event = new PluginInstallEvent($entity, $metadata, $installedSchema);
 
-                $this->eventDispatcher->dispatch($event, PluginEvents::ON_PLUGIN_INSTALL);
+                $this->eventDispatcher->dispatch($event);
 
                 $installedPlugins[$entity->getBundle()] = $entity;
             }

--- a/app/bundles/PluginBundle/Integration/AbstractIntegration.php
+++ b/app/bundles/PluginBundle/Integration/AbstractIntegration.php
@@ -1051,8 +1051,7 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
 
         /** @var PluginIntegrationAuthCallbackUrlEvent $event */
         $event = $this->dispatcher->dispatch(
-            new PluginIntegrationAuthCallbackUrlEvent($this, $defaultUrl),
-            PluginEvents::PLUGIN_ON_INTEGRATION_GET_AUTH_CALLBACK_URL
+            new PluginIntegrationAuthCallbackUrlEvent($this, $defaultUrl)
         );
 
         return $event->getCallbackUrl();
@@ -2034,8 +2033,7 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
     public function modifyForm($builder, $options): void
     {
         $this->dispatcher->dispatch(
-            new PluginIntegrationFormBuildEvent($this, $builder, $options),
-            PluginEvents::PLUGIN_ON_INTEGRATION_FORM_BUILD
+            new PluginIntegrationFormBuildEvent($this, $builder, $options)
         );
     }
 
@@ -2075,8 +2073,7 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
     {
         /** @var PluginIntegrationFormDisplayEvent $event */
         $event = $this->dispatcher->dispatch(
-            new PluginIntegrationFormDisplayEvent($this, $this->getFormSettings()),
-            PluginEvents::PLUGIN_ON_INTEGRATION_FORM_DISPLAY
+            new PluginIntegrationFormDisplayEvent($this, $this->getFormSettings())
         );
 
         return $event->getSettings();

--- a/app/bundles/PluginBundle/Tests/Form/Constraint/CanPublishValidatorTest.php
+++ b/app/bundles/PluginBundle/Tests/Form/Constraint/CanPublishValidatorTest.php
@@ -7,7 +7,6 @@ namespace Mautic\PluginBundle\Tests\Form\Constraint;
 use Mautic\PluginBundle\Event\PluginIsPublishedEvent;
 use Mautic\PluginBundle\Form\Constraint\CanPublish;
 use Mautic\PluginBundle\Form\Constraint\CanPublishValidator;
-use Mautic\PluginBundle\PluginEvents;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -70,7 +69,7 @@ final class CanPublishValidatorTest extends TestCase
 
         $this->dispatcher->expects($this->never())
             ->method('dispatch')
-            ->with(PluginEvents::PLUGIN_IS_PUBLISHED_STATE_CHANGING)
+            ->with($this->isInstanceOf(PluginIsPublishedEvent::class))
             ->willReturn($this->event);
 
         $this->canPublishValidator->initialize($this->createStub(ExecutionContext::class));
@@ -90,7 +89,7 @@ final class CanPublishValidatorTest extends TestCase
 
         $this->dispatcher->expects($this->never())
             ->method('dispatch')
-            ->with(PluginEvents::PLUGIN_IS_PUBLISHED_STATE_CHANGING)
+            ->with($this->isInstanceOf(PluginIsPublishedEvent::class))
             ->willReturn($this->event);
 
         $this->canPublishValidator->initialize($this->createStub(ExecutionContext::class));

--- a/app/bundles/PluginBundle/Tests/Helper/ReloadHelperTest.php
+++ b/app/bundles/PluginBundle/Tests/Helper/ReloadHelperTest.php
@@ -10,7 +10,6 @@ use Mautic\PluginBundle\Entity\Plugin;
 use Mautic\PluginBundle\Event\PluginInstallEvent;
 use Mautic\PluginBundle\Event\PluginUpdateEvent;
 use Mautic\PluginBundle\Helper\ReloadHelper;
-use Mautic\PluginBundle\PluginEvents;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -127,7 +126,7 @@ final class ReloadHelperTest extends \PHPUnit\Framework\TestCase
             $this->sampleMetaData['MauticPlugin\MauticZapierBundle'],
             $this->sampleSchemas['MauticPlugin\MauticZapierBundle']
         );
-        $this->eventDispatcher->expects($this->once())->method('dispatch')->with($event, PluginEvents::ON_PLUGIN_UPDATE);
+        $this->eventDispatcher->expects($this->once())->method('dispatch')->with($event);
         $updatedPlugins = $this->helper->updatePlugins($this->sampleAllPlugins, $sampleInstalledPlugins, $this->sampleMetaData, $this->sampleSchemas);
 
         $this->assertCount(1, $updatedPlugins);
@@ -146,7 +145,7 @@ final class ReloadHelperTest extends \PHPUnit\Framework\TestCase
             $this->sampleMetaData['MauticPlugin\MauticZapierBundle'],
             null
         );
-        $this->eventDispatcher->expects($this->once())->method('dispatch')->with($event, PluginEvents::ON_PLUGIN_INSTALL);
+        $this->eventDispatcher->expects($this->once())->method('dispatch')->with($event);
 
         $installedPlugins = $this->helper->installPlugins($this->sampleAllPlugins, $sampleInstalledPlugins, $this->sampleMetaData, $this->sampleSchemas);
 

--- a/plugins/MauticCrmBundle/EventListener/PluginSubscriber.php
+++ b/plugins/MauticCrmBundle/EventListener/PluginSubscriber.php
@@ -8,7 +8,6 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Mautic\PluginBundle\Bundle\PluginDatabase;
 use Mautic\PluginBundle\Event\PluginInstallEvent;
-use Mautic\PluginBundle\PluginEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final readonly class PluginSubscriber implements EventSubscriberInterface
@@ -50,7 +49,7 @@ final readonly class PluginSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            PluginEvents::ON_PLUGIN_INSTALL => ['onInstall', 100],
+            PluginInstallEvent::class => ['onInstall', 100],
         ];
     }
 


### PR DESCRIPTION
Follow-up to #17157 (which converted CoreBundle)