### PR TITLE
[tests] ci: only load pcov when coverage is actually collected

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,8 +88,8 @@ jobs:
       with:
         php-version: ${{ matrix.php-versions }}
         extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, mysql, pdo_mysql
-        coverage: pcov
-        ini-values: pcov.enabled=0, pcov.directory=., pcov.exclude="~tests|themes|vendor~", zend.assertions=1
+        coverage: ${{ env.COVERAGE == 'true' && 'pcov' || 'none' }}
+        ini-values: ${{ env.COVERAGE == 'true' && 'pcov.enabled=0, pcov.directory=., pcov.exclude="~tests|themes|vendor~", zend.assertions=1' || 'zend.assertions=1' }}
 
     - name: add MySQL config file
       run: |


### PR DESCRIPTION
## Description

The PHPUnit workflow always installs the `pcov` extension and sets its ini options, even for matrix jobs and pull requests that never collect coverage. Coverage is already gated behind the `COVERAGE` env var (only `8.4` + `mariadb:10.11` on `mautic/mautic` for push/schedule).

This makes the `coverage`/`ini-values` inputs of `setup-php` follow that same gate, so non-coverage runs skip pcov entirely.

```diff
-        coverage: pcov
-        ini-values: pcov.enabled=0, pcov.directory=., pcov.exclude="~tests|themes|vendor~", zend.assertions=1
+        coverage: ${{ env.COVERAGE == 'true' && 'pcov' || 'none' }}
+        ini-values: ${{ env.COVERAGE == 'true' && 'pcov.enabled=0, pcov.directory=., pcov.exclude="~tests|themes|vendor~", zend.assertions=1' || 'zend.assertions=1' }}
```

- Coverage on → pcov + pcov ini options (unchanged behaviour).
- Coverage off → `coverage: none`, no pcov extension, only `zend.assertions=1` kept.

## Unit test runtime (PR runs, coverage off)

Baseline = recent normal PR run ([run 33050331503](https://github.com/mautic/mautic/actions/runs/33050331503)); this PR = [run 33073222291](https://github.com/mautic/mautic/actions/runs/33073222291).

| Job | Before | After | Δ |
| --- | --- | --- | --- |
| PHPUnit 8.4 mysql:8.4 | 11m27s | 11m24s | −3s |
| PHPUnit 8.4 mariadb:10.11 | 10m42s | 10m38s | −4s |
| PHPUnit 8.5 mysql:9.2 | 11m32s | 11m35s | +3s |
| PHPUnit 8.5 mariadb:11.4 | 10m30s | 10m37s | +7s |

The deltas sit within normal CI noise (~1%): a `pcov` extension loaded with `pcov.enabled=0` costs almost nothing, so this is not a measurable speedup on PRs. The change is a config cleanup — don't install/configure an extension a job never uses — rather than a performance win.

https://claude.ai/code/session_01RLsdu7PgEtkk6LzEjrqtjB