### PR TITLE
Use configured site URL for links generated in subrequests

### DIFF
--- a/app/bundles/CoreBundle/EventListener/RouterSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/RouterSubscriber.php
@@ -3,7 +3,6 @@
 namespace Mautic\CoreBundle\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Routing\RouterInterface;
 
@@ -35,7 +34,8 @@ final class RouterSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            KernelEvents::REQUEST => ['setRouterRequestContext', 1],
+            KernelEvents::REQUEST        => ['setRouterRequestContext', 1],
+            KernelEvents::FINISH_REQUEST => ['setRouterRequestContext', -1],
         ];
     }
 
@@ -44,13 +44,9 @@ final class RouterSubscriber implements EventSubscriberInterface
      * in order to prevent mismatches between cached URLs generated during web requests and URLs generated
      * via CLI/cron jobs.
      */
-    public function setRouterRequestContext(RequestEvent $event): void
+    public function setRouterRequestContext(): void
     {
         if (empty($this->host)) {
-            return;
-        }
-
-        if (!$event->isMainRequest()) {
             return;
         }
 

--- a/app/bundles/CoreBundle/Tests/Unit/EventListener/RouterSubscriberTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/EventListener/RouterSubscriberTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CoreBundle\Tests\Unit\EventListener;
+
+use Mautic\CoreBundle\EventListener\RouterSubscriber;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\RouterInterface;
+
+final class RouterSubscriberTest extends TestCase
+{
+    public function testRouterContextUsesConfiguredSiteUrl(): void
+    {
+        $context = new RequestContext('/subrequest', 'GET', 'request.example.com', 'http', 80, 443, '/index.php/');
+        $router  = $this->createStub(RouterInterface::class);
+        $router->method('getContext')->willReturn($context);
+
+        $subscriber = new RouterSubscriber($router, 'https', 'mautic.example.com', '8443', '8080', '/mautic');
+        $subscriber->setRouterRequestContext();
+
+        $this->assertSame('/mautic', $context->getBaseUrl());
+        $this->assertSame('https', $context->getScheme());
+        $this->assertSame('mautic.example.com', $context->getHost());
+        $this->assertSame(8080, $context->getHttpPort());
+        $this->assertSame(8443, $context->getHttpsPort());
+    }
+
+    public function testRouterContextIsReappliedAfterSubrequestFinishes(): void
+    {
+        $context = new RequestContext('', 'GET', 'request.example.com', 'http');
+        $router  = $this->createStub(RouterInterface::class);
+        $router->method('getContext')->willReturn($context);
+
+        $subscriber = new RouterSubscriber($router, 'https', 'mautic.example.com', null, null, '');
+        $subscriber->setRouterRequestContext();
+
+        // Symfony restores the parent request context when a subrequest finishes.
+        $context->setScheme('http');
+        $context->setHost('request.example.com');
+        $subscriber->setRouterRequestContext();
+
+        $this->assertSame('https', $context->getScheme());
+        $this->assertSame('mautic.example.com', $context->getHost());
+        $this->assertSame(['setRouterRequestContext', -1], RouterSubscriber::getSubscribedEvents()[KernelEvents::FINISH_REQUEST]);
+    }
+}

--- a/app/bundles/EmailBundle/Tests/Functional/CustomSiteUrlFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Functional/CustomSiteUrlFunctionalTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\EmailBundle\Tests\Functional;
+
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\CoreBundle\Tests\Functional\CreateTestEntitiesTrait;
+use Mautic\EmailBundle\Entity\Email;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Mailer\EventListener\MessageLoggerListener;
+use Symfony\Component\Mime\Message;
+
+final class CustomSiteUrlFunctionalTest extends MauticMysqlTestCase
+{
+    use CreateTestEntitiesTrait;
+
+    protected function setUp(): void
+    {
+        $this->configParams['disable_trackable_urls'] = false;
+        $this->configParams['site_url']               = 'https://my-new-mautic.com';
+        parent::setUp();
+    }
+
+    public function testTrackedEmailLinkUsesConfiguredSiteUrl(): void
+    {
+        $lead    = $this->createLead('John', 'Doe', 'mtc-11550@example.com');
+        $segment = $this->createSegment('mtc-11550-segment', []);
+        $this->createListLead($segment, $lead);
+
+        $email = new Email();
+        $email->setDateAdded(new \DateTime());
+        $email->setName('Email name');
+        $email->setSubject('Test subject for site url');
+        $email->setEmailType('list');
+        $email->setLists(['mtc-11550-segment' => $segment]);
+        $email->setTemplate('Blank');
+        $email->setCustomHtml('<!DOCTYPE html><html><body><a href="https://externalsite.org/page">Click Me</a></body></html>');
+        $this->em->persist($email);
+        $this->em->flush();
+        $this->em->clear();
+
+        /** @var MessageLoggerListener $messageLogger */
+        $messageLogger = self::getContainer()->get('mailer.message_logger_listener'); // @phpstan-ignore mautic.noContainerGet
+        $this->assertInstanceOf(MessageLoggerListener::class, $messageLogger);
+
+        $this->setCsrfHeader();
+        $this->client->xmlHttpRequest(
+            Request::METHOD_POST,
+            '/s/ajax?action=email:sendBatch',
+            ['id' => $email->getId(), 'pending' => 1],
+        );
+
+        self::assertResponseIsSuccessful();
+        $this->assertStringContainsString('"sent":1', (string) $this->client->getResponse()->getContent());
+
+        $messages = $messageLogger->getEvents()->getMessages();
+        $this->assertCount(1, $messages);
+        $this->assertInstanceOf(Message::class, $messages[0]);
+
+        $body = quoted_printable_decode($messages[0]->getBody()->bodyToString());
+        preg_match('/<a href="([^"]+)">Click Me<\/a>/i', $body, $matches);
+
+        $this->assertArrayHasKey(1, $matches, "Could not find the tracked link in the email body: {$body}");
+        $this->assertSame('my-new-mautic.com', parse_url($matches[1], PHP_URL_HOST));
+        $this->assertStringStartsWith('/r/', (string) parse_url($matches[1], PHP_URL_PATH));
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | ✔️ |
| New feature/enhancement? | ❌ |
| Deprecations? | ❌ |
| BC breaks? | ❌ |
| Automated tests included? | ✔️ |
| Related user documentation PR URL | |
| Related developer documentation PR URL | |
| Issue(s) addressed | Fixes #12703 |

## Description

Some Mautic actions, such as sending a segment email, execute another controller internally as a subrequest. Symfony resets the URL-generation context for that subrequest, causing generated links to use the admin request host instead of the configured `site_url`.

The router context now applies the configured `site_url` to main requests and subrequests, then reapplies it after Symfony restores the parent context.

---
### 📋 Steps to test this PR:

1. Configure Site URL with a host different from the host used to access Mautic.
2. Create a segment email containing a manually added external link.
3. Send the email to a test contact.
4. Confirm the generated tracking URL uses the configured Site URL host.
