### PR TITLE
[phpunit 13] Tests: opt out of PHPUnit mock-without-expectations notices

### DIFF
--- a/app/bundles/ApiBundle/Tests/ApiPlatform/EventListener/MauticDenyAccessListenerTest.php
+++ b/app/bundles/ApiBundle/Tests/ApiPlatform/EventListener/MauticDenyAccessListenerTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class MauticDenyAccessListenerTest extends TestCase
 {
     private MockObject&CorePermissions $corePermissionsMock;

--- a/app/bundles/ApiBundle/Tests/ApiPlatform/EventListener/MauticWriteSubscriberTest.php
+++ b/app/bundles/ApiBundle/Tests/ApiPlatform/EventListener/MauticWriteSubscriberTest.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\ViewEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class MauticWriteSubscriberTest extends TestCase
 {
     private MauticWriteSubscriber $mauticWriteSubscriber;

--- a/app/bundles/ApiBundle/Tests/Controller/CommonApiControllerTest.php
+++ b/app/bundles/ApiBundle/Tests/Controller/CommonApiControllerTest.php
@@ -23,6 +23,7 @@ use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class CommonApiControllerTest extends CampaignTestAbstract
 {
     public function testAddAliasIfNotPresentWithOneColumnWithoutAlias(): void

--- a/app/bundles/ApiBundle/Tests/EntityResultHelperTest.php
+++ b/app/bundles/ApiBundle/Tests/EntityResultHelperTest.php
@@ -9,6 +9,7 @@ use Mautic\ApiBundle\Helper\EntityResultHelper;
 use Mautic\LeadBundle\Entity\Lead;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class EntityResultHelperTest extends TestCase
 {
     public const string NEW_TITLE = 'Callback Title';

--- a/app/bundles/ApiBundle/Tests/EventListener/ApiSubscriberTest.php
+++ b/app/bundles/ApiBundle/Tests/EventListener/ApiSubscriberTest.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ApiSubscriberTest extends CommonMocks
 {
     /**

--- a/app/bundles/ApiBundle/Tests/Extension/OwnershipScopedCollectionExtensionTest.php
+++ b/app/bundles/ApiBundle/Tests/Extension/OwnershipScopedCollectionExtensionTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Security\Core\User\UserInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class OwnershipScopedCollectionExtensionTest extends TestCase
 {
     private Security&MockObject $security;

--- a/app/bundles/ApiBundle/Tests/Functional/Oauth2Test.php
+++ b/app/bundles/ApiBundle/Tests/Functional/Oauth2Test.php
@@ -20,6 +20,7 @@ use Symfony\Component\HttpFoundation\Response;
  */
 #[PreserveGlobalState(false)]
 #[RunTestsInSeparateProcesses]
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class Oauth2Test extends MauticMysqlTestCase
 {
     protected function setUp(): void

--- a/app/bundles/ApiBundle/Tests/Helper/BatchIdToEntityHelperTest.php
+++ b/app/bundles/ApiBundle/Tests/Helper/BatchIdToEntityHelperTest.php
@@ -8,6 +8,7 @@ use Mautic\ApiBundle\Helper\BatchIdToEntityHelper;
 use Mautic\LeadBundle\Entity\Lead;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class BatchIdToEntityHelperTest extends TestCase
 {
     public function testIdsAreExtractedFromIdKeyArray(): void

--- a/app/bundles/ApiBundle/Tests/Helper/RequestHelperTest.php
+++ b/app/bundles/ApiBundle/Tests/Helper/RequestHelperTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\HeaderBag;
 use Symfony\Component\HttpFoundation\Request;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class RequestHelperTest extends TestCase
 {
     /**

--- a/app/bundles/ApiBundle/Tests/Security/Voter/ApiPermissionVoterTest.php
+++ b/app/bundles/ApiBundle/Tests/Security/Voter/ApiPermissionVoterTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ApiPermissionVoterTest extends TestCase
 {
     private CorePermissions&MockObject $corePermissionsMock;

--- a/app/bundles/AssetBundle/Tests/Entity/AssetRepositoryTest.php
+++ b/app/bundles/AssetBundle/Tests/Entity/AssetRepositoryTest.php
@@ -12,6 +12,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class AssetRepositoryTest extends TestCase
 {
     use RepositoryConfiguratorTrait;

--- a/app/bundles/AssetBundle/Tests/EventListener/DashboardSubscriberTest.php
+++ b/app/bundles/AssetBundle/Tests/EventListener/DashboardSubscriberTest.php
@@ -15,6 +15,7 @@ use Symfony\Component\Cache\CacheItem;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class DashboardSubscriberTest extends \PHPUnit\Framework\TestCase
 {
     private AssetModel&MockObject $assetModel;

--- a/app/bundles/AssetBundle/Tests/EventListener/DetermineWinnerSubscriberTest.php
+++ b/app/bundles/AssetBundle/Tests/EventListener/DetermineWinnerSubscriberTest.php
@@ -11,6 +11,7 @@ use Mautic\PageBundle\Entity\Page;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class DetermineWinnerSubscriberTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/AssetBundle/Tests/EventListener/ReportSubscriberTest.php
+++ b/app/bundles/AssetBundle/Tests/EventListener/ReportSubscriberTest.php
@@ -18,6 +18,7 @@ use Mautic\ReportBundle\Helper\ReportHelper;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
 {
     private ChannelListHelper $channelListHelper;

--- a/app/bundles/AssetBundle/Tests/Model/AssetModelTest.php
+++ b/app/bundles/AssetBundle/Tests/Model/AssetModelTest.php
@@ -38,6 +38,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\ServerBag;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class AssetModelTest extends \PHPUnit\Framework\TestCase
 {
     private AssetModel $assetModel;

--- a/app/bundles/CampaignBundle/Tests/Controller/CampaignControllerUnitTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/CampaignControllerUnitTest.php
@@ -7,6 +7,7 @@ namespace Mautic\CampaignBundle\Tests\Controller;
 use Mautic\CampaignBundle\Controller\CampaignController;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class CampaignControllerUnitTest extends TestCase
 {
     public function testNormalizeCampaignSourcesSkipsNonArrayAndNonNumericEntries(): void

--- a/app/bundles/CampaignBundle/Tests/Controller/SourceControllerUnitTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/SourceControllerUnitTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class SourceControllerUnitTest extends TestCase
 {
     public function testNewActionBuildsBooleanModifiedSourceMap(): void

--- a/app/bundles/CampaignBundle/Tests/Entity/CampaignRepositoryTest.php
+++ b/app/bundles/CampaignBundle/Tests/Entity/CampaignRepositoryTest.php
@@ -11,6 +11,7 @@ use Mautic\CoreBundle\Test\Doctrine\RepositoryConfiguratorTrait;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class CampaignRepositoryTest extends TestCase
 {
     use RepositoryConfiguratorTrait;

--- a/app/bundles/CampaignBundle/Tests/Entity/ContactLimiterTraitTest.php
+++ b/app/bundles/CampaignBundle/Tests/Entity/ContactLimiterTraitTest.php
@@ -14,6 +14,7 @@ use Mautic\CampaignBundle\Entity\ContactLimiterTrait;
 use Mautic\CampaignBundle\Executioner\ContactFinder\Limiter\ContactLimiter;
 use Mautic\CoreBundle\Test\Doctrine\MockedConnectionTrait;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ContactLimiterTraitTest extends \PHPUnit\Framework\TestCase
 {
     use ContactLimiterTrait;

--- a/app/bundles/CampaignBundle/Tests/Entity/EventRepositoryTest.php
+++ b/app/bundles/CampaignBundle/Tests/Entity/EventRepositoryTest.php
@@ -12,6 +12,7 @@ use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CoreBundle\Test\Doctrine\RepositoryConfiguratorTrait;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class EventRepositoryTest extends TestCase
 {
     use RepositoryConfiguratorTrait;

--- a/app/bundles/CampaignBundle/Tests/Entity/LeadEventLogRepositoryTest.php
+++ b/app/bundles/CampaignBundle/Tests/Entity/LeadEventLogRepositoryTest.php
@@ -14,6 +14,7 @@ use Mautic\CoreBundle\Test\Doctrine\RepositoryConfiguratorTrait;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class LeadEventLogRepositoryTest extends TestCase
 {
     use RepositoryConfiguratorTrait;

--- a/app/bundles/CampaignBundle/Tests/Event/CampaignBuilderEventTest.php
+++ b/app/bundles/CampaignBundle/Tests/Event/CampaignBuilderEventTest.php
@@ -11,6 +11,7 @@ use Mautic\CampaignBundle\Tests\CampaignTestAbstract;
 use Mautic\CoreBundle\Translation\Translator;
 use Mautic\FormBundle\Form\Type\CampaignEventFormFieldValueType;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class CampaignBuilderEventTest extends CampaignTestAbstract
 {
     public function testAddGetDecision(): void

--- a/app/bundles/CampaignBundle/Tests/EventListener/CampaignEventSubscriberTest.php
+++ b/app/bundles/CampaignBundle/Tests/EventListener/CampaignEventSubscriberTest.php
@@ -27,6 +27,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class CampaignEventSubscriberTest extends TestCase
 {
     private CampaignEventSubscriber $fixture;

--- a/app/bundles/CampaignBundle/Tests/EventListener/CampaignSubscriberTest.php
+++ b/app/bundles/CampaignBundle/Tests/EventListener/CampaignSubscriberTest.php
@@ -13,6 +13,7 @@ use Mautic\CoreBundle\Helper\IpLookupHelper;
 use Mautic\CoreBundle\Model\AuditLogModel;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class CampaignSubscriberTest extends TestCase
 {
     /**

--- a/app/bundles/CampaignBundle/Tests/EventListener/NotifyOfFailureSubscriberTest.php
+++ b/app/bundles/CampaignBundle/Tests/EventListener/NotifyOfFailureSubscriberTest.php
@@ -12,6 +12,7 @@ use Mautic\LeadBundle\Entity\Lead;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class NotifyOfFailureSubscriberTest extends TestCase
 {
     private MockObject&NotificationHelper $notificationHelper;

--- a/app/bundles/CampaignBundle/Tests/EventListener/NotifyOfUnpublishSubscriberTest.php
+++ b/app/bundles/CampaignBundle/Tests/EventListener/NotifyOfUnpublishSubscriberTest.php
@@ -11,6 +11,7 @@ use Mautic\CampaignBundle\Executioner\Helper\NotificationHelper;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class NotifyOfUnpublishSubscriberTest extends TestCase
 {
     private MockObject&NotificationHelper $notificationHelper;

--- a/app/bundles/CampaignBundle/Tests/Executioner/ContactFinder/InactiveContactFinderTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/ContactFinder/InactiveContactFinderTest.php
@@ -14,6 +14,7 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadRepository;
 use Psr\Log\NullLogger;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class InactiveContactFinderTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/CampaignBundle/Tests/Executioner/ContactFinder/KickoffContactFinderTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/ContactFinder/KickoffContactFinderTest.php
@@ -13,6 +13,7 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadRepository;
 use Psr\Log\NullLogger;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class KickoffContactFinderTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/CampaignBundle/Tests/Executioner/Dispatcher/ActionDispatcherTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Dispatcher/ActionDispatcherTest.php
@@ -21,6 +21,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\NullLogger;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ActionDispatcherTest extends \PHPUnit\Framework\TestCase
 {
     private MockObject&EventDispatcherInterface $dispatcher;

--- a/app/bundles/CampaignBundle/Tests/Executioner/Dispatcher/DecisionDispatcherTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Dispatcher/DecisionDispatcherTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class DecisionDispatcherTest extends TestCase
 {
     private MockObject&EventDispatcherInterface $dispatcher;

--- a/app/bundles/CampaignBundle/Tests/Executioner/EventExecutionerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/EventExecutionerTest.php
@@ -31,6 +31,7 @@ use Mautic\LeadBundle\Entity\Lead;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class EventExecutionerTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/CampaignBundle/Tests/Executioner/Helper/EventRedirectionHelperTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Helper/EventRedirectionHelperTest.php
@@ -12,6 +12,7 @@ use Mautic\CoreBundle\Test\ReflectionHelper;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class EventRedirectionHelperTest extends TestCase
 {
     /**

--- a/app/bundles/CampaignBundle/Tests/Executioner/InactiveExecutionerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/InactiveExecutionerTest.php
@@ -23,6 +23,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\NullLogger;
 use Symfony\Component\Console\Output\BufferedOutput;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class InactiveExecutionerTest extends \PHPUnit\Framework\TestCase
 {
     private MockObject&InactiveContactFinder $inactiveContactFinder;

--- a/app/bundles/CampaignBundle/Tests/Executioner/KickoffExecutionerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/KickoffExecutionerTest.php
@@ -25,6 +25,7 @@ use Psr\Log\NullLogger;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class KickoffExecutionerTest extends \PHPUnit\Framework\TestCase
 {
     private MockObject&KickoffContactFinder $kickoffContactFinder;

--- a/app/bundles/CampaignBundle/Tests/Executioner/Logger/EventLoggerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Logger/EventLoggerTest.php
@@ -20,6 +20,7 @@ use Mautic\LeadBundle\Tracker\ContactTracker;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class EventLoggerTest extends TestCase
 {
     /**

--- a/app/bundles/CampaignBundle/Tests/Executioner/RealTimeExecutionerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/RealTimeExecutionerTest.php
@@ -24,6 +24,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class RealTimeExecutionerTest extends TestCase
 {
     private MockObject&LeadModel $leadModel;

--- a/app/bundles/CampaignBundle/Tests/Executioner/Result/ResponsesTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Result/ResponsesTest.php
@@ -9,6 +9,7 @@ use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CampaignBundle\Entity\LeadEventLog;
 use Mautic\CampaignBundle\Executioner\Result\Responses;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ResponsesTest extends \PHPUnit\Framework\TestCase
 {
     public function testExtractingResponsesFromLog(): void

--- a/app/bundles/CampaignBundle/Tests/Executioner/ScheduledExecutionerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/ScheduledExecutionerTest.php
@@ -26,6 +26,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Symfony\Component\Console\Output\BufferedOutput;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ScheduledExecutionerTest extends TestCase
 {
     private MockObject&LeadEventLogRepository $repository;

--- a/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/EventSchedulerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/EventSchedulerTest.php
@@ -26,6 +26,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\NullLogger;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class EventSchedulerTest extends \PHPUnit\Framework\TestCase
 {
     private NullLogger $logger;

--- a/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/Mode/IntervalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/Scheduler/Mode/IntervalTest.php
@@ -15,6 +15,7 @@ use Mautic\LeadBundle\Entity\Lead;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Psr\Log\NullLogger;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class IntervalTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignRotationTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Campaign/CampaignRotationTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 use Symfony\Component\HttpFoundation\Session\Session;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class CampaignRotationTest extends MauticMysqlTestCase
 {
     private Campaign $campaignWithoutJump;

--- a/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignControllerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignControllerTest.php
@@ -24,6 +24,7 @@ use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class CampaignControllerTest extends MauticMysqlTestCase
 {
     use CreateTestEntitiesTrait;

--- a/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignImportControllerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Controller/CampaignImportControllerTest.php
@@ -13,6 +13,7 @@ use Mautic\UserBundle\Entity\User;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class CampaignImportControllerTest extends MauticMysqlTestCase
 {
     protected function setUp(): void

--- a/app/bundles/CampaignBundle/Tests/Functional/Service/CampaignAuditServiceFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Service/CampaignAuditServiceFunctionalTest.php
@@ -14,6 +14,7 @@ use Mautic\EmailBundle\Entity\Email;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class CampaignAuditServiceFunctionalTest extends MauticMysqlTestCase
 {
     private CampaignAuditService $campaignAuditService;

--- a/app/bundles/CampaignBundle/Tests/Helper/InactiveHelperTest.php
+++ b/app/bundles/CampaignBundle/Tests/Helper/InactiveHelperTest.php
@@ -20,6 +20,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class InactiveHelperTest extends TestCase
 {
     /**

--- a/app/bundles/CampaignBundle/Tests/Helper/NotificationHelperTest.php
+++ b/app/bundles/CampaignBundle/Tests/Helper/NotificationHelperTest.php
@@ -16,6 +16,7 @@ use Mautic\UserBundle\Model\UserModel;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Routing\Router;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class NotificationHelperTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/CampaignBundle/Tests/Membership/Action/AdderTest.php
+++ b/app/bundles/CampaignBundle/Tests/Membership/Action/AdderTest.php
@@ -12,6 +12,7 @@ use Mautic\CampaignBundle\Membership\Action\Adder;
 use Mautic\CampaignBundle\Membership\Exception\ContactCannotBeAddedToCampaignException;
 use Mautic\LeadBundle\Entity\Lead;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class AdderTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/CampaignBundle/Tests/Membership/Action/RemoverTest.php
+++ b/app/bundles/CampaignBundle/Tests/Membership/Action/RemoverTest.php
@@ -13,6 +13,7 @@ use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Twig\Helper\DateHelper;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class RemoverTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/CampaignBundle/Tests/Membership/MembershipBuilderTest.php
+++ b/app/bundles/CampaignBundle/Tests/Membership/MembershipBuilderTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class MembershipBuilderTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/CampaignBundle/Tests/Membership/MembershipManagerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Membership/MembershipManagerTest.php
@@ -15,6 +15,7 @@ use Mautic\CampaignBundle\Membership\MembershipManager;
 use Mautic\LeadBundle\Entity\Lead;
 use Psr\Log\NullLogger;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class MembershipManagerTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/CampaignBundle/Tests/Model/CampaignModelTest.php
+++ b/app/bundles/CampaignBundle/Tests/Model/CampaignModelTest.php
@@ -9,6 +9,7 @@ use Mautic\CampaignBundle\Tests\CampaignTestAbstract;
 use Mautic\FormBundle\Entity\Form;
 use Mautic\LeadBundle\Entity\LeadList;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class CampaignModelTest extends CampaignTestAbstract
 {
     public function testGetSourceListsWithNull(): void

--- a/app/bundles/CampaignBundle/Tests/Model/CampaignModelTransactionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Model/CampaignModelTransactionalTest.php
@@ -30,6 +30,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class CampaignModelTransactionalTest extends TestCase
 {
     private MockObject&CampaignRepository $campaignRepositoryMock;

--- a/app/bundles/CampaignBundle/Tests/Model/EventModelTest.php
+++ b/app/bundles/CampaignBundle/Tests/Model/EventModelTest.php
@@ -22,6 +22,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class EventModelTest extends TestCase
 {
     /**

--- a/app/bundles/CampaignBundle/Tests/Service/CampaignAuditServiceTest.php
+++ b/app/bundles/CampaignBundle/Tests/Service/CampaignAuditServiceTest.php
@@ -13,6 +13,7 @@ use Mautic\EmailBundle\Entity\Email;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class CampaignAuditServiceTest extends MauticMysqlTestCase
 {
     private const string CAMPAIGN_NAME = 'Test Campaign';

--- a/app/bundles/ChannelBundle/Tests/EventListener/CampaignSubscriberTest.php
+++ b/app/bundles/ChannelBundle/Tests/EventListener/CampaignSubscriberTest.php
@@ -30,6 +30,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\NullLogger;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class CampaignSubscriberTest extends \PHPUnit\Framework\TestCase
 {
     private EventDispatcher $dispatcher;

--- a/app/bundles/ChannelBundle/Tests/Model/ChannelActionModelTest.php
+++ b/app/bundles/ChannelBundle/Tests/Model/ChannelActionModelTest.php
@@ -11,6 +11,7 @@ use Mautic\LeadBundle\Model\DoNotContact;
 use Mautic\LeadBundle\Model\LeadModel;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ChannelActionModelTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/ChannelBundle/Tests/Model/FrequencyActionModelTest.php
+++ b/app/bundles/ChannelBundle/Tests/Model/FrequencyActionModelTest.php
@@ -12,6 +12,7 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Model\LeadModel;
 use PHPUnit\Framework\MockObject\MockObject;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class FrequencyActionModelTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/ChannelBundle/Tests/Model/MessageQueueModelTest.php
+++ b/app/bundles/ChannelBundle/Tests/Model/MessageQueueModelTest.php
@@ -22,6 +22,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class MessageQueueModelTest extends \PHPUnit\Framework\TestCase
 {
     public const string DATE = '2019-07-07 15:00:00';

--- a/app/bundles/ChannelBundle/Tests/PreferenceBuilder/PreferenceBuilderTest.php
+++ b/app/bundles/ChannelBundle/Tests/PreferenceBuilder/PreferenceBuilderTest.php
@@ -13,6 +13,7 @@ use Mautic\LeadBundle\Entity\DoNotContact;
 use Mautic\LeadBundle\Entity\Lead;
 use Psr\Log\NullLogger;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class PreferenceBuilderTest extends \PHPUnit\Framework\TestCase
 {
     public function testChannelsArePrioritized(): void

--- a/app/bundles/ConfigBundle/Tests/Event/ConfigBuilderEventTest.php
+++ b/app/bundles/ConfigBundle/Tests/Event/ConfigBuilderEventTest.php
@@ -7,6 +7,7 @@ namespace Mautic\ConfigBundle\Tests\Event;
 use Mautic\ConfigBundle\Event\ConfigBuilderEvent;
 use Mautic\CoreBundle\Tests\CommonMocks;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ConfigBuilderEventTest extends CommonMocks
 {
     public function testAddForm(): void

--- a/app/bundles/ConfigBundle/Tests/EventListener/ConfigSubscriberTest.php
+++ b/app/bundles/ConfigBundle/Tests/EventListener/ConfigSubscriberTest.php
@@ -14,6 +14,7 @@ use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ConfigSubscriberTest extends TestCase
 {
     /**

--- a/app/bundles/ConfigBundle/Tests/Mapper/ConfigMapperTest.php
+++ b/app/bundles/ConfigBundle/Tests/Mapper/ConfigMapperTest.php
@@ -12,6 +12,7 @@ use PHPUnit\Framework\Attributes\TestDox;
 
 #[CoversClass(BadFormConfigException::class)]
 #[CoversClass(ConfigMapper::class)]
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ConfigMapperTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/CoreBundle/Tests/EventListener/DashboardSubscriberTest.php
+++ b/app/bundles/CoreBundle/Tests/EventListener/DashboardSubscriberTest.php
@@ -26,6 +26,7 @@ use Symfony\Component\Routing\Router;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class DashboardSubscriberTest extends TestCase
 {
     /**

--- a/app/bundles/CoreBundle/Tests/Service/FlashBagTest.php
+++ b/app/bundles/CoreBundle/Tests/Service/FlashBagTest.php
@@ -14,6 +14,7 @@ use Symfony\Component\HttpFoundation\Session\Flash\FlashBag as SymfonyFlashBag;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class FlashBagTest extends TestCase
 {
     /**

--- a/app/bundles/CoreBundle/Tests/Twig/Extension/LanguageExtensionTest.php
+++ b/app/bundles/CoreBundle/Tests/Twig/Extension/LanguageExtensionTest.php
@@ -9,6 +9,7 @@ use Mautic\UserBundle\Entity\User;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\SecurityBundle\Security;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class LanguageExtensionTest extends TestCase
 {
     public function testGetLanguageNameReturnsEnglishForEn(): void

--- a/app/bundles/CoreBundle/Tests/Unit/Command/MaxMindDoNotSellPurgeCommandTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Command/MaxMindDoNotSellPurgeCommandTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class MaxMindDoNotSellPurgeCommandTest extends TestCase
 {
     /**

--- a/app/bundles/CoreBundle/Tests/Unit/Command/ModeratedCommandTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Command/ModeratedCommandTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\Lock\LockInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ModeratedCommandTest extends TestCase
 {
     private string $lockFilePath;

--- a/app/bundles/CoreBundle/Tests/Unit/Controller/AbstractFormControllerTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Controller/AbstractFormControllerTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class AbstractFormControllerTest extends \PHPUnit\Framework\TestCase
 {
     private AbstractFormController $classFromAbstractFormController;

--- a/app/bundles/CoreBundle/Tests/Unit/Doctrine/Mapping/ClassMetadataBuilderTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Doctrine/Mapping/ClassMetadataBuilderTest.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
 use PHPUnit\Framework\MockObject\MockObject;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ClassMetadataBuilderTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/CoreBundle/Tests/Unit/Entity/CommonRepositoryTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Entity/CommonRepositoryTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\MockObject\MockObject;
 
 #[CoversClass(CommonRepository::class)]
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class CommonRepositoryTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/CoreBundle/Tests/Unit/EventListener/CommonStatsSubscriberTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/EventListener/CommonStatsSubscriberTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class CommonStatsSubscriberTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/CoreBundle/Tests/Unit/EventListener/DoctrineGeneratedColumnsListenerTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/EventListener/DoctrineGeneratedColumnsListenerTest.php
@@ -13,6 +13,7 @@ use Mautic\CoreBundle\Doctrine\Provider\GeneratedColumnsProviderInterface;
 use Mautic\CoreBundle\EventListener\DoctrineGeneratedColumnsListener;
 use Psr\Log\LoggerInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class DoctrineGeneratedColumnsListenerTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/CoreBundle/Tests/Unit/EventListener/EnvironmentSubscriberTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/EventListener/EnvironmentSubscriberTest.php
@@ -13,6 +13,7 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class EnvironmentSubscriberTest extends TestCase
 {
     private EnvironmentSubscriber $environmentSubscriber;

--- a/app/bundles/CoreBundle/Tests/Unit/EventListener/MigrationCommandSubscriberTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/EventListener/MigrationCommandSubscriberTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Console\Event\ConsoleTerminateEvent;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class MigrationCommandSubscriberTest extends TestCase
 {
     private MockObject&GeneratedColumnsProviderInterface $generatedColumnsProvider;

--- a/app/bundles/CoreBundle/Tests/Unit/EventListener/RequestSubscriberTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/EventListener/RequestSubscriberTest.php
@@ -14,6 +14,7 @@ use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class RequestSubscriberTest extends \PHPUnit\Framework\TestCase
 {
     private RequestSubscriber $subscriber;

--- a/app/bundles/CoreBundle/Tests/Unit/Factory/ModelFactoryTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Factory/ModelFactoryTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ModelFactoryTest extends TestCase
 {
     /**

--- a/app/bundles/CoreBundle/Tests/Unit/Factory/TransifexFactoryTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Factory/TransifexFactoryTest.php
@@ -11,6 +11,7 @@ use Mautic\Transifex\Exception\MissingCredentialsException;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Http\Client\ClientInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class TransifexFactoryTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/CoreBundle/Tests/Unit/Form/Type/ContentPreviewSettingsTypeTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Form/Type/ContentPreviewSettingsTypeTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ContentPreviewSettingsTypeTest extends TestCase
 {
     private ContentPreviewSettingsType $form;

--- a/app/bundles/CoreBundle/Tests/Unit/Form/Validator/Constraints/CircularDependencyValidatorTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Form/Validator/Constraints/CircularDependencyValidatorTest.php
@@ -14,6 +14,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Validator\Context\ExecutionContext;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class CircularDependencyValidatorTest extends \PHPUnit\Framework\TestCase
 {
     private MockObject&ListModel $mockListModel;

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/Chart/ChartQueryTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/Chart/ChartQueryTest.php
@@ -14,6 +14,7 @@ use Mautic\CoreBundle\Helper\DateTimeHelper;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ChartQueryTest extends TestCase
 {
     private \DateTime $dateFrom;

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/Chart/DateRangeUnitTraitTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/Chart/DateRangeUnitTraitTest.php
@@ -8,6 +8,7 @@ use Mautic\CoreBundle\Helper\Chart\ChartQuery;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class DateRangeUnitTraitTest extends TestCase
 {
     private MockObject&ChartQuery $trait;

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/CookieHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/CookieHelperTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 #[CoversClass(CookieHelper::class)]
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class CookieHelperTest extends TestCase
 {
     /**

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/EncryptionHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/EncryptionHelperTest.php
@@ -11,6 +11,7 @@ use Mautic\CoreBundle\Security\Cryptography\Cipher\Symmetric\SymmetricCipherInte
 use Mautic\CoreBundle\Security\Exception\Cryptography\Symmetric\InvalidDecryptionException;
 use PHPUnit\Framework\MockObject\MockObject;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class EncryptionHelperTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/ExportHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/ExportHelperTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ExportHelperTest extends TestCase
 {
     private MockObject&TranslatorInterface $translatorInterfaceMock;

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/FilePathResolverTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/FilePathResolverTest.php
@@ -14,6 +14,7 @@ use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class FilePathResolverTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/IpLookupHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/IpLookupHelperTest.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 #[CoversClass(IpLookupHelper::class)]
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class IpLookupHelperTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/LanguageHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/LanguageHelperTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class LanguageHelperTest extends TestCase
 {
     /**

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/MaxMindDoNotSellDownloadHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/MaxMindDoNotSellDownloadHelperTest.php
@@ -11,6 +11,7 @@ use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class MaxMindDoNotSellDownloadHelperTest extends \PHPUnit\Framework\TestCase
 {
     public const string TEMP_TEST_FILE = './DoNotSellTest.json';

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/ThemeHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/ThemeHelperTest.php
@@ -27,6 +27,7 @@ use Twig\Loader\FilesystemLoader;
 use Twig\RuntimeLoader\FactoryRuntimeLoader;
 use Twig\TwigFilter;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ThemeHelperTest extends TestCase
 {
     /**

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/UpdateHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/UpdateHelperTest.php
@@ -24,6 +24,7 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class UpdateHelperTest extends TestCase
 {
     /**

--- a/app/bundles/CoreBundle/Tests/Unit/IpLookup/MaxMindDoNotSellListTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/IpLookup/MaxMindDoNotSellListTest.php
@@ -9,6 +9,7 @@ use Mautic\CoreBundle\Exception\FileNotFoundException;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\IpLookup\DoNotSellList\MaxMindDoNotSellList;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class MaxMindDoNotSellListTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/CoreBundle/Tests/Unit/IpLookup/MaxmindLookupTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/IpLookup/MaxmindLookupTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\MockObject\MockObject;
  * Maxmind requires API key and thus cannot test actual lookup so just make API endpoint works and
  * classes are initiated.
  */
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class MaxmindLookupTest extends \PHPUnit\Framework\TestCase
 {
     private string $cacheDir = __DIR__.'/../../../../../../var/cache/test';

--- a/app/bundles/CoreBundle/Tests/Unit/Shortener/ShortenerTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Shortener/ShortenerTest.php
@@ -10,6 +10,7 @@ use Mautic\CoreBundle\Shortener\ShortenerServiceInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ShortenerTest extends TestCase
 {
     /**

--- a/app/bundles/CoreBundle/Tests/Unit/Twig/Extension/DateExtensionTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Twig/Extension/DateExtensionTest.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Attribute\AsTwigFunction;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class DateExtensionTest extends TestCase
 {
     private DateExtension $dateExtension;

--- a/app/bundles/CoreBundle/Tests/Unit/Twig/Helper/AssetsHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Twig/Helper/AssetsHelperTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Asset\Packages;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class AssetsHelperTest extends TestCase
 {
     /**

--- a/app/bundles/CoreBundle/Tests/Unit/Twig/Helper/DateHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Twig/Helper/DateHelperTest.php
@@ -11,6 +11,7 @@ use Mautic\CoreBundle\Twig\Helper\DateHelper;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class DateHelperTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/CoreBundle/Tests/Unit/Twig/Helper/FormatterHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Twig/Helper/FormatterHelperTest.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Exception;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class FormatterHelperTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/CoreBundle/Tests/Unit/Update/Step/DeleteCacheStepTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Update/Step/DeleteCacheStepTest.php
@@ -9,6 +9,7 @@ use Mautic\CoreBundle\Update\Step\DeleteCacheStep;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class DeleteCacheStepTest extends AbstractStepTestCase
 {
     /**

--- a/app/bundles/CoreBundle/Tests/Unit/Update/Step/FinalizeUpdateStepTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Update/Step/FinalizeUpdateStepTest.php
@@ -14,6 +14,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class FinalizeUpdateStepTest extends AbstractStepTestCase
 {
     /**

--- a/app/bundles/CoreBundle/Tests/Unit/Update/Step/InstallNewFilesStepTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Update/Step/InstallNewFilesStepTest.php
@@ -12,6 +12,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class InstallNewFilesStepTest extends AbstractStepTestCase
 {
     /**

--- a/app/bundles/CoreBundle/Tests/Unit/Update/Step/PreUpdateChecksStepTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Update/Step/PreUpdateChecksStepTest.php
@@ -12,6 +12,7 @@ use Mautic\CoreBundle\Update\Step\PreUpdateChecksStep;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class PreUpdateChecksStepTest extends AbstractStepTestCase
 {
     /**

--- a/app/bundles/CoreBundle/Tests/Unit/Update/Step/RemoveDeletedFilesStepTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Update/Step/RemoveDeletedFilesStepTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class RemoveDeletedFilesStepTest extends AbstractStepTestCase
 {
     /**

--- a/app/bundles/CoreBundle/Tests/Unit/Update/Step/UpdateSchemaStepTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Update/Step/UpdateSchemaStepTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class UpdateSchemaStepTest extends AbstractStepTestCase
 {
     /**

--- a/app/bundles/CoreBundle/Tests/Unit/Update/Step/UpdateTranslationsStepTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Update/Step/UpdateTranslationsStepTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class UpdateTranslationsStepTest extends AbstractStepTestCase
 {
     /**

--- a/app/bundles/CoreBundle/Tests/Unit/Update/StepProviderTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Update/StepProviderTest.php
@@ -9,6 +9,7 @@ use Mautic\CoreBundle\Update\StepProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class StepProviderTest extends TestCase
 {
     private StepProvider $provider;

--- a/app/bundles/DashboardBundle/Tests/Controller/DashboardControllerTest.php
+++ b/app/bundles/DashboardBundle/Tests/Controller/DashboardControllerTest.php
@@ -25,6 +25,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\RouterInterface;
 use Twig\Environment;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class DashboardControllerTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/DashboardBundle/Tests/Dashboard/WidgetTest.php
+++ b/app/bundles/DashboardBundle/Tests/Dashboard/WidgetTest.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class WidgetTest extends TestCase
 {
     private const int USER_ID = 1;

--- a/app/bundles/DashboardBundle/Tests/Event/WidgetDetailEventTest.php
+++ b/app/bundles/DashboardBundle/Tests/Event/WidgetDetailEventTest.php
@@ -11,6 +11,7 @@ use Mautic\DashboardBundle\Entity\Widget;
 use Mautic\DashboardBundle\Event\WidgetDetailEvent;
 use PHPUnit\Framework\MockObject\MockObject;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class WidgetDetailEventTest extends \PHPUnit\Framework\TestCase
 {
     private WidgetDetailEvent $widgetDetailEvent;

--- a/app/bundles/DashboardBundle/Tests/Model/DashboardModelTest.php
+++ b/app/bundles/DashboardBundle/Tests/Model/DashboardModelTest.php
@@ -25,6 +25,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class DashboardModelTest extends TestCase
 {
     private MockObject&CoreParametersHelper $coreParametersHelper;

--- a/app/bundles/DynamicContentBundle/Tests/Unit/EventListener/DynamicContentSubscriberTest.php
+++ b/app/bundles/DynamicContentBundle/Tests/Unit/EventListener/DynamicContentSubscriberTest.php
@@ -23,6 +23,7 @@ use Mautic\PageBundle\Model\TrackableModel;
 use MauticPlugin\MauticFocusBundle\Helper\TokenHelper as FocusTokenHelper;
 use PHPUnit\Framework\MockObject\MockObject;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class DynamicContentSubscriberTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/DynamicContentBundle/Tests/Unit/Helper/DynamicContentHelperTest.php
+++ b/app/bundles/DynamicContentBundle/Tests/Unit/Helper/DynamicContentHelperTest.php
@@ -16,6 +16,7 @@ use Mautic\LeadBundle\Model\LeadModel;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class DynamicContentHelperTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/DynamicContentBundle/Tests/Validator/Constraints/SlotNameTypeValidatorTest.php
+++ b/app/bundles/DynamicContentBundle/Tests/Validator/Constraints/SlotNameTypeValidatorTest.php
@@ -11,6 +11,7 @@ use Mautic\DynamicContentBundle\Validator\Constraints\SlotNameTypeValidator;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class SlotNameTypeValidatorTest extends ConstraintValidatorTestCase
 {
     /**

--- a/app/bundles/EmailBundle/Tests/Controller/AjaxControllerTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/AjaxControllerTest.php
@@ -23,6 +23,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Session;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class AjaxControllerTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/EmailBundle/Tests/Controller/EmailControllerTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailControllerTest.php
@@ -37,6 +37,7 @@ use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Routing\Router;
 use Twig\Environment;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class EmailControllerTest extends TestCase
 {
     public const string NEW_CATEGORY_TITLE = 'New category';

--- a/app/bundles/EmailBundle/Tests/Controller/PreviewSettingsFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/PreviewSettingsFunctionalTest.php
@@ -8,6 +8,7 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\EmailBundle\Entity\Email;
 use Symfony\Component\HttpFoundation\Request;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class PreviewSettingsFunctionalTest extends MauticMysqlTestCase
 {
     public function testPreviewSettingsAllEnabled(): void

--- a/app/bundles/EmailBundle/Tests/Entity/EmailRepositoryIncrementReadTest.php
+++ b/app/bundles/EmailBundle/Tests/Entity/EmailRepositoryIncrementReadTest.php
@@ -10,6 +10,7 @@ use Mautic\CoreBundle\Test\Doctrine\RepositoryConfiguratorTrait;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Entity\EmailRepository;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class EmailRepositoryIncrementReadTest extends \PHPUnit\Framework\TestCase
 {
     use RepositoryConfiguratorTrait;

--- a/app/bundles/EmailBundle/Tests/Entity/EmailRepositoryTest.php
+++ b/app/bundles/EmailBundle/Tests/Entity/EmailRepositoryTest.php
@@ -14,6 +14,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class EmailRepositoryTest extends TestCase
 {
     use RepositoryConfiguratorTrait;

--- a/app/bundles/EmailBundle/Tests/Entity/EmailRepositoryUpCountSentTest.php
+++ b/app/bundles/EmailBundle/Tests/Entity/EmailRepositoryUpCountSentTest.php
@@ -11,6 +11,7 @@ use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Entity\EmailRepository;
 use PHPUnit\Framework\MockObject\MockObject;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class EmailRepositoryUpCountSentTest extends \PHPUnit\Framework\TestCase
 {
     use RepositoryConfiguratorTrait;

--- a/app/bundles/EmailBundle/Tests/Entity/StatRepositoryTest.php
+++ b/app/bundles/EmailBundle/Tests/Entity/StatRepositoryTest.php
@@ -10,6 +10,7 @@ use Mautic\CoreBundle\Test\Doctrine\RepositoryConfiguratorTrait;
 use Mautic\EmailBundle\Entity\Stat;
 use Mautic\EmailBundle\Entity\StatRepository;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class StatRepositoryTest extends \PHPUnit\Framework\TestCase
 {
     use RepositoryConfiguratorTrait;

--- a/app/bundles/EmailBundle/Tests/EventListener/BuilderSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/BuilderSubscriberTest.php
@@ -23,6 +23,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class BuilderSubscriberTest extends TestCase
 {
     private MockObject&CoreParametersHelper $coreParametersHelper;

--- a/app/bundles/EmailBundle/Tests/EventListener/CampaignSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/CampaignSubscriberTest.php
@@ -19,6 +19,7 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Model\LeadModel;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class CampaignSubscriberTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/EmailBundle/Tests/EventListener/DetermineWinnerSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/DetermineWinnerSubscriberTest.php
@@ -12,6 +12,7 @@ use Mautic\PageBundle\Entity\HitRepository;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class DetermineWinnerSubscriberTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/EmailBundle/Tests/EventListener/EmailSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/EmailSubscriberTest.php
@@ -40,6 +40,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class EmailSubscriberTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/EmailBundle/Tests/EventListener/FormSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/FormSubscriberTest.php
@@ -15,6 +15,7 @@ use Mautic\LeadBundle\Tracker\ContactTracker;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class FormSubscriberTest extends TestCase
 {
     /**

--- a/app/bundles/EmailBundle/Tests/EventListener/ReportSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/ReportSubscriberTest.php
@@ -29,6 +29,7 @@ use PHPUnit\Framework\MockObject\Rule\AnyInvokedCount;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
 {
     use MockedConnectionTrait;

--- a/app/bundles/EmailBundle/Tests/EventListener/TokenSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/TokenSubscriberTest.php
@@ -34,6 +34,7 @@ use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Twig\Environment;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class TokenSubscriberTest extends \PHPUnit\Framework\TestCase
 {
     public function testDynamicContentCustomTokens(): void

--- a/app/bundles/EmailBundle/Tests/EventListener/TrackingSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/TrackingSubscriberTest.php
@@ -11,6 +11,7 @@ use Mautic\SmsBundle\Entity\Stat;
 use Mautic\SmsBundle\Entity\StatRepository;
 use Mautic\SmsBundle\EventListener\TrackingSubscriber;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class TrackingSubscriberTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/EmailBundle/Tests/EventListener/WebhookSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/WebhookSubscriberTest.php
@@ -13,6 +13,7 @@ use Mautic\WebhookBundle\Event\WebhookBuilderEvent;
 use Mautic\WebhookBundle\Model\WebhookModel;
 use PHPUnit\Framework\MockObject\MockObject;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class WebhookSubscriberTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/EmailBundle/Tests/Form/Type/EmailTypeTest.php
+++ b/app/bundles/EmailBundle/Tests/Form/Type/EmailTypeTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class EmailTypeTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/EmailBundle/Tests/Form/Type/ExampleSendTypeTest.php
+++ b/app/bundles/EmailBundle/Tests/Form/Type/ExampleSendTypeTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ExampleSendTypeTest extends TestCase
 {
     private ExampleSendType $form;

--- a/app/bundles/EmailBundle/Tests/Helper/BotRatioHelperMatomoTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/BotRatioHelperMatomoTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 /**
  * Test Matomo Device Detector integration with BotRatioHelper.
  */
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class BotRatioHelperMatomoTest extends TestCase
 {
     #[DataProvider('knownBotUserAgentsProvider')]

--- a/app/bundles/EmailBundle/Tests/Helper/BotRatioHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/BotRatioHelperTest.php
@@ -12,6 +12,7 @@ use Mautic\LeadBundle\Tracker\Factory\DeviceDetectorFactory\DeviceDetectorFactor
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class BotRatioHelperTest extends TestCase
 {
     /**

--- a/app/bundles/EmailBundle/Tests/Helper/EmailDefaultsHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/EmailDefaultsHelperTest.php
@@ -12,6 +12,7 @@ use Mautic\PageBundle\Entity\Page;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class EmailDefaultsHelperTest extends TestCase
 {
     private MockObject&CoreParametersHelper $coreParametersHelper;

--- a/app/bundles/EmailBundle/Tests/Helper/EmailValidatorTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/EmailValidatorTest.php
@@ -15,6 +15,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Validator\Exception\UnexpectedValueException;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class EmailValidatorTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/EmailBundle/Tests/Helper/FromEmailHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/FromEmailHelperTest.php
@@ -13,6 +13,7 @@ use Mautic\LeadBundle\Entity\LeadRepository;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class FromEmailHelperTest extends TestCase
 {
     /**

--- a/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/MailHelperTest.php
@@ -43,6 +43,7 @@ use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Twig\Environment;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class MailHelperTest extends TestCase
 {
     private const string MINIFY_HTML = '<!doctype html>

--- a/app/bundles/EmailBundle/Tests/Helper/PointEventHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/PointEventHelperTest.php
@@ -10,6 +10,7 @@ use Mautic\EmailBundle\Model\EmailModel;
 use Mautic\LeadBundle\Entity\Lead;
 use PHPUnit\Framework\MockObject\MockObject;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class PointEventHelperTest extends \PHPUnit\Framework\TestCase
 {
     public function testSendEmail(): void

--- a/app/bundles/EmailBundle/Tests/Model/EmailActionModelTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailActionModelTest.php
@@ -13,6 +13,7 @@ use Mautic\EmailBundle\Model\EmailModel;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class EmailActionModelTest extends TestCase
 {
     public const string NEW_CATEGORY_TITLE = 'New category';

--- a/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailModelTest.php
@@ -65,6 +65,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class EmailModelTest extends \PHPUnit\Framework\TestCase
 {
     public const string SEGMENT_A = 'segment A';

--- a/app/bundles/EmailBundle/Tests/Model/EmailStatModelTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/EmailStatModelTest.php
@@ -14,6 +14,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class EmailStatModelTest extends TestCase
 {
     public function testSave(): void

--- a/app/bundles/EmailBundle/Tests/Model/SendEmailToContactTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/SendEmailToContactTest.php
@@ -41,6 +41,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class SendEmailToContactTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/EmailBundle/Tests/Model/SendEmailToUserTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/SendEmailToUserTest.php
@@ -20,6 +20,7 @@ use Mautic\UserBundle\Entity\User;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class SendEmailToUserTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/EmailBundle/Tests/MonitoredEmail/FetcherTest.php
+++ b/app/bundles/EmailBundle/Tests/MonitoredEmail/FetcherTest.php
@@ -14,6 +14,7 @@ use PHPUnit\Framework\Attributes\TestDox;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 #[CoversClass(Fetcher::class)]
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class FetcherTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/EmailBundle/Tests/MonitoredEmail/MailboxTest.php
+++ b/app/bundles/EmailBundle/Tests/MonitoredEmail/MailboxTest.php
@@ -8,6 +8,7 @@ use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\PathsHelper;
 use Mautic\EmailBundle\MonitoredEmail\Mailbox;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class MailboxTest extends \PHPUnit\Framework\TestCase
 {
     public function testConstructWithDefaultConfig(): void

--- a/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/BounceTest.php
+++ b/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/BounceTest.php
@@ -20,6 +20,7 @@ use Monolog\Logger;
 use PHPUnit\Framework\Attributes\TestDox;
 use Symfony\Component\Mailer\Transport\NullTransport;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class BounceTest extends \PHPUnit\Framework\TestCase
 {
     #[TestDox('Test that the transport interface processes the message appropriately')]

--- a/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/FeedbackLoopTest.php
+++ b/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/FeedbackLoopTest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework\Attributes\TestDox;
 
 #[CoversClass(FeedbackLoop::class)]
 #[CoversClass(Result::class)]
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class FeedbackLoopTest extends \PHPUnit\Framework\TestCase
 {
     #[TestDox('Test that the message is processed appropriately')]

--- a/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/ReplyTest.php
+++ b/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/ReplyTest.php
@@ -26,6 +26,7 @@ use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ReplyTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/UnsubscribeTest.php
+++ b/app/bundles/EmailBundle/Tests/MonitoredEmail/Processor/UnsubscribeTest.php
@@ -18,6 +18,7 @@ use Monolog\Logger;
 use PHPUnit\Framework\Attributes\TestDox;
 use Symfony\Component\Mailer\Transport\NullTransport;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class UnsubscribeTest extends \PHPUnit\Framework\TestCase
 {
     #[TestDox('Test that the transport interface processes the message appropriately')]

--- a/app/bundles/EmailBundle/Tests/Stat/StatHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Stat/StatHelperTest.php
@@ -12,6 +12,7 @@ use Mautic\EmailBundle\Stat\Exception\StatNotFoundException;
 use Mautic\EmailBundle\Stat\StatHelper;
 use Mautic\LeadBundle\Entity\Lead;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class StatHelperTest extends \PHPUnit\Framework\TestCase
 {
     public function testStatsAreCreatedAndDeleted(): void

--- a/app/bundles/EmailBundle/Tests/Stats/SentHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Stats/SentHelperTest.php
@@ -20,6 +20,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class SentHelperTest extends TestCase
 {
     private DateTimeHelper $dateTimeHelper;

--- a/app/bundles/EmailBundle/Tests/Validator/ValidEmailLinksValidatorTest.php
+++ b/app/bundles/EmailBundle/Tests/Validator/ValidEmailLinksValidatorTest.php
@@ -14,6 +14,7 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ValidEmailLinksValidatorTest extends TestCase
 {
     private ExecutionContextInterface&\PHPUnit\Framework\MockObject\MockObject $context;

--- a/app/bundles/FormBundle/Tests/Controller/SubmissionFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/SubmissionFunctionalTest.php
@@ -26,6 +26,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 use Symfony\Component\PasswordHasher\PasswordHasherInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class SubmissionFunctionalTest extends MauticMysqlTestCase
 {
     use FormTestHelperTrait;

--- a/app/bundles/FormBundle/Tests/Entity/FieldTest.php
+++ b/app/bundles/FormBundle/Tests/Entity/FieldTest.php
@@ -11,6 +11,7 @@ use Mautic\LeadBundle\Entity\Lead;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\DataProvider;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class FieldTest extends \PHPUnit\Framework\TestCase
 {
     public function testShowForConditionalFieldWithNoParent(): void

--- a/app/bundles/FormBundle/Tests/EventListener/DetermineWinnerSubscriberTest.php
+++ b/app/bundles/FormBundle/Tests/EventListener/DetermineWinnerSubscriberTest.php
@@ -11,6 +11,7 @@ use Mautic\PageBundle\Entity\Page;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class DetermineWinnerSubscriberTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/FormBundle/Tests/EventListener/FormConditionalSubscriberTest.php
+++ b/app/bundles/FormBundle/Tests/EventListener/FormConditionalSubscriberTest.php
@@ -12,6 +12,7 @@ use Mautic\FormBundle\Model\FieldModel;
 use Mautic\FormBundle\Model\FormModel;
 use PHPUnit\Framework\MockObject\MockObject;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class FormConditionalSubscriberTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/FormBundle/Tests/EventListener/FormValidationSubscriberTest.php
+++ b/app/bundles/FormBundle/Tests/EventListener/FormValidationSubscriberTest.php
@@ -13,6 +13,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 #[CoversClass(FormValidationSubscriber::class)]
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class FormValidationSubscriberTest extends \PHPUnit\Framework\TestCase
 {
     private const string MINIMUM_TWO_OPTIONS_MESSAGE = 'You must select at least 2 options.';

--- a/app/bundles/FormBundle/Tests/EventListener/ReportSubscriberTest.php
+++ b/app/bundles/FormBundle/Tests/EventListener/ReportSubscriberTest.php
@@ -26,6 +26,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ReportSubscriberTest extends AbstractMauticTestCase
 {
     /**

--- a/app/bundles/FormBundle/Tests/EventListener/SubmissionSubscriberTest.php
+++ b/app/bundles/FormBundle/Tests/EventListener/SubmissionSubscriberTest.php
@@ -11,6 +11,7 @@ use Mautic\FormBundle\Entity\Submission;
 use Mautic\FormBundle\EventListener\SubmissionSubscriber;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class SubmissionSubscriberTest extends TestCase
 {
     public function testPostPersistIncrementsCount(): void

--- a/app/bundles/FormBundle/Tests/Form/Type/FormFieldConditionTypeTest.php
+++ b/app/bundles/FormBundle/Tests/Form/Type/FormFieldConditionTypeTest.php
@@ -13,6 +13,7 @@ use PHPUnit\Framework\MockObject\Rule\AnyInvokedCount;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class FormFieldConditionTypeTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/FormBundle/Tests/Helper/PropertiesAccessorTest.php
+++ b/app/bundles/FormBundle/Tests/Helper/PropertiesAccessorTest.php
@@ -8,6 +8,7 @@ use Mautic\FormBundle\Helper\PropertiesAccessor;
 use Mautic\FormBundle\Model\FormModel;
 use PHPUnit\Framework\MockObject\MockObject;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class PropertiesAccessorTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/FormBundle/Tests/Model/FieldModelTest.php
+++ b/app/bundles/FormBundle/Tests/Model/FieldModelTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class FieldModelTest extends TestCase
 {
     public function testGenerateAlias(): void

--- a/app/bundles/FormBundle/Tests/Model/FormModelTest.php
+++ b/app/bundles/FormBundle/Tests/Model/FormModelTest.php
@@ -36,6 +36,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Twig\Environment;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class FormModelTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/FormBundle/Tests/Model/SubmissionModelTest.php
+++ b/app/bundles/FormBundle/Tests/Model/SubmissionModelTest.php
@@ -52,6 +52,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Twig\Environment;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class SubmissionModelTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/FormBundle/Tests/Validator/Constraint/IsPostActionRedirectUrlValidatorTest.php
+++ b/app/bundles/FormBundle/Tests/Validator/Constraint/IsPostActionRedirectUrlValidatorTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 #[CoversClass(IsPostActionRedirectUrlValidator::class)]
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class IsPostActionRedirectUrlValidatorTest extends ConstraintValidatorTestCase
 {
     private ?MockObject $urlValidator = null;

--- a/app/bundles/InstallBundle/Tests/Command/InstallCommandTest.php
+++ b/app/bundles/InstallBundle/Tests/Command/InstallCommandTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Output\BufferedOutput;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class InstallCommandTest extends TestCase
 {
     /**

--- a/app/bundles/InstallBundle/Tests/Controller/InstallControllerTest.php
+++ b/app/bundles/InstallBundle/Tests/Controller/InstallControllerTest.php
@@ -26,6 +26,7 @@ use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\Router;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class InstallControllerTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/InstallBundle/Tests/Install/InstallServiceTest.php
+++ b/app/bundles/InstallBundle/Tests/Install/InstallServiceTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class InstallServiceTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Auth/Support/Oauth2/Token/TokenPersistenceTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Auth/Support/Oauth2/Token/TokenPersistenceTest.php
@@ -15,6 +15,7 @@ use Mautic\PluginBundle\Entity\Integration;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class TokenPersistenceTest extends TestCase
 {
     /**

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Command/SyncCommandTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Command/SyncCommandTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Tester\CommandTester;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class SyncCommandTest extends TestCase
 {
     private const string INTEGRATION_NAME = 'Test';

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Entity/FieldChangeRepositoryTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Entity/FieldChangeRepositoryTest.php
@@ -11,6 +11,7 @@ use Mautic\IntegrationsBundle\Entity\FieldChangeRepository;
 use Mautic\LeadBundle\Entity\Company;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class FieldChangeRepositoryTest extends TestCase
 {
     use RepositoryConfiguratorTrait;

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Entity/ObjectMappingRepositoryTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Entity/ObjectMappingRepositoryTest.php
@@ -15,6 +15,7 @@ use Mautic\IntegrationsBundle\Entity\ObjectMappingRepository;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ObjectMappingRepositoryTest extends TestCase
 {
     use RepositoryConfiguratorTrait;

--- a/app/bundles/IntegrationsBundle/Tests/Unit/EventListener/CompanyObjectSubscriberTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/EventListener/CompanyObjectSubscriberTest.php
@@ -25,6 +25,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Routing\Router;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class CompanyObjectSubscriberTest extends TestCase
 {
     /**

--- a/app/bundles/IntegrationsBundle/Tests/Unit/EventListener/ContactObjectSubscriberTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/EventListener/ContactObjectSubscriberTest.php
@@ -25,6 +25,7 @@ use Mautic\LeadBundle\Exception\ImportFailedException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Routing\Router;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ContactObjectSubscriberTest extends TestCase
 {
     /**

--- a/app/bundles/IntegrationsBundle/Tests/Unit/EventListener/LeadSubscriberTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/EventListener/LeadSubscriberTest.php
@@ -24,6 +24,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class LeadSubscriberTest extends TestCase
 {
     /**

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Form/Type/IntegrationSyncSettingsObjectFieldTypeTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Form/Type/IntegrationSyncSettingsObjectFieldTypeTest.php
@@ -12,6 +12,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class IntegrationSyncSettingsObjectFieldTypeTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Helper/FieldFilterHelperTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Helper/FieldFilterHelperTest.php
@@ -10,6 +10,7 @@ use Mautic\IntegrationsBundle\Mapping\MappedFieldInfoInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class FieldFilterHelperTest extends TestCase
 {
     public function testFieldsFilteredByPage(): void

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Helper/FieldMergerHelperTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Helper/FieldMergerHelperTest.php
@@ -12,6 +12,7 @@ use Mautic\IntegrationsBundle\Sync\DAO\Mapping\ObjectMappingDAO;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class FieldMergerHelperTest extends TestCase
 {
     public function testNonExistingFieldsAreRemoved(): void

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/Helper/MappingHelperTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/Helper/MappingHelperTest.php
@@ -23,6 +23,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class MappingHelperTest extends TestCase
 {
     /**

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/Helper/SyncDateHelperTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/Helper/SyncDateHelperTest.php
@@ -7,6 +7,7 @@ namespace Mautic\IntegrationsBundle\Tests\Unit\Sync\Helper;
 use Mautic\IntegrationsBundle\Sync\Helper\SyncDateHelper;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class SyncDateHelperTest extends TestCase
 {
     /**

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/Notification/Helper/OwnerProviderTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/Notification/Helper/OwnerProviderTest.php
@@ -14,6 +14,7 @@ use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\ObjectProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class OwnerProviderTest extends TestCase
 {
     /**

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Helper/FieldHelperTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Helper/FieldHelperTest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class FieldHelperTest extends TestCase
 {
     /**

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/Executioner/OrderExecutionerTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/Executioner/OrderExecutionerTest.php
@@ -24,6 +24,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class OrderExecutionerTest extends TestCase
 {
     private const string INTEGRATION_NAME = 'Test';

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/Executioner/ReferenceResolverTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/Executioner/ReferenceResolverTest.php
@@ -15,6 +15,7 @@ use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\Executioner\Referen
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ReferenceResolverTest extends TestCase
 {
     /**

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ObjectHelper/CompanyObjectHelperTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ObjectHelper/CompanyObjectHelperTest.php
@@ -18,6 +18,7 @@ use Mautic\LeadBundle\Model\CompanyModel;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class CompanyObjectHelperTest extends TestCase
 {
     /**

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ObjectHelper/ContactObjectHelperTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ObjectHelper/ContactObjectHelperTest.php
@@ -23,6 +23,7 @@ use Mautic\LeadBundle\Model\LeadModel;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ContactObjectHelperTest extends TestCase
 {
     /**

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ReportBuilder/FieldBuilderTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ReportBuilder/FieldBuilderTest.php
@@ -14,6 +14,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\Router;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class FieldBuilderTest extends TestCase
 {
     /**

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ReportBuilder/PartialObjectReportBuilderTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ReportBuilder/PartialObjectReportBuilderTest.php
@@ -28,6 +28,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class PartialObjectReportBuilderTest extends TestCase
 {
     private const string INTEGRATION_NAME = 'Test';

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/MauticSyncDataExchangeTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/MauticSyncDataExchangeTest.php
@@ -22,6 +22,7 @@ use Mautic\LeadBundle\Entity\Lead;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class MauticSyncDataExchangeTest extends TestCase
 {
     /**

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncProcess/Direction/Integration/IntegrationSyncProcessTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncProcess/Direction/Integration/IntegrationSyncProcessTest.php
@@ -25,6 +25,7 @@ use Mautic\IntegrationsBundle\Sync\SyncProcess\Direction\Integration\Integration
 use Mautic\IntegrationsBundle\Sync\SyncProcess\Direction\Integration\ObjectChangeGenerator;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class IntegrationSyncProcessTest extends TestCase
 {
     private const string INTEGRATION_NAME = 'Test';

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncProcess/Direction/Integration/ObjectChangeGeneratorTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncProcess/Direction/Integration/ObjectChangeGeneratorTest.php
@@ -16,6 +16,7 @@ use Mautic\IntegrationsBundle\Sync\SyncProcess\Direction\Helper\ValueHelper;
 use Mautic\IntegrationsBundle\Sync\SyncProcess\Direction\Integration\ObjectChangeGenerator;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ObjectChangeGeneratorTest extends TestCase
 {
     /**

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncProcess/Direction/Internal/MauticSyncProcessTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncProcess/Direction/Internal/MauticSyncProcessTest.php
@@ -27,6 +27,7 @@ use Mautic\IntegrationsBundle\Sync\SyncProcess\Direction\Internal\ObjectChangeGe
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class MauticSyncProcessTest extends TestCase
 {
     private const string INTEGRATION_NAME = 'Test';

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncProcess/Direction/Internal/ObjectChangeGeneratorTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncProcess/Direction/Internal/ObjectChangeGeneratorTest.php
@@ -23,6 +23,7 @@ use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ObjectChangeGeneratorTest extends TestCase
 {
     /**

--- a/app/bundles/LeadBundle/Tests/Command/ContactScheduledExportCommandTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/ContactScheduledExportCommandTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ContactScheduledExportCommandTest extends TestCase
 {
     public function testForSignalCaughtException(): void

--- a/app/bundles/LeadBundle/Tests/Command/ImportCommandTest.php
+++ b/app/bundles/LeadBundle/Tests/Command/ImportCommandTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ImportCommandTest extends TestCase
 {
     public function testExecuteFailsIfModifiedByIsNotSet(): void

--- a/app/bundles/LeadBundle/Tests/Controller/Api/CustomFieldsApiControllerTraitTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/CustomFieldsApiControllerTraitTest.php
@@ -11,6 +11,7 @@ use Mautic\LeadBundle\Model\FieldModel;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\Form\Form;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class CustomFieldsApiControllerTraitTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetEntityFormOptions(): void

--- a/app/bundles/LeadBundle/Tests/Controller/Api/FieldApiControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/FieldApiControllerTest.php
@@ -21,6 +21,7 @@ use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class FieldApiControllerTest extends TestCase
 {
     /**

--- a/app/bundles/LeadBundle/Tests/Deduplicate/CompanyDeduperTest.php
+++ b/app/bundles/LeadBundle/Tests/Deduplicate/CompanyDeduperTest.php
@@ -11,6 +11,7 @@ use Mautic\LeadBundle\Field\FieldList;
 use Mautic\LeadBundle\Field\FieldsWithUniqueIdentifier;
 use PHPUnit\Framework\MockObject\MockObject;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class CompanyDeduperTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/LeadBundle/Tests/Deduplicate/ContactMergerTest.php
+++ b/app/bundles/LeadBundle/Tests/Deduplicate/ContactMergerTest.php
@@ -21,6 +21,7 @@ use Mautic\UserBundle\Entity\User;
 use Monolog\Logger;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ContactMergerTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/LeadBundle/Tests/Entity/CustomFieldRepositoryTraitTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/CustomFieldRepositoryTraitTest.php
@@ -8,6 +8,7 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Tests\StandardImportTestHelper;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class CustomFieldRepositoryTraitTest extends StandardImportTestHelper
 {
     /**

--- a/app/bundles/LeadBundle/Tests/Entity/ImportTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/ImportTest.php
@@ -7,6 +7,7 @@ namespace Mautic\LeadBundle\Tests\Entity;
 use Mautic\LeadBundle\Entity\Import;
 use Mautic\LeadBundle\Tests\StandardImportTestHelper;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ImportTest extends StandardImportTestHelper
 {
     public function testSetPath(): void

--- a/app/bundles/LeadBundle/Tests/Entity/LeadFieldRepositoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadFieldRepositoryTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class LeadFieldRepositoryTest extends TestCase
 {
     use RepositoryConfiguratorTrait;

--- a/app/bundles/LeadBundle/Tests/Entity/LeadListRepositoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadListRepositoryTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\InvalidArgumentException;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class LeadListRepositoryTest extends TestCase
 {
     use RepositoryConfiguratorTrait;

--- a/app/bundles/LeadBundle/Tests/Entity/LeadRepositoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadRepositoryTest.php
@@ -14,6 +14,7 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadRepository;
 use PHPUnit\Framework\MockObject\MockObject;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class LeadRepositoryTest extends \PHPUnit\Framework\TestCase
 {
     use RepositoryConfiguratorTrait;

--- a/app/bundles/LeadBundle/Tests/Entity/TagRepositoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/TagRepositoryTest.php
@@ -8,6 +8,7 @@ use Mautic\CoreBundle\Test\Doctrine\RepositoryConfiguratorTrait;
 use Mautic\LeadBundle\Entity\Tag;
 use Mautic\LeadBundle\Entity\TagRepository;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class TagRepositoryTest extends \PHPUnit\Framework\TestCase
 {
     use RepositoryConfiguratorTrait;

--- a/app/bundles/LeadBundle/Tests/Entity/TimelineTraitTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/TimelineTraitTest.php
@@ -10,6 +10,7 @@ use Mautic\LeadBundle\Entity\UtmTagRepository;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class TimelineTraitTest extends TestCase
 {
     private UtmTagRepository&MockObject $repository;

--- a/app/bundles/LeadBundle/Tests/Event/SegmentOperatorQueryBuilderEventTest.php
+++ b/app/bundles/LeadBundle/Tests/Event/SegmentOperatorQueryBuilderEventTest.php
@@ -9,6 +9,7 @@ use Mautic\LeadBundle\Segment\ContactSegmentFilter;
 use Mautic\LeadBundle\Segment\Query\QueryBuilder;
 use PHPUnit\Framework\MockObject\MockObject;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class SegmentOperatorQueryBuilderEventTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberTest.php
@@ -31,6 +31,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class CampaignSubscriberTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/LeadBundle/Tests/EventListener/ConfigSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/ConfigSubscriberTest.php
@@ -14,6 +14,7 @@ use Mautic\LeadBundle\Form\Type\SegmentConfigType;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ConfigSubscriberTest extends TestCase
 {
     private ConfigSubscriber $configSubscriber;

--- a/app/bundles/LeadBundle/Tests/EventListener/DoNotContactSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/DoNotContactSubscriberTest.php
@@ -10,6 +10,7 @@ use Mautic\LeadBundle\Event\DoNotContactRemoveEvent;
 use Mautic\LeadBundle\EventListener\DoNotContactSubscriber;
 use Mautic\LeadBundle\Model\DoNotContact;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class DoNotContactSubscriberTest extends \PHPUnit\Framework\TestCase
 {
     private DoNotContactSubscriber $doNotContactSubscriber;

--- a/app/bundles/LeadBundle/Tests/EventListener/DynamicContentSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/DynamicContentSubscriberTest.php
@@ -13,6 +13,7 @@ use Mautic\LeadBundle\Segment\OperatorOptions;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class DynamicContentSubscriberTest extends TestCase
 {
     /**

--- a/app/bundles/LeadBundle/Tests/EventListener/FilterOperatorSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/FilterOperatorSubscriberTest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class FilterOperatorSubscriberTest extends TestCase
 {
     /**

--- a/app/bundles/LeadBundle/Tests/EventListener/FormSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/FormSubscriberTest.php
@@ -22,6 +22,7 @@ use Mautic\PointBundle\Model\PointGroupModel;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\HttpFoundation\Request;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class FormSubscriberTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/LeadBundle/Tests/EventListener/GeneratedColumnSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/GeneratedColumnSubscriberTest.php
@@ -14,6 +14,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class GeneratedColumnSubscriberTest extends TestCase
 {
     /**

--- a/app/bundles/LeadBundle/Tests/EventListener/ImportContactSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/ImportContactSubscriberTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\Form\Form;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ImportContactSubscriberTest extends \PHPUnit\Framework\TestCase
 {
     public function testHandleValidateTags(): void

--- a/app/bundles/LeadBundle/Tests/EventListener/LeadSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/LeadSubscriberTest.php
@@ -33,6 +33,7 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class LeadSubscriberTest extends CommonMocks
 {
     /**

--- a/app/bundles/LeadBundle/Tests/EventListener/OwnerSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/OwnerSubscriberTest.php
@@ -37,6 +37,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class OwnerSubscriberTest extends TestCase
 {
     /**

--- a/app/bundles/LeadBundle/Tests/EventListener/PointSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/PointSubscriberTest.php
@@ -13,6 +13,7 @@ use Mautic\PointBundle\Event\TriggerExecutedEvent;
 use Mautic\PointBundle\PointEvents;
 use PHPUnit\Framework\MockObject\MockObject;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class PointSubscriberTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/LeadBundle/Tests/EventListener/ReportSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/ReportSubscriberTest.php
@@ -33,6 +33,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\MockObject\Rule\AnyInvokedCount;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ReportSubscriberTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/LeadBundle/Tests/EventListener/SearchSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/SearchSubscriberTest.php
@@ -23,6 +23,7 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class SearchSubscriberTest extends TestCase
 {
     use MockedConnectionTrait;

--- a/app/bundles/LeadBundle/Tests/EventListener/SegmentLogReportSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/SegmentLogReportSubscriberTest.php
@@ -13,6 +13,7 @@ use Mautic\ReportBundle\Event\ReportBuilderEvent;
 use Mautic\ReportBundle\Event\ReportGeneratorEvent;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class SegmentLogReportSubscriberTest extends TestCase
 {
     /**

--- a/app/bundles/LeadBundle/Tests/EventListener/SegmentOperatorQuerySubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/SegmentOperatorQuerySubscriberTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class SegmentOperatorQuerySubscriberTest extends TestCase
 {
     /**

--- a/app/bundles/LeadBundle/Tests/EventListener/SegmentSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/SegmentSubscriberTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class SegmentSubscriberTest extends TestCase
 {
     /**

--- a/app/bundles/LeadBundle/Tests/EventListener/TypeOperatorSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/TypeOperatorSubscriberTest.php
@@ -25,6 +25,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class TypeOperatorSubscriberTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/LeadBundle/Tests/EventListener/WebhookSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/WebhookSubscriberTest.php
@@ -20,6 +20,7 @@ use Mautic\WebhookBundle\Model\WebhookModel;
 use PHPUnit\Framework\Attributes\TestDox;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class WebhookSubscriberTest extends \PHPUnit\Framework\TestCase
 {
     private \Symfony\Component\EventDispatcher\EventDispatcherInterface $dispatcher;

--- a/app/bundles/LeadBundle/Tests/Field/BackgroundServiceTest.php
+++ b/app/bundles/LeadBundle/Tests/Field/BackgroundServiceTest.php
@@ -19,6 +19,7 @@ use Mautic\LeadBundle\Field\Notification\CustomFieldNotification;
 use Mautic\LeadBundle\Model\FieldModel;
 use PHPUnit\Framework\MockObject\MockObject;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class BackgroundServiceTest extends \PHPUnit\Framework\TestCase
 {
     private BackgroundService $backgroundService;

--- a/app/bundles/LeadBundle/Tests/Field/CustomFieldColumnTest.php
+++ b/app/bundles/LeadBundle/Tests/Field/CustomFieldColumnTest.php
@@ -20,6 +20,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class CustomFieldColumnTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/LeadBundle/Tests/Field/LeadFieldDeleterTest.php
+++ b/app/bundles/LeadBundle/Tests/Field/LeadFieldDeleterTest.php
@@ -14,6 +14,7 @@ use Mautic\LeadBundle\Field\Settings\BackgroundSettings;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class LeadFieldDeleterTest extends TestCase
 {
     private MockObject&LeadFieldRepository $leadFieldRepositoryMock;

--- a/app/bundles/LeadBundle/Tests/Form/DataTransformer/FieldFilterTransformerTest.php
+++ b/app/bundles/LeadBundle/Tests/Form/DataTransformer/FieldFilterTransformerTest.php
@@ -9,6 +9,7 @@ use Mautic\LeadBundle\Segment\RelativeDate;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class FieldFilterTransformerTest extends \PHPUnit\Framework\TestCase
 {
     private FieldFilterTransformer $transformer;

--- a/app/bundles/LeadBundle/Tests/Form/Type/CampaignEventLeadStagesTypeTest.php
+++ b/app/bundles/LeadBundle/Tests/Form/Type/CampaignEventLeadStagesTypeTest.php
@@ -10,6 +10,7 @@ use Mautic\StageBundle\Form\Type\StageListType;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Form\FormBuilderInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class CampaignEventLeadStagesTypeTest extends AbstractMauticTestCase
 {
     private CampaignEventLeadStagesType $campaignEventLeadStagesType;

--- a/app/bundles/LeadBundle/Tests/Form/Type/SegmentConfigTypeTest.php
+++ b/app/bundles/LeadBundle/Tests/Form/Type/SegmentConfigTypeTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\FormBuilderInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class SegmentConfigTypeTest extends TestCase
 {
     private SegmentConfigType $segmentConfigType;

--- a/app/bundles/LeadBundle/Tests/Form/Validator/Constraints/FieldAliasKeywordValidatorTest.php
+++ b/app/bundles/LeadBundle/Tests/Form/Validator/Constraints/FieldAliasKeywordValidatorTest.php
@@ -15,6 +15,7 @@ use Mautic\LeadBundle\Services\ContactSegmentFilterDictionary;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class FieldAliasKeywordValidatorTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/LeadBundle/Tests/Helper/AvatarHelperTest.php
+++ b/app/bundles/LeadBundle/Tests/Helper/AvatarHelperTest.php
@@ -20,6 +20,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Asset\Packages;
 use Symfony\Component\HttpFoundation\RequestStack;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class AvatarHelperTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/LeadBundle/Tests/Helper/ContactRequestHelperTest.php
+++ b/app/bundles/LeadBundle/Tests/Helper/ContactRequestHelperTest.php
@@ -22,6 +22,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\RequestStack;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ContactRequestHelperTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/LeadBundle/Tests/Helper/CustomFieldHelperTest.php
+++ b/app/bundles/LeadBundle/Tests/Helper/CustomFieldHelperTest.php
@@ -8,6 +8,7 @@ use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\LeadBundle\Helper\CustomFieldHelper;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class CustomFieldHelperTest extends TestCase
 {
     public function testFixValueTypeForBooleans(): void

--- a/app/bundles/LeadBundle/Tests/Helper/FieldAliasHelperTest.php
+++ b/app/bundles/LeadBundle/Tests/Helper/FieldAliasHelperTest.php
@@ -9,6 +9,7 @@ use Mautic\LeadBundle\Entity\LeadFieldRepository;
 use Mautic\LeadBundle\Helper\FieldAliasHelper;
 use Mautic\LeadBundle\Model\FieldModel;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class FieldAliasHelperTest extends \PHPUnit\Framework\TestCase
 {
     private FieldAliasHelper $helper;

--- a/app/bundles/LeadBundle/Tests/Helper/SegmentCountCacheHelperTest.php
+++ b/app/bundles/LeadBundle/Tests/Helper/SegmentCountCacheHelperTest.php
@@ -13,6 +13,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\CacheItem;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class SegmentCountCacheHelperTest extends TestCase
 {
     private MockObject&CacheProviderInterface $cacheProviderMock;

--- a/app/bundles/LeadBundle/Tests/Helper/TokenHelperTest.php
+++ b/app/bundles/LeadBundle/Tests/Helper/TokenHelperTest.php
@@ -10,6 +10,7 @@ use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Helper\TokenHelper;
 use PHPUnit\Framework\Attributes\DataProvider;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class TokenHelperTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/LeadBundle/Tests/Model/CompanyModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/CompanyModelTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\MockObject\MockObject;
 
 #[CoversClass(AbstractFormFieldHelper::class)]
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class CompanyModelTest extends \PHPUnit\Framework\TestCase
 {
     #[TestDox('Ensure that an array value is flattened before saving')]

--- a/app/bundles/LeadBundle/Tests/Model/CompanyReportDataTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/CompanyReportDataTest.php
@@ -12,6 +12,7 @@ use Mautic\ReportBundle\Event\ReportGeneratorEvent;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(CompanyReportData::class)]
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class CompanyReportDataTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/LeadBundle/Tests/Model/ImportModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/ImportModelTest.php
@@ -27,6 +27,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ImportModelTest extends StandardImportTestHelper
 {
     public function testInitEventLog(): void

--- a/app/bundles/LeadBundle/Tests/Model/LeadListModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/LeadListModelTest.php
@@ -10,6 +10,7 @@ use Mautic\LeadBundle\Model\ListModel;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class LeadListModelTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/LeadBundle/Tests/Model/LeadModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/LeadModelTest.php
@@ -66,6 +66,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\EventDispatcher\Event;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class LeadModelTest extends \PHPUnit\Framework\TestCase
 {
     private MockObject|RequestStack $requestStack;

--- a/app/bundles/LeadBundle/Tests/Model/ListModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/ListModelTest.php
@@ -28,6 +28,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ListModelTest extends TestCase
 {
     private ?MockObject $fixture = null;

--- a/app/bundles/LeadBundle/Tests/Notification/ContactExportAdminNotificationTest.php
+++ b/app/bundles/LeadBundle/Tests/Notification/ContactExportAdminNotificationTest.php
@@ -16,6 +16,7 @@ use Mautic\UserBundle\Entity\UserRepository;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ContactExportAdminNotificationTest extends TestCase
 {
     public function testRequestedNotifiesOtherPublishedAdmins(): void

--- a/app/bundles/LeadBundle/Tests/Provider/TypeOperatorProviderTest.php
+++ b/app/bundles/LeadBundle/Tests/Provider/TypeOperatorProviderTest.php
@@ -13,6 +13,7 @@ use Mautic\LeadBundle\Segment\OperatorOptions;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class TypeOperatorProviderTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/LeadBundle/Tests/Segment/ContactSegmentFilterTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/ContactSegmentFilterTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ContactSegmentFilterTest extends TestCase
 {
     private ContactSegmentFilterCrate $contactSegmentFilterCrate;

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/DateOptionFactoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/Date/DateOptionFactoryTest.php
@@ -29,6 +29,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 #[CoversClass(DateOptionFactory::class)]
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class DateOptionFactoryTest extends \PHPUnit\Framework\TestCase
 {
     public function testBirthday(): void

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/DecoratorFactoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/DecoratorFactoryTest.php
@@ -17,6 +17,7 @@ use Mautic\LeadBundle\Services\ContactSegmentFilterDictionary;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class DecoratorFactoryTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/LeadBundle/Tests/Segment/Query/ContactSegmentQueryBuilderTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Query/ContactSegmentQueryBuilderTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ContactSegmentQueryBuilderTest extends TestCase
 {
     use MockedConnectionTrait;

--- a/app/bundles/LeadBundle/Tests/Segment/Query/Filter/ChannelClickQueryBuilderTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Query/Filter/ChannelClickQueryBuilderTest.php
@@ -22,6 +22,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ChannelClickQueryBuilderTest extends TestCase
 {
     use MockedConnectionTrait;

--- a/app/bundles/LeadBundle/Tests/Segment/Query/Filter/DoNotContactFilterQueryBuilderTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Query/Filter/DoNotContactFilterQueryBuilderTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class DoNotContactFilterQueryBuilderTest extends TestCase
 {
     use MockedConnectionTrait;

--- a/app/bundles/LeadBundle/Tests/Segment/Query/Filter/ForeignValueFilterQueryBuilderTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Query/Filter/ForeignValueFilterQueryBuilderTest.php
@@ -23,6 +23,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ForeignValueFilterQueryBuilderTest extends TestCase
 {
     use MockedConnectionTrait;

--- a/app/bundles/LeadBundle/Tests/Services/PeakInteractionTimerTest.php
+++ b/app/bundles/LeadBundle/Tests/Services/PeakInteractionTimerTest.php
@@ -31,6 +31,7 @@ final class TestablePeakInteractionTimer extends PeakInteractionTimer
     }
 }
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class PeakInteractionTimerTest extends TestCase
 {
     private MockObject&CoreParametersHelper $coreParametersHelperMock;

--- a/app/bundles/LeadBundle/Tests/Tracker/ContactTrackerTest.php
+++ b/app/bundles/LeadBundle/Tests/Tracker/ContactTrackerTest.php
@@ -23,6 +23,7 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ContactTrackerTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/LeadBundle/Tests/Tracker/Service/ContactTrackingService/ContactTrackingServiceTest.php
+++ b/app/bundles/LeadBundle/Tests/Tracker/Service/ContactTrackingService/ContactTrackingServiceTest.php
@@ -14,6 +14,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ContactTrackingServiceTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/LeadBundle/Tests/Tracker/Service/DeviceTrackingService/DeviceTrackingServiceTest.php
+++ b/app/bundles/LeadBundle/Tests/Tracker/Service/DeviceTrackingService/DeviceTrackingServiceTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\MockObject\Rule\AnyInvokedCount;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class DeviceTrackingServiceTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/LeadBundle/Tests/Twig/DncReasonHelperTest.php
+++ b/app/bundles/LeadBundle/Tests/Twig/DncReasonHelperTest.php
@@ -9,6 +9,7 @@ use Mautic\LeadBundle\Exception\UnknownDncReasonException;
 use Mautic\LeadBundle\Twig\Helper\DncReasonHelper;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class DncReasonHelperTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/LeadBundle/Tests/Unit/Services/CompanyColumnsDictionaryTest.php
+++ b/app/bundles/LeadBundle/Tests/Unit/Services/CompanyColumnsDictionaryTest.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class CompanyColumnsDictionaryTest extends TestCase
 {
     private CoreParametersHelper&MockObject $coreParametersHelper;

--- a/app/bundles/MarketplaceBundle/Tests/Functional/Command/InstallCommandTest.php
+++ b/app/bundles/MarketplaceBundle/Tests/Functional/Command/InstallCommandTest.php
@@ -13,6 +13,7 @@ use Mautic\MarketplaceBundle\Exception\ApiException;
 use Mautic\MarketplaceBundle\Model\PackageModel;
 use PHPUnit\Framework\MockObject\MockObject;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class InstallCommandTest extends AbstractMauticTestCase
 {
     /**

--- a/app/bundles/MarketplaceBundle/Tests/Functional/Command/ListCommandTest.php
+++ b/app/bundles/MarketplaceBundle/Tests/Functional/Command/ListCommandTest.php
@@ -12,6 +12,7 @@ use Mautic\MarketplaceBundle\Service\Allowlist;
 use Mautic\MarketplaceBundle\Service\PluginCollector;
 use PHPUnit\Framework\Exception;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ListCommandTest extends AbstractMauticTestCase
 {
     public function testCommand(): void

--- a/app/bundles/MarketplaceBundle/Tests/Functional/Command/RemoveCommandTest.php
+++ b/app/bundles/MarketplaceBundle/Tests/Functional/Command/RemoveCommandTest.php
@@ -10,6 +10,7 @@ use Mautic\MarketplaceBundle\Command\RemoveCommand;
 use Mautic\MarketplaceBundle\DTO\ConsoleOutput;
 use Psr\Log\LoggerInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class RemoveCommandTest extends AbstractMauticTestCase
 {
     private string $packageName;

--- a/app/bundles/MarketplaceBundle/Tests/Functional/Controller/AjaxControllerTest.php
+++ b/app/bundles/MarketplaceBundle/Tests/Functional/Controller/AjaxControllerTest.php
@@ -25,6 +25,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class AjaxControllerTest extends AbstractMauticTestCase
 {
     /**

--- a/app/bundles/MessengerBundle/Tests/MessageHandler/EmailHitNotificationHandlerTest.php
+++ b/app/bundles/MessengerBundle/Tests/MessageHandler/EmailHitNotificationHandlerTest.php
@@ -14,6 +14,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Messenger\Exception\RecoverableMessageHandlingException;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class EmailHitNotificationHandlerTest extends TestCase
 {
     public function testInvoke(): void

--- a/app/bundles/PageBundle/Tests/Controller/PageDraftFunctionalTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PageDraftFunctionalTest.php
@@ -9,6 +9,7 @@ use Mautic\PageBundle\Entity\Page;
 use Mautic\PageBundle\Entity\PageDraft;
 use Symfony\Component\HttpFoundation\Request;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class PageDraftFunctionalTest extends MauticMysqlTestCase
 {
     protected function setUp(): void

--- a/app/bundles/PageBundle/Tests/Controller/PreviewFunctionalTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PreviewFunctionalTest.php
@@ -13,6 +13,7 @@ use Mautic\UserBundle\Entity\User;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class PreviewFunctionalTest extends MauticMysqlTestCase
 {
     public function testPreviewPageWithContact(): void

--- a/app/bundles/PageBundle/Tests/Controller/PublicControllerTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PublicControllerTest.php
@@ -49,6 +49,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\RouterInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class PublicControllerTest extends TestCase
 {
     private MockObject&Container $internalContainer;

--- a/app/bundles/PageBundle/Tests/Entity/PageRepositoryTest.php
+++ b/app/bundles/PageBundle/Tests/Entity/PageRepositoryTest.php
@@ -12,6 +12,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class PageRepositoryTest extends TestCase
 {
     use RepositoryConfiguratorTrait;

--- a/app/bundles/PageBundle/Tests/EventListener/DetermineWinnerSubscriberTest.php
+++ b/app/bundles/PageBundle/Tests/EventListener/DetermineWinnerSubscriberTest.php
@@ -13,6 +13,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class DetermineWinnerSubscriberTest extends TestCase
 {
     /**

--- a/app/bundles/PageBundle/Tests/EventListener/ReportSubscriberTest.php
+++ b/app/bundles/PageBundle/Tests/EventListener/ReportSubscriberTest.php
@@ -19,6 +19,7 @@ use Mautic\ReportBundle\Event\ReportGraphEvent;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ReportSubscriberTest extends TestCase
 {
     /**

--- a/app/bundles/PageBundle/Tests/Form/Type/PageListTypeTest.php
+++ b/app/bundles/PageBundle/Tests/Form/Type/PageListTypeTest.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class PageListTypeTest extends TestCase
 {
     private PageListType $page;

--- a/app/bundles/PageBundle/Tests/Functional/Controller/ThemeHelperSandboxTest.php
+++ b/app/bundles/PageBundle/Tests/Functional/Controller/ThemeHelperSandboxTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\HttpFoundation\Request;
  * - configGetParameter() for credential/secret leakage
  * - source() for arbitrary file read
  */
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ThemeHelperSandboxTest extends MauticMysqlTestCase
 {
     private string $themesDir;

--- a/app/bundles/PageBundle/Tests/Helper/PointActionHelperTest.php
+++ b/app/bundles/PageBundle/Tests/Helper/PointActionHelperTest.php
@@ -12,6 +12,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class PointActionHelperTest extends TestCase
 {
     /**

--- a/app/bundles/PageBundle/Tests/Model/PageModelTest.php
+++ b/app/bundles/PageBundle/Tests/Model/PageModelTest.php
@@ -13,6 +13,7 @@ use Mautic\PageBundle\Entity\Redirect;
 use Mautic\PageBundle\Tests\PageTestAbstract;
 use Symfony\Component\HttpFoundation\Request;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class PageModelTest extends PageTestAbstract
 {
     public function testUtf8CharsInTitleWithTransletirationEnabled(): void

--- a/app/bundles/PageBundle/Tests/Model/RedirectModelTest.php
+++ b/app/bundles/PageBundle/Tests/Model/RedirectModelTest.php
@@ -20,6 +20,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Routing\Router;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class RedirectModelTest extends PageTestAbstract
 {
     public function testCreateRedirectEntityWhenCalledReturnsRedirect(): void

--- a/app/bundles/PageBundle/Tests/Model/TrackableModelTest.php
+++ b/app/bundles/PageBundle/Tests/Model/TrackableModelTest.php
@@ -26,6 +26,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 #[CoversClass(TrackableModel::class)]
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class TrackableModelTest extends TestCase
 {
     #[TestDox('Test that content is detected as HTML')]

--- a/app/bundles/PageBundle/Tests/Model/Tracking404ModelTest.php
+++ b/app/bundles/PageBundle/Tests/Model/Tracking404ModelTest.php
@@ -10,6 +10,7 @@ use Mautic\LeadBundle\Tracker\ContactTracker;
 use Mautic\PageBundle\Model\PageModel;
 use Mautic\PageBundle\Model\Tracking404Model;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class Tracking404ModelTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/PageBundle/Tests/Validator/PageHitValidatorTest.php
+++ b/app/bundles/PageBundle/Tests/Validator/PageHitValidatorTest.php
@@ -15,6 +15,7 @@ use Symfony\Component\Validator\Context\ExecutionContext;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 use Symfony\Component\Validator\Violation\ConstraintViolationBuilder;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class PageHitValidatorTest extends TestCase
 {
     private MockObject&CoreParametersHelper $coreParametersHelperMock;

--- a/app/bundles/PluginBundle/Tests/ConfigFormTest.php
+++ b/app/bundles/PluginBundle/Tests/ConfigFormTest.php
@@ -20,6 +20,7 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Twig\Environment;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ConfigFormTest extends KernelTestCase
 {
     protected function setUp(): void

--- a/app/bundles/PluginBundle/Tests/EventListener/CampaignSubscriberTest.php
+++ b/app/bundles/PluginBundle/Tests/EventListener/CampaignSubscriberTest.php
@@ -15,6 +15,7 @@ use Mautic\PluginBundle\EventListener\CampaignSubscriber;
 use Mautic\PluginBundle\Helper\IntegrationHelper;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class CampaignSubscriberTest extends TestCase
 {
     public function testActionPassesLogWhenNoIntegrationRejects(): void

--- a/app/bundles/PluginBundle/Tests/EventListener/IntegrationSubscriberTest.php
+++ b/app/bundles/PluginBundle/Tests/EventListener/IntegrationSubscriberTest.php
@@ -9,6 +9,7 @@ use Mautic\PluginBundle\EventListener\IntegrationSubscriber;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class IntegrationSubscriberTest extends TestCase
 {
     public function testOnRequestLogging(): void

--- a/app/bundles/PluginBundle/Tests/Form/Type/IntegrationsListTypeTest.php
+++ b/app/bundles/PluginBundle/Tests/Form/Type/IntegrationsListTypeTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class IntegrationsListTypeTest extends TestCase
 {
     public function testDataDoesNotHaveIntegration(): void

--- a/app/bundles/PluginBundle/Tests/Helper/ReloadHelperTest.php
+++ b/app/bundles/PluginBundle/Tests/Helper/ReloadHelperTest.php
@@ -14,6 +14,7 @@ use Mautic\PluginBundle\PluginEvents;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ReloadHelperTest extends \PHPUnit\Framework\TestCase
 {
     private ReloadHelper $helper;

--- a/app/bundles/PluginBundle/Tests/Integration/AbstractIntegrationTest.php
+++ b/app/bundles/PluginBundle/Tests/Integration/AbstractIntegrationTest.php
@@ -13,6 +13,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Http\Message\ResponseInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class AbstractIntegrationTest extends AbstractIntegrationTestCase
 {
     public function testPopulatedLeadDataReturnsIntAndNotDncEntityForMauticContactIsContactableByEmail(): void

--- a/app/bundles/ReportBundle/Tests/Builder/MauticReportBuilderTest.php
+++ b/app/bundles/ReportBundle/Tests/Builder/MauticReportBuilderTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class MauticReportBuilderTest extends TestCase
 {
     use MockedConnectionTrait;

--- a/app/bundles/ReportBundle/Tests/Entity/SchedulerRepositoryTest.php
+++ b/app/bundles/ReportBundle/Tests/Entity/SchedulerRepositoryTest.php
@@ -11,6 +11,7 @@ use Mautic\ReportBundle\Entity\Scheduler;
 use Mautic\ReportBundle\Scheduler\Option\ExportOption;
 use PHPUnit\Framework\MockObject\MockObject;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class SchedulerRepositoryTest extends \PHPUnit\Framework\TestCase
 {
     use RepositoryConfiguratorTrait;

--- a/app/bundles/ReportBundle/Tests/Event/ReportGeneratorEventTest.php
+++ b/app/bundles/ReportBundle/Tests/Event/ReportGeneratorEventTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\MockObject\Rule\AnyInvokedCount;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ReportGeneratorEventTest extends TestCase
 {
     /**

--- a/app/bundles/ReportBundle/Tests/Form/Type/DynamicFiltersTypeTest.php
+++ b/app/bundles/ReportBundle/Tests/Form/Type/DynamicFiltersTypeTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[AllowMockObjectsWithoutExpectations]
 final class DynamicFiltersTypeTest extends TestCase
 {
     /**

--- a/app/bundles/ReportBundle/Tests/Form/Type/ReportTypeTest.php
+++ b/app/bundles/ReportBundle/Tests/Form/Type/ReportTypeTest.php
@@ -13,6 +13,7 @@ use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ReportTypeTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/ReportBundle/Tests/Model/CsvExporterTest.php
+++ b/app/bundles/ReportBundle/Tests/Model/CsvExporterTest.php
@@ -15,6 +15,7 @@ use Mautic\ReportBundle\Tests\Fixtures;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class CsvExporterTest extends \PHPUnit\Framework\TestCase
 {
     public const string DATEONLYFORMAT = 'F j, Y';

--- a/app/bundles/ReportBundle/Tests/Model/ExcelExporterTest.php
+++ b/app/bundles/ReportBundle/Tests/Model/ExcelExporterTest.php
@@ -16,6 +16,7 @@ use PhpOffice\PhpSpreadsheet\Reader\Xlsx;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ExcelExporterTest extends TestCase
 {
     private ExcelExporter $excelExporter;

--- a/app/bundles/ReportBundle/Tests/Model/ReportModelTest.php
+++ b/app/bundles/ReportBundle/Tests/Model/ReportModelTest.php
@@ -25,6 +25,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Twig\Environment;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ReportModelTest extends \PHPUnit\Framework\TestCase
 {
     private ReportModel $reportModel;

--- a/app/bundles/ReportBundle/Tests/Model/ScheduleModelTest.php
+++ b/app/bundles/ReportBundle/Tests/Model/ScheduleModelTest.php
@@ -12,6 +12,7 @@ use Mautic\ReportBundle\Scheduler\Model\SchedulerPlanner;
 use Mautic\ReportBundle\Scheduler\Option\ExportOption;
 use PHPUnit\Framework\MockObject\MockObject;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ScheduleModelTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/ReportBundle/Tests/Scheduler/Date/DateBuilderTest.php
+++ b/app/bundles/ReportBundle/Tests/Scheduler/Date/DateBuilderTest.php
@@ -14,6 +14,7 @@ use Mautic\ReportBundle\Scheduler\Exception\NotSupportedScheduleTypeException;
 use Mautic\ReportBundle\Scheduler\Factory\SchedulerTemplateFactory;
 use PHPUnit\Framework\MockObject\MockObject;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class DateBuilderTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/ReportBundle/Tests/Scheduler/Model/FileHandlerTest.php
+++ b/app/bundles/ReportBundle/Tests/Scheduler/Model/FileHandlerTest.php
@@ -12,6 +12,7 @@ use Mautic\ReportBundle\Exception\FileTooBigException;
 use Mautic\ReportBundle\Scheduler\Model\FileHandler;
 use PHPUnit\Framework\MockObject\MockObject;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class FileHandlerTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/ReportBundle/Tests/Scheduler/Model/MessageScheduleTest.php
+++ b/app/bundles/ReportBundle/Tests/Scheduler/Model/MessageScheduleTest.php
@@ -11,6 +11,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\Router;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class MessageScheduleTest extends \PHPUnit\Framework\TestCase
 {
     private MockObject&Router $router;

--- a/app/bundles/SmsBundle/Tests/DependencyInjection/Compiler/SmsTransportPassTest.php
+++ b/app/bundles/SmsBundle/Tests/DependencyInjection/Compiler/SmsTransportPassTest.php
@@ -10,6 +10,7 @@ use Mautic\SmsBundle\Sms\TransportChain;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class SmsTransportPassTest extends TestCase
 {
     public function testProcess(): void

--- a/app/bundles/SmsBundle/Tests/EventListener/CampaignSendSubscriberTest.php
+++ b/app/bundles/SmsBundle/Tests/EventListener/CampaignSendSubscriberTest.php
@@ -18,6 +18,7 @@ use Mautic\SmsBundle\Sms\TransportChain;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class CampaignSendSubscriberTest extends \PHPUnit\Framework\TestCase
 {
     private MockObject&SmsModel $smsModel;

--- a/app/bundles/SmsBundle/Tests/EventListener/SendSmsSubscriberTest.php
+++ b/app/bundles/SmsBundle/Tests/EventListener/SendSmsSubscriberTest.php
@@ -15,6 +15,7 @@ use Mautic\SmsBundle\EventListener\SendSmsSubscriber;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class SendSmsSubscriberTest extends TestCase
 {
     private SendSmsSubscriber $subscriber;

--- a/app/bundles/SmsBundle/Tests/EventListener/SmsSubscriberTest.php
+++ b/app/bundles/SmsBundle/Tests/EventListener/SmsSubscriberTest.php
@@ -15,6 +15,7 @@ use Mautic\SmsBundle\EventListener\SmsSubscriber;
 use Mautic\SmsBundle\Helper\SmsHelper;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class SmsSubscriberTest extends TestCase
 {
     private string $messageText = 'custom http://mautic.com text';

--- a/app/bundles/SmsBundle/Tests/EventListener/TrackingSubscriberTest.php
+++ b/app/bundles/SmsBundle/Tests/EventListener/TrackingSubscriberTest.php
@@ -11,6 +11,7 @@ use Mautic\EmailBundle\EventListener\TrackingSubscriber;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Event\ContactIdentificationEvent;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class TrackingSubscriberTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/SmsBundle/Tests/EventListener/WebhookSubscriberTest.php
+++ b/app/bundles/SmsBundle/Tests/EventListener/WebhookSubscriberTest.php
@@ -12,6 +12,7 @@ use Mautic\WebhookBundle\Event\WebhookBuilderEvent;
 use Mautic\WebhookBundle\Model\WebhookModel;
 use PHPUnit\Framework\MockObject\MockObject;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class WebhookSubscriberTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/SmsBundle/Tests/Helper/DTO/SmsRecipientDTOTest.php
+++ b/app/bundles/SmsBundle/Tests/Helper/DTO/SmsRecipientDTOTest.php
@@ -11,6 +11,7 @@ use Mautic\SmsBundle\Helper\DTO\SmsRecipientDTO;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class SmsRecipientDTOTest extends TestCase
 {
     private MockObject&Lead $lead;

--- a/app/bundles/SmsBundle/Tests/Integration/Twilio/TwilioCallbackTest.php
+++ b/app/bundles/SmsBundle/Tests/Integration/Twilio/TwilioCallbackTest.php
@@ -11,6 +11,7 @@ use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class TwilioCallbackTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/SmsBundle/Tests/Integration/Twilio/TwilioTransportTest.php
+++ b/app/bundles/SmsBundle/Tests/Integration/Twilio/TwilioTransportTest.php
@@ -12,6 +12,7 @@ use Monolog\Logger;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class TwilioTransportTest extends TestCase
 {
     private TwilioTransport $twilioTransport;

--- a/app/bundles/SmsBundle/Tests/Model/SmsModelTest.php
+++ b/app/bundles/SmsBundle/Tests/Model/SmsModelTest.php
@@ -28,6 +28,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class SmsModelTest extends \PHPUnit\Framework\TestCase
 {
     private \PHPUnit\Framework\MockObject\Stub&EntityManagerInterface $entityManger;

--- a/app/bundles/SmsBundle/Tests/Sms/TransportChainTest.php
+++ b/app/bundles/SmsBundle/Tests/Sms/TransportChainTest.php
@@ -17,6 +17,7 @@ use Mautic\SmsBundle\Sms\TransportChain;
 use Mautic\SmsBundle\Sms\TransportInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class TransportChainTest extends MauticMysqlTestCase
 {
     private TransportChain $transportChain;

--- a/app/bundles/UserBundle/Tests/Controller/ProfileControllerTest.php
+++ b/app/bundles/UserBundle/Tests/Controller/ProfileControllerTest.php
@@ -8,6 +8,7 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\UserBundle\Tests\Traits\CreateEntityTrait;
 use Symfony\Component\HttpFoundation\Request;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ProfileControllerTest extends MauticMysqlTestCase
 {
     use CreateEntityTrait;

--- a/app/bundles/UserBundle/Tests/Controller/UserControllerTest.php
+++ b/app/bundles/UserBundle/Tests/Controller/UserControllerTest.php
@@ -8,6 +8,7 @@ use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\UserBundle\Tests\Traits\CreateEntityTrait;
 use Symfony\Component\HttpFoundation\Request;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class UserControllerTest extends MauticMysqlTestCase
 {
     use CreateEntityTrait;

--- a/app/bundles/UserBundle/Tests/EventListener/ApiUserSubscriberTest.php
+++ b/app/bundles/UserBundle/Tests/EventListener/ApiUserSubscriberTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Event\AuthenticationTokenCreatedEvent;
 use Symfony\Component\Security\Http\Event\CheckPassportEvent;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ApiUserSubscriberTest extends TestCase
 {
     public function testSubscribedEvents(): void

--- a/app/bundles/UserBundle/Tests/EventListener/LightSAMLExceptionListenerTest.php
+++ b/app/bundles/UserBundle/Tests/EventListener/LightSAMLExceptionListenerTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Routing\Router;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class LightSAMLExceptionListenerTest extends MauticMysqlTestCase
 {
     protected function setUp(): void

--- a/app/bundles/UserBundle/Tests/EventListener/PasswordStrengthSubscriberTest.php
+++ b/app/bundles/UserBundle/Tests/EventListener/PasswordStrengthSubscriberTest.php
@@ -11,6 +11,7 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\PasswordC
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Event\CheckPassportEvent;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class PasswordStrengthSubscriberTest extends TestCase
 {
     public function testNoCheckPassportEvent(): void

--- a/app/bundles/UserBundle/Tests/EventListener/PasswordSubscriberTest.php
+++ b/app/bundles/UserBundle/Tests/EventListener/PasswordSubscriberTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\Credentia
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Event\CheckPassportEvent;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class PasswordSubscriberTest extends TestCase
 {
     private PasswordSubscriber $passwordSubscriber;

--- a/app/bundles/UserBundle/Tests/EventListener/SAMLSubscriberTest.php
+++ b/app/bundles/UserBundle/Tests/EventListener/SAMLSubscriberTest.php
@@ -13,6 +13,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\Routing\Router;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class SAMLSubscriberTest extends TestCase
 {
     /**

--- a/app/bundles/UserBundle/Tests/Form/Type/UserInviteRegistrationTypeTest.php
+++ b/app/bundles/UserBundle/Tests/Form/Type/UserInviteRegistrationTypeTest.php
@@ -12,6 +12,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class UserInviteRegistrationTypeTest extends TestCase
 {
     private MockObject&LanguageHelper $languageHelper;

--- a/app/bundles/UserBundle/Tests/Security/Authenticator/PluginAuthenticatorTest.php
+++ b/app/bundles/UserBundle/Tests/Security/Authenticator/PluginAuthenticatorTest.php
@@ -30,6 +30,7 @@ use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 use Symfony\Component\Security\Http\SecurityEvents;
 use Symfony\Component\Security\Http\SecurityRequestAttributes;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class PluginAuthenticatorTest extends TestCase
 {
     public function testAuthenticateByPreAuthenticationReplacesToken(): void

--- a/app/bundles/WebhookBundle/Tests/Unit/EventListener/WebhookSubscriberTest.php
+++ b/app/bundles/WebhookBundle/Tests/Unit/EventListener/WebhookSubscriberTest.php
@@ -13,6 +13,7 @@ use Mautic\WebhookBundle\Notificator\WebhookKillNotificator;
 use Mautic\WebhookBundle\WebhookEvents;
 use PHPUnit\Framework\MockObject\MockObject;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class WebhookSubscriberTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/app/bundles/WebhookBundle/Tests/Unit/Model/WebhookModelTest.php
+++ b/app/bundles/WebhookBundle/Tests/Unit/Model/WebhookModelTest.php
@@ -28,6 +28,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Routing\Generator\UrlGenerator;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class WebhookModelTest extends TestCase
 {
     /**

--- a/plugins/GrapesJsBuilderBundle/Tests/Functional/Controller/AssertCustomMjmlTest.php
+++ b/plugins/GrapesJsBuilderBundle/Tests/Functional/Controller/AssertCustomMjmlTest.php
@@ -13,6 +13,7 @@ use MauticPlugin\GrapesJsBuilderBundle\Entity\GrapesJsBuilder;
 use MauticPlugin\GrapesJsBuilderBundle\Entity\GrapesJsBuilderRepository;
 use Symfony\Component\HttpFoundation\Request;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class AssertCustomMjmlTest extends MauticMysqlTestCase
 {
     protected function setUp(): void

--- a/plugins/MauticClearbitBundle/Tests/Unit/Helper/LookupHelperTest.php
+++ b/plugins/MauticClearbitBundle/Tests/Unit/Helper/LookupHelperTest.php
@@ -22,6 +22,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class LookupHelperTest extends TestCase
 {
     private MockObject&IntegrationsHelper $integrationsHelper;

--- a/plugins/MauticCrmBundle/Tests/Api/SalesforceApiTest.php
+++ b/plugins/MauticCrmBundle/Tests/Api/SalesforceApiTest.php
@@ -15,6 +15,7 @@ use Psr\SimpleCache\CacheInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 #[CoversClass(SalesforceApi::class)]
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class SalesforceApiTest extends \PHPUnit\Framework\TestCase
 {
     #[TestDox('Test that a locked record request is retried up to 3 times')]

--- a/plugins/MauticCrmBundle/Tests/CrmAbstractIntegrationTest.php
+++ b/plugins/MauticCrmBundle/Tests/CrmAbstractIntegrationTest.php
@@ -11,6 +11,7 @@ use Mautic\PluginBundle\Tests\Integration\AbstractIntegrationTestCase;
 use MauticPlugin\MauticCrmBundle\Integration\VtigerIntegration;
 use MauticPlugin\MauticCrmBundle\Tests\Fixtures\Model\CompanyModelStub;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class CrmAbstractIntegrationTest extends AbstractIntegrationTestCase
 {
     public function testFieldMatchingPriority(): void

--- a/plugins/MauticCrmBundle/Tests/DynamicsApiTest.php
+++ b/plugins/MauticCrmBundle/Tests/DynamicsApiTest.php
@@ -8,6 +8,7 @@ use Mautic\PluginBundle\Tests\Integration\AbstractIntegrationTestCase;
 use MauticPlugin\MauticCrmBundle\Api\DynamicsApi;
 use MauticPlugin\MauticCrmBundle\Integration\DynamicsIntegration;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class DynamicsApiTest extends AbstractIntegrationTestCase
 {
     private DynamicsIntegration $integration;

--- a/plugins/MauticCrmBundle/Tests/DynamicsIntegrationTest.php
+++ b/plugins/MauticCrmBundle/Tests/DynamicsIntegrationTest.php
@@ -7,6 +7,7 @@ namespace MauticPlugin\MauticCrmBundle\Tests;
 use Mautic\PluginBundle\Tests\Integration\AbstractIntegrationTestCase;
 use MauticPlugin\MauticCrmBundle\Integration\DynamicsIntegration;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class DynamicsIntegrationTest extends AbstractIntegrationTestCase
 {
     private DynamicsIntegration $integration;

--- a/plugins/MauticCrmBundle/Tests/Integration/ConnectwiseIntegrationTest.php
+++ b/plugins/MauticCrmBundle/Tests/Integration/ConnectwiseIntegrationTest.php
@@ -12,6 +12,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\TestDox;
 
 #[CoversClass(ConnectwiseIntegration::class)]
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class ConnectwiseIntegrationTest extends AbstractIntegrationTestCase
 {
     use DataGeneratorTrait;

--- a/plugins/MauticCrmBundle/Tests/Integration/HubspotIntegrationTest.php
+++ b/plugins/MauticCrmBundle/Tests/Integration/HubspotIntegrationTest.php
@@ -13,6 +13,7 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class HubspotIntegrationTest extends AbstractIntegrationTestCase
 {
     private HubspotIntegration $integration;

--- a/plugins/MauticCrmBundle/Tests/Integration/SalesforceIntegrationTest.php
+++ b/plugins/MauticCrmBundle/Tests/Integration/SalesforceIntegrationTest.php
@@ -20,6 +20,7 @@ use MauticPlugin\MauticCrmBundle\Integration\SalesforceIntegration;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\MockObject\Rule\AnyInvokedCount;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class SalesforceIntegrationTest extends AbstractIntegrationTestCase
 {
     public const string SC_MULTIPLE_SF_LEADS        = 'multiple_sf_leads';

--- a/plugins/MauticFocusBundle/Tests/EventListener/CampaignSubscriberTest.php
+++ b/plugins/MauticFocusBundle/Tests/EventListener/CampaignSubscriberTest.php
@@ -16,6 +16,7 @@ use MauticPlugin\MauticFocusBundle\EventListener\CampaignSubscriber;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Routing\RouterInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class CampaignSubscriberTest extends TestCase
 {
     public function testActionPassesWhenFocusIsConfigured(): void

--- a/plugins/MauticFocusBundle/Tests/EventListener/LeadSubscriberTest.php
+++ b/plugins/MauticFocusBundle/Tests/EventListener/LeadSubscriberTest.php
@@ -20,6 +20,7 @@ use PHPUnit\Framework\MockObject\Rule\AnyInvokedCount;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Routing\RouterInterface;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class LeadSubscriberTest extends CommonMocks
 {
     /**

--- a/plugins/MauticOutlookBundle/Tests/Integration/OutlookIntegrationTest.php
+++ b/plugins/MauticOutlookBundle/Tests/Integration/OutlookIntegrationTest.php
@@ -7,6 +7,7 @@ namespace MauticPlugin\MauticOutlookBundle\Tests\Integration;
 use Mautic\PluginBundle\Tests\Integration\AbstractIntegrationTestCase;
 use MauticPlugin\MauticOutlookBundle\Integration\OutlookIntegration;
 
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class OutlookIntegrationTest extends AbstractIntegrationTestCase
 {
     private OutlookIntegration $integration;

--- a/plugins/MauticSocialBundle/Tests/Integration/FoursquareIntegrationTest.php
+++ b/plugins/MauticSocialBundle/Tests/Integration/FoursquareIntegrationTest.php
@@ -10,6 +10,7 @@ use MauticPlugin\MauticSocialBundle\Integration\FoursquareIntegration;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(FoursquareIntegration::class)]
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class FoursquareIntegrationTest extends AbstractIntegrationTestCase
 {
     private FoursquareIntegration $integration;

--- a/plugins/MauticSocialBundle/Tests/Integration/InstagramIntegrationTest.php
+++ b/plugins/MauticSocialBundle/Tests/Integration/InstagramIntegrationTest.php
@@ -10,6 +10,7 @@ use MauticPlugin\MauticSocialBundle\Integration\InstagramIntegration;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(InstagramIntegration::class)]
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class InstagramIntegrationTest extends AbstractIntegrationTestCase
 {
     private InstagramIntegration $integration;


### PR DESCRIPTION
Follow up to https://github.com/mautic/mautic/pull/17019, to improve PHPUnit test report in CI.
Now there is spam of 20 000+ lines just to mention the doubles/mocks notice.

This attributes will silence it and hopefully make tests readable again :+1:  
It prevents forcing us to spends dozens of hours on pointless mock changes.

---

## Description

PHPUnit 12+ emits a notice for every mock object created without a configured expectation:

> No expectations were configured for the mock object for `X`. Consider refactoring your test code to use a test stub instead. The `#[AllowMockObjectsWithoutExpectations]` attribute can be used to opt out of this check.

The current suite triggers **7204** such notices across **1792 test cases** in **331 test classes**, so the run ends with `PHPUnit Notices: 1792` and a non-zero exit.

This PR opts the affected classes out of the check by adding the class-level attribute PHPUnit itself recommends. No test logic changes — one line per class:

```diff
+#[\PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations]
 final class IntervalTest extends \PHPUnit\Framework\TestCase
 {
```

## Notes

- Attribute applied at class level (covers all methods) to the exact classes the notices name.
- 331 files, 331 insertions, no deletions.
- Two classes already imported the attribute — the short form is reused there; everywhere else the FQCN is used, no new `use` added.
