### PR TITLE
[tests] Resolve PHPUnit and PHP deprecations in tests

### DIFF
--- a/app/bundles/CoreBundle/Tests/Unit/DependencyInjection/Builder/Metadata/ConfigMetadataTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/DependencyInjection/Builder/Metadata/ConfigMetadataTest.php
@@ -21,7 +21,12 @@ final class ConfigMetadataTest extends TestCase
     {
         $this->metadata = $this->getMockBuilder(BundleMetadata::class)
             ->onlyMethods(['getDirectory'])
-            ->disableOriginalConstructor()
+            ->setConstructorArgs([[
+                'directory'         => '',
+                'namespace'         => '',
+                'bundle'            => '',
+                'symfonyBundleName' => '',
+            ]])
             ->getMock();
     }
 

--- a/app/bundles/EmailBundle/Tests/Controller/PreviewSettingsFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/PreviewSettingsFunctionalTest.php
@@ -64,6 +64,7 @@ final class PreviewSettingsFunctionalTest extends MauticMysqlTestCase
         $emailVariant->setLanguage('en');
 
         // Add variant relationship to main page
+        $emailMain->setVariantSettings(['winnerCriteria' => 'email.openrate']);
         $emailMain->addVariantChild($emailVariant);
 
         $this->em->persist($emailMain);

--- a/app/bundles/EmailBundle/Tests/EventListener/BuilderSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/BuilderSubscriberTest.php
@@ -60,6 +60,8 @@ final class BuilderSubscriberTest extends TestCase
 
     public function testOwnerSignatureIsUsedOnEmailGenerate(): void
     {
+        $this->emailModel->method('buildUrl')->willReturn('https://some.url');
+
         $email = new Email();
         $email->setUseOwnerAsMailer(true);
 

--- a/app/bundles/LeadBundle/Tests/EventListener/OwnerSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/OwnerSubscriberTest.php
@@ -200,7 +200,7 @@ final class OwnerSubscriberTest extends TestCase
     {
         $mockLeadRepository = $this->createMock(LeadRepository::class);
 
-        $mockLeadRepository->expects($this->atLeast(0))->method('getLeadOwner')
+        $mockLeadRepository->method('getLeadOwner')
             ->willReturnMap(
                 [
                     [1, ['id' => 1, 'email' => 'owner1@owner.com', 'first_name' => '', 'last_name' => '', 'signature' => 'owner 1']],


### PR DESCRIPTION
Resolves several PHPUnit and PHP deprecation notices surfaced by the test suite. Every fix is in test code - no production behaviour is changed; each deprecation is addressed at the setup/mock that produced the bad value.

### Test fixes

- **OwnerSubscriberTest** - `Calling atLeast() with an argument that is not positive is deprecated` (becomes an error in PHPUnit 14). `atLeast(0)` was a no-op constraint; replaced with a plain `method()` stub. `atLeastOnce()` is not usable here - the shared repository mock is reused by tests that never call `getLeadOwner` (build / fake-owner / no-owner paths).
- **ConfigMetadataTest** - `Undefined array key "namespace"/"bundle"/"symfonyBundleName"`. The mock skipped the constructor with `disableOriginalConstructor()`; it now runs the real `BundleMetadata` constructor via `setConstructorArgs()` with a complete metadata array, so no key is missing.
- **PreviewSettingsFunctionalTest** - `Using null as an array offset is deprecated`. The variant email had no winner criteria, so `$abTestSettings['winnerCriteria']` was null. The fixture now sets `variantSettings.winnerCriteria = email.openrate`, matching a real A/B configuration.
- **BuilderSubscriberTest** - `str_replace(): Passing null to parameter #2`. `EmailModel::buildUrl()` always returns a string in production; the null came from an un-stubbed mock in `testOwnerSignatureIsUsedOnEmailGenerate`. The test now stubs `buildUrl` like its sibling tests.
