### PR TITLE
[types] add bool param typehints (part 3/3)

### DIFF
--- a/app/bundles/ApiBundle/Model/ClientModel.php
+++ b/app/bundles/ApiBundle/Model/ClientModel.php
@@ -99,7 +99,7 @@ final class ClientModel extends FormModel implements GlobalSearchInterface
     /**
      * @throws MethodNotAllowedHttpException
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?Event $event = null): ?Event
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?Event $event = null): ?Event
     {
         if (!$entity instanceof Client) {
             throw new MethodNotAllowedHttpException(['Client']);

--- a/app/bundles/AssetBundle/Entity/AssetRepository.php
+++ b/app/bundles/AssetBundle/Entity/AssetRepository.php
@@ -36,14 +36,13 @@ class AssetRepository extends CommonRepository
     }
 
     /**
-     * @param string     $search
-     * @param int        $limit
-     * @param int        $start
-     * @param bool|false $viewOther
+     * @param string $search
+     * @param int    $limit
+     * @param int    $start
      *
      * @return array
      */
-    public function getAssetList($search = '', $limit = 10, $start = 0, $viewOther = false)
+    public function getAssetList($search = '', $limit = 10, $start = 0, bool $viewOther = false)
     {
         $q = $this->createQueryBuilder('a');
         $q->select('partial a.{id, title, path, alias, language}');

--- a/app/bundles/AssetBundle/Model/AssetModel.php
+++ b/app/bundles/AssetBundle/Model/AssetModel.php
@@ -85,7 +85,7 @@ class AssetModel extends FormModel implements GlobalSearchInterface
         parent::__construct($em, $security, $dispatcher, $router, $translator, $userHelper, $logger, $coreParametersHelper);
     }
 
-    public function saveEntity($entity, $unlock = true): void
+    public function saveEntity($entity, bool $unlock = true): void
     {
         if (!$entity->isNew()) {
             // increase the revision
@@ -336,7 +336,7 @@ class AssetModel extends FormModel implements GlobalSearchInterface
     /**
      * @throws MethodNotAllowedHttpException
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?Event $event = null): ?Event
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?Event $event = null): ?Event
     {
         if (!$entity instanceof Asset) {
             throw new MethodNotAllowedHttpException(['Asset']);
@@ -435,7 +435,7 @@ class AssetModel extends FormModel implements GlobalSearchInterface
      *
      * @return float
      */
-    public function getMaxUploadSize(string $unit = 'M', $humanReadable = false)
+    public function getMaxUploadSize(string $unit = 'M', bool $humanReadable = false)
     {
         $maxAssetSize  = $this->maxAssetSize;
         $maxAssetSize  = (-1 == $maxAssetSize || 0 === $maxAssetSize) ? PHP_INT_MAX : FileHelper::convertMegabytesToBytes($maxAssetSize);
@@ -487,12 +487,11 @@ class AssetModel extends FormModel implements GlobalSearchInterface
     /**
      * Get line chart data of downloads.
      *
-     * @param string|null $unit          {@link php.net/manual/en/function.date.php#refsect1-function.date-parameters}
+     * @param string|null $unit       {@link php.net/manual/en/function.date.php#refsect1-function.date-parameters}
      * @param string      $dateFormat
      * @param array       $filter
-     * @param bool        $canViewOthers
      */
-    public function getDownloadsLineChartData($unit, \DateTime $dateFrom, \DateTime $dateTo, $dateFormat = null, $filter = [], $canViewOthers = true): array
+    public function getDownloadsLineChartData($unit, \DateTime $dateFrom, \DateTime $dateTo, $dateFormat = null, $filter = [], bool $canViewOthers = true): array
     {
         $chart = new LineChart($unit, $dateFrom, $dateTo, $dateFormat);
         $query = new ChartQuery($this->em->getConnection(), $dateFrom, $dateTo);

--- a/app/bundles/CampaignBundle/Entity/Campaign.php
+++ b/app/bundles/CampaignBundle/Entity/Campaign.php
@@ -316,7 +316,7 @@ class Campaign extends FormEntity implements OptimisticLockInterface, UuidInterf
     /**
      * Override to convert projects changes to final format.
      */
-    public function getChanges($includePast = false)
+    public function getChanges(bool $includePast = false)
     {
         $changes = parent::getChanges($includePast);
 

--- a/app/bundles/CampaignBundle/Entity/CampaignRepository.php
+++ b/app/bundles/CampaignBundle/Entity/CampaignRepository.php
@@ -65,7 +65,7 @@ class CampaignRepository extends CommonRepository
      *
      * @return array
      */
-    public function getPublishedCampaigns($specificId = null, ?int $leadId = null, $forList = false, $viewOther = false)
+    public function getPublishedCampaigns($specificId = null, ?int $leadId = null, bool $forList = false, bool $viewOther = false)
     {
         $q = $this->getEntityManager()->createQueryBuilder()
             ->from(Campaign::class, 'c', 'c.id');
@@ -480,13 +480,12 @@ class CampaignRepository extends CommonRepository
     /**
      * Get lead data of a campaign.
      *
-     * @param int        $start
-     * @param bool|false $limit
-     * @param array      $select
+     * @param int   $start
+     * @param array $select
      *
      * @return mixed[]
      */
-    public function getCampaignLeads($campaignId, $start = 0, $limit = false, $select = ['cl.lead_id']): array
+    public function getCampaignLeads($campaignId, $start = 0, bool $limit = false, $select = ['cl.lead_id']): array
     {
         $q = $this->getReplicaConnection()->createQueryBuilder();
 

--- a/app/bundles/CampaignBundle/Entity/EventRepository.php
+++ b/app/bundles/CampaignBundle/Entity/EventRepository.php
@@ -178,12 +178,11 @@ class EventRepository extends CommonRepository
     }
 
     /**
-     * @param int  $campaignId
-     * @param bool $ignoreDeleted
+     * @param int $campaignId
      *
      * @return array<int,mixed[]>
      */
-    public function getCampaignEvents($campaignId, $ignoreDeleted = true): array
+    public function getCampaignEvents($campaignId, bool $ignoreDeleted = true): array
     {
         $q = $this->getEntityManager()->createQueryBuilder();
         $q->select('e, IDENTITY(e.parent)')

--- a/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
@@ -215,18 +215,15 @@ class LeadEventLogRepository extends CommonRepository
     }
 
     /**
-     * @param int  $campaignId
-     * @param bool $excludeScheduled
-     * @param bool $excludeNegative
-     * @param bool $all
+     * @param int $campaignId
      *
      * @throws \Doctrine\DBAL\Cache\CacheException
      */
     public function getCampaignLogCounts(
         $campaignId,
-        $excludeScheduled = false,
-        $excludeNegative = true,
-        $all = false,
+        bool $excludeScheduled = false,
+        bool $excludeNegative = true,
+        bool $all = false,
         ?\DateTimeInterface $dateFrom = null,
         ?\DateTimeInterface $dateTo = null,
         ?int $eventId = null,

--- a/app/bundles/CampaignBundle/Entity/LeadRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadRepository.php
@@ -350,10 +350,9 @@ class LeadRepository extends CommonRepository
     }
 
     /**
-     * @param int  $campaignId
-     * @param bool $campaignCanBeRestarted
+     * @param int $campaignId
      */
-    public function getCountsForCampaignContactsBySegment($campaignId, ContactLimiter $limiter, $campaignCanBeRestarted = false): CountResult
+    public function getCountsForCampaignContactsBySegment($campaignId, ContactLimiter $limiter, bool $campaignCanBeRestarted = false): CountResult
     {
         if (!$segments = $this->getCampaignSegments($campaignId)) {
             return new CountResult(0, 0, 0);
@@ -371,7 +370,7 @@ class LeadRepository extends CommonRepository
             ->setParameter('segments', $segments, ArrayParameterType::INTEGER);
 
         $this->updateQueryFromContactLimiter('ll', $qb, $limiter, true);
-        $this->updateQueryWithExistingMembershipExclusion((int) $campaignId, $qb, (bool) $campaignCanBeRestarted);
+        $this->updateQueryWithExistingMembershipExclusion((int) $campaignId, $qb, $campaignCanBeRestarted);
 
         if (!$campaignCanBeRestarted) {
             $this->updateQueryWithHistoryExclusion($campaignId, $qb);
@@ -388,12 +387,11 @@ class LeadRepository extends CommonRepository
      * and the campaign setting if a contact is allowed to restart
      * a campaign.
      *
-     * @param int  $campaignId
-     * @param bool $campaignCanBeRestarted
+     * @param int $campaignId
      *
      * @return array<int|string, string>
      */
-    public function getCampaignContactsBySegments($campaignId, ContactLimiter $limiter, $campaignCanBeRestarted = false): array
+    public function getCampaignContactsBySegments($campaignId, ContactLimiter $limiter, bool $campaignCanBeRestarted = false): array
     {
         if (!$segments = $this->getCampaignSegments($campaignId)) {
             return [];
@@ -412,7 +410,7 @@ class LeadRepository extends CommonRepository
             ->orderBy('ll.lead_id');
 
         $this->updateQueryFromContactLimiter('ll', $qb, $limiter);
-        $this->updateQueryWithExistingMembershipExclusion((int) $campaignId, $qb, (bool) $campaignCanBeRestarted);
+        $this->updateQueryWithExistingMembershipExclusion((int) $campaignId, $qb, $campaignCanBeRestarted);
 
         if (!$campaignCanBeRestarted) {
             $this->updateQueryWithHistoryExclusion($campaignId, $qb);

--- a/app/bundles/CampaignBundle/Executioner/EventExecutioner.php
+++ b/app/bundles/CampaignBundle/Executioner/EventExecutioner.php
@@ -77,14 +77,13 @@ class EventExecutioner
 
     /**
      * @param ArrayCollection<int,Lead> $contacts
-     * @param bool                      $isInactiveEvent
      *
      * @throws Dispatcher\Exception\LogNotProcessedException
      * @throws Dispatcher\Exception\LogPassedAndFailedException
      * @throws Exception\CannotProcessEventException
      * @throws Scheduler\Exception\NotSchedulableException
      */
-    public function executeForContacts(Event $event, ArrayCollection $contacts, ?Counter $counter = null, $isInactiveEvent = false): void
+    public function executeForContacts(Event $event, ArrayCollection $contacts, ?Counter $counter = null, bool $isInactiveEvent = false): void
     {
         if (!$contacts->count()) {
             $this->logger->debug('CAMPAIGN: No contacts to process for event ID '.$event->getId());
@@ -145,14 +144,12 @@ class EventExecutioner
     }
 
     /**
-     * @param bool $isInactive
-     *
      * @throws Dispatcher\Exception\LogNotProcessedException
      * @throws Dispatcher\Exception\LogPassedAndFailedException
      * @throws Exception\CannotProcessEventException
      * @throws Scheduler\Exception\NotSchedulableException
      */
-    public function executeEventsForContacts(ArrayCollection $events, ArrayCollection $contacts, ?Counter $childrenCounter = null, $isInactive = false): void
+    public function executeEventsForContacts(ArrayCollection $events, ArrayCollection $contacts, ?Counter $childrenCounter = null, bool $isInactive = false): void
     {
         if (!$contacts->count()) {
             return;
@@ -188,10 +185,7 @@ class EventExecutioner
         }
     }
 
-    /**
-     * @param bool $isInactiveEvent
-     */
-    public function recordLogsAsExecutedForEvent(Event $event, ArrayCollection $contacts, $isInactiveEvent = false): void
+    public function recordLogsAsExecutedForEvent(Event $event, ArrayCollection $contacts, bool $isInactiveEvent = false): void
     {
         $config = $this->collector->getEventConfig($event);
         $logs   = $this->eventLogger->generateLogsFromContacts($event, $config, $contacts, $isInactiveEvent);
@@ -203,10 +197,7 @@ class EventExecutioner
         }
     }
 
-    /**
-     * @param bool $isInactiveEvent
-     */
-    public function recordLogsAsFailedForEvent(Event $event, ArrayCollection $contacts, $reason, $isInactiveEvent = false): void
+    public function recordLogsAsFailedForEvent(Event $event, ArrayCollection $contacts, $reason, bool $isInactiveEvent = false): void
     {
         $config = $this->collector->getEventConfig($event);
         $logs   = $this->eventLogger->generateLogsFromContacts($event, $config, $contacts, $isInactiveEvent);

--- a/app/bundles/CampaignBundle/Model/CampaignModel.php
+++ b/app/bundles/CampaignBundle/Model/CampaignModel.php
@@ -178,7 +178,7 @@ class CampaignModel extends CommonFormModel implements GlobalSearchInterface
     /**
      * @throws MethodNotAllowedHttpException
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?\Symfony\Contracts\EventDispatcher\Event $event = null): ?\Symfony\Contracts\EventDispatcher\Event
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?\Symfony\Contracts\EventDispatcher\Event $event = null): ?\Symfony\Contracts\EventDispatcher\Event
     {
         if ($entity instanceof CampaignLead) {
             return null;
@@ -520,9 +520,8 @@ class CampaignModel extends CommonFormModel implements GlobalSearchInterface
      * Get a list of source choices.
      *
      * @param string $sourceType
-     * @param bool   $globalOnly
      */
-    public function getSourceLists($sourceType = null, $globalOnly = false, bool $useIdsForLists = false): array
+    public function getSourceLists($sourceType = null, bool $globalOnly = false, bool $useIdsForLists = false): array
     {
         $choices = [];
         switch ($sourceType) {
@@ -574,11 +573,9 @@ class CampaignModel extends CommonFormModel implements GlobalSearchInterface
     /**
      * Gets the campaigns a specific lead is part of.
      *
-     * @param bool $forList
-     *
      * @return mixed
      */
-    public function getLeadCampaigns(?Lead $lead = null, $forList = false)
+    public function getLeadCampaigns(?Lead $lead = null, bool $forList = false)
     {
         static $campaigns = [];
 
@@ -674,12 +671,11 @@ class CampaignModel extends CommonFormModel implements GlobalSearchInterface
     /**
      * Get line chart data of leads added to campaigns.
      *
-     * @param string $unit          {@link php.net/manual/en/function.date.php#refsect1-function.date-parameters}
+     * @param string $unit       {@link php.net/manual/en/function.date.php#refsect1-function.date-parameters}
      * @param string $dateFormat
      * @param array  $filter
-     * @param bool   $canViewOthers
      */
-    public function getLeadsAddedLineChartData($unit, \DateTime $dateFrom, \DateTime $dateTo, $dateFormat = null, $filter = [], $canViewOthers = true): array
+    public function getLeadsAddedLineChartData($unit, \DateTime $dateFrom, \DateTime $dateTo, $dateFormat = null, $filter = [], bool $canViewOthers = true): array
     {
         $chart = new LineChart($unit, $dateFrom, $dateTo, $dateFormat);
         $query = new ChartQuery($this->em->getConnection(), $dateFrom, $dateTo);
@@ -785,10 +781,9 @@ class CampaignModel extends CommonFormModel implements GlobalSearchInterface
     }
 
     /**
-     * @param int  $limit
-     * @param bool $maxLeads
+     * @param int $limit
      */
-    public function rebuildCampaignLeads(Campaign $campaign, $limit = 1000, $maxLeads = false, ?OutputInterface $output = null): int
+    public function rebuildCampaignLeads(Campaign $campaign, $limit = 1000, bool $maxLeads = false, ?OutputInterface $output = null): int
     {
         $contactLimiter = new ContactLimiter($limit);
 

--- a/app/bundles/CampaignBundle/Model/EventModel.php
+++ b/app/bundles/CampaignBundle/Model/EventModel.php
@@ -123,12 +123,11 @@ class EventModel extends FormModel
     /**
      * Get line chart data of campaign events.
      *
-     * @param string $unit          {@link php.net/manual/en/function.date.php#refsect1-function.date-parameters}
+     * @param string $unit       {@link php.net/manual/en/function.date.php#refsect1-function.date-parameters}
      * @param string $dateFormat
      * @param array  $filter
-     * @param bool   $canViewOthers
      */
-    public function getEventLineChartData($unit, \DateTime $dateFrom, \DateTime $dateTo, $dateFormat = null, $filter = [], $canViewOthers = true): array
+    public function getEventLineChartData($unit, \DateTime $dateFrom, \DateTime $dateTo, $dateFormat = null, $filter = [], bool $canViewOthers = true): array
     {
         $chart = new LineChart($unit, $dateFrom, $dateTo, $dateFormat);
         $query = new ChartQuery($this->em->getConnection(), $dateFrom, $dateTo);

--- a/app/bundles/CampaignBundle/Tests/EventListener/CampaignActionJumpToEventSubscriberTest.php
+++ b/app/bundles/CampaignBundle/Tests/EventListener/CampaignActionJumpToEventSubscriberTest.php
@@ -204,7 +204,7 @@ final class CampaignActionJumpToEventSubscriberTest extends TestCase
             {
             }
 
-            public function executeForContacts(Event $event, ArrayCollection $contacts, ?Counter $counter = null, $isInactiveEvent = false): void
+            public function executeForContacts(Event $event, ArrayCollection $contacts, ?Counter $counter = null, bool $isInactiveEvent = false): void
             {
                 Assert::assertSame(222, $event->getId());
                 Assert::assertCount(1, $contacts);

--- a/app/bundles/CategoryBundle/Entity/CategoryRepository.php
+++ b/app/bundles/CategoryBundle/Entity/CategoryRepository.php
@@ -34,7 +34,7 @@ class CategoryRepository extends CommonRepository
      *
      * @return mixed[]
      */
-    public function getCategoryList($bundle, $search = '', $limit = 10, $start = 0, $includeGlobal = true)
+    public function getCategoryList($bundle, $search = '', $limit = 10, $start = 0, bool $includeGlobal = true)
     {
         $q = $this->createQueryBuilder('c');
         $q->select('partial c.{id, title, alias, color, bundle}');

--- a/app/bundles/CategoryBundle/Model/CategoryModel.php
+++ b/app/bundles/CategoryBundle/Model/CategoryModel.php
@@ -66,7 +66,7 @@ class CategoryModel extends FormModel implements AjaxLookupModelInterface
         return $bundle.':categories';
     }
 
-    public function saveEntity($entity, $unlock = true): void
+    public function saveEntity($entity, bool $unlock = true): void
     {
         $alias = $entity->getAlias();
         if (empty($alias)) {
@@ -124,7 +124,7 @@ class CategoryModel extends FormModel implements AjaxLookupModelInterface
     /**
      * @throws MethodNotAllowedHttpException
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?Event $event = null): ?Event
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?Event $event = null): ?Event
     {
         if (!$entity instanceof Category) {
             throw new MethodNotAllowedHttpException(['Category']);

--- a/app/bundles/ChannelBundle/Model/MessageModel.php
+++ b/app/bundles/ChannelBundle/Model/MessageModel.php
@@ -52,9 +52,8 @@ class MessageModel extends FormModel implements AjaxLookupModelInterface, Global
 
     /**
      * @param Message $entity
-     * @param bool    $unlock
      */
-    public function saveEntity($entity, $unlock = true): void
+    public function saveEntity($entity, bool $unlock = true): void
     {
         $isNew = $entity->isNew();
 
@@ -233,7 +232,7 @@ class MessageModel extends FormModel implements AjaxLookupModelInterface, Global
     /**
      * @throws MethodNotAllowedHttpException
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?Event $event = null): ?Event
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?Event $event = null): ?Event
     {
         if (!$entity instanceof Message) {
             throw new MethodNotAllowedHttpException(['Message']);

--- a/app/bundles/ChannelBundle/Model/MessageQueueModel.php
+++ b/app/bundles/ChannelBundle/Model/MessageQueueModel.php
@@ -280,10 +280,7 @@ class MessageQueueModel extends FormModel
         return $counter;
     }
 
-    /**
-     * @param bool $persist
-     */
-    public function reschedule($message, \DateInterval $rescheduleInterval, $leadId = null, $channel = null, $channelId = null, $persist = false): void
+    public function reschedule($message, \DateInterval $rescheduleInterval, $leadId = null, $channel = null, $channelId = null, bool $persist = false): void
     {
         if (!$message instanceof MessageQueue && $leadId && $channel && $channelId) {
             $message = $this->messageQueueRepository->findMessage($channel, $channelId, $leadId);
@@ -320,7 +317,7 @@ class MessageQueueModel extends FormModel
      *
      * @throws \Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?Event $event = null): ?Event
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?Event $event = null): ?Event
     {
         switch ($action) {
             case 'process_message_queue':

--- a/app/bundles/CoreBundle/Entity/CommonEntity.php
+++ b/app/bundles/CoreBundle/Entity/CommonEntity.php
@@ -115,11 +115,9 @@ class CommonEntity implements \Stringable
     }
 
     /**
-     * @param bool $includePast
-     *
      * @return mixed[]
      */
-    public function getChanges($includePast = false)
+    public function getChanges(bool $includePast = false)
     {
         if ($includePast && empty($this->changes) && !empty($this->pastChanges)) {
             return $this->pastChanges;

--- a/app/bundles/CoreBundle/Entity/CommonRepository.php
+++ b/app/bundles/CoreBundle/Entity/CommonRepository.php
@@ -191,7 +191,7 @@ class CommonRepository extends ServiceEntityRepository
      *
      * @param bool $flush true by default; use false if persisting in batches
      */
-    public function deleteEntity(object $entity, $flush = true): void
+    public function deleteEntity(object $entity, bool $flush = true): void
     {
         // delete entity
         $this->_em->remove($entity);
@@ -295,11 +295,10 @@ class CommonRepository extends ServiceEntityRepository
      * Gets the properties of an ORM entity.
      *
      * @param string $entityClass
-     * @param bool   $returnColumnNames
      *
      * @return array
      */
-    public function getBaseColumns($entityClass, $returnColumnNames = false)
+    public function getBaseColumns($entityClass, bool $returnColumnNames = false)
     {
         static $baseCols = [true => [], false => []];
 
@@ -514,8 +513,6 @@ class CommonRepository extends ServiceEntityRepository
      * The Expr() sets a :now and :true parameter that must be set in the calling function.
      *
      * @param string|null $alias
-     * @param bool        $setNowParameter
-     * @param bool        $setTrueParameter
      * @param bool        $allowNullForPublishedUp Allow entities without a published up date
      *
      * @return mixed
@@ -523,9 +520,9 @@ class CommonRepository extends ServiceEntityRepository
     public function getPublishedByDateExpression(
         $q,
         $alias = null,
-        $setNowParameter = true,
-        $setTrueParameter = true,
-        $allowNullForPublishedUp = true,
+        bool $setNowParameter = true,
+        bool $setTrueParameter = true,
+        bool $allowNullForPublishedUp = true,
     ) {
         $isORM = $q instanceof QueryBuilder;
 
@@ -806,7 +803,7 @@ class CommonRepository extends ServiceEntityRepository
      *
      * @param bool $flush true by default; use false if persisting in batches
      */
-    public function saveEntity(object $entity, $flush = true): void
+    public function saveEntity(object $entity, bool $flush = true): void
     {
         $this->getEntityManager()->persist($entity);
 

--- a/app/bundles/CoreBundle/Entity/FormEntity.php
+++ b/app/bundles/CoreBundle/Entity/FormEntity.php
@@ -221,11 +221,8 @@ class FormEntity extends CommonEntity
 
     /**
      * Check publish status with option to check against category, publish up and down dates.
-     *
-     * @param bool $checkPublishStatus
-     * @param bool $checkCategoryStatus
      */
-    public function isPublished($checkPublishStatus = true, $checkCategoryStatus = true): bool
+    public function isPublished(bool $checkPublishStatus = true, bool $checkCategoryStatus = true): bool
     {
         if ($checkPublishStatus && method_exists($this, 'getPublishUp')) {
             $status = $this->getPublishStatus();

--- a/app/bundles/CoreBundle/Entity/NotificationRepository.php
+++ b/app/bundles/CoreBundle/Entity/NotificationRepository.php
@@ -84,11 +84,9 @@ class NotificationRepository extends CommonRepository
     /**
      * Fetch notifications for this user.
      *
-     * @param bool $includeRead
-     *
      * @return array
      */
-    public function getNotifications($userId, $afterId = null, $includeRead = false, $type = null, $limit = null)
+    public function getNotifications($userId, $afterId = null, bool $includeRead = false, $type = null, $limit = null)
     {
         $qb = $this->createQueryBuilder('n');
 

--- a/app/bundles/CoreBundle/Model/AbstractCommonModel.php
+++ b/app/bundles/CoreBundle/Model/AbstractCommonModel.php
@@ -129,11 +129,9 @@ abstract class AbstractCommonModel implements MauticModelInterface
     /**
      * Decode a string appended to URL into an array.
      *
-     * @param bool $urlDecode
-     *
      * @return mixed
      */
-    public function decodeArrayFromUrl($string, $urlDecode = true)
+    public function decodeArrayFromUrl($string, bool $urlDecode = true)
     {
         try {
             return ClickthroughHelper::decodeArrayFromUrl($string, $urlDecode);
@@ -143,12 +141,11 @@ abstract class AbstractCommonModel implements MauticModelInterface
     }
 
     /**
-     * @param bool  $absolute
      * @param array $clickthrough
      *
      * @return string
      */
-    public function buildUrl(string $route, array $routeParams = [], $absolute = true, $clickthrough = [])
+    public function buildUrl(string $route, array $routeParams = [], bool $absolute = true, $clickthrough = [])
     {
         $referenceType = ($absolute) ? UrlGeneratorInterface::ABSOLUTE_URL : UrlGeneratorInterface::ABSOLUTE_PATH;
         $url           = $this->router->generate($route, $routeParams, $referenceType);

--- a/app/bundles/CoreBundle/Model/FormModel.php
+++ b/app/bundles/CoreBundle/Model/FormModel.php
@@ -112,10 +112,9 @@ class FormModel extends AbstractCommonModel
     /**
      * Create/edit entity.
      *
-     * @param T    $entity
-     * @param bool $unlock
+     * @param T $entity
      */
-    public function saveEntity($entity, $unlock = true): void
+    public function saveEntity($entity, bool $unlock = true): void
     {
         $isNew = $this->isNewEntity($entity);
 
@@ -129,10 +128,8 @@ class FormModel extends AbstractCommonModel
 
     /**
      * Create/edit entity then detach to preserve RAM.
-     *
-     * @param bool $unlock
      */
-    public function saveAndDetachEntity($entity, $unlock = true): void
+    public function saveAndDetachEntity($entity, bool $unlock = true): void
     {
         $this->saveEntity($entity, $unlock);
 
@@ -143,9 +140,8 @@ class FormModel extends AbstractCommonModel
      * Save an array of entities.
      *
      * @param iterable<T> $entities
-     * @param bool        $unlock
      */
-    public function saveEntities($entities, $unlock = true): void
+    public function saveEntities($entities, bool $unlock = true): void
     {
         // iterate over the results so the events are dispatched on each delete
         $batchSize             = 20;
@@ -253,9 +249,8 @@ class FormModel extends AbstractCommonModel
      *
      * @param object $entity
      * @param bool   $isNew
-     * @param bool   $unlock
      */
-    public function setTimestamps(&$entity, $isNew, $unlock = true): void
+    public function setTimestamps(&$entity, $isNew, bool $unlock = true): void
     {
         // unlock the row if applicable
         if ($unlock && method_exists($entity, 'setCheckedOut')) {
@@ -392,9 +387,8 @@ class FormModel extends AbstractCommonModel
      *
      * @param string $action
      * @param object $entity
-     * @param bool   $isNew
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?Event $event = null): ?Event
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?Event $event = null): ?Event
     {
         // ...
 

--- a/app/bundles/CoreBundle/Model/NotificationModel.php
+++ b/app/bundles/CoreBundle/Model/NotificationModel.php
@@ -83,7 +83,7 @@ class NotificationModel extends FormModel
     public function addNotification(
         $message,
         $type = null,
-        $isRead = false,
+        bool $isRead = false,
         $header = null,
         $iconClass = null,
         ?\DateTime $datetime = null,
@@ -143,10 +143,9 @@ class NotificationModel extends FormModel
     /**
      * Get content for notifications.
      *
-     * @param bool $includeRead
-     * @param int  $limit
+     * @param int $limit
      */
-    public function getNotificationContent($afterId = null, $includeRead = false, $limit = null): array
+    public function getNotificationContent($afterId = null, bool $includeRead = false, $limit = null): array
     {
         if ($this->userHelper->getUser()->isGuest()) {
             return [[], false, ''];

--- a/app/bundles/CoreBundle/Security/Permissions/CorePermissions.php
+++ b/app/bundles/CoreBundle/Security/Permissions/CorePermissions.php
@@ -81,12 +81,11 @@ class CorePermissions implements ResetInterface
     /**
      * Returns the permission class object and sets it to global array.
      *
-     * @param string $bundle         can be either short bundle name or full path to the permissions class
-     * @param bool   $throwException
+     * @param string $bundle can be either short bundle name or full path to the permissions class
      *
      * @throws \InvalidArgumentException
      */
-    public function getPermissionObject($bundle, $throwException = true): false|AbstractPermissions
+    public function getPermissionObject($bundle, bool $throwException = true): false|AbstractPermissions
     {
         if (empty($bundle)) {
             throw new \InvalidArgumentException("Bundle and permission type must be specified. {$bundle} given.");
@@ -196,7 +195,7 @@ class CorePermissions implements ResetInterface
      *
      * @throws \InvalidArgumentException
      */
-    public function isGranted($requestedPermission, $mode = 'MATCH_ALL', $userEntity = null, $allowUnknown = false): bool|array
+    public function isGranted($requestedPermission, $mode = 'MATCH_ALL', $userEntity = null, bool $allowUnknown = false): bool|array
     {
         // Initialize all permission classes if
         $this->getPermissionObjects();
@@ -382,10 +381,8 @@ class CorePermissions implements ResetInterface
 
     /**
      * Retrieves all permissions.
-     *
-     * @param bool $forJs
      */
-    public function getAllPermissions($forJs = false): array
+    public function getAllPermissions(bool $forJs = false): array
     {
         $permissionObjects = $this->getPermissionObjects();
         $permissions       = [];

--- a/app/bundles/CoreBundle/Tests/Unit/Model/FormModelTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Model/FormModelTest.php
@@ -66,7 +66,7 @@ final class FormModelTest extends TestCase
              */
             private array $actions = [];
 
-            protected function dispatchEvent($action, &$entity, $isNew = false, ?Event $event = null): ?Event
+            protected function dispatchEvent($action, &$entity, bool $isNew = false, ?Event $event = null): ?Event
             {
                 $this->actions[] = $action;
 

--- a/app/bundles/CoreBundle/Tests/Unit/Service/BulkNotificationTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Service/BulkNotificationTest.php
@@ -77,7 +77,7 @@ final class BulkNotificationTest extends TestCase
             {
             }
 
-            public function addNotification($message, $type = null, $isRead = false, $header = null, $iconClass = null, ?\DateTime $datetime = null, ?User $user = null, ?string $deduplicateValue = null, ?\DateTime $deduplicateDateTimeFrom = null): void
+            public function addNotification($message, $type = null, bool $isRead = false, $header = null, $iconClass = null, ?\DateTime $datetime = null, ?User $user = null, ?string $deduplicateValue = null, ?\DateTime $deduplicateDateTimeFrom = null): void
             {
                 $this->notifications[] = func_get_args();
             }

--- a/app/bundles/DashboardBundle/Model/DashboardModel.php
+++ b/app/bundles/DashboardBundle/Model/DashboardModel.php
@@ -80,11 +80,9 @@ class DashboardModel extends FormModel
     /**
      * Load widgets for the current user from database.
      *
-     * @param bool $ignorePaginator
-     *
      * @return array
      */
-    public function getWidgets($ignorePaginator = false)
+    public function getWidgets(bool $ignorePaginator = false)
     {
         return $this->getEntities([
             'orderBy' => 'w.ordering',
@@ -289,11 +287,10 @@ class DashboardModel extends FormModel
      * Create/edit entity.
      *
      * @param object $entity
-     * @param bool   $unlock
      *
      * @throws \Exception
      */
-    public function saveEntity($entity, $unlock = true): void
+    public function saveEntity($entity, bool $unlock = true): void
     {
         // Set widget name from widget type if empty
         if (!$entity->getName()) {

--- a/app/bundles/DynamicContentBundle/Entity/DynamicContent.php
+++ b/app/bundles/DynamicContentBundle/Entity/DynamicContent.php
@@ -432,11 +432,9 @@ class DynamicContent extends FormEntity implements VariantEntityInterface, Trans
     }
 
     /**
-     * @param bool $includeVariants
-     *
      * @return int
      */
-    public function getSentCount($includeVariants = false)
+    public function getSentCount(bool $includeVariants = false)
     {
         return $includeVariants ? $this->getAccumulativeTranslationCount('getSentCount') : $this->sentCount;
     }

--- a/app/bundles/DynamicContentBundle/Entity/DynamicContentRepository.php
+++ b/app/bundles/DynamicContentBundle/Entity/DynamicContentRepository.php
@@ -139,14 +139,13 @@ final class DynamicContentRepository extends CommonRepository
      * @param string $search
      * @param int    $limit
      * @param int    $start
-     * @param bool   $viewOther
      * @param bool   $topLevel
      * @param array  $ignoreIds
      * @param string $where
      *
      * @return array
      */
-    public function getDynamicContentList($search = '', $limit = 10, $start = 0, $viewOther = false, $topLevel = false, $ignoreIds = [], $where = null)
+    public function getDynamicContentList($search = '', $limit = 10, $start = 0, bool $viewOther = false, $topLevel = false, $ignoreIds = [], $where = null)
     {
         $q = $this->createQueryBuilder('e');
         $q->select('partial e.{id, name, language}');

--- a/app/bundles/DynamicContentBundle/Model/DynamicContentModel.php
+++ b/app/bundles/DynamicContentBundle/Model/DynamicContentModel.php
@@ -73,9 +73,8 @@ class DynamicContentModel extends FormModel implements AjaxLookupModelInterface,
 
     /**
      * @param object $entity
-     * @param bool   $unlock
      */
-    public function saveEntity($entity, $unlock = true): void
+    public function saveEntity($entity, bool $unlock = true): void
     {
         parent::saveEntity($entity, $unlock);
 
@@ -218,7 +217,7 @@ class DynamicContentModel extends FormModel implements AjaxLookupModelInterface,
     /**
      * @throws MethodNotAllowedHttpException
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?Event $event = null): ?Event
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?Event $event = null): ?Event
     {
         if (!$entity instanceof DynamicContent) {
             throw new MethodNotAllowedHttpException(['Dynamic Content']);
@@ -268,11 +267,10 @@ class DynamicContentModel extends FormModel implements AjaxLookupModelInterface,
     /**
      * Get line chart data of hits.
      *
-     * @param ?string $unit          {@link php.net/manual/en/function.date.php#refsect1-function.date-parameters}
+     * @param ?string $unit       {@link php.net/manual/en/function.date.php#refsect1-function.date-parameters}
      * @param string  $dateFormat
-     * @param bool    $canViewOthers
      */
-    public function getHitsLineChartData($unit, \DateTime $dateFrom, \DateTime $dateTo, $dateFormat = null, array $filter = [], $canViewOthers = true): array
+    public function getHitsLineChartData($unit, \DateTime $dateFrom, \DateTime $dateTo, $dateFormat = null, array $filter = [], bool $canViewOthers = true): array
     {
         $flag = null;
 

--- a/app/bundles/EmailBundle/Entity/Email.php
+++ b/app/bundles/EmailBundle/Entity/Email.php
@@ -687,7 +687,7 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
     /**
      * @return int
      */
-    public function getReadCount($includeVariants = false)
+    public function getReadCount(bool $includeVariants = false)
     {
         return ($includeVariants) ? $this->getAccumulativeVariantCount('getReadCount') : $this->readCount;
     }
@@ -923,11 +923,9 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
     }
 
     /**
-     * @param bool $includeVariants
-     *
      * @return int
      */
-    public function getSentCount($includeVariants = false)
+    public function getSentCount(bool $includeVariants = false)
     {
         return ($includeVariants) ? $this->getAccumulativeVariantCount('getSentCount') : $this->sentCount;
     }
@@ -942,7 +940,7 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
     /**
      * @return int
      */
-    public function getVariantSentCount($includeVariants = false)
+    public function getVariantSentCount(bool $includeVariants = false)
     {
         return ($includeVariants) ? $this->getAccumulativeVariantCount('getVariantSentCount') : $this->variantSentCount;
     }
@@ -1201,7 +1199,7 @@ class Email extends FormEntity implements VariantEntityInterface, TranslationEnt
     /**
      * Calculate Read Percentage for each Email.
      */
-    public function getReadPercentage($includevariants = false): float|int
+    public function getReadPercentage(bool $includevariants = false): float|int
     {
         if ($this->getSentCount($includevariants) > 0) {
             return round($this->getReadCount($includevariants) / $this->getSentCount($includevariants) * 100, 2);

--- a/app/bundles/EmailBundle/Entity/EmailRepository.php
+++ b/app/bundles/EmailBundle/Entity/EmailRepository.php
@@ -157,22 +157,20 @@ class EmailRepository extends CommonRepository
      * @param int            $emailId
      * @param int[]|null     $variantIds
      * @param int[]|null     $listIds
-     * @param bool           $countOnly
      * @param int|null       $limit
      * @param int|null       $minContactId
      * @param int|null       $maxContactId
-     * @param bool           $countWithMaxMin
      * @param \DateTime|null $maxDate
      */
     public function getEmailPendingQuery(
         $emailId,
         $variantIds = null,
         $listIds = null,
-        $countOnly = false,
+        bool $countOnly = false,
         $limit = null,
         $minContactId = null,
         $maxContactId = null,
-        $countWithMaxMin = false,
+        bool $countWithMaxMin = false,
         $maxDate = null,
         ?int $maxThreads = null,
         ?int $threadId = null,
@@ -332,11 +330,9 @@ class EmailRepository extends CommonRepository
      * @param int        $emailId
      * @param int[]|null $variantIds
      * @param int[]|null $listIds
-     * @param bool       $countOnly
      * @param int|null   $limit
      * @param int|null   $minContactId
      * @param int|null   $maxContactId
-     * @param bool       $countWithMaxMin
      *
      * @return array|int
      */
@@ -344,11 +340,11 @@ class EmailRepository extends CommonRepository
         $emailId,
         $variantIds = null,
         $listIds = null,
-        $countOnly = false,
+        bool $countOnly = false,
         $limit = null,
         $minContactId = null,
         $maxContactId = null,
-        $countWithMaxMin = false,
+        bool $countWithMaxMin = false,
         ?int $maxThreads = null,
         ?int $threadId = null,
         ?\DateTimeInterface $sendStopDate = null,
@@ -393,14 +389,13 @@ class EmailRepository extends CommonRepository
      * @param string|array<int|string> $search
      * @param int                      $limit
      * @param int                      $start
-     * @param bool                     $viewOther
      * @param bool                     $topLevel
      * @param string|null              $emailType
      * @param int|null                 $variantParentId
      *
      * @return array
      */
-    public function getEmailList($search = '', $limit = 10, $start = 0, $viewOther = false, $topLevel = false, $emailType = null, array $ignoreIds = [], $variantParentId = null)
+    public function getEmailList($search = '', $limit = 10, $start = 0, bool $viewOther = false, $topLevel = false, $emailType = null, array $ignoreIds = [], $variantParentId = null)
     {
         $q = $this->createQueryBuilder('e');
         $q->select('partial e.{id, subject, name, language}');

--- a/app/bundles/EmailBundle/Entity/StatRepository.php
+++ b/app/bundles/EmailBundle/Entity/StatRepository.php
@@ -213,11 +213,10 @@ class StatRepository extends CommonRepository
     /**
      * @param array<int,int|string>|int|null      $emailIds
      * @param array<int,int|string>|int|true|null $listId
-     * @param bool                                $combined
      *
      * @return array|int
      */
-    public function getSentCount($emailIds = null, $listId = null, ?ChartQuery $chartQuery = null, $combined = false)
+    public function getSentCount($emailIds = null, $listId = null, ?ChartQuery $chartQuery = null, bool $combined = false)
     {
         return $this->getStatusCount('is_sent', $emailIds, $listId, $chartQuery, $combined);
     }
@@ -225,11 +224,10 @@ class StatRepository extends CommonRepository
     /**
      * @param array<int,int|string>|int|null $emailIds
      * @param array<int,int|string>|int|null $listId
-     * @param bool                           $combined
      *
      * @return array|int
      */
-    public function getReadCount($emailIds = null, $listId = null, ?ChartQuery $chartQuery = null, $combined = false)
+    public function getReadCount($emailIds = null, $listId = null, ?ChartQuery $chartQuery = null, bool $combined = false)
     {
         return $this->getStatusCount('is_read', $emailIds, $listId, $chartQuery, $combined);
     }
@@ -237,11 +235,10 @@ class StatRepository extends CommonRepository
     /**
      * @param array<int,int|string>|int|null      $emailIds
      * @param array<int,int|string>|int|true|null $listId
-     * @param bool                                $combined
      *
      * @return array|int
      */
-    public function getFailedCount($emailIds = null, $listId = null, ?ChartQuery $chartQuery = null, $combined = false)
+    public function getFailedCount($emailIds = null, $listId = null, ?ChartQuery $chartQuery = null, bool $combined = false)
     {
         return $this->getStatusCount('is_failed', $emailIds, $listId, $chartQuery, $combined);
     }
@@ -250,11 +247,10 @@ class StatRepository extends CommonRepository
      * @param string                              $column
      * @param array<int,int|string>|int|null      $emailIds
      * @param array<int,int|string>|int|true|null $listId
-     * @param bool                                $combined
      *
      * @return array|int
      */
-    public function getStatusCount($column, $emailIds = null, $listId = null, ?ChartQuery $chartQuery = null, $combined = false)
+    public function getStatusCount($column, $emailIds = null, $listId = null, ?ChartQuery $chartQuery = null, bool $combined = false)
     {
         $q = $this->_em->getConnection()->createQueryBuilder();
 

--- a/app/bundles/EmailBundle/Event/EmailSendEvent.php
+++ b/app/bundles/EmailBundle/Event/EmailSendEvent.php
@@ -116,7 +116,7 @@ class EmailSendEvent extends CommonEvent
      *
      * @return string
      */
-    public function getContent($replaceTokens = false)
+    public function getContent(bool $replaceTokens = false)
     {
         if (null !== $this->helper) {
             $content = $this->helper->getBody();
@@ -245,7 +245,7 @@ class EmailSendEvent extends CommonEvent
     /**
      * Get token array.
      */
-    public function getTokens($includeGlobal = true): array
+    public function getTokens(bool $includeGlobal = true): array
     {
         if ($includeGlobal && null !== $this->helper) {
             return array_merge($this->helper->getGlobalTokens(), $this->tokens);

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -220,7 +220,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
     /**
      * @param Email $entity
      */
-    public function saveEntity($entity, $unlock = true): void
+    public function saveEntity($entity, bool $unlock = true): void
     {
         $type = $entity->getEmailType();
         if (empty($type)) {
@@ -281,7 +281,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
     /**
      * Save an array of entities.
      */
-    public function saveEntities($entities, $unlock = true): void
+    public function saveEntities($entities, bool $unlock = true): void
     {
         // iterate over the results so the events are dispatched on each delete
         $batchSize = 20;
@@ -379,7 +379,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
     /**
      * @throws MethodNotAllowedHttpException
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?Event $event = null): ?Event
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?Event $event = null): ?Event
     {
         if (!$entity instanceof Email) {
             throw new MethodNotAllowedHttpException(['Email']);
@@ -708,10 +708,8 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
 
     /**
      * Get a stats for email by list.
-     *
-     * @param bool $includeVariants
      */
-    public function getEmailListStats($email, $includeVariants = false, ?\DateTime $dateFrom = null, ?\DateTime $dateTo = null): array
+    public function getEmailListStats($email, bool $includeVariants = false, ?\DateTime $dateFrom = null, ?\DateTime $dateTo = null): array
     {
         $dateTo = $dateTo ? (clone $dateTo)->setTime(23, 59, 59) : null;
 
@@ -804,9 +802,8 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
      * Get a stats for email by list.
      *
      * @param Email|int $email
-     * @param bool      $includeVariants
      */
-    public function getEmailDeviceStats($email, $includeVariants = false, ?\DateTime $dateFrom = null, ?\DateTime $dateTo = null): array
+    public function getEmailDeviceStats($email, bool $includeVariants = false, ?\DateTime $dateFrom = null, ?\DateTime $dateTo = null): array
     {
         if (!$email instanceof Email) {
             $email = $this->getEntity($email);
@@ -999,13 +996,13 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
     public function getPendingLeads(
         Email $email,
         $listId = null,
-        $countOnly = false,
+        bool $countOnly = false,
         $limit = null,
-        $includeVariants = true,
+        bool $includeVariants = true,
         $minContactId = null,
         $maxContactId = null,
-        $countWithMaxMin = false,
-        $storeToCache = true,
+        bool $countWithMaxMin = false,
+        bool $storeToCache = true,
         ?int $maxThreads = null,
         ?int $threadId = null,
     ) {
@@ -1040,10 +1037,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
         return $total;
     }
 
-    /**
-     * @param bool $includeVariants
-     */
-    public function getQueuedCounts(Email $email, $includeVariants = true): int
+    public function getQueuedCounts(Email $email, bool $includeVariants = true): int
     {
         $ids = ($includeVariants) ? $email->getRelatedEntityIds() : null;
         if (!in_array($email->getId(), $ids)) {
@@ -1200,11 +1194,9 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
     /**
      * Gets template, stats, weights, etc for an email in preparation to be sent.
      *
-     * @param bool $includeVariants
-     *
      * @return array
      */
-    public function &getEmailSettings(Email $email, $includeVariants = true)
+    public function &getEmailSettings(Email $email, bool $includeVariants = true)
     {
         if (empty($this->emailSettings[$email->getId()])) {
             // store the settings of all the variants in order to properly disperse the emails
@@ -1575,7 +1567,6 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
      * Send an email to lead(s).
      *
      * @param mixed[]|int $users
-     * @param bool        $saveStat
      *
      * @return false|string[]
      *
@@ -1587,7 +1578,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
         ?array $lead = null,
         array $tokens = [],
         array $assetAttachments = [],
-        $saveStat = false,
+        bool $saveStat = false,
         array $to = [],
         array $cc = [],
         array $bcc = [],
@@ -1793,10 +1784,9 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
     }
 
     /**
-     * @param int  $reason
-     * @param bool $flush
+     * @param int $reason
      */
-    public function setEmailDoNotContact($email, $reason = DoNotContact::BOUNCED, ?string $comments = '', $flush = true, $leadId = null): array
+    public function setEmailDoNotContact($email, $reason = DoNotContact::BOUNCED, ?string $comments = '', bool $flush = true, $leadId = null): array
     {
         if (null === $leadId) {
             $leadId = (array) $this->leadRepository->getLeadByEmail($email, true);
@@ -1842,14 +1832,13 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
 
     /**
      * @param string $column
-     * @param bool   $canViewOthers
      */
     public function getBestHours(
         $column,
         \DateTime $dateFrom,
         \DateTime $dateTo,
         array $filter = [],
-        $canViewOthers = true,
+        bool $canViewOthers = true,
         $timeFormat = 24,
     ): array {
         $companyId  = ArrayHelper::pickValue('companyId', $filter);
@@ -1988,9 +1977,8 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
      * @param string $dateFrom
      * @param string $dateTo
      * @param array  $filters
-     * @param bool   $canViewOthers
      */
-    public function getIgnoredVsReadPieChartData($dateFrom, $dateTo, $filters = [], $canViewOthers = true): array
+    public function getIgnoredVsReadPieChartData($dateFrom, $dateTo, $filters = [], bool $canViewOthers = true): array
     {
         $chart = new PieChart();
         $query = new ChartQuery($this->em->getConnection(), $dateFrom, $dateTo);
@@ -2117,10 +2105,9 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
     /**
      * Get a list of upcoming emails.
      *
-     * @param int  $limit
-     * @param bool $canViewOthers
+     * @param int $limit
      */
-    public function getUpcomingEmails($limit = 10, $canViewOthers = true): array
+    public function getUpcomingEmails($limit = 10, bool $canViewOthers = true): array
     {
         $this->leadEventLogRepository->setCurrentUser($this->userHelper->getUser());
 
@@ -2193,7 +2180,6 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
      *
      * @param array                   $assetAttachments
      * @param array<string>|Lead|null $leadFields
-     * @param bool                    $saveStat
      *
      * @return false|mixed[]
      *
@@ -2205,7 +2191,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
         $leadFields = null,
         array $tokens = [],
         $assetAttachments = [],
-        $saveStat = true,
+        bool $saveStat = true,
     ): false|array {
         if (!$emailId = $email->getId()) {
             return false;
@@ -2346,12 +2332,11 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
 
     /**
      * @param array<string, string>|array<string, int> $routeParams
-     * @param bool                                     $absolute
      * @param array<array<string>>                     $clickthrough
      *
      * @return string
      */
-    public function buildUrl(string $route, array $routeParams = [], $absolute = true, $clickthrough = [])
+    public function buildUrl(string $route, array $routeParams = [], bool $absolute = true, $clickthrough = [])
     {
         $parts = parse_url($this->coreParametersHelper->get('site_url') ?: '');
 

--- a/app/bundles/EmailBundle/Tests/Model/SendEmailToUserTest.php
+++ b/app/bundles/EmailBundle/Tests/Model/SendEmailToUserTest.php
@@ -124,11 +124,9 @@ final class SendEmailToUserTest extends \PHPUnit\Framework\TestCase
             }
 
             /**
-             * @param bool $includeGlobal
-             *
              * @return string[]
              */
-            public function getTokens($includeGlobal = true): array
+            public function getTokens(bool $includeGlobal = true): array
             {
                 ++$this->getTokenMethodCallCounter;
 
@@ -211,7 +209,7 @@ final class SendEmailToUserTest extends \PHPUnit\Framework\TestCase
         $this->emailModel
             ->expects($this->once())
             ->method('sendEmailToUser')
-            ->willReturnCallback(function ($email, $users, ?array $leadCredentials, array $tokens, array $assetAttachments, $saveStat, array $to, array $cc, array $bcc): array {
+            ->willReturnCallback(function ($email, $users, ?array $leadCredentials, array $tokens, array $assetAttachments, bool $saveStat, array $to, array $cc, array $bcc): array {
                 $expectedUsers = [
                     ['id' => 6],
                     ['id' => 7],

--- a/app/bundles/FormBundle/Entity/Form.php
+++ b/app/bundles/FormBundle/Entity/Form.php
@@ -413,7 +413,7 @@ class Form extends FormEntity implements UuidInterface
     /**
      * @return string|null
      */
-    public function getDescription($truncate = false, $length = 45)
+    public function getDescription(bool $truncate = false, $length = 45)
     {
         if ($truncate) {
             if (strlen($this->description) > $length) {

--- a/app/bundles/FormBundle/Entity/FormRepository.php
+++ b/app/bundles/FormBundle/Entity/FormRepository.php
@@ -57,9 +57,8 @@ class FormRepository extends CommonRepository
      * @param string $search
      * @param int    $limit
      * @param int    $start
-     * @param bool   $viewOther
      */
-    public function getFormList($search = '', $limit = 10, $start = 0, $viewOther = false): array
+    public function getFormList($search = '', $limit = 10, $start = 0, bool $viewOther = false): array
     {
         $q = $this->createQueryBuilder('f');
         $q->select('partial f.{id, name, alias}');

--- a/app/bundles/FormBundle/Entity/SubmissionRepository.php
+++ b/app/bundles/FormBundle/Entity/SubmissionRepository.php
@@ -19,9 +19,8 @@ class SubmissionRepository extends CommonRepository
 
     /**
      * @param Submission $entity
-     * @param bool       $flush
      */
-    public function saveEntity(object $entity, $flush = true): void
+    public function saveEntity(object $entity, bool $flush = true): void
     {
         parent::saveEntity($entity, $flush);
 

--- a/app/bundles/FormBundle/Model/FieldModel.php
+++ b/app/bundles/FormBundle/Model/FieldModel.php
@@ -132,7 +132,7 @@ class FieldModel extends CommonFormModel
     /**
      * @throws MethodNotAllowedHttpException
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?Event $event = null): ?Event
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?Event $event = null): ?Event
     {
         if (!$entity instanceof Field) {
             throw new MethodNotAllowedHttpException(['Form']);

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -131,7 +131,7 @@ class FormModel extends CommonFormModel implements GlobalSearchInterface
     /**
      * @throws MethodNotAllowedHttpException
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?Event $event = null): ?Event
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?Event $event = null): ?Event
     {
         if (!$entity instanceof Form) {
             throw new MethodNotAllowedHttpException(['Form']);
@@ -320,7 +320,7 @@ class FormModel extends CommonFormModel implements GlobalSearchInterface
         }
     }
 
-    public function saveEntity($entity, $unlock = true): void
+    public function saveEntity($entity, bool $unlock = true): void
     {
         $isNew = !(bool) $entity->getId();
 
@@ -344,11 +344,8 @@ class FormModel extends CommonFormModel implements GlobalSearchInterface
 
     /**
      * Obtains the content.
-     *
-     * @param bool|true $withScript
-     * @param bool|true $useCache
      */
-    public function getContent(Form $form, $withScript = true, $useCache = true): string
+    public function getContent(Form $form, bool $withScript = true, bool $useCache = true): string
     {
         if ($form->isSubmissionLimitReached()) {
             $message = $form->getSubmissionLimitMessage() ?? $this->translator->trans('mautic.form.submission.limit_reached');
@@ -368,11 +365,9 @@ class FormModel extends CommonFormModel implements GlobalSearchInterface
     /**
      * Obtains the cached HTML of a form and generates it if missing.
      *
-     * @param bool|true $useCache
-     *
      * @return string
      */
-    public function getFormHtml(Form $form, $useCache = true)
+    public function getFormHtml(Form $form, bool $useCache = true)
     {
         if ($useCache && !$form->usesProgressiveProfiling()) {
             $cachedHtml = $form->getCachedHtml();
@@ -408,10 +403,8 @@ class FormModel extends CommonFormModel implements GlobalSearchInterface
 
     /**
      * Generate the form's html.
-     *
-     * @param bool $persist
      */
-    public function generateHtml(Form $entity, $persist = true): string
+    public function generateHtml(Form $entity, bool $persist = true): string
     {
         // Use specific template or system-wide default theme
         $theme         = $entity->getTemplate() ?? $this->coreParametersHelper->get('theme');
@@ -525,11 +518,8 @@ class FormModel extends CommonFormModel implements GlobalSearchInterface
 
     /**
      * Creates the table structure for form results.
-     *
-     * @param bool $isNew
-     * @param bool $dropExisting
      */
-    public function createTableSchema(Form $entity, $isNew = false, $dropExisting = false): void
+    public function createTableSchema(Form $entity, bool $isNew = false, bool $dropExisting = false): void
     {
         // create the field as its own column in the leads table
         $name         = 'form_results_'.$entity->getId().'_'.$entity->getAlias();

--- a/app/bundles/FormBundle/Model/SubmissionModel.php
+++ b/app/bundles/FormBundle/Model/SubmissionModel.php
@@ -119,11 +119,9 @@ final class SubmissionModel extends CommonFormModel
     }
 
     /**
-     * @param bool $returnEvent
-     *
      * @throws ORMException
      */
-    public function saveSubmission(array $post, array $server, Form $form, Request $request, $returnEvent = false): array|false
+    public function saveSubmission(array $post, array $server, Form $form, Request $request, bool $returnEvent = false): array|false
     {
         $leadFields = array_merge($this->leadFieldModel->getFieldListWithProperties(false), $this->leadFieldModel->getSpecialLeadFields());
 
@@ -794,10 +792,9 @@ final class SubmissionModel extends CommonFormModel
     /**
      * Get line chart data of submissions.
      *
-     * @param string|null $unit          {@link php.net/manual/en/function.date.php#refsect1-function.date-parameters}
+     * @param string|null $unit       {@link php.net/manual/en/function.date.php#refsect1-function.date-parameters}
      * @param string      $dateFormat
      * @param array       $filter
-     * @param bool        $canViewOthers
      */
     public function getSubmissionsLineChartData(
         ?string $unit,
@@ -805,7 +802,7 @@ final class SubmissionModel extends CommonFormModel
         \DateTime $dateTo,
         $dateFormat = null,
         $filter = [],
-        $canViewOthers = true,
+        bool $canViewOthers = true,
     ): array {
         $chart = new LineChart($unit, $dateFrom, $dateTo, $dateFormat);
         $query = new ChartQuery($this->em->getConnection(), $dateFrom, $dateTo);
@@ -830,9 +827,8 @@ final class SubmissionModel extends CommonFormModel
      * @param string $dateFrom
      * @param string $dateTo
      * @param array  $filters
-     * @param bool   $canViewOthers
      */
-    public function getTopSubmissionReferrers($limit = 10, $dateFrom = null, $dateTo = null, $filters = [], $canViewOthers = true): array
+    public function getTopSubmissionReferrers($limit = 10, $dateFrom = null, $dateTo = null, $filters = [], bool $canViewOthers = true): array
     {
         $q = $this->em->getConnection()->createQueryBuilder();
         $q->select('COUNT(DISTINCT t.id) AS submissions, t.referer')
@@ -861,9 +857,8 @@ final class SubmissionModel extends CommonFormModel
      * @param string $dateFrom
      * @param string $dateTo
      * @param array  $filters
-     * @param bool   $canViewOthers
      */
-    public function getTopSubmitters($limit = 10, $dateFrom = null, $dateTo = null, $filters = [], $canViewOthers = true): array
+    public function getTopSubmitters($limit = 10, $dateFrom = null, $dateTo = null, $filters = [], bool $canViewOthers = true): array
     {
         $q = $this->em->getConnection()->createQueryBuilder();
         $q->select('COUNT(DISTINCT t.id) AS submissions, t.lead_id, l.firstname, l.lastname, l.email')
@@ -936,7 +931,7 @@ final class SubmissionModel extends CommonFormModel
         $uniqueLeadFields = $this->fieldsWithUniqueIdentifier->getFieldsWithUniqueIdentifier();
 
         // Closure to get data and unique fields
-        $getData = function (array $currentFields, $uniqueOnly = false) use ($leadFields, $uniqueLeadFields): array {
+        $getData = function (array $currentFields, bool $uniqueOnly = false) use ($leadFields, $uniqueLeadFields): array {
             $uniqueFieldsWithData = $data = [];
             foreach ($leadFields as $alias => $properties) {
                 if (isset($currentFields[$alias])) {

--- a/app/bundles/IntegrationsBundle/Tests/Unit/EventListener/LeadSubscriberTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/EventListener/LeadSubscriberTest.php
@@ -471,7 +471,7 @@ final class LeadSubscriberTest extends TestCase
                 return false;
             }
 
-            public function getChanges($includePast = false): array
+            public function getChanges(bool $includePast = false): array
             {
                 return $this->fieldChanges;
             }
@@ -498,7 +498,7 @@ final class LeadSubscriberTest extends TestCase
             ) {
             }
 
-            public function getChanges($includePast = false): array
+            public function getChanges(bool $includePast = false): array
             {
                 return $this->fieldChanges;
             }

--- a/app/bundles/LeadBundle/Entity/CompanyLeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/CompanyLeadRepository.php
@@ -19,7 +19,7 @@ class CompanyLeadRepository extends CommonRepository
     /**
      * @param CompanyLead[] $entities
      */
-    public function saveEntities($entities, $new = true): void
+    public function saveEntities($entities, bool $new = true): void
     {
         // Get a list of contacts and set primary to 0
         if ($new) {

--- a/app/bundles/LeadBundle/Entity/CompanyRepository.php
+++ b/app/bundles/LeadBundle/Entity/CompanyRepository.php
@@ -231,12 +231,11 @@ class CompanyRepository extends CommonRepository implements CustomFieldRepositor
     }
 
     /**
-     * @param bool   $user
      * @param string $id
      *
      * @return array|mixed
      */
-    public function getCompanies($user = false, $id = '')
+    public function getCompanies(bool $user = false, $id = '')
     {
         $q                = $this->_em->getConnection()->createQueryBuilder();
         static $companies = [];

--- a/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
+++ b/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
@@ -180,10 +180,9 @@ trait CustomFieldRepositoryTrait
     }
 
     /**
-     * @param bool   $byGroup
      * @param string $object
      */
-    public function getFieldValues($id, $byGroup = true, $object = 'lead'): array
+    public function getFieldValues($id, bool $byGroup = true, $object = 'lead'): array
     {
         // use DBAL to get entity fields
         $q = $this->getEntitiesDbalQueryBuilder();
@@ -254,10 +253,7 @@ trait CustomFieldRepositoryTrait
         }
     }
 
-    /**
-     * @param bool $flush
-     */
-    public function saveEntity(object $entity, $flush = true): void
+    public function saveEntity(object $entity, bool $flush = true): void
     {
         $this->preSaveEntity($entity);
 
@@ -302,10 +298,9 @@ trait CustomFieldRepositoryTrait
 
     /**
      * @param array  $values
-     * @param bool   $byGroup
      * @param string $object
      */
-    protected function formatFieldValues($values, $byGroup = true, $object = 'lead'): array
+    protected function formatFieldValues($values, bool $byGroup = true, $object = 'lead'): array
     {
         [$fields, $fixedFields] = $this->getCustomFieldList($object);
 

--- a/app/bundles/LeadBundle/Entity/DoNotContactRepository.php
+++ b/app/bundles/LeadBundle/Entity/DoNotContactRepository.php
@@ -30,9 +30,8 @@ class DoNotContactRepository extends CommonRepository
      * @param array<int,int|string>|int|null      $ids
      * @param int|null                            $reason
      * @param array<int,int|string>|int|true|null $listId
-     * @param bool                                $combined
      */
-    public function getCount($channel = null, $ids = null, $reason = null, $listId = null, ?ChartQuery $chartQuery = null, $combined = false): array|int
+    public function getCount($channel = null, $ids = null, $reason = null, $listId = null, ?ChartQuery $chartQuery = null, bool $combined = false): array|int
     {
         $q = $this->_em->getConnection()->createQueryBuilder();
 

--- a/app/bundles/LeadBundle/Entity/Import.php
+++ b/app/bundles/LeadBundle/Entity/Import.php
@@ -503,7 +503,7 @@ class Import extends FormEntity
      *
      * @phpstan-impure
      */
-    public function end($removeFile = true): self
+    public function end(bool $removeFile = true): self
     {
         $this->setDateEnded(new \DateTime());
 

--- a/app/bundles/LeadBundle/Entity/Lead.php
+++ b/app/bundles/LeadBundle/Entity/Lead.php
@@ -687,11 +687,9 @@ class Lead extends FormEntity implements CustomFieldEntityInterface, IdentifierF
     /**
      * Get full name.
      *
-     * @param bool $lastFirst
-     *
      * @return string
      */
-    public function getName($lastFirst = false)
+    public function getName(bool $lastFirst = false)
     {
         $fullName = '';
         if ($lastFirst && $this->firstname && $this->lastname) {
@@ -726,11 +724,9 @@ class Lead extends FormEntity implements CustomFieldEntityInterface, IdentifierF
     /**
      * Get the primary identifier for the lead.
      *
-     * @param bool $lastFirst
-     *
      * @return string
      */
-    public function getPrimaryIdentifier($lastFirst = false)
+    public function getPrimaryIdentifier(bool $lastFirst = false)
     {
         if ($name = $this->getName($lastFirst)) {
             return $name;
@@ -996,11 +992,7 @@ class Lead extends FormEntity implements CustomFieldEntityInterface, IdentifierF
         return $this->companyChangeLog;
     }
 
-    /**
-     * @param bool $enabled
-     * @param bool $mobile
-     */
-    public function addPushIDEntry($identifier, $enabled = true, $mobile = false): static
+    public function addPushIDEntry($identifier, bool $enabled = true, bool $mobile = false): static
     {
         $entity = new PushID();
 

--- a/app/bundles/LeadBundle/Entity/LeadFieldRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadFieldRepository.php
@@ -32,11 +32,9 @@ class LeadFieldRepository extends CommonRepository
      * Retrieves array of aliases used to ensure unique alias for new fields.
      *
      * @param int    $exludingId
-     * @param bool   $publishedOnly
-     * @param bool   $includeEntityFields
-     * @param string $object              name of object using the custom fields
+     * @param string $object     name of object using the custom fields
      */
-    public function getAliases($exludingId, $publishedOnly = false, $includeEntityFields = true, $object = 'lead'): array
+    public function getAliases($exludingId, bool $publishedOnly = false, bool $includeEntityFields = true, $object = 'lead'): array
     {
         $q = $this->_em->getConnection()->createQueryBuilder()
             ->select('l.alias')

--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -127,14 +127,11 @@ class LeadListRepository extends CommonRepository
     /**
      * Get lists for a specific lead.
      *
-     * @param int|Lead[] $lead                 Lead ID or array of Leads
-     * @param bool       $forList
-     * @param bool       $singleArrayHydration
-     * @param bool       $isPublic
+     * @param int|Lead[] $lead Lead ID or array of Leads
      *
      * @return mixed
      */
-    public function getLeadLists($lead, $forList = false, $singleArrayHydration = false, $isPublic = false, $isPreferenceCenter = false)
+    public function getLeadLists($lead, bool $forList = false, bool $singleArrayHydration = false, bool $isPublic = false, bool $isPreferenceCenter = false)
     {
         if (is_array($lead)) {
             $q = $this->getEntityManager()->createQueryBuilder()

--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -118,11 +118,10 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
      * @param string          $field
      * @param string[]|string $value
      * @param ?int            $ignoreId
-     * @param bool            $indexByColumn
      *
      * @return array
      */
-    public function getLeadsByFieldValue($field, $value, $ignoreId = null, $indexByColumn = false)
+    public function getLeadsByFieldValue($field, $value, $ignoreId = null, bool $indexByColumn = false)
     {
         $results = $this->getEntities([
             'qb'               => $this->buildQueryForGetLeadsByFieldValue($field, $value, $ignoreId),
@@ -319,7 +318,7 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
      *
      * @return array|null
      */
-    public function getLeadByEmail($email, $all = false)
+    public function getLeadByEmail($email, bool $all = false)
     {
         $q = $this->getEntityManager()->getConnection()->createQueryBuilder()
             ->select('l.id')
@@ -339,11 +338,9 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
     /**
      * Get leads by IP address.
      *
-     * @param bool $byId
-     *
      * @return array
      */
-    public function getLeadsByIp($ip, $byId = false)
+    public function getLeadsByIp($ip, bool $byId = false)
     {
         $q = $this->createQueryBuilder('l')
             ->leftJoin('l.ipAddresses', 'i');

--- a/app/bundles/LeadBundle/Entity/TagRepository.php
+++ b/app/bundles/LeadBundle/Entity/TagRepository.php
@@ -16,7 +16,7 @@ class TagRepository extends CommonRepository
      * @param Tag  $entity
      * @param bool $flush  true by default; use false if persisting in batches
      */
-    public function deleteEntity(object $entity, $flush = true): void
+    public function deleteEntity(object $entity, bool $flush = true): void
     {
         if ($entity instanceof Tag && null !== $entity->getId()) {
             $this->deleteLeadAssociations((int) $entity->getId());

--- a/app/bundles/LeadBundle/Model/CompanyModel.php
+++ b/app/bundles/LeadBundle/Model/CompanyModel.php
@@ -89,9 +89,8 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
 
     /**
      * @param Company $entity
-     * @param bool    $unlock
      */
-    public function saveEntity($entity, $unlock = true): void
+    public function saveEntity($entity, bool $unlock = true): void
     {
         // Update leads primary company name
         $this->setEntityDefaultValues($entity, 'company');
@@ -103,9 +102,8 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
      * Save an array of entities.
      *
      * @param array $entities
-     * @param bool  $unlock
      */
-    public function saveEntities($entities, $unlock = true): void
+    public function saveEntities($entities, bool $unlock = true): void
     {
         // Update leads primary company name
         foreach ($entities as $entity) {
@@ -614,7 +612,7 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
     /**
      * @throws MethodNotAllowedHttpException
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?Event $event = null): ?Event
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?Event $event = null): ?Event
     {
         if (!$entity instanceof Company) {
             throw new MethodNotAllowedHttpException(['Email']);
@@ -792,7 +790,7 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
     /**
      * @throws \Exception
      */
-    public function importCompany(array $fields, array $data, $owner = null, $persist = true, $skipIfExists = false): ?Company
+    public function importCompany(array $fields, array $data, $owner = null, bool $persist = true, bool $skipIfExists = false): ?Company
     {
         try {
             $duplicateCompanies = $this->companyDeduper->checkForDuplicateCompanies($this->getFieldData($fields, $data));

--- a/app/bundles/LeadBundle/Model/DeviceModel.php
+++ b/app/bundles/LeadBundle/Model/DeviceModel.php
@@ -73,7 +73,7 @@ final class DeviceModel extends FormModel
     /**
      * @throws MethodNotAllowedHttpException
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?Event $event = null): ?Event
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?Event $event = null): ?Event
     {
         if (!$entity instanceof LeadDevice) {
             throw new MethodNotAllowedHttpException(['LeadDevice']);

--- a/app/bundles/LeadBundle/Model/FieldModel.php
+++ b/app/bundles/LeadBundle/Model/FieldModel.php
@@ -604,7 +604,6 @@ class FieldModel extends FormModel
 
     /**
      * @param LeadField $entity
-     * @param bool      $unlock
      *
      * @throws AbortColumnCreateException
      * @throws AbortColumnUpdateException
@@ -613,7 +612,7 @@ class FieldModel extends FormModel
      * @throws SchemaException
      * @throws \Mautic\CoreBundle\Exception\SchemaException
      */
-    public function saveEntity($entity, $unlock = true): void
+    public function saveEntity($entity, bool $unlock = true): void
     {
         if (!$entity instanceof LeadField) {
             throw new MethodNotAllowedHttpException(['LeadEntity']);
@@ -646,7 +645,6 @@ class FieldModel extends FormModel
      * Build schema for each entity.
      *
      * @param array $entities
-     * @param bool  $unlock
      *
      * @throws AbortColumnCreateException
      * @throws Exception
@@ -654,7 +652,7 @@ class FieldModel extends FormModel
      * @throws SchemaException
      * @throws \Mautic\CoreBundle\Exception\SchemaException
      */
-    public function saveEntities($entities, $unlock = true): void
+    public function saveEntities($entities, bool $unlock = true): void
     {
         foreach ($entities as $entity) {
             $this->saveEntity($entity, $unlock);
@@ -855,7 +853,7 @@ class FieldModel extends FormModel
     /**
      * @throws MethodNotAllowedHttpException
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?Event $event = null): ?Event
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?Event $event = null): ?Event
     {
         switch ($action) {
             case 'pre_save':

--- a/app/bundles/LeadBundle/Model/ImportModel.php
+++ b/app/bundles/LeadBundle/Model/ImportModel.php
@@ -596,7 +596,7 @@ class ImportModel extends FormModel
     /**
      * @throws MethodNotAllowedHttpException
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?Event $event = null): ?Event
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?Event $event = null): ?Event
     {
         if (!$entity instanceof Import) {
             throw new MethodNotAllowedHttpException(['Import']);

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -375,7 +375,7 @@ class LeadModel extends FormModel
     /**
      * @throws MethodNotAllowedHttpException
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?Event $event = null): ?Event
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?Event $event = null): ?Event
     {
         if (!$entity instanceof Lead) {
             throw new MethodNotAllowedHttpException(['Lead'], 'Entity must be of class Lead()');
@@ -466,9 +466,8 @@ class LeadModel extends FormModel
 
     /**
      * @param Lead $entity
-     * @param bool $unlock
      */
-    public function saveEntity($entity, $unlock = true): void
+    public function saveEntity($entity, bool $unlock = true): void
     {
         $companyFieldMatches = [];
         $fields              = $entity->getFields();
@@ -560,13 +559,11 @@ class LeadModel extends FormModel
     /**
      * Populates custom field values for updating the lead. Also retrieves social media data.
      *
-     * @param bool|false $overwriteWithBlank
-     * @param bool|true  $fetchSocialProfiles
-     * @param bool|false $bindWithForm        Send $data through the Lead form and only use valid data (should be used with request data)
+     * @param bool|false $bindWithForm Send $data through the Lead form and only use valid data (should be used with request data)
      *
      * @throws ImportFailedException
      */
-    public function setFieldValues(Lead $lead, array $data, $overwriteWithBlank = false, $fetchSocialProfiles = true, $bindWithForm = false): void
+    public function setFieldValues(Lead $lead, array $data, bool $overwriteWithBlank = false, bool $fetchSocialProfiles = true, bool $bindWithForm = false): void
     {
         if ($fetchSocialProfiles) {
             // @todo - add a catch to NOT do social gleaning if a lead is created via a form, etc as we do not want the user to experience the wait
@@ -881,11 +878,9 @@ class LeadModel extends FormModel
     }
 
     /**
-     * @param bool $returnWithQueryFields
-     *
      * @return array{Lead, mixed[]}|Lead
      */
-    public function checkForDuplicateContact(array $queryFields, $returnWithQueryFields = false, $onlyPubliclyUpdateable = false)
+    public function checkForDuplicateContact(array $queryFields, bool $returnWithQueryFields = false, bool $onlyPubliclyUpdateable = false)
     {
         // Search for lead by request and/or update lead fields if some data were sent in the URL query
         if ([] === $this->availableLeadFields) {
@@ -942,13 +937,9 @@ class LeadModel extends FormModel
     /**
      * Get a list of segments this lead belongs to.
      *
-     * @param bool $forLists
-     * @param bool $arrayHydration
-     * @param bool $isPublic
-     *
      * @return mixed
      */
-    public function getLists(Lead $lead, $forLists = false, $arrayHydration = false, $isPublic = false, $isPreferenceCenter = false)
+    public function getLists(Lead $lead, bool $forLists = false, bool $arrayHydration = false, bool $isPublic = false, bool $isPreferenceCenter = false)
     {
         return $this->leadListRepository->getLeadLists($lead->getId(), $forLists, $arrayHydration, $isPublic, $isPreferenceCenter);
     }
@@ -968,19 +959,16 @@ class LeadModel extends FormModel
      *
      * @param array|Lead|int $lead
      * @param array|LeadList $lists
-     * @param bool           $manuallyAdded
      */
-    public function addToLists($lead, $lists, $manuallyAdded = true): void
+    public function addToLists($lead, $lists, bool $manuallyAdded = true): void
     {
         $this->leadListModel->addLead($lead, $lists, $manuallyAdded);
     }
 
     /**
      * Remove lead from lists.
-     *
-     * @param bool $manuallyRemoved
      */
-    public function removeFromLists($lead, $lists, $manuallyRemoved = true): void
+    public function removeFromLists($lead, $lists, bool $manuallyRemoved = true): void
     {
         $this->leadListModel->removeLead($lead, $lists, $manuallyRemoved);
     }
@@ -990,9 +978,8 @@ class LeadModel extends FormModel
      *
      * @param array|Lead  $lead
      * @param array|Stage $stage
-     * @param bool        $manuallyAdded
      */
-    public function addToStages($lead, $stage, $manuallyAdded = true): static
+    public function addToStages($lead, $stage, bool $manuallyAdded = true): static
     {
         if (!$lead instanceof Lead) {
             $leadId = (is_array($lead) && isset($lead['id'])) ? $lead['id'] : $lead;
@@ -1010,10 +997,8 @@ class LeadModel extends FormModel
 
     /**
      * Remove lead from Stage.
-     *
-     * @param bool $manuallyRemoved
      */
-    public function removeFromStages($lead, $stage, $manuallyRemoved = true): static
+    public function removeFromStages($lead, $stage, bool $manuallyRemoved = true): static
     {
         $lead->setStage(null);
         $lead->stageChangeLogEntry(
@@ -1051,7 +1036,7 @@ class LeadModel extends FormModel
      * @param array<string, mixed> $data
      * @param array<LeadList>      $leadLists
      */
-    public function setFrequencyRules(Lead $lead, array $data, array $leadLists, $persist = true): bool
+    public function setFrequencyRules(Lead $lead, array $data, array $leadLists, bool $persist = true): bool
     {
         // One query to get all the lead's current frequency rules and go ahead and create entities for them
         $frequencyRules = $lead->getFrequencyRules()->toArray();
@@ -1579,10 +1564,8 @@ class LeadModel extends FormModel
 
     /**
      * Update a leads tags.
-     *
-     * @param bool|false $removeOrphans
      */
-    public function setTags(Lead $lead, array $tags, $removeOrphans = false): void
+    public function setTags(Lead $lead, array $tags, bool $removeOrphans = false): void
     {
         /** @var Tag[] $currentTags */
         $currentTags  = $lead->getTags();
@@ -1864,13 +1847,12 @@ class LeadModel extends FormModel
     /**
      * Get bar chart data of contacts.
      *
-     * @param string    $unit          {@link php.net/manual/en/function.date.php#refsect1-function.date-parameters}
+     * @param string    $unit       {@link php.net/manual/en/function.date.php#refsect1-function.date-parameters}
      * @param \DateTime $dateFrom
      * @param \DateTime $dateTo
      * @param string    $dateFormat
-     * @param bool      $canViewOthers
      */
-    public function getLeadsLineChartData($unit, $dateFrom, $dateTo, $dateFormat = null, array $filter = [], $canViewOthers = true): array
+    public function getLeadsLineChartData($unit, $dateFrom, $dateTo, $dateFormat = null, array $filter = [], bool $canViewOthers = true): array
     {
         $flag        = null;
         $topLists    = null;
@@ -1949,9 +1931,8 @@ class LeadModel extends FormModel
      * @param string $dateFrom
      * @param string $dateTo
      * @param array  $filters
-     * @param bool   $canViewOthers
      */
-    public function getAnonymousVsIdentifiedPieChartData($dateFrom, $dateTo, $filters = [], $canViewOthers = true): array
+    public function getAnonymousVsIdentifiedPieChartData($dateFrom, $dateTo, $filters = [], bool $canViewOthers = true): array
     {
         $chart = new PieChart();
         $query = new ChartQuery($this->em->getConnection(), $dateFrom, $dateTo);
@@ -1975,9 +1956,8 @@ class LeadModel extends FormModel
      * @param \DateTime $dateFrom
      * @param \DateTime $dateTo
      * @param mixed[]   $filters
-     * @param bool      $canViewOthers
      */
-    public function getLeadMapData($dateFrom, $dateTo, $filters = [], $canViewOthers = true): array
+    public function getLeadMapData($dateFrom, $dateTo, $filters = [], bool $canViewOthers = true): array
     {
         if (!$canViewOthers) {
             $filter['owner_id'] = $this->userHelper->getUser()->getId();
@@ -2349,10 +2329,7 @@ class LeadModel extends FormModel
         }
     }
 
-    /**
-     * @param bool $persist
-     */
-    protected function createNewContact(IpAddress $ip, $persist = true): Lead
+    protected function createNewContact(IpAddress $ip, bool $persist = true): Lead
     {
         // let's create a lead
         $lead = new Lead();

--- a/app/bundles/LeadBundle/Model/ListModel.php
+++ b/app/bundles/LeadBundle/Model/ListModel.php
@@ -115,11 +115,10 @@ class ListModel extends FormModel implements GlobalSearchInterface
 
     /**
      * @param LeadList $entity
-     * @param bool     $unlock
      *
      * @throws \Doctrine\DBAL\Exception
      */
-    public function saveEntity($entity, $unlock = true): void
+    public function saveEntity($entity, bool $unlock = true): void
     {
         $isNew = !(bool) $entity->getId();
 
@@ -255,7 +254,7 @@ class ListModel extends FormModel implements GlobalSearchInterface
     /**
      * @throws MethodNotAllowedHttpException
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?Event $event = null): ?Event
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?Event $event = null): ?Event
     {
         if (!$entity instanceof LeadList) {
             throw new MethodNotAllowedHttpException(['LeadList'], 'Entity must be of class LeadList()');
@@ -377,12 +376,11 @@ class ListModel extends FormModel implements GlobalSearchInterface
     }
 
     /**
-     * @param int      $limit
-     * @param bool|int $maxLeads
+     * @param int $limit
      *
      * @throws \Exception
      */
-    public function rebuildListLeads(LeadList $leadList, $limit = 100, $maxLeads = false, ?OutputInterface $output = null): int
+    public function rebuildListLeads(LeadList $leadList, $limit = 100, int|bool|null $maxLeads = false, ?OutputInterface $output = null): int
     {
         defined('MAUTIC_REBUILDING_LEAD_LISTS') || define('MAUTIC_REBUILDING_LEAD_LISTS', 1);
 
@@ -597,14 +595,12 @@ class ListModel extends FormModel implements GlobalSearchInterface
      *
      * @param array|int|Lead $lead
      * @param array|LeadList $lists
-     * @param bool           $manuallyAdded
-     * @param bool           $batchProcess
      * @param int            $searchListLead  0 = reference, 1 = yes, -1 = known to not exist
      * @param \DateTime      $dateManipulated
      *
      * @throws \Exception
      */
-    public function addLead($lead, $lists, $manuallyAdded = false, $batchProcess = false, $searchListLead = 1, $dateManipulated = null): void
+    public function addLead($lead, $lists, bool $manuallyAdded = false, bool $batchProcess = false, $searchListLead = 1, $dateManipulated = null): void
     {
         if (null == $dateManipulated) {
             $dateManipulated = new \DateTime();
@@ -739,13 +735,9 @@ class ListModel extends FormModel implements GlobalSearchInterface
     /**
      * Remove a lead from lists.
      *
-     * @param bool $manuallyRemoved
-     * @param bool $batchProcess
-     * @param bool $skipFindOne
-     *
      * @throws \Exception
      */
-    public function removeLead($lead, $lists, $manuallyRemoved = false, $batchProcess = false, $skipFindOne = false): void
+    public function removeLead($lead, $lists, bool $manuallyRemoved = false, bool $batchProcess = false, bool $skipFindOne = false): void
     {
         if (!$lead instanceof Lead) {
             $leadId = (is_array($lead) && isset($lead['id'])) ? $lead['id'] : $lead;
@@ -897,9 +889,8 @@ class ListModel extends FormModel implements GlobalSearchInterface
      * @param int       $limit
      * @param \DateTime $dateFrom
      * @param \DateTime $dateTo
-     * @param bool      $canViewOthers
      */
-    public function getTopLists($limit = 10, $dateFrom = null, $dateTo = null, $canViewOthers = true): array
+    public function getTopLists($limit = 10, $dateFrom = null, $dateTo = null, bool $canViewOthers = true): array
     {
         $q = $this->em->getConnection()->createQueryBuilder();
         $q->select('COUNT(t.date_added) AS leads, ll.id, ll.name, ll.alias')
@@ -1022,10 +1013,7 @@ class ListModel extends FormModel implements GlobalSearchInterface
         return $chart->render(false);
     }
 
-    /**
-     * @param bool $canViewOthers
-     */
-    public function getStagesBarChartData($unit, \DateTime $dateFrom, \DateTime $dateTo, $dateFormat = null, array $filter = [], $canViewOthers = true): array
+    public function getStagesBarChartData($unit, \DateTime $dateFrom, \DateTime $dateTo, $dateFormat = null, array $filter = [], bool $canViewOthers = true): array
     {
         $data['values'] = [];
         $data['labels'] = [];
@@ -1082,10 +1070,7 @@ class ListModel extends FormModel implements GlobalSearchInterface
             ], ];
     }
 
-    /**
-     * @param bool $canViewOthers
-     */
-    public function getDeviceGranularityData($unit, \DateTime $dateFrom, \DateTime $dateTo, $dateFormat = null, array $filter = [], $canViewOthers = true): array
+    public function getDeviceGranularityData($unit, \DateTime $dateFrom, \DateTime $dateTo, $dateFormat = null, array $filter = [], bool $canViewOthers = true): array
     {
         $data['values'] = [];
         $data['labels'] = [];

--- a/app/bundles/LeadBundle/Model/NoteModel.php
+++ b/app/bundles/LeadBundle/Model/NoteModel.php
@@ -80,7 +80,7 @@ final class NoteModel extends FormModel
     /**
      * @throws MethodNotAllowedHttpException
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?Event $event = null): ?Event
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?Event $event = null): ?Event
     {
         if (!$entity instanceof LeadNote) {
             throw new MethodNotAllowedHttpException(['LeadNote']);
@@ -117,7 +117,7 @@ final class NoteModel extends FormModel
         return null;
     }
 
-    public function getNoteCount(Lead $lead, $useFilters = false): int
+    public function getNoteCount(Lead $lead, bool $useFilters = false): int
     {
         $viewPermissions = $this->security->isGranted(['lead:notes:viewown', 'lead:notes:viewother'], 'RETURN_ARRAY');
         $canViewOwn      = $viewPermissions['lead:notes:viewown'] ?? false;

--- a/app/bundles/LeadBundle/Model/TagModel.php
+++ b/app/bundles/LeadBundle/Model/TagModel.php
@@ -116,7 +116,7 @@ class TagModel extends FormModel
     /**
      * @throws MethodNotAllowedHttpException
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?Event $event = null): ?Event
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?Event $event = null): ?Event
     {
         if (!$entity instanceof Tag) {
             throw new MethodNotAllowedHttpException(['Tag']);

--- a/app/bundles/LeadBundle/Tests/EventListener/ContactExportSchedulerNotificationSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/ContactExportSchedulerNotificationSubscriberTest.php
@@ -36,7 +36,7 @@ final class ContactExportSchedulerNotificationSubscriberTest extends TestCase
                 // Intentionally bypass the parent constructor because this test double only records notifications.
             }
 
-            public function addNotification($message, $type = null, $isRead = false, $header = null, $iconClass = null, ?\DateTime $datetime = null, ?User $user = null, ?string $deduplicateValue = null, ?\DateTime $deduplicateDateTimeFrom = null): void
+            public function addNotification($message, $type = null, bool $isRead = false, $header = null, $iconClass = null, ?\DateTime $datetime = null, ?User $user = null, ?string $deduplicateValue = null, ?\DateTime $deduplicateDateTimeFrom = null): void
             {
                 $this->notifications[] = func_get_args();
             }

--- a/app/bundles/LeadBundle/Tests/EventListener/ImportCompanySubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/ImportCompanySubscriberTest.php
@@ -48,7 +48,7 @@ final class ImportCompanySubscriberTest extends \PHPUnit\Framework\TestCase
                 /**
                  * @param string $requestedPermission
                  */
-                public function isGranted($requestedPermission, $mode = 'MATCH_ALL', $userEntity = null, $allowUnknown = false): bool
+                public function isGranted($requestedPermission, $mode = 'MATCH_ALL', $userEntity = null, bool $allowUnknown = false): bool
                 {
                     Assert::assertSame('lead:imports:create', $requestedPermission);
 
@@ -75,7 +75,7 @@ final class ImportCompanySubscriberTest extends \PHPUnit\Framework\TestCase
                 /**
                  * @param string $requestedPermission
                  */
-                public function isGranted($requestedPermission, $mode = 'MATCH_ALL', $userEntity = null, $allowUnknown = false): bool
+                public function isGranted($requestedPermission, $mode = 'MATCH_ALL', $userEntity = null, bool $allowUnknown = false): bool
                 {
                     Assert::assertSame('lead:imports:create', $requestedPermission);
 

--- a/app/bundles/LeadBundle/Tests/EventListener/ImportContactSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/ImportContactSubscriberTest.php
@@ -123,7 +123,7 @@ final class ImportContactSubscriberTest extends \PHPUnit\Framework\TestCase
                 /**
                  * @param string $requestedPermission
                  */
-                public function isGranted($requestedPermission, $mode = 'MATCH_ALL', $userEntity = null, $allowUnknown = false): bool
+                public function isGranted($requestedPermission, $mode = 'MATCH_ALL', $userEntity = null, bool $allowUnknown = false): bool
                 {
                     Assert::assertSame('lead:imports:create', $requestedPermission);
 
@@ -150,7 +150,7 @@ final class ImportContactSubscriberTest extends \PHPUnit\Framework\TestCase
                 /**
                  * @param string $requestedPermission
                  */
-                public function isGranted($requestedPermission, $mode = 'MATCH_ALL', $userEntity = null, $allowUnknown = false): bool
+                public function isGranted($requestedPermission, $mode = 'MATCH_ALL', $userEntity = null, bool $allowUnknown = false): bool
                 {
                     Assert::assertSame('lead:imports:create', $requestedPermission);
 

--- a/app/bundles/LeadBundle/Tests/Model/SetFrequencyRulesFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/SetFrequencyRulesFunctionalTest.php
@@ -46,14 +46,14 @@ final class SetFrequencyRulesFunctionalTest extends MauticMysqlTestCase
 
         /** @var LeadModel $model */
         $model = self::getContainer()->get(LeadModel::class);
-        $model->setFrequencyRules($lead, $data, [], []);
+        $model->setFrequencyRules($lead, $data, [], false);
 
         $subscribedCategories   = $model->getLeadCategories($lead);
         $this->assertEmpty(array_diff($subscribedCategories, array_keys($categoriesToSubscribe)));
 
         // Unsubscribe categories.
         $data['global_categories'] = array_keys($categoriesToUnsubscribe);
-        $model->setFrequencyRules($lead, $data, [], []);
+        $model->setFrequencyRules($lead, $data, [], false);
 
         $unsubscribedCategories = $model->getUnsubscribedLeadCategoriesIds($lead);
         $this->assertEmpty(array_diff($unsubscribedCategories, array_keys($categoriesToSubscribe)));

--- a/app/bundles/LeadBundle/Tests/Notification/ContactExportAdminNotificationTest.php
+++ b/app/bundles/LeadBundle/Tests/Notification/ContactExportAdminNotificationTest.php
@@ -41,7 +41,7 @@ final class ContactExportAdminNotificationTest extends TestCase
                 // Intentionally bypass the parent constructor because this test double only records notifications.
             }
 
-            public function addNotification($message, $type = null, $isRead = false, $header = null, $iconClass = null, ?\DateTime $datetime = null, ?User $user = null, ?string $deduplicateValue = null, ?\DateTime $deduplicateDateTimeFrom = null): void
+            public function addNotification($message, $type = null, bool $isRead = false, $header = null, $iconClass = null, ?\DateTime $datetime = null, ?User $user = null, ?string $deduplicateValue = null, ?\DateTime $deduplicateDateTimeFrom = null): void
             {
                 $this->notifications[] = func_get_args();
             }

--- a/app/bundles/NotificationBundle/Entity/NotificationRepository.php
+++ b/app/bundles/NotificationBundle/Entity/NotificationRepository.php
@@ -148,12 +148,11 @@ final class NotificationRepository extends CommonRepository
      * @param string $search
      * @param int    $limit
      * @param int    $start
-     * @param bool   $viewOther
      * @param string $notificationType
      *
      * @return array
      */
-    public function getNotificationList($search = '', $limit = 10, $start = 0, $viewOther = false, $notificationType = null)
+    public function getNotificationList($search = '', $limit = 10, $start = 0, bool $viewOther = false, $notificationType = null)
     {
         $q = $this->createQueryBuilder('e');
         $q->select('partial e.{id, name, language}');

--- a/app/bundles/NotificationBundle/Model/NotificationModel.php
+++ b/app/bundles/NotificationBundle/Model/NotificationModel.php
@@ -70,7 +70,7 @@ final class NotificationModel extends FormModel implements AjaxLookupModelInterf
         return 'notification:notifications';
     }
 
-    public function saveEntities($entities, $unlock = true): void
+    public function saveEntities($entities, bool $unlock = true): void
     {
         // iterate over the results so the events are dispatched on each delete
         $batchSize = 20;
@@ -132,7 +132,7 @@ final class NotificationModel extends FormModel implements AjaxLookupModelInterf
         return parent::getEntity($id);
     }
 
-    public function saveEntity($entity, $unlock = true): void
+    public function saveEntity($entity, bool $unlock = true): void
     {
         parent::saveEntity($entity, $unlock);
 
@@ -158,7 +158,7 @@ final class NotificationModel extends FormModel implements AjaxLookupModelInterf
     /**
      * @throws MethodNotAllowedHttpException
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?Event $event = null): ?Event
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?Event $event = null): ?Event
     {
         if (!$entity instanceof Notification) {
             throw new MethodNotAllowedHttpException(['Notification']);
@@ -208,11 +208,10 @@ final class NotificationModel extends FormModel implements AjaxLookupModelInterf
     /**
      * Get line chart data of hits.
      *
-     * @param ?string $unit          {@link php.net/manual/en/function.date.php#refsect1-function.date-parameters}
+     * @param ?string $unit       {@link php.net/manual/en/function.date.php#refsect1-function.date-parameters}
      * @param string  $dateFormat
-     * @param bool    $canViewOthers
      */
-    public function getHitsLineChartData($unit, \DateTime $dateFrom, \DateTime $dateTo, $dateFormat = null, array $filter = [], $canViewOthers = true): array
+    public function getHitsLineChartData($unit, \DateTime $dateFrom, \DateTime $dateTo, $dateFormat = null, array $filter = [], bool $canViewOthers = true): array
     {
         $flag = null;
 

--- a/app/bundles/PageBundle/Entity/HitRepository.php
+++ b/app/bundles/PageBundle/Entity/HitRepository.php
@@ -264,11 +264,10 @@ class HitRepository extends CommonRepository
      * Get the number of bounces.
      *
      * @param array|string $pageIds
-     * @param bool         $isVariantCheck
      *
      * @return mixed[]
      */
-    public function getBounces($pageIds, ?\DateTime $fromDate = null, $isVariantCheck = false): array
+    public function getBounces($pageIds, ?\DateTime $fromDate = null, bool $isVariantCheck = false): array
     {
         $inOrEq = (!is_array($pageIds)) ? 'eq' : 'in';
 

--- a/app/bundles/PageBundle/Entity/Page.php
+++ b/app/bundles/PageBundle/Entity/Page.php
@@ -524,11 +524,9 @@ class Page extends FormEntity implements TranslationEntityInterface, VariantEnti
     }
 
     /**
-     * @param bool $includeVariants
-     *
      * @return int|mixed
      */
-    public function getHits($includeVariants = false)
+    public function getHits(bool $includeVariants = false)
     {
         return ($includeVariants) ? $this->getAccumulativeVariantCount('getHits') : $this->hits;
     }
@@ -764,17 +762,15 @@ class Page extends FormEntity implements TranslationEntityInterface, VariantEnti
     /**
      * @return int
      */
-    public function getUniqueHits($includeVariants = false)
+    public function getUniqueHits(bool $includeVariants = false)
     {
         return ($includeVariants) ? $this->getAccumulativeVariantCount('getUniqueHits') : $this->uniqueHits;
     }
 
     /**
-     * @param bool $includeVariants
-     *
      * @return int|mixed
      */
-    public function getVariantHits($includeVariants = false)
+    public function getVariantHits(bool $includeVariants = false)
     {
         return ($includeVariants) ? $this->getAccumulativeVariantCount('getVariantHits') : $this->variantHits;
     }

--- a/app/bundles/PageBundle/Entity/PageRepository.php
+++ b/app/bundles/PageBundle/Entity/PageRepository.php
@@ -65,15 +65,13 @@ class PageRepository extends CommonRepository
      * @param string      $search
      * @param int         $limit
      * @param int         $start
-     * @param bool        $viewOther
      * @param string|bool $topLevel
      * @param array       $ignoreIds
      * @param array       $extraColumns
-     * @param bool        $publishedOnly
      *
      * @return array
      */
-    public function getPageList($search = '', $limit = 10, $start = 0, $viewOther = false, $topLevel = false, $ignoreIds = [], $extraColumns = [], $publishedOnly = false)
+    public function getPageList($search = '', $limit = 10, $start = 0, bool $viewOther = false, $topLevel = false, $ignoreIds = [], $extraColumns = [], bool $publishedOnly = false)
     {
         $q = $this->createQueryBuilder('p');
         $q->select(sprintf('partial p.{id, title, language, alias %s}', empty($extraColumns) ? '' : ','.implode(',', $extraColumns)));
@@ -251,11 +249,9 @@ class PageRepository extends CommonRepository
     }
 
     /**
-     * @param int        $increaseBy
-     * @param bool|false $unique
-     * @param bool|false $variant
+     * @param int $increaseBy
      */
-    public function upHitCount($id, $increaseBy = 1, $unique = false, $variant = false): void
+    public function upHitCount($id, $increaseBy = 1, bool $unique = false, bool $variant = false): void
     {
         $q = $this->getEntityManager()->getConnection()->createQueryBuilder();
 

--- a/app/bundles/PageBundle/Entity/RedirectRepository.php
+++ b/app/bundles/PageBundle/Entity/RedirectRepository.php
@@ -27,10 +27,9 @@ class RedirectRepository extends CommonRepository
     }
 
     /**
-     * @param int        $increaseBy
-     * @param bool|false $unique
+     * @param int $increaseBy
      */
-    public function upHitCount($id, $increaseBy = 1, $unique = false): void
+    public function upHitCount($id, $increaseBy = 1, bool $unique = false): void
     {
         $q = $this->getEntityManager()->getConnection()->createQueryBuilder();
 

--- a/app/bundles/PageBundle/Entity/TrackableRepository.php
+++ b/app/bundles/PageBundle/Entity/TrackableRepository.php
@@ -87,10 +87,9 @@ class TrackableRepository extends CommonRepository
     }
 
     /**
-     * @param int  $increaseBy
-     * @param bool $unique
+     * @param int $increaseBy
      */
-    public function upHitCount($redirectId, $channel, $channelId, $increaseBy = 1, $unique = false): void
+    public function upHitCount($redirectId, $channel, $channelId, $increaseBy = 1, bool $unique = false): void
     {
         $q = $this->getEntityManager()->getConnection()->createQueryBuilder();
 
@@ -115,12 +114,11 @@ class TrackableRepository extends CommonRepository
     /**
      * Get hit count.
      *
-     * @param bool   $combined
      * @param string $countColumn
      *
      * @return array|int
      */
-    public function getCount($channel, $channelIds, $listId, ?ChartQuery $chartQuery = null, $combined = false, $countColumn = 'ph.id')
+    public function getCount($channel, $channelIds, $listId, ?ChartQuery $chartQuery = null, bool $combined = false, $countColumn = 'ph.id')
     {
         $q = $this->_em->getConnection()->createQueryBuilder()
             ->select('count('.$countColumn.') as click_count')

--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -164,9 +164,8 @@ class PageModel extends FormModel implements GlobalSearchInterface
 
     /**
      * @param Page $entity
-     * @param bool $unlock
      */
-    public function saveEntity($entity, $unlock = true): void
+    public function saveEntity($entity, bool $unlock = true): void
     {
         $pageIds = $entity->getRelatedEntityIds();
 
@@ -262,7 +261,7 @@ class PageModel extends FormModel implements GlobalSearchInterface
     /**
      * @throws MethodNotAllowedHttpException
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?Event $event = null): ?Event
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?Event $event = null): ?Event
     {
         if (!$entity instanceof Page) {
             throw new MethodNotAllowedHttpException(['Page']);
@@ -328,12 +327,11 @@ class PageModel extends FormModel implements GlobalSearchInterface
      * Generate URL for a page.
      *
      * @param Page  $entity
-     * @param bool  $absolute
      * @param array $clickthrough
      *
      * @return string
      */
-    public function generateUrl($entity, $absolute = true, $clickthrough = [])
+    public function generateUrl($entity, bool $absolute = true, $clickthrough = [])
     {
         // If this is a variant, then get the parent's URL
         $parent = $entity->getVariantParent();
@@ -800,11 +798,10 @@ class PageModel extends FormModel implements GlobalSearchInterface
     /**
      * Get line chart data of hits.
      *
-     * @param ?string $unit          {@link php.net/manual/en/function.date.php#refsect1-function.date-parameters}
+     * @param ?string $unit       {@link php.net/manual/en/function.date.php#refsect1-function.date-parameters}
      * @param string  $dateFormat
-     * @param bool    $canViewOthers
      */
-    public function getHitsLineChartData($unit, \DateTime $dateFrom, \DateTime $dateTo, $dateFormat = null, array $filter = [], $canViewOthers = true): array
+    public function getHitsLineChartData($unit, \DateTime $dateFrom, \DateTime $dateTo, $dateFormat = null, array $filter = [], bool $canViewOthers = true): array
     {
         $flag = null;
 
@@ -913,9 +910,8 @@ class PageModel extends FormModel implements GlobalSearchInterface
      * Get pie chart data of dwell times.
      *
      * @param array $filters
-     * @param bool  $canViewOthers
      */
-    public function getDwellTimesPieChartData(\DateTime $dateFrom, \DateTime $dateTo, $filters = [], $canViewOthers = true): array
+    public function getDwellTimesPieChartData(\DateTime $dateFrom, \DateTime $dateTo, $filters = [], bool $canViewOthers = true): array
     {
         $timesOnSite = $this->hitRepository->getDwellTimeLabels();
         $chart       = new PieChart();
@@ -938,7 +934,7 @@ class PageModel extends FormModel implements GlobalSearchInterface
     /**
      * Get bar chart data of hits.
      */
-    public function getDeviceGranularityData(\DateTime $dateFrom, \DateTime $dateTo, $filters = [], $canViewOthers = true): array
+    public function getDeviceGranularityData(\DateTime $dateFrom, \DateTime $dateTo, $filters = [], bool $canViewOthers = true): array
     {
         $q = $this->em->getConnection()->createQueryBuilder();
 
@@ -977,9 +973,8 @@ class PageModel extends FormModel implements GlobalSearchInterface
      *
      * @param int   $limit
      * @param array $filters
-     * @param bool  $canViewOthers
      */
-    public function getPopularPages($limit = 10, ?\DateTime $dateFrom = null, ?\DateTime $dateTo = null, $filters = [], $canViewOthers = true): array
+    public function getPopularPages($limit = 10, ?\DateTime $dateFrom = null, ?\DateTime $dateTo = null, $filters = [], bool $canViewOthers = true): array
     {
         $q = $this->em->getConnection()->createQueryBuilder();
         $q->select('COUNT(DISTINCT t.id) AS hits, p.id, p.title, p.alias')
@@ -1006,9 +1001,8 @@ class PageModel extends FormModel implements GlobalSearchInterface
      *
      * @param int   $limit
      * @param array $filters
-     * @param bool  $canViewOthers
      */
-    public function getPageList($limit = 10, ?\DateTime $dateFrom = null, ?\DateTime $dateTo = null, $filters = [], $canViewOthers = true): array
+    public function getPageList($limit = 10, ?\DateTime $dateFrom = null, ?\DateTime $dateTo = null, $filters = [], bool $canViewOthers = true): array
     {
         $q = $this->em->getConnection()->createQueryBuilder();
         $q->select('t.id, t.title AS name, t.date_added, t.date_modified')

--- a/app/bundles/PageBundle/Model/TrackableModel.php
+++ b/app/bundles/PageBundle/Model/TrackableModel.php
@@ -95,7 +95,7 @@ class TrackableModel extends AbstractCommonModel
     public function generateTrackableUrl(
         Trackable $trackable,
         array $clickthrough = [],
-        $shortenUrl = false,
+        bool $shortenUrl = false,
         $utmTags = [],
     ) {
         $clickthrough['channel'] ??= [$trackable->getChannel() => $trackable->getChannelId()];
@@ -239,7 +239,7 @@ class TrackableModel extends AbstractCommonModel
      *
      * @return array{string|string[],Redirect[]|Trackable[]}
      */
-    public function parseContentForTrackables($content, array $contentTokens = [], ?string $channel = null, int|string|null $channelId = null, $usingClickthrough = true): array
+    public function parseContentForTrackables($content, array $contentTokens = [], ?string $channel = null, int|string|null $channelId = null, bool $usingClickthrough = true): array
     {
         $this->usingClickthrough = $usingClickthrough;
 
@@ -526,10 +526,7 @@ class TrackableModel extends AbstractCommonModel
         return $this->isValidUrl($tokenValue);
     }
 
-    /**
-     * @param bool $forceScheme
-     */
-    protected function isValidUrl($url, $forceScheme = true): bool
+    protected function isValidUrl($url, bool $forceScheme = true): bool
     {
         $urlParts = (!is_array($url)) ? parse_url($url) : $url;
 

--- a/app/bundles/PluginBundle/Entity/IntegrationEntityRepository.php
+++ b/app/bundles/PluginBundle/Entity/IntegrationEntityRepository.php
@@ -15,7 +15,6 @@ class IntegrationEntityRepository extends CommonRepository
      * @param array<int>|int|null               $internalEntityIds
      * @param mixed                             $startDate
      * @param mixed                             $endDate
-     * @param bool                              $push
      * @param int                               $start
      * @param int                               $limit
      * @param int|string|array<int|string>|null $integrationEntityIds
@@ -27,7 +26,7 @@ class IntegrationEntityRepository extends CommonRepository
         $internalEntityIds = null,
         $startDate = null,
         $endDate = null,
-        $push = false,
+        bool $push = false,
         $start = 0,
         $limit = 0,
         $integrationEntityIds = null,

--- a/app/bundles/PointBundle/Model/PointGroupModel.php
+++ b/app/bundles/PointBundle/Model/PointGroupModel.php
@@ -84,7 +84,7 @@ class PointGroupModel extends CommonFormModel implements GlobalSearchInterface
     /**
      * @throws MethodNotAllowedHttpException
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?Event $event = null): ?Event
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?Event $event = null): ?Event
     {
         if (!$entity instanceof Group) {
             throw new MethodNotAllowedHttpException(['Group']);

--- a/app/bundles/PointBundle/Model/PointModel.php
+++ b/app/bundles/PointBundle/Model/PointModel.php
@@ -108,7 +108,7 @@ class PointModel extends CommonFormModel implements GlobalSearchInterface, Reset
     /**
      * @throws MethodNotAllowedHttpException
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?Event $event = null): ?Event
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?Event $event = null): ?Event
     {
         if (!$entity instanceof Point) {
             throw new MethodNotAllowedHttpException(['Point']);
@@ -168,13 +168,12 @@ class PointModel extends CommonFormModel implements GlobalSearchInterface, Reset
     /**
      * Triggers a specific point change.
      *
-     * @param mixed $eventDetails     passthrough from function triggering action to the callback function
-     * @param mixed $typeId           Something unique to the triggering event to prevent  unnecessary duplicate calls
-     * @param bool  $allowUserRequest
+     * @param mixed $eventDetails passthrough from function triggering action to the callback function
+     * @param mixed $typeId       Something unique to the triggering event to prevent  unnecessary duplicate calls
      *
      * @throws \ReflectionException
      */
-    public function triggerAction($type, $eventDetails = null, $typeId = null, ?Lead $lead = null, $allowUserRequest = false): void
+    public function triggerAction($type, $eventDetails = null, $typeId = null, ?Lead $lead = null, bool $allowUserRequest = false): void
     {
         // only trigger actions for not logged Mautic users
         if (!$this->security->isAnonymous() && !$allowUserRequest) {
@@ -316,12 +315,11 @@ class PointModel extends CommonFormModel implements GlobalSearchInterface, Reset
     /**
      * Get line chart data of points.
      *
-     * @param string $unit          {@link php.net/manual/en/function.date.php#refsect1-function.date-parameters}
+     * @param string $unit       {@link php.net/manual/en/function.date.php#refsect1-function.date-parameters}
      * @param string $dateFormat
      * @param array  $filter
-     * @param bool   $canViewOthers
      */
-    public function getPointLineChartData($unit, \DateTime $dateFrom, \DateTime $dateTo, $dateFormat = null, $filter = [], $canViewOthers = true): array
+    public function getPointLineChartData($unit, \DateTime $dateFrom, \DateTime $dateTo, $dateFormat = null, $filter = [], bool $canViewOthers = true): array
     {
         $chart = new LineChart($unit, $dateFrom, $dateTo, $dateFormat);
         $query = new ChartQuery($this->em->getConnection(), $dateFrom, $dateTo);

--- a/app/bundles/PointBundle/Model/TriggerModel.php
+++ b/app/bundles/PointBundle/Model/TriggerModel.php
@@ -105,9 +105,8 @@ class TriggerModel extends CommonFormModel implements GlobalSearchInterface
 
     /**
      * @param Trigger $entity
-     * @param bool    $unlock
      */
-    public function saveEntity($entity, $unlock = true): void
+    public function saveEntity($entity, bool $unlock = true): void
     {
         $isNew = !(bool) $entity->getId();
 
@@ -202,7 +201,7 @@ class TriggerModel extends CommonFormModel implements GlobalSearchInterface
     /**
      * @throws MethodNotAllowedHttpException
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?Event $event = null): ?Event
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?Event $event = null): ?Event
     {
         if (!$entity instanceof Trigger) {
             throw new MethodNotAllowedHttpException(['Trigger']);
@@ -308,11 +307,10 @@ class TriggerModel extends CommonFormModel implements GlobalSearchInterface
      * Triggers a specific event.
      *
      * @param array $event triggerEvent converted to array
-     * @param bool  $force
      *
      * @return bool Was event triggered
      */
-    public function triggerEvent(array $event, ?Lead $lead = null, $force = false): bool
+    public function triggerEvent(array $event, ?Lead $lead = null, bool $force = false): bool
     {
         // only trigger events for anonymous users
         if (!$force && !$this->security->isAnonymous()) {

--- a/app/bundles/ReportBundle/Model/ReportModel.php
+++ b/app/bundles/ReportBundle/Model/ReportModel.php
@@ -147,7 +147,7 @@ class ReportModel extends FormModel implements GlobalSearchInterface
     /**
      * @throws MethodNotAllowedHttpException
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?Event $event = null): ?Event
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?Event $event = null): ?Event
     {
         if (!$entity instanceof Report) {
             throw new MethodNotAllowedHttpException(['Report']);
@@ -291,7 +291,7 @@ class ReportModel extends FormModel implements GlobalSearchInterface
      *
      * @return \stdClass ['choices' => [], 'choiceHtml' => '', definitions => []]
      */
-    public function getColumnList($context, $isGroupBy = false): \stdClass
+    public function getColumnList($context, bool $isGroupBy = false): \stdClass
     {
         $tableData           = $this->getTableData($context);
         $columns             = $tableData['columns'] ?? [];

--- a/app/bundles/SmsBundle/Model/SmsModel.php
+++ b/app/bundles/SmsBundle/Model/SmsModel.php
@@ -96,7 +96,7 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface, GlobalSear
         return 'sms:smses';
     }
 
-    public function saveEntity($entity, $unlock = true): void
+    public function saveEntity($entity, bool $unlock = true): void
     {
         parent::saveEntity($entity, $unlock);
 
@@ -108,7 +108,7 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface, GlobalSear
      *
      * @param iterable<Sms> $entities
      */
-    public function saveEntities($entities, $unlock = true): void
+    public function saveEntities($entities, bool $unlock = true): void
     {
         // iterate over the results so the events are dispatched on each delete
         $batchSize = 20;
@@ -380,11 +380,9 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface, GlobalSear
     }
 
     /**
-     * @param bool $persist
-     *
      * @throws \Exception
      */
-    public function createStatEntry(Sms $sms, Lead $lead, $source = null, $persist = true, $listId = null): Stat
+    public function createStatEntry(Sms $sms, Lead $lead, $source = null, bool $persist = true, $listId = null): Stat
     {
         $stat = new Stat();
         $stat->setDateSent(new \DateTime());
@@ -410,7 +408,7 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface, GlobalSear
     /**
      * @throws MethodNotAllowedHttpException
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?Event $event = null): ?Event
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?Event $event = null): ?Event
     {
         if (!$entity instanceof Sms) {
             throw new MethodNotAllowedHttpException(['Sms']);
@@ -460,11 +458,10 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface, GlobalSear
     /**
      * Get line chart data of hits.
      *
-     * @param ?string $unit          {@link php.net/manual/en/function.date.php#refsect1-function.date-parameters}
+     * @param ?string $unit       {@link php.net/manual/en/function.date.php#refsect1-function.date-parameters}
      * @param string  $dateFormat
-     * @param bool    $canViewOthers
      */
-    public function getHitsLineChartData($unit, \DateTime $dateFrom, \DateTime $dateTo, $dateFormat = null, array $filter = [], $canViewOthers = true): array
+    public function getHitsLineChartData($unit, \DateTime $dateFrom, \DateTime $dateTo, $dateFormat = null, array $filter = [], bool $canViewOthers = true): array
     {
         $flag = null;
 

--- a/app/bundles/StageBundle/Entity/StageRepository.php
+++ b/app/bundles/StageBundle/Entity/StageRepository.php
@@ -124,12 +124,11 @@ class StageRepository extends CommonRepository
     /**
      * Get a list of lists.
      *
-     * @param bool|object $user
-     * @param string      $id
+     * @param string $id
      *
      * @return array<int, array<string, mixed>>
      */
-    public function getStages($user = false, $id = ''): array
+    public function getStages(object|bool $user = false, $id = ''): array
     {
         if (is_object($user)) {
             $user = $user->getId();

--- a/app/bundles/StageBundle/Model/StageModel.php
+++ b/app/bundles/StageBundle/Model/StageModel.php
@@ -89,7 +89,7 @@ class StageModel extends CommonFormModel implements GlobalSearchInterface
     /**
      * @throws MethodNotAllowedHttpException
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?Event $event = null): ?Event
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?Event $event = null): ?Event
     {
         if (!$entity instanceof Stage) {
             throw new MethodNotAllowedHttpException(['Stage']);
@@ -151,12 +151,11 @@ class StageModel extends CommonFormModel implements GlobalSearchInterface
     /**
      * Get line chart data of stages.
      *
-     * @param ?string $unit          {@link php.net/manual/en/function.date.php#refsect1-function.date-parameters}
+     * @param ?string $unit       {@link php.net/manual/en/function.date.php#refsect1-function.date-parameters}
      * @param string  $dateFormat
      * @param array   $filter
-     * @param bool    $canViewOthers
      */
-    public function getStageLineChartData($unit, \DateTime $dateFrom, \DateTime $dateTo, $dateFormat = null, $filter = [], $canViewOthers = true): array
+    public function getStageLineChartData($unit, \DateTime $dateFrom, \DateTime $dateTo, $dateFormat = null, $filter = [], bool $canViewOthers = true): array
     {
         $chart = new LineChart($unit, $dateFrom, $dateTo, $dateFormat);
         $query = new ChartQuery($this->em->getConnection(), $dateFrom, $dateTo);

--- a/app/bundles/StageBundle/Tests/Unit/EventListener/CampaignSubscriberTest.php
+++ b/app/bundles/StageBundle/Tests/Unit/EventListener/CampaignSubscriberTest.php
@@ -154,7 +154,7 @@ final class CampaignSubscriberTest extends TestCase
             {
             }
 
-            public function saveEntity($entity, $unlock = true): void
+            public function saveEntity($entity, bool $unlock = true): void
             {
             }
         };
@@ -386,7 +386,7 @@ final class CampaignSubscriberTest extends TestCase
             {
             }
 
-            public function saveEntity($entity, $unlock = true): void
+            public function saveEntity($entity, bool $unlock = true): void
             {
             }
         };

--- a/app/bundles/UserBundle/Entity/PermissionRepository.php
+++ b/app/bundles/UserBundle/Entity/PermissionRepository.php
@@ -28,10 +28,8 @@ class PermissionRepository extends CommonRepository
 
     /**
      * Retrieves array of permissions for a set role.  If $forForm, then the array will contain.
-     *
-     * @param bool $forForm
      */
-    public function getPermissionsByRole(Role $role, $forForm = false): array
+    public function getPermissionsByRole(Role $role, bool $forForm = false): array
     {
         $query = $this
             ->createQueryBuilder('p')

--- a/app/bundles/UserBundle/Entity/User.php
+++ b/app/bundles/UserBundle/Entity/User.php
@@ -477,10 +477,8 @@ class User extends FormEntity implements UserInterface, EquatableInterface, Pass
 
     /**
      * Get full name.
-     *
-     * @param bool $lastFirst
      */
-    public function getName($lastFirst = false): string
+    public function getName(bool $lastFirst = false): string
     {
         return ($lastFirst) ? $this->lastName.', '.$this->firstName : $this->firstName.' '.$this->lastName;
     }

--- a/app/bundles/UserBundle/Entity/UserTokenRepository.php
+++ b/app/bundles/UserBundle/Entity/UserTokenRepository.php
@@ -46,7 +46,7 @@ final class UserTokenRepository extends CommonRepository implements UserTokenRep
         return true;
     }
 
-    public function deleteExpired($isDryRun = false): int
+    public function deleteExpired(bool $isDryRun = false): int
     {
         $qb = $this->createQueryBuilder('ut')
             ->where('ut.expiration <= :current_datetime')

--- a/app/bundles/UserBundle/Entity/UserTokenRepositoryInterface.php
+++ b/app/bundles/UserBundle/Entity/UserTokenRepositoryInterface.php
@@ -21,9 +21,7 @@ interface UserTokenRepositoryInterface
     /**
      * Delete expired user tokens.
      *
-     * @param bool $isDryRun
-     *
      * @return int Number of selected or deleted rows
      */
-    public function deleteExpired($isDryRun = false);
+    public function deleteExpired(bool $isDryRun = false);
 }

--- a/app/bundles/UserBundle/Model/RoleModel.php
+++ b/app/bundles/UserBundle/Model/RoleModel.php
@@ -57,7 +57,7 @@ final class RoleModel extends FormModel implements GlobalSearchInterface
     /**
      * @throws MethodNotAllowedHttpException
      */
-    public function saveEntity($entity, $unlock = true): void
+    public function saveEntity($entity, bool $unlock = true): void
     {
         if (!$entity instanceof Role) {
             throw new MethodNotAllowedHttpException(['Role'], 'Entity must be of class Role()');
@@ -151,7 +151,7 @@ final class RoleModel extends FormModel implements GlobalSearchInterface
     /**
      * @throws MethodNotAllowedHttpException
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?Event $event = null): ?Event
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?Event $event = null): ?Event
     {
         if (!$entity instanceof Role) {
             throw new MethodNotAllowedHttpException(['Role'], 'Entity must be of class Role()');

--- a/app/bundles/UserBundle/Model/UserModel.php
+++ b/app/bundles/UserBundle/Model/UserModel.php
@@ -81,7 +81,7 @@ class UserModel extends FormModel implements GlobalSearchInterface
     /**
      * @throws MethodNotAllowedHttpException
      */
-    public function saveEntity($entity, $unlock = true): void
+    public function saveEntity($entity, bool $unlock = true): void
     {
         if (!$entity instanceof User) {
             throw new MethodNotAllowedHttpException(['User'], $this->translator->trans('mautic.user.entity.must.be.user', [], 'validators'));
@@ -108,10 +108,9 @@ class UserModel extends FormModel implements GlobalSearchInterface
     /**
      * Checks for a new password and rehashes if necessary.
      *
-     * @param string     $submittedPassword
-     * @param bool|false $validate
+     * @param string $submittedPassword
      */
-    public function checkNewPassword(User $entity, $submittedPassword, $validate = false): ?string
+    public function checkNewPassword(User $entity, $submittedPassword, bool $validate = false): ?string
     {
         if ($validate) {
             if (strlen($submittedPassword) < 6) {
@@ -175,7 +174,7 @@ class UserModel extends FormModel implements GlobalSearchInterface
     /**
      * @throws MethodNotAllowedHttpException
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?Event $event = null): ?Event
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?Event $event = null): ?Event
     {
         if (!$entity instanceof User) {
             throw new MethodNotAllowedHttpException(['User'], $this->translator->trans('mautic.user.entity.must.be.user', [], 'validators'));

--- a/app/bundles/WebhookBundle/Model/WebhookModel.php
+++ b/app/bundles/WebhookBundle/Model/WebhookModel.php
@@ -154,7 +154,7 @@ class WebhookModel extends FormModel
     /**
      * @param Webhook $entity
      */
-    public function saveEntity($entity, $unlock = true): void
+    public function saveEntity($entity, bool $unlock = true): void
     {
         if (null === $entity->getSecret()) {
             $entity->setSecret(EncryptionHelper::generateKey());
@@ -626,7 +626,7 @@ class WebhookModel extends FormModel
     /**
      * @throws MethodNotAllowedHttpException
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?SymfonyEvent $event = null): ?SymfonyEvent
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?SymfonyEvent $event = null): ?SymfonyEvent
     {
         if (!$entity instanceof Webhook) {
             throw new MethodNotAllowedHttpException(['Webhook'], 'Entity must be of class Webhook()');

--- a/plugins/GrapesJsBuilderBundle/Tests/Unit/Model/GrapesJsBuilderModelTest.php
+++ b/plugins/GrapesJsBuilderBundle/Tests/Unit/Model/GrapesJsBuilderModelTest.php
@@ -44,10 +44,7 @@ final class GrapesJsBuilderModelTest extends \PHPUnit\Framework\TestCase
             {
             }
 
-            /**
-             * @param bool $flush
-             */
-            public function saveEntity(object $entity, $flush = true): void
+            public function saveEntity(object $entity, bool $flush = true): void
             {
                 ++$this->saveEntityCallCount;
             }
@@ -67,10 +64,7 @@ final class GrapesJsBuilderModelTest extends \PHPUnit\Framework\TestCase
                 return null;
             }
 
-            /**
-             * @param bool $flush
-             */
-            public function saveEntity(object $entity, $flush = true): void
+            public function saveEntity(object $entity, bool $flush = true): void
             {
                 ++$this->saveEntityCallCount;
             }
@@ -150,7 +144,7 @@ final class GrapesJsBuilderModelTest extends \PHPUnit\Framework\TestCase
             /**
              * @param Email $entity
              */
-            public function saveEntity(object $entity, $flush = true): void
+            public function saveEntity(object $entity, bool $flush = true): void
             {
                 ++$this->saveEntityCallCount;
 
@@ -175,7 +169,7 @@ final class GrapesJsBuilderModelTest extends \PHPUnit\Framework\TestCase
             /**
              * @param GrapesJsBuilder $entity
              */
-            public function saveEntity(object $entity, $flush = true): void
+            public function saveEntity(object $entity, bool $flush = true): void
             {
                 ++$this->saveEntityCallCount;
 

--- a/plugins/MauticFocusBundle/Model/FocusModel.php
+++ b/plugins/MauticFocusBundle/Model/FocusModel.php
@@ -124,18 +124,14 @@ class FocusModel extends FormModel implements GlobalSearchInterface
 
     /**
      * @param Focus $entity
-     * @param bool  $unlock
      */
-    public function saveEntity($entity, $unlock = true): void
+    public function saveEntity($entity, bool $unlock = true): void
     {
         parent::saveEntity($entity, $unlock);
         $this->generateTrackableUrl($entity);
     }
 
-    /**
-     * @param bool $isPreview
-     */
-    public function generateJavascript(Focus $focus, $isPreview = false): string
+    public function generateJavascript(Focus $focus, bool $isPreview = false): string
     {
         $lead           = $this->contactTracker->getContact();
         $focusArray     = $focus->toArray();
@@ -180,12 +176,11 @@ class FocusModel extends FormModel implements GlobalSearchInterface
     }
 
     /**
-     * @param bool   $isPreview
      * @param string $url
      *
      * @return array
      */
-    public function getContent(array $focus, $isPreview = false, $url = '#')
+    public function getContent(array $focus, bool $isPreview = false, $url = '#')
     {
         $form = (!empty($focus['form']) && 'form' === $focus['type']) ? $this->formModel->getEntity($focus['form']) : null;
 
@@ -322,7 +317,7 @@ class FocusModel extends FormModel implements GlobalSearchInterface
     /**
      * @throws MethodNotAllowedHttpException
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?Event $event = null): ?Event
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?Event $event = null): ?Event
     {
         if (!$entity instanceof Focus) {
             throw new MethodNotAllowedHttpException(['Focus']);
@@ -359,10 +354,7 @@ class FocusModel extends FormModel implements GlobalSearchInterface
         return null;
     }
 
-    /**
-     * @param bool $canViewOthers
-     */
-    public function getStats(Focus $focus, $unit, \DateTime $dateFrom, \DateTime $dateTo, $dateFormat = null, $canViewOthers = true): array
+    public function getStats(Focus $focus, $unit, \DateTime $dateFrom, \DateTime $dateTo, $dateFormat = null, bool $canViewOthers = true): array
     {
         $chart = new LineChart($unit, $dateFrom, $dateTo, $dateFormat);
         $query = new ChartQuery($this->em->getConnection(), $dateFrom, $dateTo, $unit);

--- a/plugins/MauticSocialBundle/Entity/TweetRepository.php
+++ b/plugins/MauticSocialBundle/Entity/TweetRepository.php
@@ -13,11 +13,10 @@ final class TweetRepository extends CommonRepository
      * @param string $search
      * @param int    $limit
      * @param int    $start
-     * @param bool   $viewOther
      *
      * @return array
      */
-    public function getTweetList($search = '', $limit = 10, $start = 0, $viewOther = false, array $ignoreIds = [])
+    public function getTweetList($search = '', $limit = 10, $start = 0, bool $viewOther = false, array $ignoreIds = [])
     {
         $qb = $this->createQueryBuilder('t');
         $qb->select('partial t.{id, text, name, language}');

--- a/plugins/MauticSocialBundle/Model/MonitoringModel.php
+++ b/plugins/MauticSocialBundle/Model/MonitoringModel.php
@@ -77,7 +77,7 @@ final class MonitoringModel extends FormModel
     /**
      * @throws MethodNotAllowedHttpException
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?Event $event = null): ?Event
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?Event $event = null): ?Event
     {
         if (!$entity instanceof Monitoring) {
             throw new MethodNotAllowedHttpException(['Monitoring']);
@@ -115,9 +115,8 @@ final class MonitoringModel extends FormModel
 
     /**
      * @param Monitoring $monitoringEntity
-     * @param bool       $unlock
      */
-    public function saveEntity($monitoringEntity, $unlock = true): void
+    public function saveEntity($monitoringEntity, bool $unlock = true): void
     {
         // we're editing an existing record
         if (!$monitoringEntity->isNew()) {

--- a/plugins/MauticSocialBundle/Model/TweetModel.php
+++ b/plugins/MauticSocialBundle/Model/TweetModel.php
@@ -164,7 +164,7 @@ final class TweetModel extends FormModel implements AjaxLookupModelInterface
     /**
      * @throws MethodNotAllowedHttpException
      */
-    protected function dispatchEvent($action, &$entity, $isNew = false, ?Event $event = null): ?Event
+    protected function dispatchEvent($action, &$entity, bool $isNew = false, ?Event $event = null): ?Event
     {
         if (!$entity instanceof Tweet) {
             throw new MethodNotAllowedHttpException(['Tweet']);


### PR DESCRIPTION
Adds native `bool` typehints to method parameters that default to `false`/`true`, dropping the now-redundant `@param bool` docblocks.

```diff
-    /**
-     * @param bool $unlock
-     */
-    public function saveEntity($entity, $unlock = true): void
+    public function saveEntity($entity, bool $unlock = true): void
     {
```

One of 3 parts of the param-bool typing sweep. Files are grouped so each **inheritance chain stays whole** (base class + every override in the same part) — splitting a typed override from its parent makes PHP fatal at class load, which breaks `composer install` (assets:generate) and cascades. Each part boots on its own; verified by loading every changed class + its hierarchy.

https://claude.ai/code/session_01GpHL422YrvxQdRwuebNW5X