### PR TITLE
fix(api): expose contact note creator metadata

### DIFF
--- a/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
@@ -237,7 +237,7 @@ final class LeadApiController extends CommonApiController
             Response::HTTP_OK
         );
 
-        $context = $view->getContext()->setGroups(['leadNoteDetails']);
+        $context = $view->getContext()->setGroups(['leadNoteDetails', 'publishDetails']);
         $view->setContext($context);
 
         return $this->handleView($view);

--- a/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiControllerFunctionalTest.php
@@ -1481,6 +1481,15 @@ final class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
 
         $response = $this->client->getResponse();
         $this->assertResponseIsSuccessful($response->getContent());
+
+        $payload = json_decode($response->getContent(), true);
+        $note    = reset($payload['notes']);
+
+        $this->assertSame($owner->getId(), $note['createdBy']);
+        $this->assertSame($owner->getName(), $note['createdByUser']);
+        $this->assertSame($owner->getId(), $note['modifiedBy']);
+        $this->assertSame($owner->getName(), $note['modifiedByUser']);
+        $this->assertSame('2026-08-29T00:00:00+00:00', $note['dateModified']);
     }
 
     public function testGetContactNotesActionReturnsForbiddenWithoutNoteViewPermissions(): void
@@ -1509,6 +1518,8 @@ final class LeadApiControllerFunctionalTest extends MauticMysqlTestCase
         $note->setLead($contact);
         $note->setText($text);
         $note->setCreatedBy($owner);
+        $note->setModifiedBy($owner);
+        $note->setDateModified(new \DateTime('2026-08-29 00:00:00', new \DateTimeZone('UTC')));
         $this->em->persist($note);
         $this->em->flush();
 


### PR DESCRIPTION

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️
| Related user documentation PR URL      | ❌
| Related developer documentation PR URL | ❌
| Issue(s) addressed                     | No related issue; this fixes missing creator/change metadata in the contact notes API response.

## Description

### What changed

The contact-scoped notes API response now serializes notes with both `leadNoteDetails` and `publishDetails`.
This exposes the note-level creator/change metadata in `GET /api/contacts/{id}/notes`, including:
- `createdBy`
- `createdByUser`
- `dateModified`
- `modifiedBy`
- `modifiedByUser`

### Why this is needed

API users need to know who created a note, who changed it, and when. The note entity already supports this metadata through the existing `publishDetails` serializer group, but the contact-scoped notes endpoint only used `leadNoteDetails`, so the metadata was omitted.


---
### 📋 Steps to test this PR:

1. Open this PR on GitHub Codespaces or pull it down locally.
2. Clear the cache
3. Verify the API response:
    - Create or use a contact with at least one note.
    - Ensure the note has creator and modified metadata.
    - Authenticate as a user with contact note view permissions.
    - Send a request to:
```http
GET /api/contacts/{contactId}/notes
```
4. Confirm each returned note still includes the existing note fields, such as `id`, `text`, `type`, `dateTime`, and `lead`.
5. Confirm each returned note now also includes the note-level publish metadata:
    - `createdBy`
    - `createdByUser`
    - `dateModified`
    - `modifiedBy`
    - `modifiedByUser`