### PR TITLE
[NOT-FOR-MERGE] Optimize campaign trigger for large campaigns

### DIFF
--- a/app/bundles/CampaignBundle/Entity/CampaignRepository.php
+++ b/app/bundles/CampaignBundle/Entity/CampaignRepository.php
@@ -314,20 +314,16 @@ class CampaignRepository extends CommonRepository
         $this->updateQueryFromContactLimiter('cl', $q, $limiter, true);
 
         if (count($pendingEvents) > 0) {
-            $sq = $this->getEntityManager()->getConnection()->createQueryBuilder();
-            $sq->select('null')
-                ->from(MAUTIC_TABLE_PREFIX.'campaign_lead_event_log', 'e')
-                ->where(
-                    $sq->expr()->and(
-                        $sq->expr()->eq('cl.lead_id', 'e.lead_id'),
-                        $sq->expr()->eq('e.rotation', 'cl.rotation'),
-                        $sq->expr()->in('e.event_id', $pendingEvents)
-                    )
-                );
-
-            $q->andWhere(
-                sprintf('NOT EXISTS (%s)', $sq->getSQL())
-            );
+            $q->leftJoin(
+                'cl',
+                MAUTIC_TABLE_PREFIX.'campaign_lead_event_log',
+                'e',
+                $q->expr()->and(
+                    $q->expr()->eq('cl.lead_id', 'e.lead_id'),
+                    $q->expr()->eq('e.rotation', 'cl.rotation'),
+                    $q->expr()->in('e.event_id', $pendingEvents)
+                )
+            )->andWhere($q->expr()->isNull('e.lead_id'));
         }
 
         $result = $q->executeQuery()->fetchAssociative();

--- a/app/bundles/CampaignBundle/Tests/Functional/Entity/CampaignRepositoryTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Entity/CampaignRepositoryTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CampaignBundle\Tests\Functional\Entity;
+
+use Mautic\CampaignBundle\Entity\Campaign;
+use Mautic\CampaignBundle\Entity\CampaignRepository;
+use Mautic\CampaignBundle\Entity\Event;
+use Mautic\CampaignBundle\Entity\Lead as CampaignMember;
+use Mautic\CampaignBundle\Entity\LeadEventLog;
+use Mautic\CampaignBundle\Executioner\ContactFinder\Limiter\ContactLimiter;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\LeadBundle\Entity\Lead;
+
+class CampaignRepositoryTest extends MauticMysqlTestCase
+{
+    /**
+     * @param int[] $pendingEventIndexes
+     *
+     * @dataProvider pendingEventsProvider
+     */
+    public function testGetCountsForPendingContacts(
+        array $pendingEventIndexes,
+        int $expectedCount,
+        int $expectedMinContactIndex,
+        int $expectedMaxContactIndex,
+    ): void {
+        $campaign = new Campaign();
+        $campaign->setName('Pending contacts');
+
+        $events = [
+            $this->createEvent($campaign, 'First root event'),
+            $this->createEvent($campaign, 'Second root event'),
+        ];
+
+        $contacts = [new Lead(), new Lead(), new Lead(), new Lead()];
+        foreach ($contacts as $contactIndex => $contact) {
+            $this->em->persist($contact);
+            $campaignMember = $this->createCampaignMember($campaign, $contact);
+            if (3 === $contactIndex) {
+                $campaignMember->setRotation(2);
+            }
+            $this->em->persist($campaignMember);
+        }
+
+        $this->em->persist($campaign);
+        $this->em->flush();
+
+        foreach ([[0, 0], [0, 1], [1, 1], [3, 0]] as [$contactIndex, $eventIndex]) {
+            $eventLog = new LeadEventLog();
+            $eventLog->setCampaign($campaign);
+            $eventLog->setEvent($events[$eventIndex]);
+            $eventLog->setLead($contacts[$contactIndex]);
+            $eventLog->setDateTriggered(new \DateTime());
+            $this->em->persist($eventLog);
+        }
+
+        $this->em->flush();
+
+        $repository = $this->em->getRepository(Campaign::class);
+        \assert($repository instanceof CampaignRepository);
+
+        $pendingEventIds = array_map(
+            fn (int $eventIndex): int => (int) $events[$eventIndex]->getId(),
+            $pendingEventIndexes,
+        );
+        $result = $repository->getCountsForPendingContacts(
+            $campaign->getId(),
+            $pendingEventIds,
+            new ContactLimiter(100),
+        );
+
+        self::assertSame($expectedCount, $result->getCount());
+        self::assertSame($contacts[$expectedMinContactIndex]->getId(), $result->getMinId());
+        self::assertSame($contacts[$expectedMaxContactIndex]->getId(), $result->getMaxId());
+    }
+
+    /**
+     * @return iterable<string, array{int[], int, int, int}>
+     */
+    public static function pendingEventsProvider(): iterable
+    {
+        yield 'no pending events includes all contacts' => [
+            [],
+            4,
+            0,
+            3,
+        ];
+
+        yield 'one pending event excludes only its matching log' => [
+            [0],
+            3,
+            1,
+            3,
+        ];
+
+        yield 'multiple pending events exclude logs for every matching event' => [
+            [0, 1],
+            2,
+            2,
+            3,
+        ];
+    }
+
+    private function createEvent(Campaign $campaign, string $name): Event
+    {
+        $event = new Event();
+        $event->setCampaign($campaign);
+        $event->setName($name);
+        $event->setType('lead.field_value');
+        $event->setEventType(Event::TYPE_CONDITION);
+        $this->em->persist($event);
+
+        return $event;
+    }
+
+    private function createCampaignMember(Campaign $campaign, Lead $contact): CampaignMember
+    {
+        $campaignMember = new CampaignMember();
+        $campaignMember->setCampaign($campaign);
+        $campaignMember->setLead($contact);
+        $campaignMember->setDateAdded(new \DateTime());
+
+        return $campaignMember;
+    }
+}


### PR DESCRIPTION
⚠️ This PR is provided for use as a patch and is not intended for merging into this Mautic release, as that release is no longer maintained.

Backport of https://github.com/mautic/mautic/pull/17175

## Description

`mautic:campaigns:trigger` counts campaign members that have not yet executed pending campaign events. On large campaigns with no pending contacts, the current correlated query still checks the full campaign membership.

This changes the query to an indexed `LEFT JOIN ... IS NULL` anti-join while preserving the existing behavior. In a local MariaDB 10.3 test with one million already-processed campaign members, the query improved from 1.90 seconds to 0.31 seconds, approximately 6x faster or an 84% reduction in query time.

## Manual testing

Run `mautic:campaigns:trigger` for a campaign containing pending contacts and verify that they are processed as before; run it again and verify that already-processed contacts are not processed a second time.
