### PR TITLE
[symfony] Use standard vendor/bin for tool binaries

### DIFF
--- a/.github/workflows/coverage-check.yml
+++ b/.github/workflows/coverage-check.yml
@@ -77,7 +77,7 @@ jobs:
         rm -rf var/cache
         export DB_PORT="${{ job.services.database.ports[3306] }}"
         export SAML_PORT="${{ job.services.saml.ports[8080] }}"
-        php -d zend.assertions=1 -d pcov.enabled=1 bin/phpunit -d memory_limit=3G --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist --coverage-clover=coverage.xml --log-junit=junit.xml
+        php -d zend.assertions=1 -d pcov.enabled=1 vendor/bin/phpunit -d memory_limit=3G --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist --coverage-clover=coverage.xml --log-junit=junit.xml
 
     - name: Upload coverage report
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -115,9 +115,9 @@ jobs:
         export SAML_PORT="${{ job.services.saml.ports[8080] }}"
 
         if [[ "$COVERAGE" == "true" ]]; then
-          php -d zend.assertions=1 -d pcov.enabled=1 bin/phpunit -d memory_limit=3G --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist --coverage-clover=coverage.xml --log-junit=junit.xml
+          php -d zend.assertions=1 -d pcov.enabled=1 vendor/bin/phpunit -d memory_limit=3G --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist --coverage-clover=coverage.xml --log-junit=junit.xml
         else
-          php -d zend.assertions=1 bin/phpunit -d memory_limit=2G --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist
+          php -d zend.assertions=1 vendor/bin/phpunit -d memory_limit=2G --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist
         fi
 
     - name: Upload coverage report
@@ -250,7 +250,7 @@ jobs:
         elif [[ "${{ matrix.commands }}" == "Rector" ]]; then
           export SYMFONY_ENV=test
           bin/console cache:warmup
-          bin/rector --dry-run --ansi
+          vendor/bin/rector --dry-run --ansi
         elif [[ "${{ matrix.commands }}" == "Twig Lint" ]]; then
           bin/console lint:twig app plugins
         elif [[ "${{ matrix.commands }}" == "CS Fixer" ]]; then
@@ -260,7 +260,7 @@ jobs:
             fi
           done
           if [[ $cs_fix_files ]]; then
-            bin/php-cs-fixer fix --config=.php-cs-fixer.php --dry-run --using-cache=no --show-progress=dots --diff $cs_fix_files
+            vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php --dry-run --using-cache=no --show-progress=dots --diff $cs_fix_files
           fi
         elif [[ "${{ matrix.commands }}" == "scaffolded files mismatch" ]]; then
           wget -q -O /tmp/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && chmod 755 /tmp/jq

--- a/.gitignore
+++ b/.gitignore
@@ -60,10 +60,6 @@ phpstan.neon.dist
 /vendor/*
 !/vendor/.htaccess
 
-/bin/*
-!/bin/.htaccess
-!/bin/console
-
 /assets/ckeditor/build/*
 /assets/build/*
 /var/dart-sass/*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,8 +10,8 @@ Mautic is an open-source marketing automation platform built on **Symfony 7.4** 
 
 ### Command Execution Rule
 - Prefer `ddev` wrappers for agent-run PHP, Composer, Symfony console, and PHPUnit commands in this repository.
-- Use forms like `ddev exec php bin/phpunit -c app/phpunit.xml.dist ...`, `ddev exec php bin/console ...`, and `ddev composer ...`.
-- Avoid running `php`, `composer`, `bin/console`, or `bin/phpunit` directly on the host unless the user explicitly asks for that.
+- Use forms like `ddev exec php vendor/bin/phpunit -c app/phpunit.xml.dist ...`, `ddev exec php bin/console ...`, and `ddev composer ...`.
+- Avoid running `php`, `composer`, `bin/console`, or `vendor/bin/phpunit` directly on the host unless the user explicitly asks for that.
 
 ### Development Setup
 ```bash
@@ -30,13 +30,13 @@ ddev exec php bin/console mautic:install <site-url>
 ddev composer test
 
 # Run specific test file
-ddev exec php bin/phpunit -c app/phpunit.xml.dist app/bundles/EmailBundle/Tests/Functional/EmailClickTrackingTest.php
+ddev exec php vendor/bin/phpunit -c app/phpunit.xml.dist app/bundles/EmailBundle/Tests/Functional/EmailClickTrackingTest.php
 
 # Run specific bundle tests
-ddev exec php bin/phpunit -c app/phpunit.xml.dist app/bundles/CoreBundle/Tests
+ddev exec php vendor/bin/phpunit -c app/phpunit.xml.dist app/bundles/CoreBundle/Tests
 
 # Run specific test method
-ddev exec php bin/phpunit -c app/phpunit.xml.dist --filter testGuessTimezoneFromOffset
+ddev exec php vendor/bin/phpunit -c app/phpunit.xml.dist --filter testGuessTimezoneFromOffset
 
 # E2E acceptance tests (Codeception)
 ddev composer run e2e-test

--- a/app/assets/scaffold/files/example.gitignore
+++ b/app/assets/scaffold/files/example.gitignore
@@ -60,10 +60,6 @@ phpstan.neon.dist
 /vendor/*
 !/vendor/.htaccess
 
-/bin/*
-!/bin/.htaccess
-!/bin/console
-
 /assets/ckeditor/build/*
 /assets/build/*
 /var/dart-sass/*

--- a/composer.json
+++ b/composer.json
@@ -166,16 +166,16 @@
       "@generate-assets",
       "@motd"
     ],
-    "test": "bin/phpunit -d memory_limit=2G --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist",
-    "e2e-test": "APP_ENV=test bin/codecept run acceptance",
-    "phpstan": "[ ! -f var/cache/test/AppKernelTestDebugContainer.xml ] && (echo 'Building test cache ...'; APP_ENV=test APP_DEBUG=1 bin/console > /dev/null 2>&1);  php -d memory_limit=5G bin/phpstan analyse --ansi",
+    "test": "vendor/bin/phpunit -d memory_limit=2G --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist",
+    "e2e-test": "APP_ENV=test vendor/bin/codecept run acceptance",
+    "phpstan": "[ ! -f var/cache/test/AppKernelTestDebugContainer.xml ] && (echo 'Building test cache ...'; APP_ENV=test APP_DEBUG=1 bin/console > /dev/null 2>&1);  php -d memory_limit=5G vendor/bin/phpstan analyse --ansi",
     "phpstan-baseline": "composer phpstan -- --generate-baseline phpstan-baseline.neon",
-    "cs": "bin/php-cs-fixer fix --config=.php-cs-fixer.php -v --dry-run --diff",
+    "cs": "vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php -v --dry-run --diff",
     "fixcs": [
-        "bin/php-cs-fixer fix -v",
-        "bin/ecs --fix"
+        "vendor/bin/php-cs-fixer fix -v",
+        "vendor/bin/ecs --fix"
     ],
-    "rector": "bin/rector process --ansi",
+    "rector": "vendor/bin/rector process --ansi",
     "npm-ci": "npm ci --prefer-offline --no-audit",
     "npx-patch-package": "npx patch-package",
     "gjs-build": "npm ci --prefix plugins/GrapesJsBuilderBundle --prefer-offline --no-audit && npm run build --prefix plugins/GrapesJsBuilderBundle",

--- a/composer.json
+++ b/composer.json
@@ -196,7 +196,6 @@
     "platform": {
       "php": "8.4.1"
     },
-    "bin-dir": "bin",
     "component-dir": "media/assets",
     "process-timeout": 5000,
     "sort-packages": true,

--- a/plugins/GrapesJsBuilderBundle/composer.json
+++ b/plugins/GrapesJsBuilderBundle/composer.json
@@ -23,9 +23,9 @@
     "quicktest": [
       "@unit"
     ],
-    "phpunit": "../../bin/phpunit -d memory_limit=2048M --bootstrap ../../vendor/autoload.php --configuration phpunit.xml --fail-on-warning --testsuite=all",
-    "unit": "../../bin/phpunit -d memory_limit=2048M --bootstrap ../../vendor/autoload.php --configuration phpunit.xml --fail-on-warning --testsuite=unit",
-    "coverage": "../../bin/phpunit -d memory_limit=2048M --bootstrap ../../vendor/autoload.php --configuration phpunit.xml --fail-on-warning --testsuite=all --coverage-text --coverage-html=Tests/Coverage",
+    "phpunit": "../../vendor/bin/phpunit -d memory_limit=2048M --bootstrap ../../vendor/autoload.php --configuration phpunit.xml --fail-on-warning --testsuite=all",
+    "unit": "../../vendor/bin/phpunit -d memory_limit=2048M --bootstrap ../../vendor/autoload.php --configuration phpunit.xml --fail-on-warning --testsuite=unit",
+    "coverage": "../../vendor/bin/phpunit -d memory_limit=2048M --bootstrap ../../vendor/autoload.php --configuration phpunit.xml --fail-on-warning --testsuite=all --coverage-text --coverage-html=Tests/Coverage",
     "phpstan": "vendor/bin/phpstan analyse --autoload-file=../../vendor/autoload.php --level=max Config Connection Entity Form Integration Migrations Sync Tests",
     "csfixer": "vendor/bin/ecs check .",
     "fixcs": "vendor/bin/ecs check . --fix"


### PR DESCRIPTION
Composer places dependency binaries in `vendor/bin/*` by default. Mautic overrode this with `"bin-dir": "bin"`, mixing vendor tool symlinks into the tracked `bin/` directory alongside the real `bin/console`.

This used to be  trend in Symfony 2/3, when Symfony itself placed all bin files there. But since then all `/vendor` projects started to used this path too. Better split it to and use standard path for external bins and `/bin` for ours.
