### PR TITLE
[rector] apply AssertTrueResponseIsOkToAssertResponseIsSuccessfulRector to tests

### DIFF
--- a/app/bundles/LeadBundle/Tests/Controller/ListControllerFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/ListControllerFunctionalTest.php
@@ -943,14 +943,14 @@ final class ListControllerFunctionalTest extends MauticMysqlTestCase
         $this->em->clear();
 
         $this->client->request(Request::METHOD_POST, '/s/ajax', ['action' => 'togglePublishStatus', 'model' => 'lead.list', 'id' => $list->getId()]);
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
 
         $crawler = $this->client->request(Request::METHOD_GET, '/s/segments/edit/'.$list->getId());
         $form    = $crawler->selectButton('leadlist_buttons_apply')->form();
         $form['leadlist[filters][0][properties][filter][interval]']->setValue($interval);
 
         $this->client->submit($form);
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
 
         $this->assertStringContainsString($message, (string) $this->client->getResponse()->getContent());
 

--- a/app/bundles/LeadBundle/Tests/Functional/Controller/ContactExportAdminNotificationsDisabledTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Controller/ContactExportAdminNotificationsDisabledTest.php
@@ -61,7 +61,7 @@ final class ContactExportAdminNotificationsDisabledTest extends MauticMysqlTestC
             's/contacts/batchExport',
             ['filetype' => 'csv']
         );
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
 
         /** @var ContactExportScheduler $contactExportScheduler */
         $contactExportScheduler   = $this->checkContactExportScheduler(1)[0];

--- a/app/bundles/LeadBundle/Tests/Functional/Controller/LeadControllerTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Controller/LeadControllerTest.php
@@ -111,7 +111,7 @@ final class LeadControllerTest extends MauticMysqlTestCase
             ['filetype' => 'csv']
         );
 
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
 
         /** @var ContactExportScheduler $contactExportScheduler */
         $contactExportScheduler = $this->checkContactExportScheduler(1)[0];
@@ -184,7 +184,7 @@ final class LeadControllerTest extends MauticMysqlTestCase
             self::BATCH_EXPORT_PATH,
             ['filetype' => 'csv']
         );
-        $this->assertTrue($this->client->getResponse()->isOk());
+        $this->assertResponseIsSuccessful();
 
         /** @var ContactExportScheduler $contactExportScheduler */
         $contactExportScheduler = $this->checkContactExportScheduler(1)[0];

--- a/rector.php
+++ b/rector.php
@@ -24,9 +24,11 @@ return RectorConfig::configure()
     ->withPhpSets(php84: true)
     ->withCache(__DIR__.'/var/cache/rector')
     ->withRules([
+        Utils\Rector\AssertTrueResponseIsOkToAssertResponseIsSuccessfulRector::class,
         Rector\PHPUnit\CodeQuality\Rector\ClassMethod\AssertClassToThisAssertRector::class,
         Rector\TypeDeclarationDocblocks\Rector\Property\MergePhpstanDocTagIntoNativeRector::class,
 
+        // to be added to set
         Rector\Instanceof_\Rector\Ternary\FlipNegatedTernaryInstanceofRector::class,
         Rector\TypeDeclarationDocblocks\Rector\ClassMethod\NarrowArrayCollectionUnionReturnDocblockRector::class,
         UnserializeToSerializerDecodeRector::class,


### PR DESCRIPTION
Split from #17158.

Registers `AssertTrueResponseIsOkToAssertResponseIsSuccessfulRector` and applies it: converts `assertTrue($response->isOk())` to `assertResponseIsSuccessful()` in functional tests.