### PR TITLE
[types] type isNew() method, property and event params

### DIFF
--- a/app/bundles/CoreBundle/Entity/FormEntity.php
+++ b/app/bundles/CoreBundle/Entity/FormEntity.php
@@ -426,10 +426,7 @@ class FormEntity extends CommonEntity
         return $status;
     }
 
-    /**
-     * @return bool
-     */
-    public function isNew()
+    public function isNew(): bool
     {
         if ($this->new) {
             return true;

--- a/app/bundles/CoreBundle/Event/CommonEvent.php
+++ b/app/bundles/CoreBundle/Event/CommonEvent.php
@@ -18,10 +18,7 @@ class CommonEvent extends Event
      */
     protected $entity;
 
-    /**
-     * @var bool
-     */
-    protected $isNew = true;
+    protected bool $isNew = true;
 
     /**
      * @var bool|array
@@ -45,10 +42,8 @@ class CommonEvent extends Event
 
     /**
      * Returns if a saved lead is new or not.
-     *
-     * @return bool
      */
-    public function isNew()
+    public function isNew(): bool
     {
         return $this->isNew;
     }

--- a/app/bundles/CoreBundle/Model/FormModel.php
+++ b/app/bundles/CoreBundle/Model/FormModel.php
@@ -192,10 +192,8 @@ class FormModel extends AbstractCommonModel
      * Determines if an entity is new or not.
      *
      * @param mixed $entity
-     *
-     * @return bool
      */
-    public function isNewEntity($entity)
+    public function isNewEntity($entity): bool
     {
         if (method_exists($entity, 'isNew')) {
             return $entity->isNew();

--- a/app/bundles/PointBundle/Event/TriggerEvent.php
+++ b/app/bundles/PointBundle/Event/TriggerEvent.php
@@ -14,12 +14,9 @@ final class TriggerEvent extends CommonEvent
      */
     protected $entity;
 
-    /**
-     * @param bool $isNew
-     */
     public function __construct(
         Trigger &$trigger,
-        $isNew = false,
+        bool $isNew = false,
     ) {
         $this->entity = &$trigger;
         $this->isNew = $isNew;

--- a/app/bundles/PointBundle/Event/TriggerEvent.php
+++ b/app/bundles/PointBundle/Event/TriggerEvent.php
@@ -19,9 +19,10 @@ final class TriggerEvent extends CommonEvent
      */
     public function __construct(
         Trigger &$trigger,
-        protected $isNew = false,
+        $isNew = false,
     ) {
         $this->entity = &$trigger;
+        $this->isNew = $isNew;
     }
 
     /**

--- a/app/bundles/WebhookBundle/Event/WebhookEvent.php
+++ b/app/bundles/WebhookBundle/Event/WebhookEvent.php
@@ -14,9 +14,6 @@ class WebhookEvent extends CommonEvent
      */
     protected $entity;
 
-    /**
-     * @param bool $isNew
-     */
     public function __construct(
         Webhook $webhook,
         protected bool $isNew = false,

--- a/app/bundles/WebhookBundle/Event/WebhookEvent.php
+++ b/app/bundles/WebhookBundle/Event/WebhookEvent.php
@@ -19,7 +19,7 @@ class WebhookEvent extends CommonEvent
      */
     public function __construct(
         Webhook $webhook,
-        protected $isNew = false,
+        protected bool $isNew = false,
         private string $reason = '',
     ) {
         $this->entity = $webhook;

--- a/plugins/MauticFocusBundle/Event/FocusEvent.php
+++ b/plugins/MauticFocusBundle/Event/FocusEvent.php
@@ -9,10 +9,7 @@ use MauticPlugin\MauticFocusBundle\Entity\Focus;
 
 final class FocusEvent extends CommonEvent
 {
-    /**
-     * @param bool|false $isNew
-     */
-    public function __construct(Focus $focus, $isNew = false)
+    public function __construct(Focus $focus, bool $isNew = false)
     {
         $this->entity = $focus;
         $this->isNew  = $isNew;

--- a/plugins/MauticSocialBundle/Event/SocialEvent.php
+++ b/plugins/MauticSocialBundle/Event/SocialEvent.php
@@ -9,10 +9,7 @@ use MauticPlugin\MauticSocialBundle\Entity\Monitoring;
 
 final class SocialEvent extends CommonEvent
 {
-    /**
-     * @param bool $isNew
-     */
-    public function __construct(Monitoring $monitoring, $isNew = false)
+    public function __construct(Monitoring $monitoring, bool $isNew = false)
     {
         $this->entity = $monitoring;
         $this->isNew  = $isNew;


### PR DESCRIPTION
Types the `isNew` state consistently: `bool` return types on `isNew()` / `isNewEntity()`, a typed `CommonEvent::$isNew` property, and explicit handling of the `isNew` constructor param on `TriggerEvent`.

```diff
-    /**
-     * @return bool
-     */
-    public function isNew()
+    public function isNew(): bool
     {
```

Split out from the param-bool typing work so the `isNew` semantics land on their own.

https://claude.ai/code/session_01GpHL422YrvxQdRwuebNW5X
