### PR TITLE
Throw instead of a TypeError when the lock file cannot be opened

### DIFF
--- a/app/bundles/CoreBundle/Command/ModeratedCommand.php
+++ b/app/bundles/CoreBundle/Command/ModeratedCommand.php
@@ -153,11 +153,17 @@ abstract class ModeratedCommand extends Command
         );
 
         // Check if the PID is still running
+        error_clear_last();
         $fp = @fopen($this->lockFile, 'c+');
         if (false === $fp) {
-            $this->output->writeln("<error>Failed to open {$this->lockFile}. Check that the run directory exists and is writable by the user running this command.</error>");
-
-            return false;
+            // This needs to throw an exception in order to not silently fail when there is an issue.
+            // Returning false here would report a permanent misconfiguration as ordinary lock
+            // contention, which every caller maps to a successful exit code.
+            throw new \RuntimeException(sprintf(
+                '%s could not be opened (%s). Check that the run directory is writable by the user running this command.',
+                $this->lockFile,
+                error_get_last()['message'] ?? 'reason unknown'
+            ));
         }
 
         if (!flock($fp, LOCK_EX)) {

--- a/app/bundles/CoreBundle/Command/ModeratedCommand.php
+++ b/app/bundles/CoreBundle/Command/ModeratedCommand.php
@@ -153,7 +153,13 @@ abstract class ModeratedCommand extends Command
         );
 
         // Check if the PID is still running
-        $fp = fopen($this->lockFile, 'c+');
+        $fp = @fopen($this->lockFile, 'c+');
+        if (false === $fp) {
+            $this->output->writeln("<error>Failed to open {$this->lockFile}. Check that the run directory exists and is writable by the user running this command.</error>");
+
+            return false;
+        }
+
         if (!flock($fp, LOCK_EX)) {
             $this->output->writeln("<error>Failed to lock {$this->lockFile}.</error>");
 

--- a/app/bundles/CoreBundle/Command/ModeratedCommand.php
+++ b/app/bundles/CoreBundle/Command/ModeratedCommand.php
@@ -159,11 +159,7 @@ abstract class ModeratedCommand extends Command
             // This needs to throw an exception in order to not silently fail when there is an issue.
             // Returning false here would report a permanent misconfiguration as ordinary lock
             // contention, which every caller maps to a successful exit code.
-            throw new \RuntimeException(sprintf(
-                '%s could not be opened (%s). Check that the run directory is writable by the user running this command.',
-                $this->lockFile,
-                error_get_last()['message'] ?? 'reason unknown'
-            ));
+            throw new \RuntimeException(sprintf('%s could not be opened (%s). Check that the run directory is writable by the user running this command.', $this->lockFile, error_get_last()['message'] ?? 'reason unknown'));
         }
 
         if (!flock($fp, LOCK_EX)) {

--- a/app/bundles/CoreBundle/Tests/Unit/Command/ModeratedCommandTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Command/ModeratedCommandTest.php
@@ -183,7 +183,7 @@ final class ModeratedCommandTest extends TestCase
         // mirrors a run directory owned by another user, e.g. one created by a console command
         // executed as root while the scheduled commands run as the web server user.
         mkdir($runDir);
-        chmod($runDir, 0555);
+        chmod($runDir, 0500);
         clearstatcache(true, $runDir);
 
         if (is_writable($runDir)) {
@@ -216,7 +216,7 @@ final class ModeratedCommandTest extends TestCase
         try {
             $this->fakeModeratedCommand->run($this->input, $this->output);
         } finally {
-            chmod($runDir, 0755);
+            chmod($runDir, 0700);
             rmdir($runDir);
             rmdir($cacheDir);
             rmdir($baseDir);

--- a/app/bundles/CoreBundle/Tests/Unit/Command/ModeratedCommandTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Command/ModeratedCommandTest.php
@@ -11,6 +11,7 @@ use Mautic\CoreBundle\Tests\Unit\Command\src\FakeModeratedCommand;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
@@ -165,6 +166,58 @@ final class ModeratedCommandTest extends TestCase
 
         // Cleanup
         rmdir($runDir);
+    }
+
+    public function testPidLockReportsAnErrorWhenTheLockFileCannotBeOpened(): void
+    {
+        if (!$this->fakeModeratedCommand->isPidSupported()) {
+            $this->markTestSkipped('getmypid and/or posix_getpgid are not available');
+        }
+
+        $cacheDir = __DIR__.'/resource/cache/tmp';
+        $runDir   = $cacheDir.'/../run';
+
+        // Make the run directory non-writable so opening the lock file inside it fails. This
+        // mirrors a run directory owned by another user, e.g. one created by a console command
+        // executed as root while the scheduled commands run as the web server user.
+        if (!file_exists($runDir)) {
+            mkdir($runDir);
+        }
+        chmod($runDir, 0555);
+        clearstatcache(true, $runDir);
+
+        if (is_writable($runDir)) {
+            chmod($runDir, 0755);
+            rmdir($runDir);
+            $this->markTestSkipped('The run directory could not be made non-writable; the test is running as a privileged user or on a filesystem without POSIX permissions.');
+        }
+
+        $this->pathsHelper->expects($this->once())
+            ->method('getSystemPath')
+            ->with('cache')
+            ->willReturn($cacheDir);
+
+        $this->input->method('getOption')
+            ->willReturnCallback(
+                fn (string $name): string|false|null => match ($name) {
+                    'lock_mode'      => ModeratedCommand::MODE_PID,
+                    'bypass-locking' => false,
+                    default          => null,
+                }
+            );
+
+        $output = new BufferedOutput();
+
+        try {
+            $this->fakeModeratedCommand->run($this->input, $output);
+        } finally {
+            chmod($runDir, 0755);
+            rmdir($runDir);
+        }
+
+        // Without the guard, fopen() returns false and flock() raises a TypeError on PHP 8,
+        // so the command dies before it can report anything useful about the lock file.
+        $this->assertStringContainsString('Failed to open', $output->fetch());
     }
 
     public function testFileLock(): void

--- a/app/bundles/CoreBundle/Tests/Unit/Command/ModeratedCommandTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Command/ModeratedCommandTest.php
@@ -11,7 +11,6 @@ use Mautic\CoreBundle\Tests\Unit\Command\src\FakeModeratedCommand;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
@@ -168,27 +167,29 @@ final class ModeratedCommandTest extends TestCase
         rmdir($runDir);
     }
 
-    public function testPidLockReportsAnErrorWhenTheLockFileCannotBeOpened(): void
+    public function testPidLockThrowsWhenTheLockFileCannotBeOpened(): void
     {
         if (!$this->fakeModeratedCommand->isPidSupported()) {
             $this->markTestSkipped('getmypid and/or posix_getpgid are not available');
         }
 
-        $cacheDir = __DIR__.'/resource/cache/tmp';
-        $runDir   = $cacheDir.'/../run';
+        // Directories of this test's own, so the cleanup below only removes what it created.
+        $baseDir  = sys_get_temp_dir().'/mautic_moderated_command_'.uniqid();
+        $cacheDir = $baseDir.'/tmp';
+        $runDir   = $baseDir.'/run';
+        mkdir($cacheDir, 0755, true);
 
         // Make the run directory non-writable so opening the lock file inside it fails. This
         // mirrors a run directory owned by another user, e.g. one created by a console command
         // executed as root while the scheduled commands run as the web server user.
-        if (!file_exists($runDir)) {
-            mkdir($runDir);
-        }
+        mkdir($runDir);
         chmod($runDir, 0555);
         clearstatcache(true, $runDir);
 
         if (is_writable($runDir)) {
-            chmod($runDir, 0755);
             rmdir($runDir);
+            rmdir($cacheDir);
+            rmdir($baseDir);
             $this->markTestSkipped('The run directory could not be made non-writable; the test is running as a privileged user or on a filesystem without POSIX permissions.');
         }
 
@@ -206,18 +207,20 @@ final class ModeratedCommandTest extends TestCase
                 }
             );
 
-        $output = new BufferedOutput();
+        // Without the guard, fopen() returns false and flock() raises a TypeError on PHP 8.
+        // Returning false instead of throwing would report this permanent failure as ordinary
+        // lock contention, which every caller of checkRunStatus() maps to a successful exit.
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/could not be opened/');
 
         try {
-            $this->fakeModeratedCommand->run($this->input, $output);
+            $this->fakeModeratedCommand->run($this->input, $this->output);
         } finally {
             chmod($runDir, 0755);
             rmdir($runDir);
+            rmdir($cacheDir);
+            rmdir($baseDir);
         }
-
-        // Without the guard, fopen() returns false and flock() raises a TypeError on PHP 8,
-        // so the command dies before it can report anything useful about the lock file.
-        $this->assertStringContainsString('Failed to open', $output->fetch());
     }
 
     public function testFileLock(): void


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? (use the a.b branch) | Yes |
| New feature/enhancement? (use the a.x branch) | No |
| Deprecations? | No |
| BC breaks? (use the c.x branch) | No |
| Automated tests included? | Yes |
| Related user documentation PR URL | n/a |
| Related developer documentation PR URL | n/a |
| Issue(s) addressed | none open; steps to reproduce below |

## Description

`ModeratedCommand::checkPid()` opens the lock file without checking the result:

```php
$fp = fopen($this->lockFile, 'c+');
if (!flock($fp, LOCK_EX)) {
```

When `fopen()` cannot open the file it returns `false`, and on PHP 8 `flock()` then throws
`TypeError: flock(): Argument #1 ($stream) must be of type resource, bool given`. The command
dies with a stack trace before it can say which file it failed to open, so the operator sees
an internal type error rather than the setup problem that caused it.

The realistic trigger is an ownership mismatch on `var/cache/run`. If a console command is
ever run as a different user than the scheduled commands (most easily `docker exec` as root
on the official image, while cron runs as the web server user) the run directory ends up
owned by that user. Every later run then fails: `checkRunStatus()` sees the directory already
exists so it never re-creates it, and the official image's ownership repair does not descend
into a root-owned child directory, so the state does not heal on restart. Observed on a
production Mautic 5.2.11 on the official Docker image, but the code is identical on 5.x,
6.x, 7.x, 7.1 and 8.x.

This adds the missing check and throws a `RuntimeException` naming the path.

Throwing rather than returning `false` is the point of the change, so it is worth saying why.
`checkRunStatus()` returns `false` for ordinary lock contention, and all ten callers map that
to `Command::SUCCESS`:

`SummarizeCommand`, `TriggerCampaignCommand`, `UpdateLeadCampaignsCommand`,
`ProcessMarketingMessagesQueueCommand`, `SendChannelBroadcastCommand`,
`CleanupMaintenanceCommand`, `UnusedIpDeleteCommand`, `SendWinnerEmailCommand`,
`UpdateLeadListsCommand`, `CreateCustomFieldCommand`.

That is correct for contention, where another process holds the lock and the work will happen
on the next tick. An unopenable lock file is not that: it is permanent until someone fixes the
permissions. Returning `false` would report it as contention, so segment rebuilds, campaign
triggers and broadcast sends would silently do nothing while cron kept seeing exit code 0.
Throwing matches how this same method already handles a run directory it cannot create a few
lines above, which is the same class of problem.

The underlying error from `error_get_last()` is included in the message, so a read-only mount,
an `EMFILE`, or an SELinux denial is not misreported as a permissions problem. `error_clear_last()`
runs first so the reported reason cannot be a stale one from earlier in the request. The `@`
on `fopen()` matches the `@mkdir()` a few lines above: the failure is handled and reported
explicitly, and it keeps the warning from failing the suite under the project's own
`failOnWarning="true"`.

Related permission-shaped reports, none of which fix this line: #7682, #6644, #7949, and
mautic/docker-mautic#65.

---
### Steps to test this PR:

1. Pull the branch down and install as usual.
2. Make the run directory unwritable by the user that runs the commands:
   `mkdir -p var/cache/run && sudo chown root:root var/cache/run && sudo chmod 755 var/cache/run`
3. As the web server / cron user, run any moderated command, e.g.
   `php bin/console mautic:segments:update`.
4. Before: aborts with `TypeError: flock(): Argument #1 ($stream) must be of type resource, bool given`.
   After: fails with `<path> could not be opened (<reason>). Check that the run directory is
   writable by the user running this command.` and a non-zero exit code.
5. Restore with `sudo chown -R <web user> var/cache/run` and confirm commands run normally.
6. `php bin/phpunit -c app/phpunit.xml.dist app/bundles/CoreBundle/Tests/Unit/Command/ModeratedCommandTest.php`
   passes; reverting only the guard makes the new test fail with the original TypeError.

