### PR TITLE
[types] add bool param typehints (part 2/3)

### DIFF
--- a/app/bundles/CampaignBundle/Controller/CampaignController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignController.php
@@ -410,10 +410,7 @@ class CampaignController extends AbstractStandardFormController
         return $this->deleteStandard($request, $objectId);
     }
 
-    /**
-     * @param bool $ignorePost
-     */
-    public function editAction(Request $request, $objectId, $ignorePost = false): JsonResponse|RedirectResponse|Response
+    public function editAction(Request $request, $objectId, bool $ignorePost = false): JsonResponse|RedirectResponse|Response
     {
         return $this->editStandard($request, $objectId, $ignorePost);
     }
@@ -655,10 +652,7 @@ class CampaignController extends AbstractStandardFormController
         }
     }
 
-    /**
-     * @param bool $isClone
-     */
-    protected function afterFormProcessed($isValid, $entity, FormInterface $form, $action, $isClone = false): void
+    protected function afterFormProcessed($isValid, $entity, FormInterface $form, $action, bool $isClone = false): void
     {
         if (!$isValid) {
             // Add the canvas settings to the entity to be able to rebuild it
@@ -670,10 +664,8 @@ class CampaignController extends AbstractStandardFormController
 
     /**
      * This method is called before and after form is submitted.
-     *
-     * @param bool $isClone
      */
-    protected function beforeFormProcessed($entity, FormInterface $form, $action, $isPost, $objectId = null, $isClone = false): void
+    protected function beforeFormProcessed($entity, FormInterface $form, $action, $isPost, $objectId = null, bool $isClone = false): void
     {
         $sessionId = $this->getCampaignSessionId($entity, $action, $objectId);
 
@@ -741,9 +733,8 @@ class CampaignController extends AbstractStandardFormController
 
     /**
      * @param Campaign $entity
-     * @param bool     $isClone
      */
-    protected function beforeEntitySave($entity, FormInterface $form, $action, $objectId = null, $isClone = false): bool
+    protected function beforeEntitySave($entity, FormInterface $form, $action, $objectId = null, bool $isClone = false): bool
     {
         if ([] === $this->campaignEvents) {
             // set the error
@@ -1070,10 +1061,7 @@ class CampaignController extends AbstractStandardFormController
         return $args;
     }
 
-    /**
-     * @param bool $isClone
-     */
-    protected function prepareCampaignEventsForEdit($entity, $objectId, $isClone = false): array
+    protected function prepareCampaignEventsForEdit($entity, $objectId, bool $isClone = false): array
     {
         // load existing events into session
         $campaignEvents = [];
@@ -1114,7 +1102,7 @@ class CampaignController extends AbstractStandardFormController
         return [];
     }
 
-    protected function prepareCampaignSourcesForEdit($objectId, $campaignSources, $isPost = false): void
+    protected function prepareCampaignSourcesForEdit($objectId, $campaignSources, bool $isPost = false): void
     {
         $this->campaignSources = [];
         if (is_array($campaignSources)) {

--- a/app/bundles/CampaignBundle/Entity/Campaign.php
+++ b/app/bundles/CampaignBundle/Entity/Campaign.php
@@ -316,7 +316,7 @@ class Campaign extends FormEntity implements OptimisticLockInterface, UuidInterf
     /**
      * Override to convert projects changes to final format.
      */
-    public function getChanges($includePast = false)
+    public function getChanges(bool $includePast = false)
     {
         $changes = parent::getChanges($includePast);
 

--- a/app/bundles/CampaignBundle/Entity/CampaignRepository.php
+++ b/app/bundles/CampaignBundle/Entity/CampaignRepository.php
@@ -65,7 +65,7 @@ class CampaignRepository extends CommonRepository
      *
      * @return array
      */
-    public function getPublishedCampaigns($specificId = null, ?int $leadId = null, $forList = false, $viewOther = false)
+    public function getPublishedCampaigns($specificId = null, ?int $leadId = null, bool $forList = false, bool $viewOther = false)
     {
         $q = $this->getEntityManager()->createQueryBuilder()
             ->from(Campaign::class, 'c', 'c.id');
@@ -480,13 +480,12 @@ class CampaignRepository extends CommonRepository
     /**
      * Get lead data of a campaign.
      *
-     * @param int        $start
-     * @param bool|false $limit
-     * @param array      $select
+     * @param int   $start
+     * @param array $select
      *
      * @return mixed[]
      */
-    public function getCampaignLeads($campaignId, $start = 0, $limit = false, $select = ['cl.lead_id']): array
+    public function getCampaignLeads($campaignId, $start = 0, bool $limit = false, $select = ['cl.lead_id']): array
     {
         $q = $this->getReplicaConnection()->createQueryBuilder();
 

--- a/app/bundles/CampaignBundle/Entity/EventRepository.php
+++ b/app/bundles/CampaignBundle/Entity/EventRepository.php
@@ -178,12 +178,11 @@ class EventRepository extends CommonRepository
     }
 
     /**
-     * @param int  $campaignId
-     * @param bool $ignoreDeleted
+     * @param int $campaignId
      *
      * @return array<int,mixed[]>
      */
-    public function getCampaignEvents($campaignId, $ignoreDeleted = true): array
+    public function getCampaignEvents($campaignId, bool $ignoreDeleted = true): array
     {
         $q = $this->getEntityManager()->createQueryBuilder();
         $q->select('e, IDENTITY(e.parent)')

--- a/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
@@ -215,18 +215,15 @@ class LeadEventLogRepository extends CommonRepository
     }
 
     /**
-     * @param int  $campaignId
-     * @param bool $excludeScheduled
-     * @param bool $excludeNegative
-     * @param bool $all
+     * @param int $campaignId
      *
      * @throws \Doctrine\DBAL\Cache\CacheException
      */
     public function getCampaignLogCounts(
         $campaignId,
-        $excludeScheduled = false,
-        $excludeNegative = true,
-        $all = false,
+        bool $excludeScheduled = false,
+        bool $excludeNegative = true,
+        bool $all = false,
         ?\DateTimeInterface $dateFrom = null,
         ?\DateTimeInterface $dateTo = null,
         ?int $eventId = null,

--- a/app/bundles/CampaignBundle/Entity/LeadRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadRepository.php
@@ -350,10 +350,9 @@ class LeadRepository extends CommonRepository
     }
 
     /**
-     * @param int  $campaignId
-     * @param bool $campaignCanBeRestarted
+     * @param int $campaignId
      */
-    public function getCountsForCampaignContactsBySegment($campaignId, ContactLimiter $limiter, $campaignCanBeRestarted = false): CountResult
+    public function getCountsForCampaignContactsBySegment($campaignId, ContactLimiter $limiter, bool $campaignCanBeRestarted = false): CountResult
     {
         if (!$segments = $this->getCampaignSegments($campaignId)) {
             return new CountResult(0, 0, 0);
@@ -371,7 +370,7 @@ class LeadRepository extends CommonRepository
             ->setParameter('segments', $segments, ArrayParameterType::INTEGER);
 
         $this->updateQueryFromContactLimiter('ll', $qb, $limiter, true);
-        $this->updateQueryWithExistingMembershipExclusion((int) $campaignId, $qb, (bool) $campaignCanBeRestarted);
+        $this->updateQueryWithExistingMembershipExclusion((int) $campaignId, $qb, $campaignCanBeRestarted);
 
         if (!$campaignCanBeRestarted) {
             $this->updateQueryWithHistoryExclusion($campaignId, $qb);
@@ -388,12 +387,11 @@ class LeadRepository extends CommonRepository
      * and the campaign setting if a contact is allowed to restart
      * a campaign.
      *
-     * @param int  $campaignId
-     * @param bool $campaignCanBeRestarted
+     * @param int $campaignId
      *
      * @return array<int|string, string>
      */
-    public function getCampaignContactsBySegments($campaignId, ContactLimiter $limiter, $campaignCanBeRestarted = false): array
+    public function getCampaignContactsBySegments($campaignId, ContactLimiter $limiter, bool $campaignCanBeRestarted = false): array
     {
         if (!$segments = $this->getCampaignSegments($campaignId)) {
             return [];
@@ -412,7 +410,7 @@ class LeadRepository extends CommonRepository
             ->orderBy('ll.lead_id');
 
         $this->updateQueryFromContactLimiter('ll', $qb, $limiter);
-        $this->updateQueryWithExistingMembershipExclusion((int) $campaignId, $qb, (bool) $campaignCanBeRestarted);
+        $this->updateQueryWithExistingMembershipExclusion((int) $campaignId, $qb, $campaignCanBeRestarted);
 
         if (!$campaignCanBeRestarted) {
             $this->updateQueryWithHistoryExclusion($campaignId, $qb);

--- a/app/bundles/CampaignBundle/Executioner/EventExecutioner.php
+++ b/app/bundles/CampaignBundle/Executioner/EventExecutioner.php
@@ -77,14 +77,13 @@ class EventExecutioner
 
     /**
      * @param ArrayCollection<int,Lead> $contacts
-     * @param bool                      $isInactiveEvent
      *
      * @throws Dispatcher\Exception\LogNotProcessedException
      * @throws Dispatcher\Exception\LogPassedAndFailedException
      * @throws Exception\CannotProcessEventException
      * @throws Scheduler\Exception\NotSchedulableException
      */
-    public function executeForContacts(Event $event, ArrayCollection $contacts, ?Counter $counter = null, $isInactiveEvent = false): void
+    public function executeForContacts(Event $event, ArrayCollection $contacts, ?Counter $counter = null, bool $isInactiveEvent = false): void
     {
         if (!$contacts->count()) {
             $this->logger->debug('CAMPAIGN: No contacts to process for event ID '.$event->getId());
@@ -145,14 +144,12 @@ class EventExecutioner
     }
 
     /**
-     * @param bool $isInactive
-     *
      * @throws Dispatcher\Exception\LogNotProcessedException
      * @throws Dispatcher\Exception\LogPassedAndFailedException
      * @throws Exception\CannotProcessEventException
      * @throws Scheduler\Exception\NotSchedulableException
      */
-    public function executeEventsForContacts(ArrayCollection $events, ArrayCollection $contacts, ?Counter $childrenCounter = null, $isInactive = false): void
+    public function executeEventsForContacts(ArrayCollection $events, ArrayCollection $contacts, ?Counter $childrenCounter = null, bool $isInactive = false): void
     {
         if (!$contacts->count()) {
             return;
@@ -188,10 +185,7 @@ class EventExecutioner
         }
     }
 
-    /**
-     * @param bool $isInactiveEvent
-     */
-    public function recordLogsAsExecutedForEvent(Event $event, ArrayCollection $contacts, $isInactiveEvent = false): void
+    public function recordLogsAsExecutedForEvent(Event $event, ArrayCollection $contacts, bool $isInactiveEvent = false): void
     {
         $config = $this->collector->getEventConfig($event);
         $logs   = $this->eventLogger->generateLogsFromContacts($event, $config, $contacts, $isInactiveEvent);
@@ -203,10 +197,7 @@ class EventExecutioner
         }
     }
 
-    /**
-     * @param bool $isInactiveEvent
-     */
-    public function recordLogsAsFailedForEvent(Event $event, ArrayCollection $contacts, $reason, $isInactiveEvent = false): void
+    public function recordLogsAsFailedForEvent(Event $event, ArrayCollection $contacts, $reason, bool $isInactiveEvent = false): void
     {
         $config = $this->collector->getEventConfig($event);
         $logs   = $this->eventLogger->generateLogsFromContacts($event, $config, $contacts, $isInactiveEvent);

--- a/app/bundles/CampaignBundle/Executioner/Logger/EventLogger.php
+++ b/app/bundles/CampaignBundle/Executioner/Logger/EventLogger.php
@@ -61,10 +61,7 @@ class EventLogger
         }
     }
 
-    /**
-     * @param bool $isInactiveEvent
-     */
-    public function buildLogEntry(Event $event, ?Lead $contact = null, $isInactiveEvent = false): LeadEventLog
+    public function buildLogEntry(Event $event, ?Lead $contact = null, bool $isInactiveEvent = false): LeadEventLog
     {
         $log = new LeadEventLog();
 
@@ -147,11 +144,9 @@ class EventLogger
     }
 
     /**
-     * @param bool $isInactiveEntry
-     *
      * @return ArrayCollection
      */
-    public function fetchRotationAndGenerateLogsFromContacts(Event $event, AbstractEventAccessor $config, ArrayCollection $contacts, $isInactiveEntry = false)
+    public function fetchRotationAndGenerateLogsFromContacts(Event $event, AbstractEventAccessor $config, ArrayCollection $contacts, bool $isInactiveEntry = false)
     {
         $this->hydrateContactRotationsForNewLogs($contacts->getKeys(), $event->getCampaign()->getId());
 
@@ -159,11 +154,9 @@ class EventLogger
     }
 
     /**
-     * @param bool $isInactiveEntry
-     *
      * @return ArrayCollection
      */
-    public function generateLogsFromContacts(Event $event, AbstractEventAccessor $config, ArrayCollection $contacts, $isInactiveEntry)
+    public function generateLogsFromContacts(Event $event, AbstractEventAccessor $config, ArrayCollection $contacts, bool $isInactiveEntry)
     {
         $isDecision = Event::TYPE_DECISION === $event->getEventType();
         $campaign   = $event->getCampaign();

--- a/app/bundles/CampaignBundle/Membership/MembershipManager.php
+++ b/app/bundles/CampaignBundle/Membership/MembershipManager.php
@@ -31,10 +31,7 @@ class MembershipManager
     ) {
     }
 
-    /**
-     * @param bool $isManualAction
-     */
-    public function addContact(Lead $contact, Campaign $campaign, $isManualAction = true): void
+    public function addContact(Lead $contact, Campaign $campaign, bool $isManualAction = true): void
     {
         // Validate that contact is not already in the Campaign
         /** @var CampaignMember $campaignMember */
@@ -86,9 +83,8 @@ class MembershipManager
 
     /**
      * @param ArrayCollection<int, Lead> $contacts
-     * @param bool                       $isManualAction
      */
-    public function addContacts(ArrayCollection $contacts, Campaign $campaign, $isManualAction = true): void
+    public function addContacts(ArrayCollection $contacts, Campaign $campaign, bool $isManualAction = true): void
     {
         // Get a list of existing campaign members
         $campaignMembers = $this->leadRepository->getCampaignMembers($contacts->getKeys(), $campaign);
@@ -135,10 +131,7 @@ class MembershipManager
         $this->leadRepository->detachEntities($campaignMembers);
     }
 
-    /**
-     * @param bool $isExit
-     */
-    public function removeContact(Lead $contact, Campaign $campaign, $isExit = false): void
+    public function removeContact(Lead $contact, Campaign $campaign, bool $isExit = false): void
     {
         // Validate that contact is not already in the Campaign
         /** @var CampaignMember $campaignMember */
@@ -177,7 +170,7 @@ class MembershipManager
      * @param bool                       $isExit   If true, the contact can be added by a segment/source. If false, the contact can only be added back
      *                                             by a manual process.
      */
-    public function removeContacts(ArrayCollection $contacts, Campaign $campaign, $isExit = false): void
+    public function removeContacts(ArrayCollection $contacts, Campaign $campaign, bool $isExit = false): void
     {
         // Get a list of existing campaign members
         $campaignMembers = $this->leadRepository->getCampaignMembers($contacts->getKeys(), $campaign);

--- a/app/bundles/CampaignBundle/Model/CampaignModel.php
+++ b/app/bundles/CampaignBundle/Model/CampaignModel.php
@@ -178,7 +178,7 @@ class CampaignModel extends CommonFormModel implements GlobalSearchInterface
     /**
      * @throws MethodNotAllowedHttpException
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?\Symfony\Contracts\EventDispatcher\Event $event = null): ?\Symfony\Contracts\EventDispatcher\Event
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?\Symfony\Contracts\EventDispatcher\Event $event = null): ?\Symfony\Contracts\EventDispatcher\Event
     {
         if ($entity instanceof CampaignLead) {
             return null;
@@ -520,9 +520,8 @@ class CampaignModel extends CommonFormModel implements GlobalSearchInterface
      * Get a list of source choices.
      *
      * @param string $sourceType
-     * @param bool   $globalOnly
      */
-    public function getSourceLists($sourceType = null, $globalOnly = false, bool $useIdsForLists = false): array
+    public function getSourceLists($sourceType = null, bool $globalOnly = false, bool $useIdsForLists = false): array
     {
         $choices = [];
         switch ($sourceType) {
@@ -574,11 +573,9 @@ class CampaignModel extends CommonFormModel implements GlobalSearchInterface
     /**
      * Gets the campaigns a specific lead is part of.
      *
-     * @param bool $forList
-     *
      * @return mixed
      */
-    public function getLeadCampaigns(?Lead $lead = null, $forList = false)
+    public function getLeadCampaigns(?Lead $lead = null, bool $forList = false)
     {
         static $campaigns = [];
 
@@ -674,12 +671,11 @@ class CampaignModel extends CommonFormModel implements GlobalSearchInterface
     /**
      * Get line chart data of leads added to campaigns.
      *
-     * @param string $unit          {@link php.net/manual/en/function.date.php#refsect1-function.date-parameters}
+     * @param string $unit       {@link php.net/manual/en/function.date.php#refsect1-function.date-parameters}
      * @param string $dateFormat
      * @param array  $filter
-     * @param bool   $canViewOthers
      */
-    public function getLeadsAddedLineChartData($unit, \DateTime $dateFrom, \DateTime $dateTo, $dateFormat = null, $filter = [], $canViewOthers = true): array
+    public function getLeadsAddedLineChartData($unit, \DateTime $dateFrom, \DateTime $dateTo, $dateFormat = null, $filter = [], bool $canViewOthers = true): array
     {
         $chart = new LineChart($unit, $dateFrom, $dateTo, $dateFormat);
         $query = new ChartQuery($this->em->getConnection(), $dateFrom, $dateTo);
@@ -785,10 +781,9 @@ class CampaignModel extends CommonFormModel implements GlobalSearchInterface
     }
 
     /**
-     * @param int  $limit
-     * @param bool $maxLeads
+     * @param int $limit
      */
-    public function rebuildCampaignLeads(Campaign $campaign, $limit = 1000, $maxLeads = false, ?OutputInterface $output = null): int
+    public function rebuildCampaignLeads(Campaign $campaign, $limit = 1000, bool $maxLeads = false, ?OutputInterface $output = null): int
     {
         $contactLimiter = new ContactLimiter($limit);
 

--- a/app/bundles/CampaignBundle/Model/EventModel.php
+++ b/app/bundles/CampaignBundle/Model/EventModel.php
@@ -123,12 +123,11 @@ class EventModel extends FormModel
     /**
      * Get line chart data of campaign events.
      *
-     * @param string $unit          {@link php.net/manual/en/function.date.php#refsect1-function.date-parameters}
+     * @param string $unit       {@link php.net/manual/en/function.date.php#refsect1-function.date-parameters}
      * @param string $dateFormat
      * @param array  $filter
-     * @param bool   $canViewOthers
      */
-    public function getEventLineChartData($unit, \DateTime $dateFrom, \DateTime $dateTo, $dateFormat = null, $filter = [], $canViewOthers = true): array
+    public function getEventLineChartData($unit, \DateTime $dateFrom, \DateTime $dateTo, $dateFormat = null, $filter = [], bool $canViewOthers = true): array
     {
         $chart = new LineChart($unit, $dateFrom, $dateTo, $dateFormat);
         $query = new ChartQuery($this->em->getConnection(), $dateFrom, $dateTo);

--- a/app/bundles/CampaignBundle/Tests/EventListener/CampaignActionJumpToEventSubscriberTest.php
+++ b/app/bundles/CampaignBundle/Tests/EventListener/CampaignActionJumpToEventSubscriberTest.php
@@ -204,7 +204,7 @@ final class CampaignActionJumpToEventSubscriberTest extends TestCase
             {
             }
 
-            public function executeForContacts(Event $event, ArrayCollection $contacts, ?Counter $counter = null, $isInactiveEvent = false): void
+            public function executeForContacts(Event $event, ArrayCollection $contacts, ?Counter $counter = null, bool $isInactiveEvent = false): void
             {
                 Assert::assertSame(222, $event->getId());
                 Assert::assertCount(1, $contacts);

--- a/app/bundles/CampaignBundle/Tests/Executioner/EventExecutionerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/EventExecutionerTest.php
@@ -139,7 +139,7 @@ final class EventExecutionerTest extends \PHPUnit\Framework\TestCase
         $this->eventLogger->expects($this->exactly(2))
             ->method('fetchRotationAndGenerateLogsFromContacts')
             ->willReturnCallback(
-                function (Event $event, ActionAccessor $config, ArrayCollection $contacts, $isInactiveEntry): ArrayCollection {
+                function (Event $event, ActionAccessor $config, ArrayCollection $contacts, bool $isInactiveEntry): ArrayCollection {
                     $logs = new ArrayCollection();
                     foreach ($contacts as $contact) {
                         $log = new LeadEventLog();

--- a/app/bundles/ChannelBundle/Controller/MessageController.php
+++ b/app/bundles/ChannelBundle/Controller/MessageController.php
@@ -42,10 +42,7 @@ final class MessageController extends AbstractStandardFormController
         return $this->cloneStandard($request, $objectId);
     }
 
-    /**
-     * @param bool $ignorePost
-     */
-    public function editAction(Request $request, $objectId, $ignorePost = false): Response
+    public function editAction(Request $request, $objectId, bool $ignorePost = false): Response
     {
         return $this->editStandard($request, $objectId, $ignorePost);
     }

--- a/app/bundles/ChannelBundle/Entity/MessageQueue.php
+++ b/app/bundles/ChannelBundle/Entity/MessageQueue.php
@@ -402,10 +402,7 @@ class MessageQueue
         return $this->success;
     }
 
-    /**
-     * @param bool $success
-     */
-    public function setSuccess($success = true): void
+    public function setSuccess(bool $success = true): void
     {
         $this->success = $success;
     }
@@ -418,10 +415,7 @@ class MessageQueue
         return $this->failed;
     }
 
-    /**
-     * @param bool $failed
-     */
-    public function setFailed($failed = true): static
+    public function setFailed(bool $failed = true): static
     {
         $this->failed = $failed;
 
@@ -436,10 +430,7 @@ class MessageQueue
         return $this->processed;
     }
 
-    /**
-     * @param bool $processed
-     */
-    public function setProcessed($processed = true): static
+    public function setProcessed(bool $processed = true): static
     {
         $this->processed = $processed;
 

--- a/app/bundles/ChannelBundle/Helper/ChannelListHelper.php
+++ b/app/bundles/ChannelBundle/Helper/ChannelListHelper.php
@@ -39,10 +39,7 @@ class ChannelListHelper
         return $channels;
     }
 
-    /**
-     * @param bool $listOnly
-     */
-    public function getFeatureChannels($features, $listOnly = false): array
+    public function getFeatureChannels($features, bool $listOnly = false): array
     {
         $this->setupChannels();
 

--- a/app/bundles/ChannelBundle/Model/MessageModel.php
+++ b/app/bundles/ChannelBundle/Model/MessageModel.php
@@ -52,9 +52,8 @@ class MessageModel extends FormModel implements AjaxLookupModelInterface, Global
 
     /**
      * @param Message $entity
-     * @param bool    $unlock
      */
-    public function saveEntity($entity, $unlock = true): void
+    public function saveEntity($entity, bool $unlock = true): void
     {
         $isNew = $entity->isNew();
 
@@ -233,7 +232,7 @@ class MessageModel extends FormModel implements AjaxLookupModelInterface, Global
     /**
      * @throws MethodNotAllowedHttpException
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?Event $event = null): ?Event
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?Event $event = null): ?Event
     {
         if (!$entity instanceof Message) {
             throw new MethodNotAllowedHttpException(['Message']);

--- a/app/bundles/ChannelBundle/Model/MessageQueueModel.php
+++ b/app/bundles/ChannelBundle/Model/MessageQueueModel.php
@@ -280,10 +280,7 @@ class MessageQueueModel extends FormModel
         return $counter;
     }
 
-    /**
-     * @param bool $persist
-     */
-    public function reschedule($message, \DateInterval $rescheduleInterval, $leadId = null, $channel = null, $channelId = null, $persist = false): void
+    public function reschedule($message, \DateInterval $rescheduleInterval, $leadId = null, $channel = null, $channelId = null, bool $persist = false): void
     {
         if (!$message instanceof MessageQueue && $leadId && $channel && $channelId) {
             $message = $this->messageQueueRepository->findMessage($channel, $channelId, $leadId);
@@ -320,7 +317,7 @@ class MessageQueueModel extends FormModel
      *
      * @throws \Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?Event $event = null): ?Event
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?Event $event = null): ?Event
     {
         switch ($action) {
             case 'process_message_queue':

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -1794,9 +1794,8 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
 
     /**
      * @param int  $reason
-     * @param bool $flush
      */
-    public function setEmailDoNotContact($email, $reason = DoNotContact::BOUNCED, ?string $comments = '', $flush = true, $leadId = null): array
+    public function setEmailDoNotContact($email, $reason = DoNotContact::BOUNCED, ?string $comments = '', bool $flush = true, $leadId = null): array
     {
         if (null === $leadId) {
             $leadId = (array) $this->leadRepository->getLeadByEmail($email, true);

--- a/app/bundles/LeadBundle/Controller/Api/CustomFieldsApiControllerTrait.php
+++ b/app/bundles/LeadBundle/Controller/Api/CustomFieldsApiControllerTrait.php
@@ -165,11 +165,10 @@ trait CustomFieldsApiControllerTrait
      * @param Lead|Company         $entity
      * @param FormInterface<mixed> $form
      * @param mixed[]              $parameters
-     * @param bool                 $isPostOrPatch
      *
      * @return bool|void
      */
-    protected function setCustomFieldValues($entity, $form, $parameters, $isPostOrPatch = false)
+    protected function setCustomFieldValues($entity, $form, $parameters, bool $isPostOrPatch = false)
     {
         // set the custom field values
         // pull the data from the form in order to apply the form's formatting

--- a/app/bundles/LeadBundle/Controller/CompanyController.php
+++ b/app/bundles/LeadBundle/Controller/CompanyController.php
@@ -329,10 +329,9 @@ final class CompanyController extends FormController
     /**
      * Generates edit form and processes post data.
      *
-     * @param int  $objectId
-     * @param bool $ignorePost
+     * @param int $objectId
      */
-    public function editAction(Request $request, $objectId, $ignorePost = false): Response
+    public function editAction(Request $request, $objectId, bool $ignorePost = false): Response
     {
         $entity = $this->companyModel->getEntity($objectId);
 

--- a/app/bundles/LeadBundle/Controller/FieldController.php
+++ b/app/bundles/LeadBundle/Controller/FieldController.php
@@ -237,10 +237,8 @@ final class FieldController extends FormController
 
     /**
      * Generate's edit form and processes post data.
-     *
-     * @param bool|false $ignorePost
      */
-    public function editAction(Request $request, $objectId, $ignorePost = false): Response
+    public function editAction(Request $request, $objectId, bool $ignorePost = false): Response
     {
         if (!$this->security->isGranted('lead:fields:full')) {
             $this->throwAccessDenied();

--- a/app/bundles/LeadBundle/Controller/FrequencyRuleTrait.php
+++ b/app/bundles/LeadBundle/Controller/FrequencyRuleTrait.php
@@ -31,12 +31,10 @@ trait FrequencyRuleTrait
 
     /**
      * @param array $viewParameters
-     * @param bool  $isPublic
-     * @param bool  $isPreferenceCenter
      *
      * @return true|FormInterface
      */
-    protected function getFrequencyRuleForm(Lead $lead, &$viewParameters = [], &$data = null, $isPublic = false, $action = null, $isPreferenceCenter = false)
+    protected function getFrequencyRuleForm(Lead $lead, &$viewParameters = [], &$data = null, bool $isPublic = false, $action = null, bool $isPreferenceCenter = false)
     {
         /** @var LeadModel $model */
         $model = $this->getModel('lead');
@@ -98,10 +96,7 @@ trait FrequencyRuleTrait
         return $form;
     }
 
-    /**
-     * @param bool $isPublic
-     */
-    protected function getFrequencyRuleFormData(Lead $lead, ?array $allChannels = null, $leadChannels = null, $isPublic = false, $frequencyRules = null, $isPreferenceCenter = false): array
+    protected function getFrequencyRuleFormData(Lead $lead, ?array $allChannels = null, $leadChannels = null, bool $isPublic = false, $frequencyRules = null, bool $isPreferenceCenter = false): array
     {
         $data = [];
 

--- a/app/bundles/LeadBundle/Controller/ImportController.php
+++ b/app/bundles/LeadBundle/Controller/ImportController.php
@@ -173,10 +173,9 @@ final class ImportController extends FormController
     }
 
     /**
-     * @param int  $objectId
-     * @param bool $ignorePost
+     * @param int $objectId
      */
-    public function newAction(Request $request, $objectId = 0, $ignorePost = false): Response
+    public function newAction(Request $request, $objectId = 0, bool $ignorePost = false): Response
     {
         try {
             $initEvent = $this->dispatchImportOnInit();

--- a/app/bundles/LeadBundle/Controller/LeadAccessTrait.php
+++ b/app/bundles/LeadBundle/Controller/LeadAccessTrait.php
@@ -12,11 +12,9 @@ trait LeadAccessTrait
     /**
      * Determines if the user has access to the lead the note is for.
      *
-     * @param bool $isPlugin
-     *
      * @return Response|Lead
      */
-    protected function checkLeadAccess($leadId, $action, $isPlugin = false, $integration = '')
+    protected function checkLeadAccess($leadId, $action, bool $isPlugin = false, $integration = '')
     {
         if (!$leadId instanceof Lead) {
             // make sure the user has view access to this lead

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -712,10 +712,8 @@ final class LeadController extends FormController
 
     /**
      * Generates edit form.
-     *
-     * @param bool|false $ignorePost
      */
-    public function editAction(Request $request, UserHelper $userHelper, AvatarHelper $avatarHelper, $objectId, $ignorePost = false): Response
+    public function editAction(Request $request, UserHelper $userHelper, AvatarHelper $avatarHelper, $objectId, bool $ignorePost = false): Response
     {
         $lead  = $this->leadModel->getEntity($objectId);
 

--- a/app/bundles/LeadBundle/Controller/ListController.php
+++ b/app/bundles/LeadBundle/Controller/ListController.php
@@ -206,10 +206,9 @@ final class ListController extends FormController
     /**
      * Generate's clone form and processes post data.
      *
-     * @param int  $objectId
-     * @param bool $ignorePost
+     * @param int $objectId
      */
-    public function cloneAction(Request $request, SegmentDependencies $segmentDependencies, SegmentCampaignShare $segmentCampaignShare, ListModel $listModel, AuditLogModel $auditLogModel, $objectId, $ignorePost = false): Response
+    public function cloneAction(Request $request, SegmentDependencies $segmentDependencies, SegmentCampaignShare $segmentCampaignShare, ListModel $listModel, AuditLogModel $auditLogModel, $objectId, bool $ignorePost = false): Response
     {
         if (!$this->security->isGranted(LeadPermissions::LISTS_CREATE)) {
             $this->throwAccessDenied();
@@ -228,7 +227,7 @@ final class ListController extends FormController
                 $auditLogModel,
                 $postActionVars,
                 $this->generateUrl('mautic_segment_action', ['objectAction' => 'clone', 'objectId' => $objectId]),
-                (bool) $ignorePost
+                $ignorePost
             );
         } catch (EntityNotFoundException) {
             return $this->postActionRedirect(

--- a/app/bundles/LeadBundle/Deduplicate/Helper/MergeValueHelper.php
+++ b/app/bundles/LeadBundle/Deduplicate/Helper/MergeValueHelper.php
@@ -13,13 +13,12 @@ final class MergeValueHelper
      * @param mixed $olderValue
      * @param mixed $currentValue
      * @param mixed $defaultValue
-     * @param bool  $newIsAnonymous
      *
      * @return mixed
      *
      * @throws ValueNotMergeableException
      */
-    public static function getMergeValue($newerValue, $olderValue, $currentValue = null, $defaultValue = null, $newIsAnonymous = false)
+    public static function getMergeValue($newerValue, $olderValue, $currentValue = null, $defaultValue = null, bool $newIsAnonymous = false)
     {
         if ($newerValue === $olderValue) {
             throw new ValueNotMergeableException($newerValue, $olderValue);

--- a/app/bundles/LeadBundle/Entity/CompanyLeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/CompanyLeadRepository.php
@@ -19,7 +19,7 @@ class CompanyLeadRepository extends CommonRepository
     /**
      * @param CompanyLead[] $entities
      */
-    public function saveEntities($entities, $new = true): void
+    public function saveEntities($entities, bool $new = true): void
     {
         // Get a list of contacts and set primary to 0
         if ($new) {

--- a/app/bundles/LeadBundle/Entity/CompanyRepository.php
+++ b/app/bundles/LeadBundle/Entity/CompanyRepository.php
@@ -231,12 +231,11 @@ class CompanyRepository extends CommonRepository implements CustomFieldRepositor
     }
 
     /**
-     * @param bool   $user
      * @param string $id
      *
      * @return array|mixed
      */
-    public function getCompanies($user = false, $id = '')
+    public function getCompanies(bool $user = false, $id = '')
     {
         $q                = $this->_em->getConnection()->createQueryBuilder();
         static $companies = [];

--- a/app/bundles/LeadBundle/Entity/CustomFieldEntityTrait.php
+++ b/app/bundles/LeadBundle/Entity/CustomFieldEntityTrait.php
@@ -72,11 +72,9 @@ trait CustomFieldEntityTrait
     }
 
     /**
-     * @param bool $ungroup
-     *
      * @return array
      */
-    public function getFields($ungroup = false)
+    public function getFields(bool $ungroup = false)
     {
         if ($ungroup && isset($this->fields['core'])) {
             $return = [];

--- a/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
+++ b/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
@@ -180,10 +180,9 @@ trait CustomFieldRepositoryTrait
     }
 
     /**
-     * @param bool   $byGroup
      * @param string $object
      */
-    public function getFieldValues($id, $byGroup = true, $object = 'lead'): array
+    public function getFieldValues($id, bool $byGroup = true, $object = 'lead'): array
     {
         // use DBAL to get entity fields
         $q = $this->getEntitiesDbalQueryBuilder();
@@ -254,10 +253,7 @@ trait CustomFieldRepositoryTrait
         }
     }
 
-    /**
-     * @param bool $flush
-     */
-    public function saveEntity(object $entity, $flush = true): void
+    public function saveEntity(object $entity, bool $flush = true): void
     {
         $this->preSaveEntity($entity);
 
@@ -302,10 +298,9 @@ trait CustomFieldRepositoryTrait
 
     /**
      * @param array  $values
-     * @param bool   $byGroup
      * @param string $object
      */
-    protected function formatFieldValues($values, $byGroup = true, $object = 'lead'): array
+    protected function formatFieldValues($values, bool $byGroup = true, $object = 'lead'): array
     {
         [$fields, $fixedFields] = $this->getCustomFieldList($object);
 

--- a/app/bundles/LeadBundle/Entity/DoNotContactRepository.php
+++ b/app/bundles/LeadBundle/Entity/DoNotContactRepository.php
@@ -30,9 +30,8 @@ class DoNotContactRepository extends CommonRepository
      * @param array<int,int|string>|int|null      $ids
      * @param int|null                            $reason
      * @param array<int,int|string>|int|true|null $listId
-     * @param bool                                $combined
      */
-    public function getCount($channel = null, $ids = null, $reason = null, $listId = null, ?ChartQuery $chartQuery = null, $combined = false): array|int
+    public function getCount($channel = null, $ids = null, $reason = null, $listId = null, ?ChartQuery $chartQuery = null, bool $combined = false): array|int
     {
         $q = $this->_em->getConnection()->createQueryBuilder();
 

--- a/app/bundles/LeadBundle/Entity/Import.php
+++ b/app/bundles/LeadBundle/Entity/Import.php
@@ -503,7 +503,7 @@ class Import extends FormEntity
      *
      * @phpstan-impure
      */
-    public function end($removeFile = true): self
+    public function end(bool $removeFile = true): self
     {
         $this->setDateEnded(new \DateTime());
 

--- a/app/bundles/LeadBundle/Entity/Lead.php
+++ b/app/bundles/LeadBundle/Entity/Lead.php
@@ -687,11 +687,9 @@ class Lead extends FormEntity implements CustomFieldEntityInterface, IdentifierF
     /**
      * Get full name.
      *
-     * @param bool $lastFirst
-     *
      * @return string
      */
-    public function getName($lastFirst = false)
+    public function getName(bool $lastFirst = false)
     {
         $fullName = '';
         if ($lastFirst && $this->firstname && $this->lastname) {
@@ -726,11 +724,9 @@ class Lead extends FormEntity implements CustomFieldEntityInterface, IdentifierF
     /**
      * Get the primary identifier for the lead.
      *
-     * @param bool $lastFirst
-     *
      * @return string
      */
-    public function getPrimaryIdentifier($lastFirst = false)
+    public function getPrimaryIdentifier(bool $lastFirst = false)
     {
         if ($name = $this->getName($lastFirst)) {
             return $name;
@@ -996,11 +992,7 @@ class Lead extends FormEntity implements CustomFieldEntityInterface, IdentifierF
         return $this->companyChangeLog;
     }
 
-    /**
-     * @param bool $enabled
-     * @param bool $mobile
-     */
-    public function addPushIDEntry($identifier, $enabled = true, $mobile = false): static
+    public function addPushIDEntry($identifier, bool $enabled = true, bool $mobile = false): static
     {
         $entity = new PushID();
 

--- a/app/bundles/LeadBundle/Entity/LeadFieldRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadFieldRepository.php
@@ -32,11 +32,9 @@ class LeadFieldRepository extends CommonRepository
      * Retrieves array of aliases used to ensure unique alias for new fields.
      *
      * @param int    $exludingId
-     * @param bool   $publishedOnly
-     * @param bool   $includeEntityFields
-     * @param string $object              name of object using the custom fields
+     * @param string $object     name of object using the custom fields
      */
-    public function getAliases($exludingId, $publishedOnly = false, $includeEntityFields = true, $object = 'lead'): array
+    public function getAliases($exludingId, bool $publishedOnly = false, bool $includeEntityFields = true, $object = 'lead'): array
     {
         $q = $this->_em->getConnection()->createQueryBuilder()
             ->select('l.alias')

--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -127,14 +127,11 @@ class LeadListRepository extends CommonRepository
     /**
      * Get lists for a specific lead.
      *
-     * @param int|Lead[] $lead                 Lead ID or array of Leads
-     * @param bool       $forList
-     * @param bool       $singleArrayHydration
-     * @param bool       $isPublic
+     * @param int|Lead[] $lead Lead ID or array of Leads
      *
      * @return mixed
      */
-    public function getLeadLists($lead, $forList = false, $singleArrayHydration = false, $isPublic = false, $isPreferenceCenter = false)
+    public function getLeadLists($lead, bool $forList = false, bool $singleArrayHydration = false, bool $isPublic = false, bool $isPreferenceCenter = false)
     {
         if (is_array($lead)) {
             $q = $this->getEntityManager()->createQueryBuilder()

--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -118,11 +118,10 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
      * @param string          $field
      * @param string[]|string $value
      * @param ?int            $ignoreId
-     * @param bool            $indexByColumn
      *
      * @return array
      */
-    public function getLeadsByFieldValue($field, $value, $ignoreId = null, $indexByColumn = false)
+    public function getLeadsByFieldValue($field, $value, $ignoreId = null, bool $indexByColumn = false)
     {
         $results = $this->getEntities([
             'qb'               => $this->buildQueryForGetLeadsByFieldValue($field, $value, $ignoreId),
@@ -319,7 +318,7 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
      *
      * @return array|null
      */
-    public function getLeadByEmail($email, $all = false)
+    public function getLeadByEmail($email, bool $all = false)
     {
         $q = $this->getEntityManager()->getConnection()->createQueryBuilder()
             ->select('l.id')
@@ -339,11 +338,9 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
     /**
      * Get leads by IP address.
      *
-     * @param bool $byId
-     *
      * @return array
      */
-    public function getLeadsByIp($ip, $byId = false)
+    public function getLeadsByIp($ip, bool $byId = false)
     {
         $q = $this->createQueryBuilder('l')
             ->leftJoin('l.ipAddresses', 'i');

--- a/app/bundles/LeadBundle/Entity/TagRepository.php
+++ b/app/bundles/LeadBundle/Entity/TagRepository.php
@@ -16,7 +16,7 @@ class TagRepository extends CommonRepository
      * @param Tag  $entity
      * @param bool $flush  true by default; use false if persisting in batches
      */
-    public function deleteEntity(object $entity, $flush = true): void
+    public function deleteEntity(object $entity, bool $flush = true): void
     {
         if ($entity instanceof Tag && null !== $entity->getId()) {
             $this->deleteLeadAssociations((int) $entity->getId());

--- a/app/bundles/LeadBundle/Event/LeadTimelineEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadTimelineEvent.php
@@ -325,10 +325,8 @@ final class LeadTimelineEvent extends Event
 
     /**
      * Determine if an event type should be included.
-     *
-     * @param bool $inclusive
      */
-    public function isApplicable($eventType, $inclusive = false): bool
+    public function isApplicable($eventType, bool $inclusive = false): bool
     {
         if ($this->fetchTypesOnly) {
             return false;

--- a/app/bundles/LeadBundle/Helper/TokenHelper.php
+++ b/app/bundles/LeadBundle/Helper/TokenHelper.php
@@ -22,7 +22,7 @@ final class TokenHelper
      *
      * @return array|string
      */
-    public static function findLeadTokens($content, $lead, $replace = false)
+    public static function findLeadTokens($content, $lead, bool $replace = false)
     {
         if (!$lead) {
             return $replace ? $content : [];

--- a/app/bundles/LeadBundle/Model/CompanyModel.php
+++ b/app/bundles/LeadBundle/Model/CompanyModel.php
@@ -89,9 +89,8 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
 
     /**
      * @param Company $entity
-     * @param bool    $unlock
      */
-    public function saveEntity($entity, $unlock = true): void
+    public function saveEntity($entity, bool $unlock = true): void
     {
         // Update leads primary company name
         $this->setEntityDefaultValues($entity, 'company');
@@ -103,9 +102,8 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
      * Save an array of entities.
      *
      * @param array $entities
-     * @param bool  $unlock
      */
-    public function saveEntities($entities, $unlock = true): void
+    public function saveEntities($entities, bool $unlock = true): void
     {
         // Update leads primary company name
         foreach ($entities as $entity) {
@@ -614,7 +612,7 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
     /**
      * @throws MethodNotAllowedHttpException
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?Event $event = null): ?Event
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?Event $event = null): ?Event
     {
         if (!$entity instanceof Company) {
             throw new MethodNotAllowedHttpException(['Email']);
@@ -792,7 +790,7 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
     /**
      * @throws \Exception
      */
-    public function importCompany(array $fields, array $data, $owner = null, $persist = true, $skipIfExists = false): ?Company
+    public function importCompany(array $fields, array $data, $owner = null, bool $persist = true, bool $skipIfExists = false): ?Company
     {
         try {
             $duplicateCompanies = $this->companyDeduper->checkForDuplicateCompanies($this->getFieldData($fields, $data));

--- a/app/bundles/LeadBundle/Model/DeviceModel.php
+++ b/app/bundles/LeadBundle/Model/DeviceModel.php
@@ -73,7 +73,7 @@ final class DeviceModel extends FormModel
     /**
      * @throws MethodNotAllowedHttpException
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?Event $event = null): ?Event
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?Event $event = null): ?Event
     {
         if (!$entity instanceof LeadDevice) {
             throw new MethodNotAllowedHttpException(['LeadDevice']);

--- a/app/bundles/LeadBundle/Model/DoNotContact.php
+++ b/app/bundles/LeadBundle/Model/DoNotContact.php
@@ -29,12 +29,11 @@ class DoNotContact implements MauticModelInterface
     /**
      * Remove a Lead's DNC entry based on channel.
      *
-     * @param int|Lead  $contact
-     * @param string    $channel
-     * @param bool|true $persist
-     * @param int|null  $reason
+     * @param int|Lead $contact
+     * @param string   $channel
+     * @param int|null $reason
      */
-    public function removeDncForContact($contact, $channel, $persist = true, $reason = null): bool
+    public function removeDncForContact($contact, $channel, bool $persist = true, $reason = null): bool
     {
         if (is_numeric($contact)) {
             $contact = $this->leadModel->getEntity($contact);
@@ -69,11 +68,8 @@ class DoNotContact implements MauticModelInterface
      * Create a DNC entry for a lead.
      *
      * @param Lead|int|string|null $contact
-     * @param string|mixed[]       $channel                  If an array with an ID, use the structure ['email' => 123]
-     * @param int                  $reason                   Must be a class constant from the DoNotContact class
-     * @param bool                 $persist
-     * @param bool                 $checkCurrentStatus
-     * @param bool                 $allowUnsubscribeOverride
+     * @param string|mixed[]       $channel If an array with an ID, use the structure ['email' => 123]
+     * @param int                  $reason  Must be a class constant from the DoNotContact class
      *
      * @return DNC|null If a DNC entry is added or updated, returns the DoNotContact object. If a DNC is already present
      *                  and has the specified reason, nothing is done and this returns false
@@ -83,9 +79,9 @@ class DoNotContact implements MauticModelInterface
         $channel,
         $reason = DNC::BOUNCED,
         ?string $comments = '',
-        $persist = true,
-        $checkCurrentStatus = true,
-        $allowUnsubscribeOverride = false,
+        bool $persist = true,
+        bool $checkCurrentStatus = true,
+        bool $allowUnsubscribeOverride = false,
     ): ?DNC {
         $dnc     = null;
         if (is_numeric($contact)) {

--- a/app/bundles/LeadBundle/Model/FieldModel.php
+++ b/app/bundles/LeadBundle/Model/FieldModel.php
@@ -604,7 +604,6 @@ class FieldModel extends FormModel
 
     /**
      * @param LeadField $entity
-     * @param bool      $unlock
      *
      * @throws AbortColumnCreateException
      * @throws AbortColumnUpdateException
@@ -613,7 +612,7 @@ class FieldModel extends FormModel
      * @throws SchemaException
      * @throws \Mautic\CoreBundle\Exception\SchemaException
      */
-    public function saveEntity($entity, $unlock = true): void
+    public function saveEntity($entity, bool $unlock = true): void
     {
         if (!$entity instanceof LeadField) {
             throw new MethodNotAllowedHttpException(['LeadEntity']);
@@ -646,7 +645,6 @@ class FieldModel extends FormModel
      * Build schema for each entity.
      *
      * @param array $entities
-     * @param bool  $unlock
      *
      * @throws AbortColumnCreateException
      * @throws Exception
@@ -654,7 +652,7 @@ class FieldModel extends FormModel
      * @throws SchemaException
      * @throws \Mautic\CoreBundle\Exception\SchemaException
      */
-    public function saveEntities($entities, $unlock = true): void
+    public function saveEntities($entities, bool $unlock = true): void
     {
         foreach ($entities as $entity) {
             $this->saveEntity($entity, $unlock);
@@ -855,7 +853,7 @@ class FieldModel extends FormModel
     /**
      * @throws MethodNotAllowedHttpException
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?Event $event = null): ?Event
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?Event $event = null): ?Event
     {
         switch ($action) {
             case 'pre_save':

--- a/app/bundles/LeadBundle/Model/ImportModel.php
+++ b/app/bundles/LeadBundle/Model/ImportModel.php
@@ -596,7 +596,7 @@ class ImportModel extends FormModel
     /**
      * @throws MethodNotAllowedHttpException
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?Event $event = null): ?Event
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?Event $event = null): ?Event
     {
         if (!$entity instanceof Import) {
             throw new MethodNotAllowedHttpException(['Import']);

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -375,7 +375,7 @@ class LeadModel extends FormModel
     /**
      * @throws MethodNotAllowedHttpException
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?Event $event = null): ?Event
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?Event $event = null): ?Event
     {
         if (!$entity instanceof Lead) {
             throw new MethodNotAllowedHttpException(['Lead'], 'Entity must be of class Lead()');
@@ -466,9 +466,8 @@ class LeadModel extends FormModel
 
     /**
      * @param Lead $entity
-     * @param bool $unlock
      */
-    public function saveEntity($entity, $unlock = true): void
+    public function saveEntity($entity, bool $unlock = true): void
     {
         $companyFieldMatches = [];
         $fields              = $entity->getFields();
@@ -560,13 +559,11 @@ class LeadModel extends FormModel
     /**
      * Populates custom field values for updating the lead. Also retrieves social media data.
      *
-     * @param bool|false $overwriteWithBlank
-     * @param bool|true  $fetchSocialProfiles
-     * @param bool|false $bindWithForm        Send $data through the Lead form and only use valid data (should be used with request data)
+     * @param bool|false $bindWithForm Send $data through the Lead form and only use valid data (should be used with request data)
      *
      * @throws ImportFailedException
      */
-    public function setFieldValues(Lead $lead, array $data, $overwriteWithBlank = false, $fetchSocialProfiles = true, $bindWithForm = false): void
+    public function setFieldValues(Lead $lead, array $data, bool $overwriteWithBlank = false, bool $fetchSocialProfiles = true, bool $bindWithForm = false): void
     {
         if ($fetchSocialProfiles) {
             // @todo - add a catch to NOT do social gleaning if a lead is created via a form, etc as we do not want the user to experience the wait
@@ -881,11 +878,9 @@ class LeadModel extends FormModel
     }
 
     /**
-     * @param bool $returnWithQueryFields
-     *
      * @return array{Lead, mixed[]}|Lead
      */
-    public function checkForDuplicateContact(array $queryFields, $returnWithQueryFields = false, $onlyPubliclyUpdateable = false)
+    public function checkForDuplicateContact(array $queryFields, bool $returnWithQueryFields = false, bool $onlyPubliclyUpdateable = false)
     {
         // Search for lead by request and/or update lead fields if some data were sent in the URL query
         if ([] === $this->availableLeadFields) {
@@ -942,13 +937,9 @@ class LeadModel extends FormModel
     /**
      * Get a list of segments this lead belongs to.
      *
-     * @param bool $forLists
-     * @param bool $arrayHydration
-     * @param bool $isPublic
-     *
      * @return mixed
      */
-    public function getLists(Lead $lead, $forLists = false, $arrayHydration = false, $isPublic = false, $isPreferenceCenter = false)
+    public function getLists(Lead $lead, bool $forLists = false, bool $arrayHydration = false, bool $isPublic = false, bool $isPreferenceCenter = false)
     {
         return $this->leadListRepository->getLeadLists($lead->getId(), $forLists, $arrayHydration, $isPublic, $isPreferenceCenter);
     }
@@ -968,19 +959,16 @@ class LeadModel extends FormModel
      *
      * @param array|Lead|int $lead
      * @param array|LeadList $lists
-     * @param bool           $manuallyAdded
      */
-    public function addToLists($lead, $lists, $manuallyAdded = true): void
+    public function addToLists($lead, $lists, bool $manuallyAdded = true): void
     {
         $this->leadListModel->addLead($lead, $lists, $manuallyAdded);
     }
 
     /**
      * Remove lead from lists.
-     *
-     * @param bool $manuallyRemoved
      */
-    public function removeFromLists($lead, $lists, $manuallyRemoved = true): void
+    public function removeFromLists($lead, $lists, bool $manuallyRemoved = true): void
     {
         $this->leadListModel->removeLead($lead, $lists, $manuallyRemoved);
     }
@@ -990,9 +978,8 @@ class LeadModel extends FormModel
      *
      * @param array|Lead  $lead
      * @param array|Stage $stage
-     * @param bool        $manuallyAdded
      */
-    public function addToStages($lead, $stage, $manuallyAdded = true): static
+    public function addToStages($lead, $stage, bool $manuallyAdded = true): static
     {
         if (!$lead instanceof Lead) {
             $leadId = (is_array($lead) && isset($lead['id'])) ? $lead['id'] : $lead;
@@ -1010,10 +997,8 @@ class LeadModel extends FormModel
 
     /**
      * Remove lead from Stage.
-     *
-     * @param bool $manuallyRemoved
      */
-    public function removeFromStages($lead, $stage, $manuallyRemoved = true): static
+    public function removeFromStages($lead, $stage, bool $manuallyRemoved = true): static
     {
         $lead->setStage(null);
         $lead->stageChangeLogEntry(
@@ -1051,7 +1036,7 @@ class LeadModel extends FormModel
      * @param array<string, mixed> $data
      * @param array<LeadList>      $leadLists
      */
-    public function setFrequencyRules(Lead $lead, array $data, array $leadLists, $persist = true): bool
+    public function setFrequencyRules(Lead $lead, array $data, array $leadLists, bool $persist = true): bool
     {
         // One query to get all the lead's current frequency rules and go ahead and create entities for them
         $frequencyRules = $lead->getFrequencyRules()->toArray();
@@ -1579,10 +1564,8 @@ class LeadModel extends FormModel
 
     /**
      * Update a leads tags.
-     *
-     * @param bool|false $removeOrphans
      */
-    public function setTags(Lead $lead, array $tags, $removeOrphans = false): void
+    public function setTags(Lead $lead, array $tags, bool $removeOrphans = false): void
     {
         /** @var Tag[] $currentTags */
         $currentTags  = $lead->getTags();
@@ -1864,13 +1847,12 @@ class LeadModel extends FormModel
     /**
      * Get bar chart data of contacts.
      *
-     * @param string    $unit          {@link php.net/manual/en/function.date.php#refsect1-function.date-parameters}
+     * @param string    $unit       {@link php.net/manual/en/function.date.php#refsect1-function.date-parameters}
      * @param \DateTime $dateFrom
      * @param \DateTime $dateTo
      * @param string    $dateFormat
-     * @param bool      $canViewOthers
      */
-    public function getLeadsLineChartData($unit, $dateFrom, $dateTo, $dateFormat = null, array $filter = [], $canViewOthers = true): array
+    public function getLeadsLineChartData($unit, $dateFrom, $dateTo, $dateFormat = null, array $filter = [], bool $canViewOthers = true): array
     {
         $flag        = null;
         $topLists    = null;
@@ -1949,9 +1931,8 @@ class LeadModel extends FormModel
      * @param string $dateFrom
      * @param string $dateTo
      * @param array  $filters
-     * @param bool   $canViewOthers
      */
-    public function getAnonymousVsIdentifiedPieChartData($dateFrom, $dateTo, $filters = [], $canViewOthers = true): array
+    public function getAnonymousVsIdentifiedPieChartData($dateFrom, $dateTo, $filters = [], bool $canViewOthers = true): array
     {
         $chart = new PieChart();
         $query = new ChartQuery($this->em->getConnection(), $dateFrom, $dateTo);
@@ -1975,9 +1956,8 @@ class LeadModel extends FormModel
      * @param \DateTime $dateFrom
      * @param \DateTime $dateTo
      * @param mixed[]   $filters
-     * @param bool      $canViewOthers
      */
-    public function getLeadMapData($dateFrom, $dateTo, $filters = [], $canViewOthers = true): array
+    public function getLeadMapData($dateFrom, $dateTo, $filters = [], bool $canViewOthers = true): array
     {
         if (!$canViewOthers) {
             $filter['owner_id'] = $this->userHelper->getUser()->getId();
@@ -2349,10 +2329,7 @@ class LeadModel extends FormModel
         }
     }
 
-    /**
-     * @param bool $persist
-     */
-    protected function createNewContact(IpAddress $ip, $persist = true): Lead
+    protected function createNewContact(IpAddress $ip, bool $persist = true): Lead
     {
         // let's create a lead
         $lead = new Lead();

--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -115,11 +115,10 @@ class ListModel extends FormModel implements GlobalSearchInterface
 
     /**
      * @param LeadList $entity
-     * @param bool     $unlock
      *
      * @throws \Doctrine\DBAL\Exception
      */
-    public function saveEntity($entity, $unlock = true): void
+    public function saveEntity($entity, bool $unlock = true): void
     {
         $isNew = !(bool) $entity->getId();
 
@@ -255,7 +254,7 @@ class ListModel extends FormModel implements GlobalSearchInterface
     /**
      * @throws MethodNotAllowedHttpException
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?Event $event = null): ?Event
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?Event $event = null): ?Event
     {
         if (!$entity instanceof LeadList) {
             throw new MethodNotAllowedHttpException(['LeadList'], 'Entity must be of class LeadList()');
@@ -377,12 +376,11 @@ class ListModel extends FormModel implements GlobalSearchInterface
     }
 
     /**
-     * @param int      $limit
-     * @param bool|int $maxLeads
+     * @param int $limit
      *
      * @throws \Exception
      */
-    public function rebuildListLeads(LeadList $leadList, $limit = 100, $maxLeads = false, ?OutputInterface $output = null): int
+    public function rebuildListLeads(LeadList $leadList, $limit = 100, int|bool|null $maxLeads = false, ?OutputInterface $output = null): int
     {
         defined('MAUTIC_REBUILDING_LEAD_LISTS') || define('MAUTIC_REBUILDING_LEAD_LISTS', 1);
 
@@ -597,14 +595,12 @@ class ListModel extends FormModel implements GlobalSearchInterface
      *
      * @param array|int|Lead $lead
      * @param array|LeadList $lists
-     * @param bool           $manuallyAdded
-     * @param bool           $batchProcess
      * @param int            $searchListLead  0 = reference, 1 = yes, -1 = known to not exist
      * @param \DateTime      $dateManipulated
      *
      * @throws \Exception
      */
-    public function addLead($lead, $lists, $manuallyAdded = false, $batchProcess = false, $searchListLead = 1, $dateManipulated = null): void
+    public function addLead($lead, $lists, bool $manuallyAdded = false, bool $batchProcess = false, $searchListLead = 1, $dateManipulated = null): void
     {
         if (null == $dateManipulated) {
             $dateManipulated = new \DateTime();
@@ -739,13 +735,9 @@ class ListModel extends FormModel implements GlobalSearchInterface
     /**
      * Remove a lead from lists.
      *
-     * @param bool $manuallyRemoved
-     * @param bool $batchProcess
-     * @param bool $skipFindOne
-     *
      * @throws \Exception
      */
-    public function removeLead($lead, $lists, $manuallyRemoved = false, $batchProcess = false, $skipFindOne = false): void
+    public function removeLead($lead, $lists, bool $manuallyRemoved = false, bool $batchProcess = false, bool $skipFindOne = false): void
     {
         if (!$lead instanceof Lead) {
             $leadId = (is_array($lead) && isset($lead['id'])) ? $lead['id'] : $lead;
@@ -897,9 +889,8 @@ class ListModel extends FormModel implements GlobalSearchInterface
      * @param int       $limit
      * @param \DateTime $dateFrom
      * @param \DateTime $dateTo
-     * @param bool      $canViewOthers
      */
-    public function getTopLists($limit = 10, $dateFrom = null, $dateTo = null, $canViewOthers = true): array
+    public function getTopLists($limit = 10, $dateFrom = null, $dateTo = null, bool $canViewOthers = true): array
     {
         $q = $this->em->getConnection()->createQueryBuilder();
         $q->select('COUNT(t.date_added) AS leads, ll.id, ll.name, ll.alias')
@@ -1022,10 +1013,7 @@ class ListModel extends FormModel implements GlobalSearchInterface
         return $chart->render(false);
     }
 
-    /**
-     * @param bool $canViewOthers
-     */
-    public function getStagesBarChartData($unit, \DateTime $dateFrom, \DateTime $dateTo, $dateFormat = null, array $filter = [], $canViewOthers = true): array
+    public function getStagesBarChartData($unit, \DateTime $dateFrom, \DateTime $dateTo, $dateFormat = null, array $filter = [], bool $canViewOthers = true): array
     {
         $data['values'] = [];
         $data['labels'] = [];
@@ -1082,10 +1070,7 @@ class ListModel extends FormModel implements GlobalSearchInterface
             ], ];
     }
 
-    /**
-     * @param bool $canViewOthers
-     */
-    public function getDeviceGranularityData($unit, \DateTime $dateFrom, \DateTime $dateTo, $dateFormat = null, array $filter = [], $canViewOthers = true): array
+    public function getDeviceGranularityData($unit, \DateTime $dateFrom, \DateTime $dateTo, $dateFormat = null, array $filter = [], bool $canViewOthers = true): array
     {
         $data['values'] = [];
         $data['labels'] = [];

--- a/app/bundles/LeadBundle/Model/NoteModel.php
+++ b/app/bundles/LeadBundle/Model/NoteModel.php
@@ -80,7 +80,7 @@ final class NoteModel extends FormModel
     /**
      * @throws MethodNotAllowedHttpException
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?Event $event = null): ?Event
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?Event $event = null): ?Event
     {
         if (!$entity instanceof LeadNote) {
             throw new MethodNotAllowedHttpException(['LeadNote']);
@@ -117,7 +117,7 @@ final class NoteModel extends FormModel
         return null;
     }
 
-    public function getNoteCount(Lead $lead, $useFilters = false): int
+    public function getNoteCount(Lead $lead, bool $useFilters = false): int
     {
         $viewPermissions = $this->security->isGranted(['lead:notes:viewown', 'lead:notes:viewother'], 'RETURN_ARRAY');
         $canViewOwn      = $viewPermissions['lead:notes:viewown'] ?? false;

--- a/app/bundles/LeadBundle/Model/TagModel.php
+++ b/app/bundles/LeadBundle/Model/TagModel.php
@@ -116,7 +116,7 @@ class TagModel extends FormModel
     /**
      * @throws MethodNotAllowedHttpException
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?Event $event = null): ?Event
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?Event $event = null): ?Event
     {
         if (!$entity instanceof Tag) {
             throw new MethodNotAllowedHttpException(['Tag']);

--- a/app/bundles/LeadBundle/Security/Permissions/LeadPermissions.php
+++ b/app/bundles/LeadBundle/Security/Permissions/LeadPermissions.php
@@ -80,7 +80,7 @@ final class LeadPermissions extends AbstractPermissions
         $this->addStandardFormFields($this->getName(), 'imports', $builder, $data);
     }
 
-    public function analyzePermissions(array &$permissions, $allPermissions, $isSecondRound = false): bool
+    public function analyzePermissions(array &$permissions, $allPermissions, bool $isSecondRound = false): bool
     {
         parent::analyzePermissions($permissions, $allPermissions, $isSecondRound);
 

--- a/app/bundles/LeadBundle/Tests/EventListener/ContactExportSchedulerNotificationSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/ContactExportSchedulerNotificationSubscriberTest.php
@@ -36,7 +36,7 @@ final class ContactExportSchedulerNotificationSubscriberTest extends TestCase
                 // Intentionally bypass the parent constructor because this test double only records notifications.
             }
 
-            public function addNotification($message, $type = null, $isRead = false, $header = null, $iconClass = null, ?\DateTime $datetime = null, ?User $user = null, ?string $deduplicateValue = null, ?\DateTime $deduplicateDateTimeFrom = null): void
+            public function addNotification($message, $type = null, bool $isRead = false, $header = null, $iconClass = null, ?\DateTime $datetime = null, ?User $user = null, ?string $deduplicateValue = null, ?\DateTime $deduplicateDateTimeFrom = null): void
             {
                 $this->notifications[] = func_get_args();
             }

--- a/app/bundles/LeadBundle/Tests/EventListener/ImportCompanySubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/ImportCompanySubscriberTest.php
@@ -48,7 +48,7 @@ final class ImportCompanySubscriberTest extends \PHPUnit\Framework\TestCase
                 /**
                  * @param string $requestedPermission
                  */
-                public function isGranted($requestedPermission, $mode = 'MATCH_ALL', $userEntity = null, $allowUnknown = false): bool
+                public function isGranted($requestedPermission, $mode = 'MATCH_ALL', $userEntity = null, bool $allowUnknown = false): bool
                 {
                     Assert::assertSame('lead:imports:create', $requestedPermission);
 
@@ -75,7 +75,7 @@ final class ImportCompanySubscriberTest extends \PHPUnit\Framework\TestCase
                 /**
                  * @param string $requestedPermission
                  */
-                public function isGranted($requestedPermission, $mode = 'MATCH_ALL', $userEntity = null, $allowUnknown = false): bool
+                public function isGranted($requestedPermission, $mode = 'MATCH_ALL', $userEntity = null, bool $allowUnknown = false): bool
                 {
                     Assert::assertSame('lead:imports:create', $requestedPermission);
 

--- a/app/bundles/LeadBundle/Tests/EventListener/ImportContactSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/ImportContactSubscriberTest.php
@@ -123,7 +123,7 @@ final class ImportContactSubscriberTest extends \PHPUnit\Framework\TestCase
                 /**
                  * @param string $requestedPermission
                  */
-                public function isGranted($requestedPermission, $mode = 'MATCH_ALL', $userEntity = null, $allowUnknown = false): bool
+                public function isGranted($requestedPermission, $mode = 'MATCH_ALL', $userEntity = null, bool $allowUnknown = false): bool
                 {
                     Assert::assertSame('lead:imports:create', $requestedPermission);
 
@@ -150,7 +150,7 @@ final class ImportContactSubscriberTest extends \PHPUnit\Framework\TestCase
                 /**
                  * @param string $requestedPermission
                  */
-                public function isGranted($requestedPermission, $mode = 'MATCH_ALL', $userEntity = null, $allowUnknown = false): bool
+                public function isGranted($requestedPermission, $mode = 'MATCH_ALL', $userEntity = null, bool $allowUnknown = false): bool
                 {
                     Assert::assertSame('lead:imports:create', $requestedPermission);
 

--- a/app/bundles/LeadBundle/Tests/Model/SetFrequencyRulesFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/SetFrequencyRulesFunctionalTest.php
@@ -46,14 +46,14 @@ final class SetFrequencyRulesFunctionalTest extends MauticMysqlTestCase
 
         /** @var LeadModel $model */
         $model = self::getContainer()->get(LeadModel::class);
-        $model->setFrequencyRules($lead, $data, [], []);
+        $model->setFrequencyRules($lead, $data, [], false);
 
         $subscribedCategories   = $model->getLeadCategories($lead);
         $this->assertEmpty(array_diff($subscribedCategories, array_keys($categoriesToSubscribe)));
 
         // Unsubscribe categories.
         $data['global_categories'] = array_keys($categoriesToUnsubscribe);
-        $model->setFrequencyRules($lead, $data, [], []);
+        $model->setFrequencyRules($lead, $data, [], false);
 
         $unsubscribedCategories = $model->getUnsubscribedLeadCategoriesIds($lead);
         $this->assertEmpty(array_diff($unsubscribedCategories, array_keys($categoriesToSubscribe)));

--- a/app/bundles/LeadBundle/Tests/Notification/ContactExportAdminNotificationTest.php
+++ b/app/bundles/LeadBundle/Tests/Notification/ContactExportAdminNotificationTest.php
@@ -41,7 +41,7 @@ final class ContactExportAdminNotificationTest extends TestCase
                 // Intentionally bypass the parent constructor because this test double only records notifications.
             }
 
-            public function addNotification($message, $type = null, $isRead = false, $header = null, $iconClass = null, ?\DateTime $datetime = null, ?User $user = null, ?string $deduplicateValue = null, ?\DateTime $deduplicateDateTimeFrom = null): void
+            public function addNotification($message, $type = null, bool $isRead = false, $header = null, $iconClass = null, ?\DateTime $datetime = null, ?User $user = null, ?string $deduplicateValue = null, ?\DateTime $deduplicateDateTimeFrom = null): void
             {
                 $this->notifications[] = func_get_args();
             }

--- a/app/bundles/LeadBundle/Tracker/Service/DeviceTrackingService/DeviceTrackingService.php
+++ b/app/bundles/LeadBundle/Tracker/Service/DeviceTrackingService/DeviceTrackingService.php
@@ -53,11 +53,9 @@ final class DeviceTrackingService implements DeviceTrackingServiceInterface
     }
 
     /**
-     * @param bool $replaceExistingTracking
-     *
      * @return LeadDevice
      */
-    public function trackCurrentDevice(LeadDevice $device, $replaceExistingTracking = false)
+    public function trackCurrentDevice(LeadDevice $device, bool $replaceExistingTracking = false)
     {
         $trackedDevice = $this->getTrackedDevice();
         if (null !== $trackedDevice && false === $replaceExistingTracking) {

--- a/app/bundles/LeadBundle/Tracker/Service/DeviceTrackingService/DeviceTrackingServiceInterface.php
+++ b/app/bundles/LeadBundle/Tracker/Service/DeviceTrackingService/DeviceTrackingServiceInterface.php
@@ -19,11 +19,9 @@ interface DeviceTrackingServiceInterface
     public function getTrackedDevice();
 
     /**
-     * @param bool $replaceExistingTracking
-     *
      * @return LeadDevice
      */
-    public function trackCurrentDevice(LeadDevice $device, $replaceExistingTracking = false);
+    public function trackCurrentDevice(LeadDevice $device, bool $replaceExistingTracking = false);
 
     public function clearTrackingCookies();
 

--- a/app/bundles/LeadBundle/Twig/Helper/AvatarHelper.php
+++ b/app/bundles/LeadBundle/Twig/Helper/AvatarHelper.php
@@ -87,10 +87,7 @@ final class AvatarHelper
         return $img;
     }
 
-    /**
-     * @param bool $absolute
-     */
-    public function getAvatarPath($absolute = false): string
+    public function getAvatarPath(bool $absolute = false): string
     {
         $imageDir = $this->pathsHelper->getSystemPath('images', $absolute);
 

--- a/app/bundles/PointBundle/Controller/GroupController.php
+++ b/app/bundles/PointBundle/Controller/GroupController.php
@@ -37,10 +37,9 @@ final class GroupController extends AbstractStandardFormController
     /**
      * Generates edit form and processes post data.
      *
-     * @param int  $objectId
-     * @param bool $ignorePost
+     * @param int $objectId
      */
-    public function editAction(Request $request, $objectId, $ignorePost = false): Response
+    public function editAction(Request $request, $objectId, bool $ignorePost = false): Response
     {
         return parent::editStandard($request, $objectId, $ignorePost);
     }

--- a/app/bundles/PointBundle/Controller/InsightController.php
+++ b/app/bundles/PointBundle/Controller/InsightController.php
@@ -39,10 +39,9 @@ final class InsightController extends AbstractStandardFormController
     /**
      * Generates edit form and processes post data.
      *
-     * @param int  $objectId
-     * @param bool $ignorePost
+     * @param int $objectId
      */
-    public function editAction(Request $request, $objectId, $ignorePost = false): Response
+    public function editAction(Request $request, $objectId, bool $ignorePost = false): Response
     {
         return parent::editStandard($request, $objectId, $ignorePost);
     }

--- a/app/bundles/PointBundle/Controller/PointController.php
+++ b/app/bundles/PointBundle/Controller/PointController.php
@@ -199,10 +199,9 @@ final class PointController extends AbstractFormController
     /**
      * Generates edit form and processes post data.
      *
-     * @param int  $objectId
-     * @param bool $ignorePost
+     * @param int $objectId
      */
-    public function editAction(Request $request, $objectId, $ignorePost = false): Response
+    public function editAction(Request $request, $objectId, bool $ignorePost = false): Response
     {
         $entity = $this->pointModel->getEntity($objectId);
 

--- a/app/bundles/PointBundle/Controller/TriggerController.php
+++ b/app/bundles/PointBundle/Controller/TriggerController.php
@@ -290,10 +290,9 @@ final class TriggerController extends FormController
     /**
      * Generates edit form and processes post data.
      *
-     * @param int  $objectId
-     * @param bool $ignorePost
+     * @param int $objectId
      */
-    public function editAction(Request $request, $objectId, $ignorePost = false): Response
+    public function editAction(Request $request, $objectId, bool $ignorePost = false): Response
     {
         $entity     = $this->triggerModel->getEntity($objectId);
         $session    = $request->getSession();

--- a/app/bundles/PointBundle/Model/PointGroupModel.php
+++ b/app/bundles/PointBundle/Model/PointGroupModel.php
@@ -84,7 +84,7 @@ class PointGroupModel extends CommonFormModel implements GlobalSearchInterface
     /**
      * @throws MethodNotAllowedHttpException
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?Event $event = null): ?Event
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?Event $event = null): ?Event
     {
         if (!$entity instanceof Group) {
             throw new MethodNotAllowedHttpException(['Group']);

--- a/app/bundles/PointBundle/Model/PointModel.php
+++ b/app/bundles/PointBundle/Model/PointModel.php
@@ -108,7 +108,7 @@ class PointModel extends CommonFormModel implements GlobalSearchInterface, Reset
     /**
      * @throws MethodNotAllowedHttpException
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?Event $event = null): ?Event
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?Event $event = null): ?Event
     {
         if (!$entity instanceof Point) {
             throw new MethodNotAllowedHttpException(['Point']);
@@ -168,13 +168,12 @@ class PointModel extends CommonFormModel implements GlobalSearchInterface, Reset
     /**
      * Triggers a specific point change.
      *
-     * @param mixed $eventDetails     passthrough from function triggering action to the callback function
-     * @param mixed $typeId           Something unique to the triggering event to prevent  unnecessary duplicate calls
-     * @param bool  $allowUserRequest
+     * @param mixed $eventDetails passthrough from function triggering action to the callback function
+     * @param mixed $typeId       Something unique to the triggering event to prevent  unnecessary duplicate calls
      *
      * @throws \ReflectionException
      */
-    public function triggerAction($type, $eventDetails = null, $typeId = null, ?Lead $lead = null, $allowUserRequest = false): void
+    public function triggerAction($type, $eventDetails = null, $typeId = null, ?Lead $lead = null, bool $allowUserRequest = false): void
     {
         // only trigger actions for not logged Mautic users
         if (!$this->security->isAnonymous() && !$allowUserRequest) {
@@ -316,12 +315,11 @@ class PointModel extends CommonFormModel implements GlobalSearchInterface, Reset
     /**
      * Get line chart data of points.
      *
-     * @param string $unit          {@link php.net/manual/en/function.date.php#refsect1-function.date-parameters}
+     * @param string $unit       {@link php.net/manual/en/function.date.php#refsect1-function.date-parameters}
      * @param string $dateFormat
      * @param array  $filter
-     * @param bool   $canViewOthers
      */
-    public function getPointLineChartData($unit, \DateTime $dateFrom, \DateTime $dateTo, $dateFormat = null, $filter = [], $canViewOthers = true): array
+    public function getPointLineChartData($unit, \DateTime $dateFrom, \DateTime $dateTo, $dateFormat = null, $filter = [], bool $canViewOthers = true): array
     {
         $chart = new LineChart($unit, $dateFrom, $dateTo, $dateFormat);
         $query = new ChartQuery($this->em->getConnection(), $dateFrom, $dateTo);

--- a/app/bundles/PointBundle/Model/TriggerModel.php
+++ b/app/bundles/PointBundle/Model/TriggerModel.php
@@ -105,9 +105,8 @@ class TriggerModel extends CommonFormModel implements GlobalSearchInterface
 
     /**
      * @param Trigger $entity
-     * @param bool    $unlock
      */
-    public function saveEntity($entity, $unlock = true): void
+    public function saveEntity($entity, bool $unlock = true): void
     {
         $isNew = !(bool) $entity->getId();
 
@@ -202,7 +201,7 @@ class TriggerModel extends CommonFormModel implements GlobalSearchInterface
     /**
      * @throws MethodNotAllowedHttpException
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?Event $event = null): ?Event
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?Event $event = null): ?Event
     {
         if (!$entity instanceof Trigger) {
             throw new MethodNotAllowedHttpException(['Trigger']);
@@ -308,11 +307,10 @@ class TriggerModel extends CommonFormModel implements GlobalSearchInterface
      * Triggers a specific event.
      *
      * @param array $event triggerEvent converted to array
-     * @param bool  $force
      *
      * @return bool Was event triggered
      */
-    public function triggerEvent(array $event, ?Lead $lead = null, $force = false): bool
+    public function triggerEvent(array $event, ?Lead $lead = null, bool $force = false): bool
     {
         // only trigger events for anonymous users
         if (!$force && !$this->security->isAnonymous()) {


### PR DESCRIPTION
Adds native `bool` typehints to method parameters that default to `false`/`true`, dropping the now-redundant `@param bool` docblocks.

```diff
-    /**
-     * @param bool $unlock
-     */
-    public function saveEntity($entity, $unlock = true): void
+    public function saveEntity($entity, bool $unlock = true): void
     {
```

One of 3 parts of the param-bool typing sweep. Files are grouped so each **inheritance chain stays whole** (base class + every override in the same part) — splitting a typed override from its parent makes PHP fatal at class load, which breaks `composer install` (assets:generate) and cascades. Each part boots on its own; verified by loading every changed class + its hierarchy.

https://claude.ai/code/session_01GpHL422YrvxQdRwuebNW5X