### PR TITLE
[php 7.4] Make use of ??= to default assign null values

### DIFF
--- a/app/bundles/ApiBundle/Controller/CommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/CommonApiController.php
@@ -450,10 +450,7 @@ class CommonApiController extends FetchCommonApiController
     {
         $categoryId = null;
 
-        if (null === $parameters) {
-            // get from request
-            $parameters = $request->request->all();
-        }
+        $parameters ??= $request->request->all();
 
         // Store the original parameters from the request so that callbacks can have access to them as needed
         $this->entityRequestParameters = $parameters;

--- a/app/bundles/ApiBundle/Serializer/Driver/ApiMetadataDriver.php
+++ b/app/bundles/ApiBundle/Serializer/Driver/ApiMetadataDriver.php
@@ -84,9 +84,7 @@ final class ApiMetadataDriver implements DriverInterface
      */
     public function createProperty($name): static
     {
-        if (!isset($this->properties[$name])) {
-            $this->properties[$name] = new PropertyMetadata($this->metadata->name, $name);
-        }
+        $this->properties[$name] ??= new PropertyMetadata($this->metadata->name, $name);
 
         $this->currentPropertyName = $name;
 
@@ -159,9 +157,7 @@ final class ApiMetadataDriver implements DriverInterface
 
     public function setSinceVersion($version, $property = null): static
     {
-        if (null === $property) {
-            $property = $this->getCurrentPropertyName();
-        }
+        $property ??= $this->getCurrentPropertyName();
 
         $this->properties[$property]->sinceVersion = $version;
 
@@ -170,9 +166,7 @@ final class ApiMetadataDriver implements DriverInterface
 
     public function setUntilVersion($version, $property = null): static
     {
-        if (null === $property) {
-            $property = $this->getCurrentPropertyName();
-        }
+        $property ??= $this->getCurrentPropertyName();
 
         $this->properties[$property]->untilVersion = $version;
 
@@ -181,9 +175,7 @@ final class ApiMetadataDriver implements DriverInterface
 
     public function setSerializedName($name, $property = null): static
     {
-        if (null === $property) {
-            $property = $this->getCurrentPropertyName();
-        }
+        $property ??= $this->getCurrentPropertyName();
 
         $this->properties[$property]->serializedName = $name;
 
@@ -199,9 +191,7 @@ final class ApiMetadataDriver implements DriverInterface
             $groups = [$groups];
         }
 
-        if (null === $property) {
-            $property = $this->getCurrentPropertyName();
-        }
+        $property ??= $this->getCurrentPropertyName();
 
         $this->properties[$property]->groups = $groups;
 
@@ -220,9 +210,7 @@ final class ApiMetadataDriver implements DriverInterface
                 $this->addGroup($group, $prop);
             }
         } else {
-            if (null === $property) {
-                $property = $this->getCurrentPropertyName();
-            }
+            $property ??= $this->getCurrentPropertyName();
 
             $this->properties[$property]->groups[] = $group;
         }
@@ -246,9 +234,7 @@ final class ApiMetadataDriver implements DriverInterface
      */
     public function setMaxDepth($depth, $property = null): static
     {
-        if (null === $property) {
-            $property = $this->getCurrentPropertyName();
-        }
+        $property ??= $this->getCurrentPropertyName();
 
         $this->properties[$property]->maxDepth = (int) $depth;
 

--- a/app/bundles/ApiBundle/Serializer/Driver/ApiMetadataDriver.php
+++ b/app/bundles/ApiBundle/Serializer/Driver/ApiMetadataDriver.php
@@ -82,7 +82,7 @@ final class ApiMetadataDriver implements DriverInterface
     /**
      * Create a new property.
      */
-    public function createProperty($name): static
+    public function createProperty(?string $name): static
     {
         $this->properties[$name] ??= new PropertyMetadata($this->metadata->name, $name);
 

--- a/app/bundles/CacheBundle/Cache/AbstractCacheProvider.php
+++ b/app/bundles/CacheBundle/Cache/AbstractCacheProvider.php
@@ -30,9 +30,7 @@ abstract class AbstractCacheProvider implements CacheProviderInterface
 
     public function getSimpleCache(): Psr16Cache
     {
-        if (null === $this->psr16) {
-            $this->psr16 = new Psr16Cache($this->getCacheAdapter());
-        }
+        $this->psr16 ??= new Psr16Cache($this->getCacheAdapter());
 
         return $this->psr16;
     }

--- a/app/bundles/CampaignBundle/Command/ResumeStuckCampaignCommand.php
+++ b/app/bundles/CampaignBundle/Command/ResumeStuckCampaignCommand.php
@@ -210,12 +210,10 @@ final class ResumeStuckCampaignCommand extends Command
             $contactId          = $event['contact_id'];
             $parentExecutedDate = $event['last_executed_date'];
 
-            if (!isset($eventMap[$eventId][$parentExecutedDate])) {
-                $eventMap[$eventId][$parentExecutedDate] = [
-                    'event_id'    => $eventId,
-                    'contact_ids' => [],
-                ];
-            }
+            $eventMap[$eventId][$parentExecutedDate] ??= [
+                'event_id'    => $eventId,
+                'contact_ids' => [],
+            ];
 
             $eventMap[$eventId][$parentExecutedDate]['contact_ids'][] = $contactId;
         }

--- a/app/bundles/CampaignBundle/Controller/ImportController.php
+++ b/app/bundles/CampaignBundle/Controller/ImportController.php
@@ -421,12 +421,10 @@ final class ImportController extends AbstractFormController
                         continue;
                     }
                     foreach ($entities as $entityName => $info) {
-                        if (!isset($mergedSummary[$status][$entityName])) {
-                            $mergedSummary[$status][$entityName] = [
-                                'names'   => [],
-                                'uuids'   => [],
-                            ];
-                        }
+                        $mergedSummary[$status][$entityName] ??= [
+                            'names'   => [],
+                            'uuids'   => [],
+                        ];
 
                         $mergedSummary[$status][$entityName]['names'] = array_merge(
                             $mergedSummary[$status][$entityName]['names'],

--- a/app/bundles/CampaignBundle/Entity/CampaignRepository.php
+++ b/app/bundles/CampaignBundle/Entity/CampaignRepository.php
@@ -142,13 +142,11 @@ class CampaignRepository extends CommonRepository
 
         $campaigns = [];
         foreach ($results as $result) {
-            if (!isset($campaigns[$result['id']])) {
-                $campaigns[$result['id']] = [
-                    'id'    => $result['id'],
-                    'name'  => $result['name'],
-                    'lists' => [],
-                ];
-            }
+            $campaigns[$result['id']] ??= [
+                'id'    => $result['id'],
+                'name'  => $result['name'],
+                'lists' => [],
+            ];
 
             $campaigns[$result['id']]['lists'][$result['list_id']] = [
                 'id' => $result['list_id'],

--- a/app/bundles/CampaignBundle/Entity/FailedLeadEventLog.php
+++ b/app/bundles/CampaignBundle/Entity/FailedLeadEventLog.php
@@ -88,9 +88,7 @@ class FailedLeadEventLog
 
     public function setDateAdded(?\DateTime $dateAdded = null): static
     {
-        if (null === $dateAdded) {
-            $dateAdded = new \DateTime();
-        }
+        $dateAdded ??= new \DateTime();
 
         $this->dateAdded = $dateAdded;
 

--- a/app/bundles/CampaignBundle/Entity/LeadEventLog.php
+++ b/app/bundles/CampaignBundle/Entity/LeadEventLog.php
@@ -309,9 +309,7 @@ class LeadEventLog implements ChannelInterface, OptimisticLockInterface
      */
     public function setIsScheduled($isScheduled): static
     {
-        if (null === $this->previousScheduledState) {
-            $this->previousScheduledState = $this->isScheduled;
-        }
+        $this->previousScheduledState ??= $this->isScheduled;
 
         $this->isScheduled = $isScheduled;
 

--- a/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
@@ -315,12 +315,10 @@ class LeadEventLogRepository extends CommonRepository
         // group by event id
         foreach ($results as $l) {
             if (!$excludeNegative) {
-                if (!isset($return[$l['event_id']])) {
-                    $return[$l['event_id']] = [
-                        0 => 0,
-                        1 => 0,
-                    ];
-                }
+                $return[$l['event_id']] ??= [
+                    0 => 0,
+                    1 => 0,
+                ];
 
                 $key                          = (int) $l['non_action_path_taken'] ? 0 : 1;
                 $return[$l['event_id']][$key] = (int) $l['lead_count'];

--- a/app/bundles/CampaignBundle/EventCollector/Builder/ConnectionBuilder.php
+++ b/app/bundles/CampaignBundle/EventCollector/Builder/ConnectionBuilder.php
@@ -32,12 +32,10 @@ final class ConnectionBuilder
      */
     private static function addTypeConnection($key, array $event): void
     {
-        if (!isset(self::$connectionRestrictions[$key])) {
-            self::$connectionRestrictions[$key] = [
-                'source' => self::$eventTypes,
-                'target' => self::$eventTypes,
-            ];
-        }
+        self::$connectionRestrictions[$key] ??= [
+            'source' => self::$eventTypes,
+            'target' => self::$eventTypes,
+        ];
 
         if (isset($event['connectionRestrictions'])) {
             foreach ($event['connectionRestrictions'] as $restrictionType => $restrictions) {

--- a/app/bundles/CampaignBundle/EventListener/CampaignImportExportSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/CampaignImportExportSubscriber.php
@@ -307,13 +307,11 @@ final readonly class CampaignImportExportSubscriber implements EventSubscriberIn
             $mainStatus = $mainEvent->getStatus();
 
             foreach ($subStatus[$type] as $entityName => $statusData) {
-                if (!isset($mainStatus[$type][$entityName])) {
-                    $mainStatus[$type][$entityName] = [
-                        'names' => [],
-                        'ids'   => [],
-                        'count' => 0,
-                    ];
-                }
+                $mainStatus[$type][$entityName] ??= [
+                    'names' => [],
+                    'ids'   => [],
+                    'count' => 0,
+                ];
 
                 $mainStatus[$type][$entityName]['names'] = array_merge(
                     $mainStatus[$type][$entityName]['names'],

--- a/app/bundles/CampaignBundle/Executioner/Logger/EventLogger.php
+++ b/app/bundles/CampaignBundle/Executioner/Logger/EventLogger.php
@@ -75,9 +75,7 @@ class EventLogger
         $log->setEvent($event);
         $log->setCampaign($campaign = $event->getCampaign());
 
-        if (null === $contact) {
-            $contact = $this->contactTracker->getContact();
-        }
+        $contact ??= $this->contactTracker->getContact();
         $log->setLead($contact);
 
         if ($isInactiveEvent) {

--- a/app/bundles/CampaignBundle/Executioner/Result/Responses.php
+++ b/app/bundles/CampaignBundle/Executioner/Result/Responses.php
@@ -38,15 +38,11 @@ final class Responses
     {
         switch ($event->getEventType()) {
             case Event::TYPE_ACTION:
-                if (!isset($this->actionResponses[$event->getType()])) {
-                    $this->actionResponses[$event->getType()] = [];
-                }
+                $this->actionResponses[$event->getType()] ??= [];
                 $this->actionResponses[$event->getType()][$event->getId()] = $response;
                 break;
             case Event::TYPE_CONDITION:
-                if (!isset($this->conditionResponses[$event->getType()])) {
-                    $this->conditionResponses[$event->getType()] = [];
-                }
+                $this->conditionResponses[$event->getType()] ??= [];
                 $this->conditionResponses[$event->getType()][$event->getId()] = $response;
                 break;
         }

--- a/app/bundles/CampaignBundle/Executioner/ScheduledExecutioner.php
+++ b/app/bundles/CampaignBundle/Executioner/ScheduledExecutioner.php
@@ -395,9 +395,7 @@ class ScheduledExecutioner implements ExecutionerInterface, ResetInterface
             $metadata     = $log->getMetadata() ?? [];
 
             // Store original event information for tracking
-            if (!isset($metadata['redirection_history'])) {
-                $metadata['redirection_history'] = [];
-            }
+            $metadata['redirection_history'] ??= [];
 
             // Add to redirection history
             $metadata['redirection_history'][] = [
@@ -462,15 +460,11 @@ class ScheduledExecutioner implements ExecutionerInterface, ResetInterface
             $eventType = $event->getType();
 
             if (CampaignActionJumpToEventSubscriber::EVENT_NAME === $eventType) {
-                if (!isset($jumpTo[$event->getId()])) {
-                    $jumpTo[$event->getId()] = new ArrayCollection();
-                }
+                $jumpTo[$event->getId()] ??= new ArrayCollection();
 
                 $jumpTo[$event->getId()]->set($log->getId(), $log);
             } else {
-                if (!isset($other[$event->getId()])) {
-                    $other[$event->getId()] = new ArrayCollection();
-                }
+                $other[$event->getId()] ??= new ArrayCollection();
 
                 $other[$event->getId()]->set($log->getId(), $log);
             }

--- a/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
+++ b/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
@@ -122,9 +122,7 @@ final class Interval implements ScheduleModeInterface
                 $daysOfWeek
             );
             $key = $groupExecutionDate->format(DateTimeHelper::FORMAT_DB);
-            if (!isset($groupedExecutionDates[$key])) {
-                $groupedExecutionDates[$key] = new GroupExecutionDateDAO($groupExecutionDate);
-            }
+            $groupedExecutionDates[$key] ??= new GroupExecutionDateDAO($groupExecutionDate);
 
             $groupedExecutionDates[$key]->addContact($contact);
         }

--- a/app/bundles/CampaignBundle/Helper/RemovedContactTracker.php
+++ b/app/bundles/CampaignBundle/Helper/RemovedContactTracker.php
@@ -12,9 +12,7 @@ class RemovedContactTracker
      */
     public function addRemovedContact($campaignId, $contactId): void
     {
-        if (!isset($this->removedContacts[$campaignId])) {
-            $this->removedContacts[$campaignId] = [];
-        }
+        $this->removedContacts[$campaignId] ??= [];
 
         $this->removedContacts[$campaignId][$contactId] = $contactId;
     }

--- a/app/bundles/CampaignBundle/Model/CampaignModel.php
+++ b/app/bundles/CampaignBundle/Model/CampaignModel.php
@@ -371,9 +371,7 @@ class CampaignModel extends CommonFormModel implements GlobalSearchInterface
      */
     public function setCanvasSettings(Campaign $entity, array $settings, bool $persist = true, $events = null): array
     {
-        if (null === $events) {
-            $events = $entity->getEvents();
-        }
+        $events ??= $entity->getEvents();
 
         $tempIds = [];
 
@@ -385,9 +383,7 @@ class CampaignModel extends CommonFormModel implements GlobalSearchInterface
             }
         }
 
-        if (!isset($settings['nodes'])) {
-            $settings['nodes'] = [];
-        }
+        $settings['nodes'] ??= [];
 
         foreach ($settings['nodes'] as &$node) {
             if (str_contains($node['id'], 'new')) {
@@ -396,9 +392,7 @@ class CampaignModel extends CommonFormModel implements GlobalSearchInterface
             }
         }
 
-        if (!isset($settings['connections'])) {
-            $settings['connections'] = [];
-        }
+        $settings['connections'] ??= [];
 
         foreach ($settings['connections'] as &$connection) {
             // Check source
@@ -588,9 +582,7 @@ class CampaignModel extends CommonFormModel implements GlobalSearchInterface
     {
         static $campaigns = [];
 
-        if (null === $lead) {
-            $lead = $this->contactTracker->getContact();
-        }
+        $lead ??= $this->contactTracker->getContact();
 
         if (!isset($campaigns[$lead->getId()])) {
             $repo   = $this->getRepository();

--- a/app/bundles/CampaignBundle/Model/EventLogModel.php
+++ b/app/bundles/CampaignBundle/Model/EventLogModel.php
@@ -209,10 +209,7 @@ final class EventLogModel extends AbstractCommonModel
     public function saveEntity(LeadEventLog $entity): void
     {
         $triggerDate = $entity->getTriggerDate();
-        if (null === $triggerDate) {
-            // Reschedule for now
-            $triggerDate = new \DateTime();
-        }
+        $triggerDate ??= new \DateTime();
 
         $this->eventScheduler->rescheduleLogs(new ArrayCollection([$entity]), $triggerDate);
     }

--- a/app/bundles/CategoryBundle/Event/CategoryTypeEntityEvent.php
+++ b/app/bundles/CategoryBundle/Event/CategoryTypeEntityEvent.php
@@ -33,9 +33,7 @@ final class CategoryTypeEntityEvent extends CommonEvent
     public function addCategoryTypeEntity(string $type, ?array $data): void
     {
         if (!empty($data)) {
-            if (!isset($data['label'])) {
-                $data['label'] = 'mautic.'.$type.'.'.$type;
-            }
+            $data['label'] ??= 'mautic.'.$type.'.'.$type;
             $this->types[$type] = $data;
         }
     }

--- a/app/bundles/CategoryBundle/Event/CategoryTypesEvent.php
+++ b/app/bundles/CategoryBundle/Event/CategoryTypesEvent.php
@@ -44,9 +44,7 @@ final class CategoryTypesEvent extends CommonEvent
             $type = $label;
         }
 
-        if (null === $label) {
-            $label = 'mautic.'.$type.'.'.$type;
-        }
+        $label ??= 'mautic.'.$type.'.'.$type;
 
         $this->types[$type] = $label;
     }

--- a/app/bundles/CategoryBundle/Model/CategoryModel.php
+++ b/app/bundles/CategoryBundle/Model/CategoryModel.php
@@ -57,9 +57,7 @@ class CategoryModel extends FormModel implements AjaxLookupModelInterface
 
     public function getPermissionBase(?string $bundle = null): string
     {
-        if (null === $bundle) {
-            $bundle = $this->requestStack->getCurrentRequest()->get('bundle');
-        }
+        $bundle ??= $this->requestStack->getCurrentRequest()->get('bundle');
 
         if ('global' === $bundle || empty($bundle)) {
             $bundle = 'category';

--- a/app/bundles/ChannelBundle/Controller/Api/MessageApiController.php
+++ b/app/bundles/ChannelBundle/Controller/Api/MessageApiController.php
@@ -60,9 +60,7 @@ final class MessageApiController extends CommonApiController
         if ('PATCH' === $this->requestStack->getCurrentRequest()->getMethod() && !isset($params['channels'])) {
             return;
         }
-        if (!isset($params['channels'])) {
-            $params['channels'] = [];
-        }
+        $params['channels'] ??= [];
 
         $channels = $this->model->getChannels();
 

--- a/app/bundles/ChannelBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/ChannelBundle/EventListener/CampaignSubscriber.php
@@ -99,9 +99,7 @@ final class CampaignSubscriber implements EventSubscriberInterface
         // Set channel for the event logs
         $pendingEvent->setChannel('channel.message', $id);
 
-        if (!isset($this->messageChannels[$id])) {
-            $this->messageChannels[$id] = $this->messageModel->getMessageChannels($id);
-        }
+        $this->messageChannels[$id] ??= $this->messageModel->getMessageChannels($id);
 
         // organize into preferred channels
         $preferenceBuilder = new PreferenceBuilder($this->mmLogs, $this->pseudoEvent, $this->messageChannels[$id], $this->logger);

--- a/app/bundles/ChannelBundle/Model/FrequencyActionModel.php
+++ b/app/bundles/ChannelBundle/Model/FrequencyActionModel.php
@@ -42,9 +42,7 @@ final readonly class FrequencyActionModel
         $channels       = $this->contactModel->getPreferenceChannels();
 
         foreach ($channels as $channel) {
-            if (null === $preferredChannel) {
-                $preferredChannel = $channel;
-            }
+            $preferredChannel ??= $channel;
 
             $frequencyRule = $frequencyRules[$channel] ?? new FrequencyRule();
             $frequencyRule->setChannel($channel);

--- a/app/bundles/ChannelBundle/Model/MessageQueueModel.php
+++ b/app/bundles/ChannelBundle/Model/MessageQueueModel.php
@@ -238,12 +238,8 @@ class MessageQueueModel extends FormModel
                 $messageChannelId = 0;
             }
 
-            if (!isset($byChannel[$messageChannel])) {
-                $byChannel[$messageChannel] = [];
-            }
-            if (!isset($byChannel[$messageChannel][$messageChannelId])) {
-                $byChannel[$messageChannel][$messageChannelId] = [];
-            }
+            $byChannel[$messageChannel] ??= [];
+            $byChannel[$messageChannel][$messageChannelId] ??= [];
 
             $byChannel[$messageChannel][$messageChannelId][] = $message;
         }

--- a/app/bundles/ChannelBundle/PreferenceBuilder/ChannelPreferences.php
+++ b/app/bundles/ChannelBundle/PreferenceBuilder/ChannelPreferences.php
@@ -27,9 +27,7 @@ final class ChannelPreferences
     {
         $priority = (int) $priority;
 
-        if (!isset($this->organizedByPriority[$priority])) {
-            $this->organizedByPriority[$priority] = new ArrayCollection();
-        }
+        $this->organizedByPriority[$priority] ??= new ArrayCollection();
 
         return $this;
     }

--- a/app/bundles/ChannelBundle/PreferenceBuilder/PreferenceBuilder.php
+++ b/app/bundles/ChannelBundle/PreferenceBuilder/PreferenceBuilder.php
@@ -71,9 +71,7 @@ final class PreferenceBuilder
      */
     private function getChannelPreferenceObject($channel, int $priority)
     {
-        if (!isset($this->channels[$channel])) {
-            $this->channels[$channel] = new ChannelPreferences($this->event);
-        }
+        $this->channels[$channel] ??= new ChannelPreferences($this->event);
 
         $this->channels[$channel]->addPriority($priority);
 

--- a/app/bundles/ConfigBundle/Form/Helper/RestrictionHelper.php
+++ b/app/bundles/ConfigBundle/Form/Helper/RestrictionHelper.php
@@ -31,9 +31,7 @@ final readonly class RestrictionHelper
      */
     public function applyRestrictions(FormInterface $childType, FormInterface $parentType, ?array $restrictedFields = null): void
     {
-        if (null === $restrictedFields) {
-            $restrictedFields = $this->restrictedFields;
-        }
+        $restrictedFields ??= $this->restrictedFields;
 
         $fieldName = $childType->getName();
         if (array_key_exists($fieldName, $restrictedFields)) {

--- a/app/bundles/CoreBundle/Configurator/Configurator.php
+++ b/app/bundles/CoreBundle/Configurator/Configurator.php
@@ -65,9 +65,7 @@ class Configurator
      */
     public function addStep(StepInterface $step, $priority = 0): void
     {
-        if (!isset($this->steps[$priority])) {
-            $this->steps[$priority] = [];
-        }
+        $this->steps[$priority] ??= [];
 
         $this->steps[$priority][] = $step;
         $this->sortedSteps        = [];

--- a/app/bundles/CoreBundle/Controller/CommonController.php
+++ b/app/bundles/CoreBundle/Controller/CommonController.php
@@ -588,9 +588,7 @@ class CommonController extends AbstractController implements MauticController
      */
     protected function getNotificationContent(?Request $request = null): array
     {
-        if (null === $request) {
-            $request = $this->getCurrentRequest();
-        }
+        $request ??= $this->getCurrentRequest();
 
         $afterId = $request->get('mauticLastNotificationId');
 

--- a/app/bundles/CoreBundle/DependencyInjection/Builder/BundleMetadata.php
+++ b/app/bundles/CoreBundle/DependencyInjection/Builder/BundleMetadata.php
@@ -28,9 +28,8 @@ class BundleMetadata
      * @param array<string, mixed> $metadata
      */
     public function __construct(
-        private array $metadata
-    )
-    {
+        private array $metadata,
+    ) {
         $this->metadata['permissionClasses'] ??= [];
 
         $this->metadata['config'] ??= [];

--- a/app/bundles/CoreBundle/DependencyInjection/Builder/BundleMetadata.php
+++ b/app/bundles/CoreBundle/DependencyInjection/Builder/BundleMetadata.php
@@ -25,28 +25,20 @@ class BundleMetadata
     private $bundleName;
 
     /**
-     * @var array<string, mixed>
-     */
-    private array $metadata = [
-        'config'            => [],
-        'permissionClasses' => [],
-    ];
-
-    /**
      * @param array<string, mixed> $metadata
      */
-    public function __construct(array $metadata)
+    public function __construct(
+        private array $metadata
+    )
     {
-        $this->metadata = $metadata;
-
         $this->metadata['permissionClasses'] ??= [];
 
         $this->metadata['config'] ??= [];
 
-        $this->directory  = $metadata['directory'];
-        $this->namespace  = $metadata['namespace'];
-        $this->baseName   = $metadata['bundle'];
-        $this->bundleName = $metadata['symfonyBundleName'];
+        $this->directory  = $this->metadata['directory'];
+        $this->namespace  = $this->metadata['namespace'];
+        $this->baseName   = $this->metadata['bundle'];
+        $this->bundleName = $this->metadata['symfonyBundleName'];
     }
 
     public function getDirectory(): string

--- a/app/bundles/CoreBundle/DependencyInjection/Builder/BundleMetadata.php
+++ b/app/bundles/CoreBundle/DependencyInjection/Builder/BundleMetadata.php
@@ -39,13 +39,9 @@ class BundleMetadata
     {
         $this->metadata = $metadata;
 
-        if (!isset($this->metadata['permissionClasses'])) {
-            $this->metadata['permissionClasses'] = [];
-        }
+        $this->metadata['permissionClasses'] ??= [];
 
-        if (!isset($this->metadata['config'])) {
-            $this->metadata['config'] = [];
-        }
+        $this->metadata['config'] ??= [];
 
         $this->directory  = $metadata['directory'];
         $this->namespace  = $metadata['namespace'];

--- a/app/bundles/CoreBundle/Doctrine/AbstractMauticMigration.php
+++ b/app/bundles/CoreBundle/Doctrine/AbstractMauticMigration.php
@@ -193,9 +193,7 @@ abstract class AbstractMauticMigration extends AbstractMigration
      */
     protected function getPrefixedTableName(?string $tableName = null): string
     {
-        if (null === $tableName) {
-            $tableName = static::TABLE_NAME;
-        }
+        $tableName ??= static::TABLE_NAME;
 
         return $this->prefix.$tableName;
     }

--- a/app/bundles/CoreBundle/Doctrine/GeneratedColumn/GeneratedColumns.php
+++ b/app/bundles/CoreBundle/Doctrine/GeneratedColumn/GeneratedColumns.php
@@ -33,13 +33,9 @@ final class GeneratedColumns implements GeneratedColumnsInterface
 
         $tableName = $generatedColumn->getTableName();
 
-        if (!isset($this->dateColumnIndex[$tableName])) {
-            $this->dateColumnIndex[$tableName] = [];
-        }
+        $this->dateColumnIndex[$tableName] ??= [];
 
-        if (!isset($this->dateColumnIndex[$tableName][$originalDateColumn])) {
-            $this->dateColumnIndex[$tableName][$originalDateColumn] = [];
-        }
+        $this->dateColumnIndex[$tableName][$originalDateColumn] ??= [];
 
         $this->dateColumnIndex[$tableName][$originalDateColumn][$timeUnit] = $generatedColumn;
     }

--- a/app/bundles/CoreBundle/Doctrine/Mapping/ClassMetadataBuilder.php
+++ b/app/bundles/CoreBundle/Doctrine/Mapping/ClassMetadataBuilder.php
@@ -399,9 +399,7 @@ final class ClassMetadataBuilder extends OrmClassMetadataBuilder
     {
         $cm = $this->getClassMetadata();
 
-        if (!isset($cm->table['indexes'])) {
-            $cm->table['indexes'] = [];
-        }
+        $cm->table['indexes'] ??= [];
 
         $definition = ['columns' => $columns];
 

--- a/app/bundles/CoreBundle/Doctrine/Paginator/SimplePaginator.php
+++ b/app/bundles/CoreBundle/Doctrine/Paginator/SimplePaginator.php
@@ -37,9 +37,7 @@ final class SimplePaginator implements \IteratorAggregate, \Countable
 
     public function count(): int
     {
-        if (null === $this->count) {
-            $this->count = $this->fetchCount();
-        }
+        $this->count ??= $this->fetchCount();
 
         return $this->count;
     }

--- a/app/bundles/CoreBundle/Doctrine/Provider/VersionProvider.php
+++ b/app/bundles/CoreBundle/Doctrine/Provider/VersionProvider.php
@@ -17,9 +17,7 @@ final class VersionProvider implements VersionProviderInterface
 
     public function getVersion(): string
     {
-        if (null === $this->version) {
-            $this->version = $this->fetchVersionFromDb();
-        }
+        $this->version ??= $this->fetchVersionFromDb();
 
         return $this->version;
     }

--- a/app/bundles/CoreBundle/Entity/CommonEntity.php
+++ b/app/bundles/CoreBundle/Entity/CommonEntity.php
@@ -72,12 +72,10 @@ class CommonEntity implements \Stringable
             }
         } elseif ($current !== $val) {
             if ($current instanceof Collection || $val instanceof Collection) {
-                if (!isset($this->changes[$prop])) {
-                    $this->changes[$prop] = [
-                        'added'   => [],
-                        'removed' => [],
-                    ];
-                }
+                $this->changes[$prop] ??= [
+                    'added'   => [],
+                    'removed' => [],
+                ];
 
                 if (is_object($val)) {
                     // Entity is getting added to the collection

--- a/app/bundles/CoreBundle/Entity/CommonRepository.php
+++ b/app/bundles/CoreBundle/Entity/CommonRepository.php
@@ -426,9 +426,7 @@ class CommonRepository extends ServiceEntityRepository
 
     public function getExpressionBuilder(): ExpressionBuilder
     {
-        if (null === $this->expressionBuilder) {
-            $this->expressionBuilder = new ExpressionBuilder();
-        }
+        $this->expressionBuilder ??= new ExpressionBuilder();
 
         return $this->expressionBuilder;
     }
@@ -531,9 +529,7 @@ class CommonRepository extends ServiceEntityRepository
     ) {
         $isORM = $q instanceof QueryBuilder;
 
-        if (null === $alias) {
-            $alias = $this->getTableAlias();
-        }
+        $alias ??= $this->getTableAlias();
 
         if ($setNowParameter) {
             $now = new \DateTime();
@@ -1361,9 +1357,7 @@ class CommonRepository extends ServiceEntityRepository
                     $alias = $this->getTableAlias();
                 }
 
-                if (!isset($selects[$alias])) {
-                    $selects[$alias] = [];
-                }
+                $selects[$alias] ??= [];
 
                 $selects[$alias][] = $select;
             }

--- a/app/bundles/CoreBundle/Event/AbstractCustomRequestEvent.php
+++ b/app/bundles/CoreBundle/Event/AbstractCustomRequestEvent.php
@@ -17,10 +17,7 @@ abstract class AbstractCustomRequestEvent extends Event
      */
     protected $route;
 
-    /**
-     * @var array
-     */
-    protected $routeParams = [];
+    protected ?array $routeParams = [];
 
     public function __construct(?Request $request = null)
     {

--- a/app/bundles/CoreBundle/Event/AbstractCustomRequestEvent.php
+++ b/app/bundles/CoreBundle/Event/AbstractCustomRequestEvent.php
@@ -35,9 +35,7 @@ abstract class AbstractCustomRequestEvent extends Event
                 $this->routeParams = $this->request->attributes->get('_route_params');
             }
 
-            if (null === $this->routeParams) {
-                $this->routeParams = [];
-            }
+            $this->routeParams ??= [];
         }
     }
 

--- a/app/bundles/CoreBundle/Event/CustomAssetsEvent.php
+++ b/app/bundles/CoreBundle/Event/CustomAssetsEvent.php
@@ -14,9 +14,8 @@ class CustomAssetsEvent extends Event
 
     /**
      * @param string $location
-     * @param string $context
      */
-    public function addCustomDeclaration($declaration, $location = 'head', $context = AssetsHelper::CONTEXT_APP): static
+    public function addCustomDeclaration($declaration, $location = 'head', string $context = AssetsHelper::CONTEXT_APP): static
     {
         $this->assetsHelper->setContext($context)
             ->addCustomDeclaration($declaration, $location)
@@ -28,9 +27,8 @@ class CustomAssetsEvent extends Event
     /**
      * @param string $location
      * @param bool   $async
-     * @param string $context
      */
-    public function addScript($script, $location = 'head', $async = false, $name = null, $context = AssetsHelper::CONTEXT_APP): static
+    public function addScript($script, $location = 'head', $async = false, $name = null, string $context = AssetsHelper::CONTEXT_APP): static
     {
         $this->assetsHelper->setContext($context)
             ->addScript($script, $location, $async, $name)
@@ -41,9 +39,8 @@ class CustomAssetsEvent extends Event
 
     /**
      * @param string $location
-     * @param string $context
      */
-    public function addScriptDeclaration($script, $location = 'head', $context = AssetsHelper::CONTEXT_APP): static
+    public function addScriptDeclaration($script, $location = 'head', string $context = AssetsHelper::CONTEXT_APP): static
     {
         $this->assetsHelper->setContext($context)
             ->addScriptDeclaration($script, $location)
@@ -52,10 +49,7 @@ class CustomAssetsEvent extends Event
         return $this;
     }
 
-    /**
-     * @param string $context
-     */
-    public function addStylesheet($stylesheet, $context = AssetsHelper::CONTEXT_APP): static
+    public function addStylesheet($stylesheet, string $context = AssetsHelper::CONTEXT_APP): static
     {
         $this->assetsHelper->setContext($context)
             ->addStylesheet($stylesheet)
@@ -64,10 +58,7 @@ class CustomAssetsEvent extends Event
         return $this;
     }
 
-    /**
-     * @param string $context
-     */
-    public function addStyleDeclaration($styles, $context = AssetsHelper::CONTEXT_APP): static
+    public function addStyleDeclaration($styles, string $context = AssetsHelper::CONTEXT_APP): static
     {
         $this->assetsHelper->setContext($context)
             ->addStyleDeclaration($styles)

--- a/app/bundles/CoreBundle/Event/CustomButtonEvent.php
+++ b/app/bundles/CoreBundle/Event/CustomButtonEvent.php
@@ -45,9 +45,7 @@ final class CustomButtonEvent extends AbstractCustomRequestEvent
         }
 
         foreach ($buttons as $button) {
-            if (!isset($button['priority'])) {
-                $button['priority'] = 0;
-            }
+            $button['priority'] ??= 0;
 
             $this->buttons[$this->generateButtonKey($button)] = $button;
         }
@@ -67,9 +65,7 @@ final class CustomButtonEvent extends AbstractCustomRequestEvent
             return $this;
         }
 
-        if (!isset($button['priority'])) {
-            $button['priority'] = 0;
-        }
+        $button['priority'] ??= 0;
 
         $this->buttons[$this->generateButtonKey($button)] = $button;
 

--- a/app/bundles/CoreBundle/EventListener/CoreSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/CoreSubscriber.php
@@ -268,22 +268,12 @@ final readonly class CoreSubscriber implements EventSubscriberInterface
 
         // Set some very commonly used defaults and requirements
         if (str_contains($details['path'], '{page}')) {
-            if (!isset($defaults['page'])) {
-                $defaults['page'] = 0;
-            }
-            if (!isset($requirements['page'])) {
-                $requirements['page'] = '\d+';
-            }
+            $defaults['page'] ??= 0;
+            $requirements['page'] ??= '\d+';
         }
         if (str_contains($details['path'], '{objectId}')) {
-            if (!isset($defaults['objectId'])) {
-                // Set default to 0 for the "new" actions
-                $defaults['objectId'] = 0;
-            }
-            if (!isset($requirements['objectId'])) {
-                // Only allow alphanumeric and _- for objectId
-                $requirements['objectId'] = '[a-zA-Z0-9_-]+';
-            }
+            $defaults['objectId'] ??= 0;
+            $requirements['objectId'] ??= '[a-zA-Z0-9_-]+';
         }
         if ('api' === $type) {
             if (str_contains($details['path'], '{id}')) {
@@ -295,9 +285,7 @@ final readonly class CoreSubscriber implements EventSubscriberInterface
             if (preg_match_all('/\{(.*?Id)\}/', $details['path'], $matches)) {
                 // Force digits for IDs
                 foreach ($matches[1] as $match) {
-                    if (!isset($requirements[$match])) {
-                        $requirements[$match] = '\d+';
-                    }
+                    $requirements[$match] ??= '\d+';
                 }
             }
         }

--- a/app/bundles/CoreBundle/EventListener/MigrationCommandSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/MigrationCommandSubscriber.php
@@ -58,9 +58,7 @@ final readonly class MigrationCommandSubscriber implements EventSubscriberInterf
 
             $tableName = $generatedColumn->getTableName();
 
-            if (!isset($groupedByTableName[$tableName])) {
-                $groupedByTableName[$tableName] = [];
-            }
+            $groupedByTableName[$tableName] ??= [];
 
             $groupedByTableName[$tableName][$generatedColumn->getColumnName()] = $generatedColumn;
         }

--- a/app/bundles/CoreBundle/Form/ChoiceLoader/EntityLookupChoiceLoader.php
+++ b/app/bundles/CoreBundle/Form/ChoiceLoader/EntityLookupChoiceLoader.php
@@ -79,9 +79,7 @@ final class EntityLookupChoiceLoader implements ChoiceLoaderInterface
 
     private function getChoices(?array $data = null, bool $includeNew = false): array
     {
-        if (null === $data) {
-            $data = $this->selected;
-        }
+        $data ??= $this->selected;
 
         // Ensure we only work with scalar numeric IDs to prevent array-to-string conversions
         $data = $this->sanitizeIds($data);

--- a/app/bundles/CoreBundle/Form/RequestTrait.php
+++ b/app/bundles/CoreBundle/Form/RequestTrait.php
@@ -155,10 +155,7 @@ trait RequestTrait
             }
         }
 
-        if (!isset($masks['description'])) {
-            // Add description to support strict HTML
-            $masks['description'] = 'strict_html';
-        }
+        $masks['description'] ??= 'strict_html';
 
         if (!isset($masks['content'])) {
             // Assume HTML

--- a/app/bundles/CoreBundle/Helper/AssetGenerationHelper.php
+++ b/app/bundles/CoreBundle/Helper/AssetGenerationHelper.php
@@ -149,9 +149,7 @@ final readonly class AssetGenerationHelper
                 $fileTypes = ['css', 'js'];
                 foreach ($bundles as $bundle) {
                     foreach ($fileTypes as $ft) {
-                        if (!isset($modifiedLast[$ft])) {
-                            $modifiedLast[$ft] = [];
-                        }
+                        $modifiedLast[$ft] ??= [];
                         $dir = "{$bundle['directory']}/Assets/{$ft}";
                         if (file_exists($dir)) {
                             $modifiedLast[$ft] = array_merge($modifiedLast[$ft], $this->findAssets($dir, $ft, $env, $assets));

--- a/app/bundles/CoreBundle/Helper/Chart/BarChart.php
+++ b/app/bundles/CoreBundle/Helper/Chart/BarChart.php
@@ -40,9 +40,7 @@ final class BarChart extends AbstractChart implements ChartInterface
             'data'  => $data,
         ];
 
-        if (null === $order) {
-            $order = count($this->datasets);
-        }
+        $order ??= count($this->datasets);
 
         $this->datasets[$order] = array_merge($baseData, $this->generateColors($datasetId));
 

--- a/app/bundles/CoreBundle/Helper/Chart/ChartQuery.php
+++ b/app/bundles/CoreBundle/Helper/Chart/ChartQuery.php
@@ -189,9 +189,7 @@ class ChartQuery extends AbstractChart
      */
     public function translateTimeUnit($unit = null)
     {
-        if (null === $unit) {
-            $unit = $this->unit;
-        }
+        $unit ??= $this->unit;
 
         if (!isset($this->mysqlTimeUnits[$unit])) {
             throw new \UnexpectedValueException('Date/Time unit "'.$unit.'" is not available for MySql.');

--- a/app/bundles/CoreBundle/Helper/IpLookupHelper.php
+++ b/app/bundles/CoreBundle/Helper/IpLookupHelper.php
@@ -108,9 +108,7 @@ class IpLookupHelper
     {
         $isIpAnonymizationEnabled = (bool) $this->coreParametersHelper->get('anonymize_ip');
 
-        if (null === $ip) {
-            $ip = $this->getIpAddressFromRequest();
-        }
+        $ip ??= $this->getIpAddressFromRequest();
 
         if (empty($ip) || !$this->ipIsValid($ip)) {
             // assume local as the ip is empty

--- a/app/bundles/CoreBundle/Helper/ParamsLoaderHelper.php
+++ b/app/bundles/CoreBundle/Helper/ParamsLoaderHelper.php
@@ -17,7 +17,7 @@ final class ParamsLoaderHelper
      */
     public function getParameters(): array
     {
-        if (empty($this->parameters)) {
+        if ([] === $this->parameters) {
             $this->parameters = $this->getConfig();
         }
 

--- a/app/bundles/CoreBundle/Helper/ParamsLoaderHelper.php
+++ b/app/bundles/CoreBundle/Helper/ParamsLoaderHelper.php
@@ -10,14 +10,12 @@ final class ParamsLoaderHelper
 {
     use ConfigAwareTrait;
 
-    private $parameters = [];
+    private array $parameters = [];
 
     /**
      * Get parameters for static method.
-     *
-     * @return array
      */
-    public function getParameters()
+    public function getParameters(): array
     {
         if (empty($this->parameters)) {
             $this->parameters = $this->getConfig();

--- a/app/bundles/CoreBundle/Helper/SearchStringHelper.php
+++ b/app/bundles/CoreBundle/Helper/SearchStringHelper.php
@@ -236,12 +236,8 @@ final class SearchStringHelper
                 $string = strtolower($string);
             }
 
-            if (!isset($filters->{$baseName}[$keyCount]->strict)) {
-                $filters->{$baseName}[$keyCount]->strict = 0;
-            }
-            if (!isset($filters->{$baseName}[$keyCount]->not)) {
-                $filters->{$baseName}[$keyCount]->not = 0;
-            }
+            $filters->{$baseName}[$keyCount]->strict ??= 0;
+            $filters->{$baseName}[$keyCount]->not ??= 0;
 
             $strictPos = strpos($string, '+');
             $notPos    = strpos($string, '!');

--- a/app/bundles/CoreBundle/Menu/MenuHelper.php
+++ b/app/bundles/CoreBundle/Menu/MenuHelper.php
@@ -94,13 +94,9 @@ final class MenuHelper
 
             // Determine if this item needs to be listed in a bundle outside it's own
             if (isset($i['parent'])) {
-                if (!isset($this->orphans[$type])) {
-                    $this->orphans[$type] = [];
-                }
+                $this->orphans[$type] ??= [];
 
-                if (!isset($this->orphans[$type][$i['parent']])) {
-                    $this->orphans[$type][$i['parent']] = [];
-                }
+                $this->orphans[$type][$i['parent']] ??= [];
 
                 $this->orphans[$type][$i['parent']][$k] = $i;
 
@@ -141,13 +137,9 @@ final class MenuHelper
             if (isset($this->orphans[$type]) && isset($this->orphans[$type][$key])) {
                 $priority = $items['priority'] ?? 9999;
                 foreach ($this->orphans[$type][$key] as &$orphan) {
-                    if (!isset($orphan['extras'])) {
-                        $orphan['extras'] = [];
-                    }
+                    $orphan['extras'] ??= [];
                     $orphan['extras']['depth'] = $depth;
-                    if (!isset($orphan['priority'])) {
-                        $orphan['priority'] = $priority;
-                    }
+                    $orphan['priority'] ??= $priority;
                 }
 
                 $items['children'] =

--- a/app/bundles/CoreBundle/Model/AbstractCommonModel.php
+++ b/app/bundles/CoreBundle/Model/AbstractCommonModel.php
@@ -67,9 +67,7 @@ abstract class AbstractCommonModel implements MauticModelInterface
     {
         static $commonRepo;
 
-        if (null === $commonRepo) {
-            $commonRepo = $this->em->getRepository(FormEntity::class);
-        }
+        $commonRepo ??= $this->em->getRepository(FormEntity::class);
 
         return $commonRepo;
     }

--- a/app/bundles/CoreBundle/Model/NotificationModel.php
+++ b/app/bundles/CoreBundle/Model/NotificationModel.php
@@ -91,9 +91,7 @@ class NotificationModel extends FormModel
         ?string $deduplicateValue = null,
         ?\DateTime $deduplicateDateTimeFrom = null,
     ): void {
-        if (null === $user) {
-            $user = $this->userHelper->getUser();
-        }
+        $user ??= $this->userHelper->getUser();
 
         if (null === $user || !$user->getId()) {
             // ensure notifications aren't written for non users

--- a/app/bundles/CoreBundle/Model/TranslationModelTrait.php
+++ b/app/bundles/CoreBundle/Model/TranslationModelTrait.php
@@ -41,9 +41,7 @@ trait TranslationModelTrait
             $translationList = [];
             foreach ($translations as $id => $language) {
                 $core = $this->getTranslationLocaleCore($language);
-                if (!isset($translationList[$core])) {
-                    $translationList[$core] = [];
-                }
+                $translationList[$core] ??= [];
                 $translationList[$core][$language] = $id;
             }
 
@@ -73,9 +71,7 @@ trait TranslationModelTrait
                         // change - to _
                         $language = str_replace('-', '_', $language);
 
-                        if (!isset($languageList[$language])) {
-                            $languageList[$language] = $language;
-                        }
+                        $languageList[$language] ??= $language;
                     }
                 }
             }

--- a/app/bundles/CoreBundle/Model/VariantModelTrait.php
+++ b/app/bundles/CoreBundle/Model/VariantModelTrait.php
@@ -88,9 +88,7 @@ trait VariantModelTrait
                 $relatedIds[] = $entity->getId();
             }
 
-            if (null === $variantStartDate) {
-                $variantStartDate = new \DateTime();
-            }
+            $variantStartDate ??= new \DateTime();
 
             // Ensure UTC since we're saving directly to the DB
             $variantStartDate->setTimezone(new \DateTimeZone('UTC'));

--- a/app/bundles/CoreBundle/Security/Permissions/CorePermissions.php
+++ b/app/bundles/CoreBundle/Security/Permissions/CorePermissions.php
@@ -132,9 +132,7 @@ class CorePermissions implements ResetInterface
         $bundles = array_keys($objects);
 
         foreach ($bundles as $bundle) {
-            if (!isset($bundlePermissions[$bundle])) {
-                $bundlePermissions[$bundle] = [];
-            }
+            $bundlePermissions[$bundle] ??= [];
         }
 
         // do a first round to give bundles a chance to update everything and give an opportunity to require a second round
@@ -203,9 +201,7 @@ class CorePermissions implements ResetInterface
         // Initialize all permission classes if
         $this->getPermissionObjects();
 
-        if (null === $userEntity) {
-            $userEntity = $this->userHelper->getUser();
-        }
+        $userEntity ??= $this->userHelper->getUser();
 
         if (!is_array($requestedPermission)) {
             $requestedPermission = [$requestedPermission];

--- a/app/bundles/CoreBundle/Service/LocalFileAdapterService.php
+++ b/app/bundles/CoreBundle/Service/LocalFileAdapterService.php
@@ -48,9 +48,7 @@ final class LocalFileAdapterService extends LocalFilesystemAdapter
 
         // Explicitly set visibility to ensure correct permissions via chmod()
         $visibility = $config->get(Config::OPTION_VISIBILITY, $config->get(Config::OPTION_DIRECTORY_VISIBILITY));
-        if (null === $visibility) {
-            $visibility = Visibility::PUBLIC;
-        }
+        $visibility ??= Visibility::PUBLIC;
 
         $this->setVisibility($dirname, $visibility);
     }

--- a/app/bundles/CoreBundle/Test/Extensions/SlowTest/SlowTest.php
+++ b/app/bundles/CoreBundle/Test/Extensions/SlowTest/SlowTest.php
@@ -117,9 +117,7 @@ final class SlowTest implements Extension
 
         $class = $test->className();
 
-        if (!isset($this->classes[$class])) {
-            $this->classes[$class] = 0.0;
-        }
+        $this->classes[$class] ??= 0.0;
 
         $this->classes[$class] += $time;
     }

--- a/app/bundles/CoreBundle/Test/PhpUnitConfigCommand.php
+++ b/app/bundles/CoreBundle/Test/PhpUnitConfigCommand.php
@@ -135,9 +135,7 @@ final class PhpUnitConfigCommand extends Command
             foreach ($extraChunk as $extraChunkTest) {
                 foreach ($unit as $index => $unitFilename) {
                     if ($this->getClassName($unitFilename) === $extraChunkTest) {
-                        if (!isset($chunks[$extraChunkIndex])) {
-                            $chunks[$extraChunkIndex] = [];
-                        }
+                        $chunks[$extraChunkIndex] ??= [];
 
                         $chunks[$extraChunkIndex][] = $unitFilename;
                         unset($unit[$index]);
@@ -145,9 +143,7 @@ final class PhpUnitConfigCommand extends Command
                 }
                 foreach ($functional as $index => $functionalFilename) {
                     if ($this->getClassName($functionalFilename) === $extraChunkTest) {
-                        if (!isset($chunks[$extraChunkIndex])) {
-                            $chunks[$extraChunkIndex] = [];
-                        }
+                        $chunks[$extraChunkIndex] ??= [];
 
                         $chunks[$extraChunkIndex][] = $functionalFilename;
                         unset($functional[$index]);

--- a/app/bundles/CoreBundle/Translation/Translator.php
+++ b/app/bundles/CoreBundle/Translation/Translator.php
@@ -86,9 +86,7 @@ class Translator implements TranslatorInterface, WarmableInterface, TranslatorBa
      */
     public function hasId(string $id, ?string $domain = null, ?string $locale = null): bool
     {
-        if (null === $domain) {
-            $domain = 'messages';
-        }
+        $domain ??= 'messages';
 
         return $this->getCatalogue($locale)->has($id, $domain);
     }

--- a/app/bundles/CoreBundle/Twig/Extension/LanguageExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/LanguageExtension.php
@@ -25,9 +25,7 @@ final readonly class LanguageExtension
     #[AsTwigFilter(name: 'language_name')]
     public function getLanguageName(string $code, ?string $displayLocale = null): string
     {
-        if (null === $displayLocale) {
-            $displayLocale = $this->getCurrentUserLocale();
-        }
+        $displayLocale ??= $this->getCurrentUserLocale();
 
         try {
             return Languages::getName($code, $displayLocale) ?: $code;

--- a/app/bundles/CoreBundle/Twig/Helper/AssetsHelper.php
+++ b/app/bundles/CoreBundle/Twig/Helper/AssetsHelper.php
@@ -144,10 +144,8 @@ final class AssetsHelper
      *
      * If changing the context from app, it's important to reset the context back to app after
      * injecting/fetching assets for a different context.
-     *
-     * @param string $context
      */
-    public function setContext($context = self::CONTEXT_APP): self
+    public function setContext(string $context = self::CONTEXT_APP): self
     {
         $this->context = $context;
         $this->assets[$context] ??= [];

--- a/app/bundles/CoreBundle/Twig/Helper/AssetsHelper.php
+++ b/app/bundles/CoreBundle/Twig/Helper/AssetsHelper.php
@@ -44,9 +44,7 @@ final class AssetsHelper
         private readonly InstallService $installService,
         #[Autowire(param: 'mautic.site_url')] ?string $siteUrl,
     ) {
-        if (null === $siteUrl) {
-            $siteUrl = '';
-        }
+        $siteUrl ??= '';
 
         if ($siteUrl && str_ends_with($siteUrl, '/')) {
             $siteUrl = substr($siteUrl, 0, -1);
@@ -152,9 +150,7 @@ final class AssetsHelper
     public function setContext($context = self::CONTEXT_APP): self
     {
         $this->context = $context;
-        if (!isset($this->assets[$context])) {
-            $this->assets[$context] = [];
-        }
+        $this->assets[$context] ??= [];
 
         return $this;
     }
@@ -177,9 +173,7 @@ final class AssetsHelper
                 // special place for these so that declarations and scripts can be mingled
                 $assets['headDeclarations'][$name] = ['script' => [$s, $async]];
             } else {
-                if (!isset($assets['scripts'][$location])) {
-                    $assets['scripts'][$location] = [];
-                }
+                $assets['scripts'][$location] ??= [];
 
                 if (!in_array($s, $assets['scripts'][$location])) {
                     $assets['scripts'][$location][$name] = [$s, $async];
@@ -210,9 +204,7 @@ final class AssetsHelper
             // special place for these so that declarations and scripts can be mingled
             $this->assets[$this->context]['headDeclarations'][] = ['declaration' => $script];
         } else {
-            if (!isset($this->assets[$this->context]['scriptDeclarations'][$location])) {
-                $this->assets[$this->context]['scriptDeclarations'][$location] = [];
-            }
+            $this->assets[$this->context]['scriptDeclarations'][$location] ??= [];
 
             if (!in_array($script, $this->assets[$this->context]['scriptDeclarations'][$location])) {
                 $this->assets[$this->context]['scriptDeclarations'][$location][] = $script;
@@ -230,9 +222,7 @@ final class AssetsHelper
     public function addStylesheet($stylesheet): self
     {
         $addSheet = function ($s): void {
-            if (!isset($this->assets[$this->context]['stylesheets'])) {
-                $this->assets[$this->context]['stylesheets'] = [];
-            }
+            $this->assets[$this->context]['stylesheets'] ??= [];
 
             if (!in_array($s, $this->assets[$this->context]['stylesheets'])) {
                 $this->assets[$this->context]['stylesheets'][] = $s;
@@ -257,9 +247,7 @@ final class AssetsHelper
      */
     public function addStyleDeclaration($styles): self
     {
-        if (!isset($this->assets[$this->context]['styleDeclarations'])) {
-            $this->assets[$this->context]['styleDeclarations'] = [];
-        }
+        $this->assets[$this->context]['styleDeclarations'] ??= [];
 
         if (!in_array($styles, $this->assets[$this->context]['styleDeclarations'])) {
             $this->assets[$this->context]['styleDeclarations'][] = $styles;
@@ -279,9 +267,7 @@ final class AssetsHelper
         if ('head' == $location) {
             $this->assets[$this->context]['headDeclarations'][] = ['custom' => $declaration];
         } else {
-            if (!isset($this->assets[$this->context]['customDeclarations'][$location])) {
-                $this->assets[$this->context]['customDeclarations'][$location] = [];
-            }
+            $this->assets[$this->context]['customDeclarations'][$location] ??= [];
 
             if (!in_array($declaration, $this->assets[$this->context]['customDeclarations'][$location])) {
                 $this->assets[$this->context]['customDeclarations'][$location][] = $declaration;

--- a/app/bundles/CoreBundle/Twig/Helper/ButtonHelper.php
+++ b/app/bundles/CoreBundle/Twig/Helper/ButtonHelper.php
@@ -254,9 +254,7 @@ final class ButtonHelper
             $this->wrapClosingTag = "</li>\n";
         }
 
-        if (!isset($button['attr'])) {
-            $button['attr'] = [];
-        }
+        $button['attr'] ??= [];
 
         // Add or remove button classes based on group type
         if (self::TYPE_GROUP === $this->groupType || (self::TYPE_BUTTON_DROPDOWN === $this->groupType && $buttonCount < $this->listMarker)) {
@@ -272,9 +270,7 @@ final class ButtonHelper
                 "{$this->wrapClosingTag}\n";
         } else {
             // Default `data-toggle` for buttons
-            if (!isset($button['attr']['data-toggle'])) {
-                $button['attr']['data-toggle'] = 'ajax';
-            }
+            $button['attr']['data-toggle'] ??= 'ajax';
 
             // Generate tooltip and other attributes
             $btnTextAttr = $this->generateTextAttributes($button);

--- a/app/bundles/CoreBundle/Twig/Helper/GravatarHelper.php
+++ b/app/bundles/CoreBundle/Twig/Helper/GravatarHelper.php
@@ -46,9 +46,7 @@ final readonly class GravatarHelper
 
         $url = 'https://www.gravatar.com/avatar/'.md5(strtolower(trim($email))).'?s='.$size;
 
-        if (null === $default) {
-            $default = $localDefault;
-        }
+        $default ??= $localDefault;
 
         $default = (str_contains($default, '.') && !str_starts_with($default, 'http')) ? UrlHelper::rel2abs($default) : $default;
 

--- a/app/bundles/CoreBundle/Twig/Helper/MenuHelper.php
+++ b/app/bundles/CoreBundle/Twig/Helper/MenuHelper.php
@@ -101,9 +101,8 @@ final readonly class MenuHelper
      *
      * @param ItemInterface|string|array<ItemInterface|string> $menu
      * @param array<string, mixed>                             $options
-     * @param string                                           $renderer
      */
-    public function render($menu, array $options = [], $renderer = null): string
+    public function render($menu, array $options = [], ?string $renderer = null): string
     {
         $renderer ??= $menu;
         $options['menu'] = $menu;

--- a/app/bundles/CoreBundle/Twig/Helper/MenuHelper.php
+++ b/app/bundles/CoreBundle/Twig/Helper/MenuHelper.php
@@ -105,9 +105,7 @@ final readonly class MenuHelper
      */
     public function render($menu, array $options = [], $renderer = null): string
     {
-        if (null === $renderer) {
-            $renderer = $menu;
-        }
+        $renderer ??= $menu;
         $options['menu'] = $menu;
 
         return $this->helper->render($menu, $options, $renderer);

--- a/app/bundles/DashboardBundle/Event/WidgetDetailEvent.php
+++ b/app/bundles/DashboardBundle/Event/WidgetDetailEvent.php
@@ -115,21 +115,13 @@ class WidgetDetailEvent extends CommonEvent
         $params = $widget->getParams();
 
         // Set required params if undefined
-        if (!isset($params['timeUnit'])) {
-            $params['timeUnit'] = null;
-        }
+        $params['timeUnit'] ??= null;
 
-        if (!isset($params['amount'])) {
-            $params['amount'] = null;
-        }
+        $params['amount'] ??= null;
 
-        if (!isset($params['dateFormat'])) {
-            $params['dateFormat'] = null;
-        }
+        $params['dateFormat'] ??= null;
 
-        if (!isset($params['filter'])) {
-            $params['filter'] = [];
-        }
+        $params['filter'] ??= [];
 
         $widget->setParams($params);
 

--- a/app/bundles/DashboardBundle/Event/WidgetTypeListEvent.php
+++ b/app/bundles/DashboardBundle/Event/WidgetTypeListEvent.php
@@ -31,9 +31,7 @@ final class WidgetTypeListEvent extends CommonEvent
             $widgetTypeName = $this->translator->trans($widgetTypeName);
         }
 
-        if (!isset($this->widgetTypes[$bundle])) {
-            $this->widgetTypes[$bundle] = [];
-        }
+        $this->widgetTypes[$bundle] ??= [];
 
         $this->widgetTypes[$bundle][$widgetType] = $widgetTypeName;
     }

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -1767,10 +1767,7 @@ final class EmailController extends FormController
                     $fields = $model->enrichedContactWithCompanies($fields);
                 }
 
-                if (!isset($fields)) {
-                    // Prepare a fake contact
-                    $fields = $fakeLeadHelper->prepareFakeContactWithPrimaryCompany();
-                }
+                $fields ??= $fakeLeadHelper->prepareFakeContactWithPrimaryCompany();
 
                 $errors = [];
                 foreach ($emails as $email) {

--- a/app/bundles/EmailBundle/Entity/EmailRepository.php
+++ b/app/bundles/EmailBundle/Entity/EmailRepository.php
@@ -147,12 +147,8 @@ class EmailRepository extends CommonRepository
             ->from(Email::class, 'e');
         $results = $q->getQuery()->getSingleResult(Query::HYDRATE_ARRAY);
 
-        if (!isset($results['sent_count'])) {
-            $results['sent_count'] = 0;
-        }
-        if (!isset($results['read_count'])) {
-            $results['read_count'] = 0;
-        }
+        $results['sent_count'] ??= 0;
+        $results['read_count'] ??= 0;
 
         return $results;
     }

--- a/app/bundles/EmailBundle/EventListener/DetermineWinnerSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/DetermineWinnerSubscriber.php
@@ -144,9 +144,7 @@ final readonly class DetermineWinnerSubscriber implements EventSubscriberInterfa
                     if ($id !== $parentId && !array_key_exists($id, $children)) {
                         continue;
                     }
-                    if (!isset($sentCounts[$id])) {
-                        $sentCounts[$id] = 0;
-                    }
+                    $sentCounts[$id] ??= 0;
 
                     $rates[$id] = $sentCounts[$id] ? round(($count / $sentCounts[$id]) * 100, 2) : 0;
 

--- a/app/bundles/EmailBundle/EventListener/MatchFilterForLeadTrait.php
+++ b/app/bundles/EmailBundle/EventListener/MatchFilterForLeadTrait.php
@@ -63,9 +63,7 @@ trait MatchFilterForLeadTrait
              * If we are checking the first filter in a group
              * assume that the group will not match.
              */
-            if (null === $groups[$groupNum]) {
-                $groups[$groupNum] = false;
-            }
+            $groups[$groupNum] ??= false;
 
             $leadVal   = ($isCompanyField ? $primaryCompany[$data['field']] : $lead[$data['field']]);
             $filterVal = $data['filter'];

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -469,12 +469,10 @@ class MailHelper
                     $tokens['{signature}'] = $this->fromEmailHelper->getSignature();
                 }
 
-                if (!isset($this->metadata[$metadataKey])) {
-                    $this->metadata[$metadataKey] = [
-                        'from'     => $from,
-                        'contacts' => [],
-                    ];
-                }
+                $this->metadata[$metadataKey] ??= [
+                    'from'     => $from,
+                    'contacts' => [],
+                ];
 
                 $this->metadata[$metadataKey]['contacts'][$email] = $this->buildMetadata($name, $tokens);
             }
@@ -1150,9 +1148,7 @@ class MailHelper
      */
     public function setIdHash($idHash = null, $statToBeGenerated = true): void
     {
-        if (null === $idHash) {
-            $idHash = str_replace('.', '', uniqid('', true));
-        }
+        $idHash ??= str_replace('.', '', uniqid('', true));
 
         $this->idHash      = $idHash;
         $this->idHashState = $statToBeGenerated;
@@ -1471,17 +1467,11 @@ class MailHelper
      */
     public function dispatchSendEvent(): void
     {
-        if (null === $this->bodyInitial) {
-            $this->bodyInitial = $this->body;
-        }
+        $this->bodyInitial ??= $this->body;
 
-        if (null === $this->plainTextInitial) {
-            $this->plainTextInitial = $this->plainText;
-        }
+        $this->plainTextInitial ??= $this->plainText;
 
-        if (null === $this->subjectInitial) {
-            $this->subjectInitial = $this->subject;
-        }
+        $this->subjectInitial ??= $this->subject;
 
         // Reset body, text, subject and tokens, so the latter listeners use the same data as the former ones.
         $this->setBody($this->bodyInitial['content'], $this->bodyInitial['contentType'], $this->bodyInitial['charset'], true);
@@ -1938,9 +1928,7 @@ class MailHelper
     private function setFromForSingleMessage(): void
     {
         if ($this->lead && $this->email && $this->email->getUseOwnerAsMailer()) {
-            if (!isset($this->lead['owner_id'])) {
-                $this->lead['owner_id'] = 0;
-            }
+            $this->lead['owner_id'] ??= 0;
 
             $from = $this->fromEmailHelper->getFromAddressConsideringOwner($this->getFrom(), $this->lead, $this->email);
             $this->setMessageFrom($from);

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -1143,10 +1143,9 @@ class MailHelper
     }
 
     /**
-     * @param string|null $idHash
-     * @param bool        $statToBeGenerated Pass false if a stat entry is not to be created
+     * @param bool $statToBeGenerated Pass false if a stat entry is not to be created
      */
-    public function setIdHash($idHash = null, $statToBeGenerated = true): void
+    public function setIdHash(?string $idHash = null, $statToBeGenerated = true): void
     {
         $idHash ??= str_replace('.', '', uniqid('', true));
 

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -831,9 +831,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
                 // List doesn't matter
                 $stats[$result['device']] = $result['count'];
             } elseif (null !== $result['list_id']) {
-                if (!isset($stats[$result['list_id']])) {
-                    $stats[$result['list_id']] = [];
-                }
+                $stats[$result['list_id']] ??= [];
 
                 if (!isset($stats[$result['list_id']][$result['device']])) {
                     $stats[$result['list_id']][$result['device']] = (int) $result['count'];
@@ -873,9 +871,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
                     $listStat    = (!isset($stats[$id][$device])) ? 0 : $stats[$id][$device];
                     $listStats[] = $listStat;
 
-                    if (!isset($combined[$device])) {
-                        $combined[$device] = 0;
-                    }
+                    $combined[$device] ??= 0;
 
                     $combined[$device] += $listStat;
                 }
@@ -1238,9 +1234,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
                             $language = 'unknown';
                         }
                         $core = $this->getTranslationLocaleCore($language);
-                        if (!isset($emailSettings[$email->getId()]['languages'][$core])) {
-                            $emailSettings[$email->getId()]['languages'][$core] = [];
-                        }
+                        $emailSettings[$email->getId()]['languages'][$core] ??= [];
                         $emailSettings[$email->getId()]['languages'][$core][$language] = $translation->getId();
                     }
                 }
@@ -1288,9 +1282,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
                                             $language = 'unknown';
                                         }
                                         $core = $this->getTranslationLocaleCore($language);
-                                        if (!isset($emailSettings[$child->getId()]['languages'][$core])) {
-                                            $emailSettings[$child->getId()]['languages'][$core] = [];
-                                        }
+                                        $emailSettings[$child->getId()]['languages'][$core] ??= [];
                                         $emailSettings[$child->getId()]['languages'][$core][$language] = $translation->getId();
                                     }
                                 }
@@ -1618,9 +1610,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
         }
 
         $mailer            = $this->mailHelper->getMailer();
-        if (!isset($lead['companies'])) {
-            $lead['companies'] = $this->companyRepository->getCompaniesByLeadId($lead['id']);
-        }
+        $lead['companies'] ??= $this->companyRepository->getCompaniesByLeadId($lead['id']);
         $mailer->setLead($lead, true);
         $mailer->setTokens($tokens);
         $mailer->setEmail($email, false, $assetAttachments, !$saveStat);

--- a/app/bundles/EmailBundle/Model/SendEmailToContact.php
+++ b/app/bundles/EmailBundle/Model/SendEmailToContact.php
@@ -303,9 +303,7 @@ class SendEmailToContact
     protected function upEmailSentCount($emailId): void
     {
         // Up sent counts
-        if (!isset($this->emailSentCounts[$emailId])) {
-            $this->emailSentCounts[$emailId] = 0;
-        }
+        $this->emailSentCounts[$emailId] ??= 0;
 
         ++$this->emailSentCounts[$emailId];
     }

--- a/app/bundles/EmailBundle/Model/TransportCallback.php
+++ b/app/bundles/EmailBundle/Model/TransportCallback.php
@@ -71,9 +71,7 @@ final readonly class TransportCallback
         }
 
         $openDetails = $stat->getOpenDetails();
-        if (!isset($openDetails['bounces'])) {
-            $openDetails['bounces'] = [];
-        }
+        $openDetails['bounces'] ??= [];
         $dtHelper                 = new DateTimeHelper();
         $openDetails['bounces'][] = [
             'datetime' => $dtHelper->toUtcString(),

--- a/app/bundles/EmailBundle/MonitoredEmail/Mailbox.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Mailbox.php
@@ -260,9 +260,7 @@ class Mailbox
 
     public function getImapPath(array $settings): array
     {
-        if (!isset($settings['encryption'])) {
-            $settings['encryption'] = (!empty($settings['ssl'])) ? '/ssl' : '';
-        }
+        $settings['encryption'] ??= (!empty($settings['ssl'])) ? '/ssl' : '';
         $path     = "{{$settings['host']}:{$settings['port']}/imap{$settings['encryption']}}";
         $fullPath = $path;
 

--- a/app/bundles/EmailBundle/MonitoredEmail/Organizer/MailboxContainer.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Organizer/MailboxContainer.php
@@ -19,9 +19,7 @@ final class MailboxContainer
 
     public function addCriteria($criteria, $mailbox): void
     {
-        if (!isset($this->criteria[$criteria])) {
-            $this->criteria[$criteria] = [];
-        }
+        $this->criteria[$criteria] ??= [];
 
         $this->criteria[$criteria][] = $mailbox;
     }

--- a/app/bundles/EmailBundle/MonitoredEmail/Organizer/MailboxOrganizer.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Organizer/MailboxOrganizer.php
@@ -65,9 +65,7 @@ final class MailboxOrganizer
     private function getContainer(ConfigAccessor $config)
     {
         $key = $config->getKey();
-        if (!isset($this->containers[$key])) {
-            $this->containers[$key] = new MailboxContainer($config);
-        }
+        $this->containers[$key] ??= new MailboxContainer($config);
 
         return $this->containers[$key];
     }

--- a/app/bundles/EmailBundle/MonitoredEmail/Processor/Bounce.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Processor/Bounce.php
@@ -98,9 +98,7 @@ class Bounce implements ProcessorInterface
         $dtHelper    = new DateTimeHelper();
         $openDetails = $stat->getOpenDetails();
 
-        if (!isset($openDetails['bounces'])) {
-            $openDetails['bounces'] = [];
-        }
+        $openDetails['bounces'] ??= [];
 
         $openDetails['bounces'][] = [
             'datetime' => $dtHelper->toUtcString(),

--- a/app/bundles/EmailBundle/Tests/EventListener/MatchFilterForLeadTraitTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/MatchFilterForLeadTraitTest.php
@@ -40,9 +40,7 @@ final class MatchFilterForLeadTraitTest extends TestCase
         $this->matchFilterForLeadTrait = new MatchFilterForLeadTraitTestable();
 
         // Set required environment variable for FormFieldHelper
-        if (!isset($_ENV['MAUTIC_UPLOAD_DIR'])) {
-            $_ENV['MAUTIC_UPLOAD_DIR'] = '/tmp';
-        }
+        $_ENV['MAUTIC_UPLOAD_DIR'] ??= '/tmp';
     }
 
     /**

--- a/app/bundles/FormBundle/Controller/Api/FormApiController.php
+++ b/app/bundles/FormBundle/Controller/Api/FormApiController.php
@@ -333,9 +333,7 @@ final class FormApiController extends CommonApiController
      */
     protected function processForm(Request $request, $entity, $parameters = null, $method = 'PUT')
     {
-        if (!isset($parameters['postAction'])) {
-            $parameters['postAction'] = 'return';
-        }
+        $parameters['postAction'] ??= 'return';
 
         return parent::processForm($request, $entity, $parameters, $method);
     }

--- a/app/bundles/FormBundle/Event/FormBuilderEvent.php
+++ b/app/bundles/FormBundle/Event/FormBuilderEvent.php
@@ -201,9 +201,7 @@ final class FormBuilderEvent extends Event
 
         foreach ($this->validators as $validator) {
             if (isset($validator['fieldType'])) {
-                if (!isset($fieldValidators[$validator['fieldType']])) {
-                    $fieldValidators[$validator['fieldType']] = [];
-                }
+                $fieldValidators[$validator['fieldType']] ??= [];
 
                 $fieldValidators[$validator['fieldType']] = $validator['eventName'];
             } else {

--- a/app/bundles/FormBundle/Form/Type/FieldType.php
+++ b/app/bundles/FormBundle/Form/Type/FieldType.php
@@ -691,9 +691,7 @@ final class FieldType extends AbstractType
                     );
                     break;
                 case 'file':
-                    if (!isset($propertiesData['public'])) {
-                        $propertiesData['public'] = false;
-                    }
+                    $propertiesData['public'] ??= false;
                     $builder->add(
                         'properties',
                         FormFieldFileType::class,

--- a/app/bundles/FormBundle/Helper/FormFieldHelper.php
+++ b/app/bundles/FormBundle/Helper/FormFieldHelper.php
@@ -77,9 +77,7 @@ class FormFieldHelper extends AbstractFormFieldHelper
     {
         $this->translator = $translator;
 
-        if (null === $validator) {
-            $validator = Validation::createValidator();
-        }
+        $validator ??= Validation::createValidator();
         $this->validator = $validator;
 
         parent::__construct();

--- a/app/bundles/FormBundle/Tests/Model/FormModelTest.php
+++ b/app/bundles/FormBundle/Tests/Model/FormModelTest.php
@@ -68,9 +68,7 @@ final class FormModelTest extends \PHPUnit\Framework\TestCase
 
     protected function setUp(): void
     {
-        if (!isset($_ENV['MAUTIC_UPLOAD_DIR'])) {
-            $_ENV['MAUTIC_UPLOAD_DIR'] = sys_get_temp_dir();
-        }
+        $_ENV['MAUTIC_UPLOAD_DIR'] ??= sys_get_temp_dir();
         $this->contactTracker        = $this->createMock(ContactTracker::class);
         $this->fieldHelper           = $this->createMock(FormFieldHelper::class);
         $this->primaryCompanyHelper  = $this->createMock(PrimaryCompanyHelper::class);

--- a/app/bundles/IntegrationsBundle/Auth/Support/Oauth2/Token/TokenPersistence.php
+++ b/app/bundles/IntegrationsBundle/Auth/Support/Oauth2/Token/TokenPersistence.php
@@ -44,9 +44,7 @@ final class TokenPersistence implements TokenPersistenceInterface
         $integration = $this->getIntegration();
         $oldApiKeys  = $integration->getApiKeys();
 
-        if (null === $oldApiKeys) {
-            $oldApiKeys = [];
-        }
+        $oldApiKeys ??= [];
 
         $newApiKeys = [
             'access_token'  => $token->getAccessToken(),

--- a/app/bundles/IntegrationsBundle/Controller/FieldPaginationController.php
+++ b/app/bundles/IntegrationsBundle/Controller/FieldPaginationController.php
@@ -96,9 +96,7 @@ final class FieldPaginationController extends CommonController
     {
         $fields = $featureSettings['sync']['fieldMappings'] ?? [];
 
-        if (!isset($fields[$object])) {
-            $fields[$object] = [];
-        }
+        $fields[$object] ??= [];
 
         // Pull those changed from session
         $session       = $request->getSession();

--- a/app/bundles/IntegrationsBundle/Controller/UpdateFieldController.php
+++ b/app/bundles/IntegrationsBundle/Controller/UpdateFieldController.php
@@ -16,13 +16,9 @@ final class UpdateFieldController extends CommonController
         $session       = $request->getSession();
         $updatedFields = $session->get(sprintf('%s-fields', $integration), []);
 
-        if (!isset($updatedFields[$object])) {
-            $updatedFields[$object] = [];
-        }
+        $updatedFields[$object] ??= [];
 
-        if (!isset($updatedFields[$object][$field])) {
-            $updatedFields[$object][$field] = [];
-        }
+        $updatedFields[$object][$field] ??= [];
 
         if ($mappedField = $request->request->get('mappedField')) {
             $updatedFields[$object][$field]['mappedField'] = $mappedField;

--- a/app/bundles/IntegrationsBundle/Entity/ObjectMapping.php
+++ b/app/bundles/IntegrationsBundle/Entity/ObjectMapping.php
@@ -125,9 +125,7 @@ class ObjectMapping
 
     public function __construct(?\DateTime $dateCreated = null)
     {
-        if (null === $dateCreated) {
-            $dateCreated = new \DateTime();
-        }
+        $dateCreated ??= new \DateTime();
 
         $this->dateCreated  = $dateCreated;
         $this->lastSyncDate = $dateCreated;
@@ -253,9 +251,7 @@ class ObjectMapping
      */
     public function setLastSyncDate($lastSyncDate): static
     {
-        if (null === $lastSyncDate) {
-            $lastSyncDate = new \DateTime();
-        }
+        $lastSyncDate ??= new \DateTime();
 
         $this->lastSyncDate = $lastSyncDate;
 

--- a/app/bundles/IntegrationsBundle/Entity/ObjectMapping.php
+++ b/app/bundles/IntegrationsBundle/Entity/ObjectMapping.php
@@ -246,10 +246,7 @@ class ObjectMapping
         return $this->lastSyncDate;
     }
 
-    /**
-     * @param \DateTimeInterface|null $lastSyncDate
-     */
-    public function setLastSyncDate($lastSyncDate): static
+    public function setLastSyncDate(?\DateTimeInterface $lastSyncDate): static
     {
         $lastSyncDate ??= new \DateTime();
 

--- a/app/bundles/IntegrationsBundle/Helper/FieldMergerHelper.php
+++ b/app/bundles/IntegrationsBundle/Helper/FieldMergerHelper.php
@@ -41,9 +41,7 @@ final class FieldMergerHelper
 
     private function removeNonExistentFieldMappings(string $object): void
     {
-        if (!isset($this->currentFieldMappings[$object])) {
-            $this->currentFieldMappings[$object] = [];
-        }
+        $this->currentFieldMappings[$object] ??= [];
 
         // Remove any fields that no longer exist
         $this->currentFieldMappings[$object] = array_intersect_key($this->currentFieldMappings[$object], $this->allFields);

--- a/app/bundles/IntegrationsBundle/Sync/DAO/Sync/ObjectIdsDAO.php
+++ b/app/bundles/IntegrationsBundle/Sync/DAO/Sync/ObjectIdsDAO.php
@@ -49,9 +49,7 @@ final class ObjectIdsDAO
 
     public function addObjectId(string $objectType, string $id): void
     {
-        if (!isset($this->objects[$objectType])) {
-            $this->objects[$objectType] = [];
-        }
+        $this->objects[$objectType] ??= [];
 
         $this->objects[$objectType][] = $id;
     }

--- a/app/bundles/IntegrationsBundle/Sync/DAO/Sync/Order/ObjectChangeDAO.php
+++ b/app/bundles/IntegrationsBundle/Sync/DAO/Sync/Order/ObjectChangeDAO.php
@@ -161,9 +161,7 @@ final class ObjectChangeDAO
 
     public function setChangeDateTime(?\DateTimeInterface $changeDateTime = null): static
     {
-        if (null === $changeDateTime) {
-            $changeDateTime = new \DateTime();
-        }
+        $changeDateTime ??= new \DateTime();
 
         $this->changeDateTime = $changeDateTime;
 

--- a/app/bundles/IntegrationsBundle/Sync/DAO/Sync/Order/OrderDAO.php
+++ b/app/bundles/IntegrationsBundle/Sync/DAO/Sync/Order/OrderDAO.php
@@ -132,9 +132,7 @@ class OrderDAO
         $integrationObjectId,
         ?\DateTimeInterface $objectModifiedDate = null,
     ): void {
-        if (null === $objectModifiedDate) {
-            $objectModifiedDate = new \DateTime();
-        }
+        $objectModifiedDate ??= new \DateTime();
 
         $objectMapping = new ObjectMapping();
         $objectMapping->setIntegration($this->integration)
@@ -157,9 +155,7 @@ class OrderDAO
      */
     public function remapObject($oldObjectName, $oldObjectId, $newObjectName, $newObjectId = null): void
     {
-        if (null === $newObjectId) {
-            $newObjectId = $oldObjectId;
-        }
+        $newObjectId ??= $oldObjectId;
 
         $this->remappedObjects[$oldObjectId] = new RemappedObjectDAO($this->integration, $oldObjectName, $oldObjectId, $newObjectName, $newObjectId);
     }
@@ -169,9 +165,7 @@ class OrderDAO
      */
     public function updateLastSyncDate(ObjectChangeDAO $objectChangeDAO, ?\DateTimeInterface $objectModifiedDate = null): void
     {
-        if (null === $objectModifiedDate) {
-            $objectModifiedDate = new \DateTime();
-        }
+        $objectModifiedDate ??= new \DateTime();
 
         $this->updatedObjectMappings[] = new UpdatedObjectMappingDAO(
             $this->integration,
@@ -195,9 +189,7 @@ class OrderDAO
      */
     public function retrySyncLater(ObjectChangeDAO $objectChangeDAO): void
     {
-        if (!isset($this->retryTheseLater[$objectChangeDAO->getMappedObject()])) {
-            $this->retryTheseLater[$objectChangeDAO->getMappedObject()] = [];
-        }
+        $this->retryTheseLater[$objectChangeDAO->getMappedObject()] ??= [];
 
         $this->retryTheseLater[$objectChangeDAO->getMappedObject()][$objectChangeDAO->getMappedObjectId()] = $objectChangeDAO;
     }

--- a/app/bundles/IntegrationsBundle/Sync/DAO/Sync/Order/OrderResultsDAO.php
+++ b/app/bundles/IntegrationsBundle/Sync/DAO/Sync/Order/OrderResultsDAO.php
@@ -121,9 +121,7 @@ final class OrderResultsDAO
     private function groupNewObjectMappingsByObjectName(array $objectMappings): void
     {
         foreach ($objectMappings as $objectMapping) {
-            if (!isset($this->newObjectMappings[$objectMapping->getIntegrationObjectName()])) {
-                $this->newObjectMappings[$objectMapping->getIntegrationObjectName()] = [];
-            }
+            $this->newObjectMappings[$objectMapping->getIntegrationObjectName()] ??= [];
 
             $this->newObjectMappings[$objectMapping->getIntegrationObjectName()][] = $objectMapping;
         }
@@ -135,9 +133,7 @@ final class OrderResultsDAO
     private function groupUpdatedObjectMappingsByObjectName(array $objectMappings): void
     {
         foreach ($objectMappings as $objectMapping) {
-            if (!isset($this->updatedObjectMappings[$objectMapping->getIntegrationObjectName()])) {
-                $this->updatedObjectMappings[$objectMapping->getIntegrationObjectName()] = [];
-            }
+            $this->updatedObjectMappings[$objectMapping->getIntegrationObjectName()] ??= [];
 
             $this->updatedObjectMappings[$objectMapping->getIntegrationObjectName()][] = $objectMapping;
         }
@@ -149,9 +145,7 @@ final class OrderResultsDAO
     private function groupRemappedObjectsByObjectName(array $remappedObjects): void
     {
         foreach ($remappedObjects as $remappedObject) {
-            if (!isset($this->remappedObjects[$remappedObject->getNewObjectName()])) {
-                $this->remappedObjects[$remappedObject->getNewObjectName()] = [];
-            }
+            $this->remappedObjects[$remappedObject->getNewObjectName()] ??= [];
 
             $this->remappedObjects[$remappedObject->getNewObjectName()][] = $remappedObject;
         }
@@ -163,9 +157,7 @@ final class OrderResultsDAO
     private function groupDeletedObjectsByObjectName(array $deletedObjects): void
     {
         foreach ($deletedObjects as $deletedObject) {
-            if (!isset($this->deletedObjects[$deletedObject->getObject()])) {
-                $this->deletedObjects[$deletedObject->getObject()] = [];
-            }
+            $this->deletedObjects[$deletedObject->getObject()] ??= [];
 
             $this->deletedObjects[$deletedObject->getObject()][] = $deletedObject;
         }

--- a/app/bundles/IntegrationsBundle/Sync/DAO/Sync/Report/ReportDAO.php
+++ b/app/bundles/IntegrationsBundle/Sync/DAO/Sync/Report/ReportDAO.php
@@ -37,9 +37,7 @@ class ReportDAO
 
     public function addObject(ObjectDAO $objectDAO): static
     {
-        if (!isset($this->objects[$objectDAO->getObject()])) {
-            $this->objects[$objectDAO->getObject()] = [];
-        }
+        $this->objects[$objectDAO->getObject()] ??= [];
 
         $this->objects[$objectDAO->getObject()][$objectDAO->getObjectId()] = $objectDAO;
 
@@ -54,9 +52,7 @@ class ReportDAO
      */
     public function remapObject($oldObjectName, $oldObjectId, $newObjectName, $newObjectId = null): void
     {
-        if (null === $newObjectId) {
-            $newObjectId = $oldObjectId;
-        }
+        $newObjectId ??= $oldObjectId;
 
         $this->remappedObjects[$oldObjectId] = new RemappedObjectDAO($this->integration, $oldObjectName, $oldObjectId, $newObjectName, $newObjectId);
     }

--- a/app/bundles/IntegrationsBundle/Sync/Notification/Handler/HandlerContainer.php
+++ b/app/bundles/IntegrationsBundle/Sync/Notification/Handler/HandlerContainer.php
@@ -25,9 +25,7 @@ final class HandlerContainer
 
     private function registerHandler(HandlerInterface $handler): void
     {
-        if (!isset($this->handlers[$handler->getIntegration()])) {
-            $this->handlers[$handler->getIntegration()] = [];
-        }
+        $this->handlers[$handler->getIntegration()] ??= [];
 
         $this->handlers[$handler->getIntegration()][$handler->getSupportedObject()] = $handler;
     }

--- a/app/bundles/IntegrationsBundle/Sync/Notification/Helper/UserSummaryNotificationHelper.php
+++ b/app/bundles/IntegrationsBundle/Sync/Notification/Helper/UserSummaryNotificationHelper.php
@@ -59,13 +59,9 @@ final class UserSummaryNotificationHelper
 
     public function storeSummaryNotification(string $integrationDisplayName, string $objectDisplayName, int $id): void
     {
-        if (!isset($this->userNotifications[$integrationDisplayName])) {
-            $this->userNotifications[$integrationDisplayName] = [];
-        }
+        $this->userNotifications[$integrationDisplayName] ??= [];
 
-        if (!isset($this->userNotifications[$integrationDisplayName][$objectDisplayName])) {
-            $this->userNotifications[$integrationDisplayName][$objectDisplayName] = [];
-        }
+        $this->userNotifications[$integrationDisplayName][$objectDisplayName] ??= [];
 
         $this->userNotifications[$integrationDisplayName][$objectDisplayName][$id] = $id;
     }
@@ -82,9 +78,7 @@ final class UserSummaryNotificationHelper
         // Group by owner ID.
         foreach ($results as $result) {
             $ownerId = $result['owner_id'];
-            if (!isset($owners[$ownerId])) {
-                $owners[$ownerId] = [];
-            }
+            $owners[$ownerId] ??= [];
 
             $owners[$ownerId][] = (int) $result['id'];
         }

--- a/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Helper/FieldHelper.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Helper/FieldHelper.php
@@ -45,9 +45,7 @@ class FieldHelper
 
     public function getFieldList(string $object): array
     {
-        if (!isset($this->fieldList[$object])) {
-            $this->fieldList[$object] = $this->fieldModel->getFieldListWithProperties($object);
-        }
+        $this->fieldList[$object] ??= $this->fieldModel->getFieldListWithProperties($object);
 
         return $this->fieldList[$object];
     }

--- a/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/Executioner/FieldValidator.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/Executioner/FieldValidator.php
@@ -106,9 +106,7 @@ final class FieldValidator implements FieldValidatorInterface
      */
     private function getFieldSchema(string $object, string $alias): array
     {
-        if (!isset($this->fieldSchemaData[$object])) {
-            $this->fieldSchemaData[$object] = $this->leadFieldRepository->getFieldSchemaData($object);
-        }
+        $this->fieldSchemaData[$object] ??= $this->leadFieldRepository->getFieldSchemaData($object);
 
         if (!isset($this->fieldSchemaData[$object][$alias])) {
             throw new FieldSchemaNotFoundException($object, $alias);

--- a/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ReportBuilder/PartialObjectReportBuilder.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ReportBuilder/PartialObjectReportBuilder.php
@@ -45,9 +45,7 @@ class PartialObjectReportBuilder
 
         foreach ($requestedObjects as $objectDAO) {
             try {
-                if (!isset($this->lastProcessedTrackedId[$objectDAO->getObject()])) {
-                    $this->lastProcessedTrackedId[$objectDAO->getObject()] = 0;
-                }
+                $this->lastProcessedTrackedId[$objectDAO->getObject()] ??= 0;
 
                 $fieldsChanges = $this->fieldChangeRepository->findChangesBefore(
                     $requestDAO->getSyncToIntegration(),

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/Notification/Handler/HandlerContainerTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/Notification/Handler/HandlerContainerTest.php
@@ -24,7 +24,7 @@ final class HandlerContainerTest extends TestCase
         $this->expectException(HandlerNotSupportedException::class);
 
         $mockHandler = $this->createMock(HandlerInterface::class);
-        $mockHandler->expects($this->exactly(3))->method('getIntegration')
+        $mockHandler->expects($this->atLeast(2))->method('getIntegration')
             ->willReturn('foo');
         $mockHandler->expects($this->once())->method('getSupportedObject')
             ->willReturn('bogus');
@@ -37,8 +37,9 @@ final class HandlerContainerTest extends TestCase
     public function testHandlerIsRegistered(): void
     {
         $mockHandler = $this->createMock(HandlerInterface::class);
-        $mockHandler->expects($this->exactly(3))->method('getIntegration')
+        $mockHandler->expects($this->atLeast(2))->method('getIntegration')
             ->willReturn('foo');
+
         $mockHandler->expects($this->once())->method('getSupportedObject')
             ->willReturn('bar');
 

--- a/app/bundles/LeadBundle/Controller/Api/CustomFieldsApiControllerTrait.php
+++ b/app/bundles/LeadBundle/Controller/Api/CustomFieldsApiControllerTrait.php
@@ -102,9 +102,7 @@ trait CustomFieldsApiControllerTrait
                 }
 
                 // Some requests don't seem to have properties unserialized by default (even in M2)
-                if (!isset($fieldDefinition['properties'])) {
-                    $fieldDefinition['properties'] = [];
-                }
+                $fieldDefinition['properties'] ??= [];
                 $properties = is_string($fieldDefinition['properties']) ? \Mautic\CoreBundle\Helper\Serializer::decode($fieldDefinition['properties']) : $fieldDefinition['properties'];
 
                 $fields[$group][$field]['value']           = empty($properties['scale']) ? (int) $fields[$group][$field]['value']

--- a/app/bundles/LeadBundle/Controller/FrequencyRuleTrait.php
+++ b/app/bundles/LeadBundle/Controller/FrequencyRuleTrait.php
@@ -107,17 +107,11 @@ trait FrequencyRuleTrait
 
         /** @var LeadModel $model */
         $model = $this->getModel('lead');
-        if (null === $allChannels) {
-            $allChannels = $model->getPreferenceChannels();
-        }
+        $allChannels ??= $model->getPreferenceChannels();
 
-        if (null === $leadChannels) {
-            $leadChannels = $model->getContactChannels($lead);
-        }
+        $leadChannels ??= $model->getContactChannels($lead);
 
-        if (null === $frequencyRules) {
-            $frequencyRules = $model->getFrequencyRules($lead);
-        }
+        $frequencyRules ??= $model->getFrequencyRules($lead);
 
         foreach ($allChannels as $channel) {
             if (isset($frequencyRules[$channel])) {

--- a/app/bundles/LeadBundle/Controller/LeadDetailsTrait.php
+++ b/app/bundles/LeadBundle/Controller/LeadDetailsTrait.php
@@ -104,17 +104,11 @@ trait LeadDetailsTrait
             throw new \InvalidArgumentException('filters parameter must be an array');
         }
 
-        if (!isset($filters['search'])) {
-            $filters['search'] = '';
-        }
+        $filters['search'] ??= '';
 
-        if (!isset($filters['includeEvents'])) {
-            $filters['includeEvents'] = [];
-        }
+        $filters['includeEvents'] ??= [];
 
-        if (!isset($filters['excludeEvents'])) {
-            $filters['excludeEvents'] = [];
-        }
+        $filters['excludeEvents'] ??= [];
 
         return $filters;
     }

--- a/app/bundles/LeadBundle/Deduplicate/DeduperTrait.php
+++ b/app/bundles/LeadBundle/Deduplicate/DeduperTrait.php
@@ -14,9 +14,9 @@ trait DeduperTrait
     private FieldsWithUniqueIdentifier $fieldsWithUniqueIdentifier;
 
     /**
-     * @var array
+     * @var array<mixed>|null
      */
-    private $availableFields;
+    private ?array $availableFields = null;
 
     public function getUniqueData(array $queryFields): array
     {
@@ -37,21 +37,16 @@ trait DeduperTrait
         return $uniqueLeadFieldData;
     }
 
-    /**
-     * @return array
-     */
-    private function getAvailableFields()
+    private function getAvailableFields(): array
     {
-        if (null === $this->availableFields) {
-            $this->availableFields = $this->fieldList->getFieldList(
-                false,
-                false,
-                [
-                    'isPublished' => true,
-                    'object'      => $this->object,
-                ]
-            );
-        }
+        $this->availableFields ??= $this->fieldList->getFieldList(
+            false,
+            false,
+            [
+                'isPublished' => true,
+                'object'      => $this->object,
+            ]
+        );
 
         return $this->availableFields;
     }

--- a/app/bundles/LeadBundle/Entity/CompanyRepository.php
+++ b/app/bundles/LeadBundle/Entity/CompanyRepository.php
@@ -307,9 +307,7 @@ class CompanyRepository extends CommonRepository implements CustomFieldRepositor
 
         // Ensure lists without leads have a value
         foreach ($companyIds as $l) {
-            if (!isset($return[$l])) {
-                $return[$l] = 0;
-            }
+            $return[$l] ??= 0;
         }
 
         return ($returnArray) ? $return : $return[$companyIds[0]];
@@ -379,9 +377,7 @@ class CompanyRepository extends CommonRepository implements CustomFieldRepositor
         // Group companies per contact
         $contactCompanies = [];
         foreach ($companies as $company) {
-            if (!isset($contactCompanies[$company['lead_id']])) {
-                $contactCompanies[$company['lead_id']] = [];
-            }
+            $contactCompanies[$company['lead_id']] ??= [];
 
             $contactCompanies[$company['lead_id']][] = $company;
         }

--- a/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
+++ b/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
@@ -106,9 +106,7 @@ trait CustomFieldRepositoryTrait
 
                 // make sure each group key is present
                 foreach ($groups as $g) {
-                    if (!isset($fieldValues[$id][$g])) {
-                        $fieldValues[$id][$g] = [];
-                    }
+                    $fieldValues[$id][$g] ??= [];
                 }
             }
 
@@ -353,9 +351,7 @@ trait CustomFieldRepositoryTrait
             // make sure each group key is present
             $groups = $this->getFieldGroups();
             foreach ($groups as $g) {
-                if (!isset($fieldValues[$g])) {
-                    $fieldValues[$g] = [];
-                }
+                $fieldValues[$g] ??= [];
             }
         }
 

--- a/app/bundles/LeadBundle/Entity/DoNotContactRepository.php
+++ b/app/bundles/LeadBundle/Entity/DoNotContactRepository.php
@@ -172,9 +172,7 @@ class DoNotContactRepository extends CommonRepository
         $dnc = [];
         foreach ($results as $r) {
             if (isset($r['lead_id'])) {
-                if (!isset($dnc[$r['lead_id']])) {
-                    $dnc[$r['lead_id']] = [];
-                }
+                $dnc[$r['lead_id']] ??= [];
 
                 $dnc[$r['lead_id']][$r['channel']] = $r['reason'];
             } else {

--- a/app/bundles/LeadBundle/Entity/ExpressionHelperTrait.php
+++ b/app/bundles/LeadBundle/Entity/ExpressionHelperTrait.php
@@ -20,10 +20,7 @@ trait ExpressionHelperTrait
             $parameter = ":{$parameter}";
         }
 
-        if (null === $includeIsNull) {
-            // Auto determine based on negate operators
-            $includeIsNull = in_array($operator, ['neq', 'notLike', 'notIn']);
-        }
+        $includeIsNull ??= in_array($operator, ['neq', 'notLike', 'notIn']);
 
         if ($includeIsNull) {
             $expr = $q->expr()->or(

--- a/app/bundles/LeadBundle/Entity/FrequencyRuleRepository.php
+++ b/app/bundles/LeadBundle/Entity/FrequencyRuleRepository.php
@@ -81,9 +81,7 @@ class FrequencyRuleRepository extends CommonRepository
 
         foreach ($results as $result) {
             if ($groupByLeads) {
-                if (!isset($frequencyRules[$result['lead_id']])) {
-                    $frequencyRules[$result['lead_id']] = [];
-                }
+                $frequencyRules[$result['lead_id']] ??= [];
 
                 $frequencyRules[$result['lead_id']][$result['channel']] = $result;
             } else {

--- a/app/bundles/LeadBundle/Entity/Lead.php
+++ b/app/bundles/LeadBundle/Entity/Lead.php
@@ -586,9 +586,7 @@ class Lead extends FormEntity implements CustomFieldEntityInterface, IdentifierF
                 }
             }
         } elseif ('frequencyRules' == $prop) {
-            if (!isset($this->changes['frequencyRules'])) {
-                $this->changes['frequencyRules'] = [];
-            }
+            $this->changes['frequencyRules'] ??= [];
 
             if ($val instanceof FrequencyRule) {
                 $channel = $val->getChannel();
@@ -832,9 +830,7 @@ class Lead extends FormEntity implements CustomFieldEntityInterface, IdentifierF
 
         // Keep track of point changes to make a direct DB query
         // Ignoring Aunt Sally here (PEMDAS)
-        if (!isset($this->pointChanges[$operator])) {
-            $this->pointChanges[$operator] = 0;
-        }
+        $this->pointChanges[$operator] ??= 0;
         $this->pointChanges[$operator] += $points;
 
         $this->isChanged('points', (int) $this->updatedPoints, (int) $oldPoints);

--- a/app/bundles/LeadBundle/Entity/LeadListRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadListRepository.php
@@ -318,9 +318,7 @@ class LeadListRepository extends CommonRepository
 
         // Ensure lists without leads have a value
         foreach ($listIds as $l) {
-            if (!isset($return[$l])) {
-                $return[$l] = 0;
-            }
+            $return[$l] ??= 0;
         }
 
         return (1 === $countListIds) ? $return[$listIds[0]] : $return;

--- a/app/bundles/LeadBundle/Entity/MergeRecord.php
+++ b/app/bundles/LeadBundle/Entity/MergeRecord.php
@@ -87,9 +87,7 @@ class MergeRecord
 
     public function setDateAdded(?\DateTime $dateAdded = null): static
     {
-        if (null === $dateAdded) {
-            $dateAdded = new \DateTime();
-        }
+        $dateAdded ??= new \DateTime();
 
         $this->dateAdded = $dateAdded;
 

--- a/app/bundles/LeadBundle/Event/LeadListFiltersChoicesEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadListFiltersChoicesEvent.php
@@ -60,9 +60,7 @@ final class LeadListFiltersChoicesEvent extends AbstractCustomRequestEvent
      */
     public function addChoice($object, $choiceKey, $choiceConfig): void
     {
-        if (!isset($this->choices[$object])) {
-            $this->choices[$object] = [];
-        }
+        $this->choices[$object] ??= [];
         if (!array_key_exists($choiceKey, $this->choices[$object])) {
             $this->choices[$object][$choiceKey] = $choiceConfig;
         }
@@ -73,9 +71,7 @@ final class LeadListFiltersChoicesEvent extends AbstractCustomRequestEvent
      */
     public function setChoice(string $object, string $choiceKey, array $choiceConfig): void
     {
-        if (!isset($this->choices[$object])) {
-            $this->choices[$object] = [];
-        }
+        $this->choices[$object] ??= [];
 
         $this->choices[$object][$choiceKey] = $choiceConfig;
     }

--- a/app/bundles/LeadBundle/Event/LeadTimelineEvent.php
+++ b/app/bundles/LeadBundle/Event/LeadTimelineEvent.php
@@ -116,15 +116,11 @@ final class LeadTimelineEvent extends Event
                 $count = $this->chartQuery->completeTimeData($countData);
                 $this->addToCounter($data['event'], $count);
             } else {
-                if (!isset($this->totalEvents[$data['event']])) {
-                    $this->totalEvents[$data['event']] = 0;
-                }
+                $this->totalEvents[$data['event']] ??= 0;
                 ++$this->totalEvents[$data['event']];
             }
         } else {
-            if (!isset($this->events[$data['event']])) {
-                $this->events[$data['event']] = [];
-            }
+            $this->events[$data['event']] ??= [];
 
             if (!$this->forTimeline) {
                 // standardize the payload
@@ -388,9 +384,7 @@ final class LeadTimelineEvent extends Event
     {
         // BC support for old formats
         foreach ($this->events as $type => $events) {
-            if (!isset($this->totalEvents[$type])) {
-                $this->totalEvents[$type] = count($events);
-            }
+            $this->totalEvents[$type] ??= count($events);
         }
 
         $counter = [
@@ -411,9 +405,7 @@ final class LeadTimelineEvent extends Event
      */
     public function addToCounter($eventType, $count): void
     {
-        if (!isset($this->totalEvents[$eventType])) {
-            $this->totalEvents[$eventType] = 0;
-        }
+        $this->totalEvents[$eventType] ??= 0;
 
         if (is_array($count)) {
             if (isset($count['total'])) {
@@ -421,9 +413,7 @@ final class LeadTimelineEvent extends Event
             } elseif ($this->countOnly && $this->groupUnit) {
                 // Group counts across events by unit
                 foreach ($count as $key => $data) {
-                    if (!isset($this->totalEventsByUnit[$key])) {
-                        $this->totalEventsByUnit[$key] = 0;
-                    }
+                    $this->totalEventsByUnit[$key] ??= 0;
                     $this->totalEventsByUnit[$key] += (int) $data;
                     $this->totalEvents[$eventType] += (int) $data;
                 }

--- a/app/bundles/LeadBundle/EventListener/OwnerSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/OwnerSubscriber.php
@@ -156,9 +156,7 @@ final class OwnerSubscriber implements EventSubscriberInterface
      */
     private function getOwner(int $ownerId)
     {
-        if (!isset($this->owners[$ownerId])) {
-            $this->owners[$ownerId] = $this->leadRepository->getLeadOwner($ownerId);
-        }
+        $this->owners[$ownerId] ??= $this->leadRepository->getLeadOwner($ownerId);
 
         return $this->owners[$ownerId];
     }

--- a/app/bundles/LeadBundle/Field/FieldsWithUniqueIdentifier.php
+++ b/app/bundles/LeadBundle/Field/FieldsWithUniqueIdentifier.php
@@ -28,9 +28,7 @@ class FieldsWithUniqueIdentifier
         $filters = $this->prepareFilters($filters);
 
         $key = base64_encode(json_encode($filters));
-        if (!isset($this->uniqueIdentifierFields[$key])) {
-            $this->uniqueIdentifierFields[$key] = $this->fieldList->getFieldList(false, true, $filters);
-        }
+        $this->uniqueIdentifierFields[$key] ??= $this->fieldList->getFieldList(false, true, $filters);
 
         return $this->uniqueIdentifierFields[$key];
     }

--- a/app/bundles/LeadBundle/Form/Type/FilterTrait.php
+++ b/app/bundles/LeadBundle/Form/Type/FilterTrait.php
@@ -210,9 +210,7 @@ trait FilterTrait
                 if ($customOptions['multiple']) {
                     array_unshift($customOptions['choices'], ['' => '']);
 
-                    if (!isset($data['filter'])) {
-                        $data['filter'] = [];
-                    }
+                    $data['filter'] ??= [];
                 }
 
                 break;

--- a/app/bundles/LeadBundle/Helper/DncFormatterHelper.php
+++ b/app/bundles/LeadBundle/Helper/DncFormatterHelper.php
@@ -28,14 +28,12 @@ final class DncFormatterHelper
      */
     public function getDncReasons(): array
     {
-        if (null === $this->dncReasons) {
-            $this->dncReasons = [
-                DoNotContact::IS_CONTACTABLE => $this->translator->trans('mautic.lead.report.dnc_contactable'),
-                DoNotContact::UNSUBSCRIBED   => $this->translator->trans('mautic.lead.report.dnc_unsubscribed'),
-                DoNotContact::BOUNCED        => $this->translator->trans('mautic.lead.report.dnc_bounced'),
-                DoNotContact::MANUAL         => $this->translator->trans('mautic.lead.report.dnc_manual'),
-            ];
-        }
+        $this->dncReasons ??= [
+            DoNotContact::IS_CONTACTABLE => $this->translator->trans('mautic.lead.report.dnc_contactable'),
+            DoNotContact::UNSUBSCRIBED   => $this->translator->trans('mautic.lead.report.dnc_unsubscribed'),
+            DoNotContact::BOUNCED        => $this->translator->trans('mautic.lead.report.dnc_bounced'),
+            DoNotContact::MANUAL         => $this->translator->trans('mautic.lead.report.dnc_manual'),
+        ];
 
         return $this->dncReasons;
     }

--- a/app/bundles/LeadBundle/Helper/TokenHelper.php
+++ b/app/bundles/LeadBundle/Helper/TokenHelper.php
@@ -12,10 +12,7 @@ final class TokenHelper
 
     private const string DATETIME_REGEX = '/({|%7B)datetime=(.*?)(}|%7D)/';
 
-    /**
-     * @var array
-     */
-    private static $parameters;
+    private static ?array $parameters = null;
 
     /**
      * @param string $content

--- a/app/bundles/LeadBundle/Helper/TokenHelper.php
+++ b/app/bundles/LeadBundle/Helper/TokenHelper.php
@@ -174,7 +174,9 @@ final class TokenHelper
      */
     private static function getParameter(string $parameter)
     {
-        self::$parameters ??= new ParamsLoaderHelper()->getParameters();
+        if ([] === self::$parameters) {
+            self::$parameters = new ParamsLoaderHelper()->getParameters();
+        }
 
         return self::$parameters[$parameter];
     }

--- a/app/bundles/LeadBundle/Helper/TokenHelper.php
+++ b/app/bundles/LeadBundle/Helper/TokenHelper.php
@@ -174,9 +174,7 @@ final class TokenHelper
      */
     private static function getParameter(string $parameter)
     {
-        if (null === self::$parameters) {
-            self::$parameters = new ParamsLoaderHelper()->getParameters();
-        }
+        self::$parameters ??= new ParamsLoaderHelper()->getParameters();
 
         return self::$parameters[$parameter];
     }

--- a/app/bundles/LeadBundle/Model/CompanyModel.php
+++ b/app/bundles/LeadBundle/Model/CompanyModel.php
@@ -217,9 +217,7 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
         // make sure each group key is present
         $groups = ['core', 'social', 'personal', 'professional'];
         foreach ($groups as $g) {
-            if (!isset($array[$g])) {
-                $array[$g] = [];
-            }
+            $array[$g] ??= [];
         }
 
         return $array;
@@ -251,9 +249,7 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
         // update existing values
         foreach ($fieldValues as &$groupFields) {
             foreach ($groupFields as $alias => &$field) {
-                if (!isset($field['value'])) {
-                    $field['value'] = null;
-                }
+                $field['value'] ??= null;
                 // Only update fields that are part of the passed $data array
                 if (array_key_exists($alias, $data)) {
                     $curValue = $field['value'];

--- a/app/bundles/LeadBundle/Model/DefaultValueTrait.php
+++ b/app/bundles/LeadBundle/Model/DefaultValueTrait.php
@@ -20,9 +20,7 @@ trait DefaultValueTrait
             return;
         }
 
-        if (!isset($this->cachedDefaultFields[$object])) {
-            $this->cachedDefaultFields[$object] = $this->leadFieldModel->getFieldListWithProperties($object);
-        }
+        $this->cachedDefaultFields[$object] ??= $this->leadFieldModel->getFieldListWithProperties($object);
 
         foreach ($this->cachedDefaultFields[$object] as $alias => $field) {
             // Prevent defaults from overwriting values already set

--- a/app/bundles/LeadBundle/Model/ImportModel.php
+++ b/app/bundles/LeadBundle/Model/ImportModel.php
@@ -168,9 +168,7 @@ class ImportModel extends FormModel
      */
     public function beginImport(Import $import, Progress $progress, $limit = 0, ?float $start = null): void
     {
-        if (null === $start) {
-            $start = microtime(true);
-        }
+        $start ??= microtime(true);
 
         $this->setGhostImportsAsFailed();
 

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -674,9 +674,7 @@ class LeadModel extends FormModel
             }
 
             foreach ($groupFields as $alias => &$field) {
-                if (!isset($field['value'])) {
-                    $field['value'] = null;
-                }
+                $field['value'] ??= null;
 
                 // Only update fields that are part of the passed $data array
                 if (array_key_exists($alias, $data)) {
@@ -866,9 +864,7 @@ class LeadModel extends FormModel
         // make sure each group key is present
         $groups = ['core', 'social', 'personal', 'professional'];
         foreach ($groups as $g) {
-            if (!isset($array[$g])) {
-                $array[$g] = [];
-            }
+            $array[$g] ??= [];
         }
 
         return $array;

--- a/app/bundles/LeadBundle/Segment/ContactSegmentFilterFactory.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentFilterFactory.php
@@ -124,9 +124,7 @@ final class ContactSegmentFilterFactory
                 if (isset($filter['type']) && in_array($filter['type'], ['date', 'datetime'], true)) {
                     $shrinkedFilters[] = $filter;
                 } else {
-                    if (!isset($arrStacks[$key])) {
-                        $arrStacks[$key] = [];
-                    }
+                    $arrStacks[$key] ??= [];
                     $arrStacks[$key][] = $filter;
                 }
             } else { // glue = and

--- a/app/bundles/LeadBundle/Segment/Query/ContactSegmentQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/ContactSegmentQueryBuilder.php
@@ -249,9 +249,7 @@ final class ContactSegmentQueryBuilder
     {
         $seen[] = $segmentId;
 
-        if (!isset($this->dependencyMap[$segmentId])) {
-            $this->dependencyMap[$segmentId] = $this->getSegmentEdges($segmentId);
-        }
+        $this->dependencyMap[$segmentId] ??= $this->getSegmentEdges($segmentId);
 
         $edges = $this->dependencyMap[$segmentId];
 

--- a/app/bundles/LeadBundle/Tracker/ContactTracker.php
+++ b/app/bundles/LeadBundle/Tracker/ContactTracker.php
@@ -228,10 +228,7 @@ class ContactTracker
             $this->hydrateCustomFieldData($lead);
         }
 
-        if (null === $lead) {
-            // Check to see if a contact is being tracked via the old cookie method in order to migrate them to the new
-            $lead = $this->contactTrackingService->getTrackedLead();
-        }
+        $lead ??= $this->contactTrackingService->getTrackedLead();
 
         if ($lead) {
             $this->logger->debug("CONTACT: Existing lead found with ID# {$lead->getId()}.");

--- a/app/bundles/MessengerBundle/Retry/RetryStrategy.php
+++ b/app/bundles/MessengerBundle/Retry/RetryStrategy.php
@@ -30,14 +30,12 @@ final class RetryStrategy implements RetryStrategyInterface
 
     private function getRetryStrategy(): RetryStrategyInterface
     {
-        if (!isset($this->retryStrategy)) {
-            $this->retryStrategy = new MultiplierRetryStrategy(
-                (int) $this->parametersHelper->get('messenger_retry_strategy_max_retries'),
-                (int) $this->parametersHelper->get('messenger_retry_strategy_delay'),
-                (float) $this->parametersHelper->get('messenger_retry_strategy_multiplier'),
-                (int) $this->parametersHelper->get('messenger_retry_strategy_max_delay'),
-            );
-        }
+        $this->retryStrategy ??= new MultiplierRetryStrategy(
+            (int) $this->parametersHelper->get('messenger_retry_strategy_max_retries'),
+            (int) $this->parametersHelper->get('messenger_retry_strategy_delay'),
+            (float) $this->parametersHelper->get('messenger_retry_strategy_multiplier'),
+            (int) $this->parametersHelper->get('messenger_retry_strategy_max_delay'),
+        );
 
         return $this->retryStrategy;
     }

--- a/app/bundles/NotificationBundle/Entity/NotificationRepository.php
+++ b/app/bundles/NotificationBundle/Entity/NotificationRepository.php
@@ -43,12 +43,8 @@ final class NotificationRepository extends CommonRepository
             ->from(Notification::class, 'e');
         $results = $q->getQuery()->getSingleResult(Query::HYDRATE_ARRAY);
 
-        if (!isset($results['sent_count'])) {
-            $results['sent_count'] = 0;
-        }
-        if (!isset($results['read_count'])) {
-            $results['read_count'] = 0;
-        }
+        $results['sent_count'] ??= 0;
+        $results['read_count'] ??= 0;
 
         return $results;
     }

--- a/app/bundles/NotificationBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/NotificationBundle/EventListener/CampaignSubscriber.php
@@ -302,12 +302,10 @@ class CampaignSubscriber implements EventSubscriberInterface
             $sendNotification = $this->buildNotificationToSend($notification, $log->getLead());
             $uniqueKey        = md5(sprintf('[%s][%s]', $sendNotification->getHeading(), $sendNotification->getMessage()));
 
-            if (!isset($batches[$uniqueKey])) {
-                $batches[$uniqueKey] = [
-                    'sendNotification' => $sendNotification,
-                    'playerIds'        => [],
-                ];
-            }
+            $batches[$uniqueKey] ??= [
+                'sendNotification' => $sendNotification,
+                'playerIds'        => [],
+            ];
 
             foreach ($playerIds as $playerId) {
                 $batches[$uniqueKey]['playerIds'][$playerId] = $log;

--- a/app/bundles/PageBundle/Controller/PageController.php
+++ b/app/bundles/PageBundle/Controller/PageController.php
@@ -218,9 +218,7 @@ final class PageController extends FormController
 
                 if (is_array($variantSettings) && isset($variantSettings['winnerCriteria'])) {
                     if ($c->isPublished()) {
-                        if (!isset($lastCriteria)) {
-                            $lastCriteria = $variantSettings['winnerCriteria'];
-                        }
+                        $lastCriteria ??= $variantSettings['winnerCriteria'];
 
                         // make sure all the variants are configured with the same criteria
                         if ($lastCriteria != $variantSettings['winnerCriteria']) {

--- a/app/bundles/PageBundle/Entity/Redirect.php
+++ b/app/bundles/PageBundle/Entity/Redirect.php
@@ -110,9 +110,7 @@ class Redirect extends FormEntity
      */
     public function setRedirectId($redirectId = null): void
     {
-        if (null === $redirectId) {
-            $redirectId = substr(hash('sha1', uniqid(mt_rand())), 0, 25);
-        }
+        $redirectId ??= substr(hash('sha1', uniqid(mt_rand())), 0, 25);
         $this->redirectId = $redirectId;
     }
 

--- a/app/bundles/PageBundle/Helper/PointActionHelper.php
+++ b/app/bundles/PageBundle/Helper/PointActionHelper.php
@@ -65,9 +65,7 @@ class PointActionHelper
         }
 
         if ($action['properties']['accumulative_time']) {
-            if (!isset($hitStats)) {
-                $hitStats = $this->hitRepository->getDwellTimesForUrl($urlWithSqlWC, ['leadId' => $lead->getId()]);
-            }
+            $hitStats ??= $this->hitRepository->getDwellTimesForUrl($urlWithSqlWC, ['leadId' => $lead->getId()]);
 
             if (isset($hitStats['sum'])) {
                 if ($action['properties']['accumulative_time'] <= $hitStats['sum']) {
@@ -80,9 +78,7 @@ class PointActionHelper
             }
         }
         if ($action['properties']['page_hits']) {
-            if (!isset($hitStats)) {
-                $hitStats = $this->hitRepository->getDwellTimesForUrl($urlWithSqlWC, ['leadId' => $lead->getId()]);
-            }
+            $hitStats ??= $this->hitRepository->getDwellTimesForUrl($urlWithSqlWC, ['leadId' => $lead->getId()]);
             if (isset($hitStats['count']) && $hitStats['count'] >= $action['properties']['page_hits']) {
                 $changePoints['page_hits'] = true;
             } else {

--- a/app/bundles/PageBundle/Model/TrackableModel.php
+++ b/app/bundles/PageBundle/Model/TrackableModel.php
@@ -98,9 +98,7 @@ class TrackableModel extends AbstractCommonModel
         $shortenUrl = false,
         $utmTags = [],
     ) {
-        if (!isset($clickthrough['channel'])) {
-            $clickthrough['channel'] = [$trackable->getChannel() => $trackable->getChannelId()];
-        }
+        $clickthrough['channel'] ??= [$trackable->getChannel() => $trackable->getChannelId()];
 
         $redirect = $trackable->getRedirect();
 

--- a/app/bundles/PageBundle/Tests/Entity/HitRepositoryTest.php
+++ b/app/bundles/PageBundle/Tests/Entity/HitRepositoryTest.php
@@ -186,9 +186,7 @@ final class HitRepositoryTest extends MauticMysqlTestCase
 
     private function getIpAddress(): IpAddress
     {
-        if (!isset($this->ipAddress)) {
-            $this->ipAddress = new IpAddress('127.0.0.1');
-        }
+        $this->ipAddress ??= new IpAddress('127.0.0.1');
 
         return $this->ipAddress;
     }

--- a/app/bundles/PluginBundle/Command/FetchLeadsCommand.php
+++ b/app/bundles/PluginBundle/Command/FetchLeadsCommand.php
@@ -117,9 +117,7 @@ final class FetchLeadsCommand extends Command
 
         defined('MAUTIC_CONSOLE_VERBOSITY') || define('MAUTIC_CONSOLE_VERBOSITY', $output->getVerbosity());
 
-        if (!isset($config['objects'])) {
-            $config['objects'] = [];
-        }
+        $config['objects'] ??= [];
 
         $params['start']    = $startDate;
         $params['end']      = $endDate;

--- a/app/bundles/PluginBundle/Form/Type/FieldsTypeTrait.php
+++ b/app/bundles/PluginBundle/Form/Type/FieldsTypeTrait.php
@@ -49,9 +49,7 @@ trait FieldsTypeTrait
                     $groupName = '0default';
                     if (is_array($details)) {
                         if (isset($details['group'])) {
-                            if (!isset($choices[$details['group']])) {
-                                $choices[$details['group']] = [];
-                            }
+                            $choices[$details['group']] ??= [];
                             $label           = $details['optionLabel'] ?? $details['label'];
                             $group[$field]   = $groupName = $details['group'];
                             $choices[$field] = $label;

--- a/app/bundles/PluginBundle/Form/Type/IntegrationsListType.php
+++ b/app/bundles/PluginBundle/Form/Type/IntegrationsListType.php
@@ -31,9 +31,7 @@ final class IntegrationsListType extends AbstractType
 
             if ($settings->isPublished()) {
                 $pluginName = $settings->getPlugin()->getName();
-                if (!isset($integrations[$pluginName])) {
-                    $integrations[$pluginName] = [];
-                }
+                $integrations[$pluginName] ??= [];
                 $integrations[$pluginName][$object->getDisplayName()] = $object->getName();
             }
         }

--- a/app/bundles/PluginBundle/Helper/IntegrationHelper.php
+++ b/app/bundles/PluginBundle/Helper/IntegrationHelper.php
@@ -144,9 +144,7 @@ class IntegrationHelper
                         // Sort by feature and plugin for later
                         $features = $settings->getSupportedFeatures();
                         foreach ($features as $feature) {
-                            if (!isset($this->byFeatureList[$feature])) {
-                                $this->byFeatureList[$feature] = [];
-                            }
+                            $this->byFeatureList[$feature] ??= [];
                             $this->byFeatureList[$feature][] = $integrationName;
                         }
                         $this->byPlugin[$id][] = $integrationName;
@@ -440,9 +438,7 @@ class IntegrationHelper
                     }
 
                     if (!empty($profile['profile']) || !empty($profile['activity'])) {
-                        if (!isset($socialCache[$integration])) {
-                            $socialCache[$integration] = [];
-                        }
+                        $socialCache[$integration] ??= [];
 
                         $socialCache[$integration]['profile']     = (!empty($profile['profile'])) ? $profile['profile'] : [];
                         $socialCache[$integration]['activity']    = (!empty($profile['activity'])) ? $profile['activity'] : [];

--- a/app/bundles/PluginBundle/Integration/AbstractIntegration.php
+++ b/app/bundles/PluginBundle/Integration/AbstractIntegration.php
@@ -672,9 +672,7 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
             $parameters = $event->getParameters();
         }
 
-        if (!isset($settings['query'])) {
-            $settings['query'] = [];
-        }
+        $settings['query'] ??= [];
 
         if (isset($parameters['append_to_query'])) {
             $settings['query'] = array_merge(
@@ -1419,10 +1417,7 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
 
             // Check that the remaining fields have an updateKey set
             foreach ($mappedFields as $field => $mauticField) {
-                if (!isset($featureSettings[$updateKey][$field])) {
-                    // Assume it's mapped to Mautic
-                    $featureSettings[$updateKey][$field] = 1;
-                }
+                $featureSettings[$updateKey][$field] ??= 1;
             }
 
             // Check if required fields are missing
@@ -1723,9 +1718,7 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
 
         // Update the social cache
         $leadSocialCache = $lead->getSocialCache();
-        if (!isset($leadSocialCache[$this->getName()])) {
-            $leadSocialCache[$this->getName()] = [];
-        }
+        $leadSocialCache[$this->getName()] ??= [];
 
         if (null !== $socialCache) {
             $leadSocialCache[$this->getName()] = array_merge($leadSocialCache[$this->getName()], $socialCache);
@@ -1921,21 +1914,19 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
     public function logIntegrationError(\Exception $e, ?Lead $contact = null): void
     {
         if ($e instanceof ApiErrorException) {
-            if (null === $this->adminUsers) {
-                $this->adminUsers = $this->userRepository->getEntities(
-                    [
-                        'filter' => [
-                            'force' => [
-                                [
-                                    'column' => 'r.isAdmin',
-                                    'expr'   => 'eq',
-                                    'value'  => true,
-                                ],
+            $this->adminUsers ??= $this->userRepository->getEntities(
+                [
+                    'filter' => [
+                        'force' => [
+                            [
+                                'column' => 'r.isAdmin',
+                                'expr'   => 'eq',
+                                'value'  => true,
                             ],
                         ],
-                    ]
-                );
-            }
+                    ],
+                ]
+            );
 
             $errorMessage = $e->getMessage();
             $errorHeader  = $this->translator->trans(

--- a/app/bundles/PluginBundle/Model/PluginModel.php
+++ b/app/bundles/PluginBundle/Model/PluginModel.php
@@ -126,9 +126,7 @@ class PluginModel extends FormModel
 
             if (str_contains($namespace, 'MauticPlugin')) {
                 $bundleName = preg_replace('/\\\Entity$/', '', $namespace);
-                if (!isset($pluginsMetadata[$bundleName])) {
-                    $pluginsMetadata[$bundleName] = [];
-                }
+                $pluginsMetadata[$bundleName] ??= [];
                 $pluginsMetadata[$bundleName][$meta->getName()] = $meta;
             }
         }
@@ -152,9 +150,7 @@ class PluginModel extends FormModel
             foreach ($pluginMetadata as $meta) {
                 $table = $meta->getTableName();
 
-                if (!isset($installedPluginsTables[$bundleName])) {
-                    $installedPluginsTables[$bundleName] = [];
-                }
+                $installedPluginsTables[$bundleName] ??= [];
 
                 if ($currentSchema->hasTable($table)) {
                     $installedPluginsTables[$bundleName][] = $currentSchema->getTable($table);

--- a/app/bundles/PointBundle/Model/TriggerModel.php
+++ b/app/bundles/PointBundle/Model/TriggerModel.php
@@ -319,9 +319,7 @@ class TriggerModel extends CommonFormModel implements GlobalSearchInterface
             return false;
         }
 
-        if (null === $lead) {
-            $lead = $this->contactTracker->getContact();
-        }
+        $lead ??= $this->contactTracker->getContact();
 
         if (!$force) {
             // get a list of events that has already been performed on this lead

--- a/app/bundles/ReportBundle/Event/ReportBuilderEvent.php
+++ b/app/bundles/ReportBundle/Event/ReportBuilderEvent.php
@@ -61,12 +61,10 @@ class ReportBuilderEvent extends AbstractReportEvent
 
         foreach ($data['columns'] as $column => &$d) {
             $d['label'] = null !== $d['label'] ? $this->translator->trans($d['label']) : '';
-            if (!isset($d['alias'])) {
-                $d['alias'] = substr(
-                    $column,
-                    false !== ($pos = strpos($column, '.')) ? $pos + 1 : 0
-                );
-            }
+            $d['alias'] ??= substr(
+                $column,
+                false !== ($pos = strpos($column, '.')) ? $pos + 1 : 0
+            );
         }
 
         uasort($data['columns'], fn ($a, $b): int => strnatcmp((string) $a['label'], (string) $b['label']));
@@ -74,12 +72,10 @@ class ReportBuilderEvent extends AbstractReportEvent
         if (isset($data['filters'])) {
             foreach ($data['filters'] as $column => &$d) {
                 $d['label'] = $this->translator->trans($d['label']);
-                if (!isset($d['alias'])) {
-                    $d['alias'] = substr(
-                        $column,
-                        false !== ($pos = strpos($column, '.')) ? $pos + 1 : 0
-                    );
-                }
+                $d['alias'] ??= substr(
+                    $column,
+                    false !== ($pos = strpos($column, '.')) ? $pos + 1 : 0
+                );
             }
 
             uasort($data['filters'], fn ($a, $b): int => strnatcmp((string) $a['label'], (string) $b['label']));

--- a/app/bundles/ReportBundle/Event/ReportGraphEvent.php
+++ b/app/bundles/ReportBundle/Event/ReportGraphEvent.php
@@ -35,9 +35,7 @@ class ReportGraphEvent extends AbstractReportEvent
      */
     public function setGraph($graph, $data): void
     {
-        if (!isset($this->requestedGraphs[$graph]['data'])) {
-            $this->requestedGraphs[$graph]['data'] = [];
-        }
+        $this->requestedGraphs[$graph]['data'] ??= [];
         $this->requestedGraphs[$graph]['data'] = $data;
     }
 
@@ -60,9 +58,7 @@ class ReportGraphEvent extends AbstractReportEvent
      */
     public function setOption($graph, $key, $value): void
     {
-        if (!isset($this->requestedGraphs[$graph]['options'])) {
-            $this->requestedGraphs[$graph]['options'] = [];
-        }
+        $this->requestedGraphs[$graph]['options'] ??= [];
         $this->requestedGraphs[$graph]['options'][$key] = $value;
     }
 

--- a/app/bundles/ReportBundle/EventListener/DashboardSubscriber.php
+++ b/app/bundles/ReportBundle/EventListener/DashboardSubscriber.php
@@ -68,9 +68,7 @@ final class DashboardSubscriber extends MainDashboardSubscriber
 
                     if (isset($reportData['graphs'][$graph])) {
                         $graphData = $reportData['graphs'][$graph];
-                        if (!isset($graphData['data'])) {
-                            $graphData['data'] = $reportData['data'];
-                        }
+                        $graphData['data'] ??= $reportData['data'];
 
                         $templateData = $this->prepareTemplateData($graphData, $widget, $report, $params, $reportData['columns']);
                         $event->setTemplateData($templateData);

--- a/app/bundles/ReportBundle/Form/Type/FilterSelectorType.php
+++ b/app/bundles/ReportBundle/Form/Type/FilterSelectorType.php
@@ -43,9 +43,7 @@ final class FilterSelectorType extends AbstractType
             $data   = $formEvent->getData();
             $column = $data['column'] ?? null;
             $form   = $formEvent->getForm();
-            if (null === $column) {
-                $column = array_key_first($options['filterList']);
-            }
+            $column ??= array_key_first($options['filterList']);
             $choices = $options['operatorList'][$column] ?? [];
 
             // Build a list of condition values

--- a/app/bundles/ReportBundle/Model/ReportModel.php
+++ b/app/bundles/ReportBundle/Model/ReportModel.php
@@ -461,9 +461,7 @@ class ReportModel extends FormModel implements GlobalSearchInterface
         if ($resetTime && isset($options['dateFrom'])) {
             $now = new \DateTime();
 
-            if (!isset($options['dateTo'])) {
-                $options['dateTo'] = $now;
-            }
+            $options['dateTo'] ??= $now;
 
             // Set time to the last second of the "to date" date
             if ($now->format('Y-m-d') === $options['dateTo']->format('Y-m-d')) {

--- a/app/bundles/SmsBundle/Entity/SmsRepository.php
+++ b/app/bundles/SmsBundle/Entity/SmsRepository.php
@@ -97,9 +97,7 @@ class SmsRepository extends CommonRepository
             ->from(Sms::class, 'e');
         $results = $q->getQuery()->getSingleResult(Query::HYDRATE_ARRAY);
 
-        if (!isset($results['sent_count'])) {
-            $results['sent_count'] = 0;
-        }
+        $results['sent_count'] ??= 0;
 
         return $results;
     }

--- a/app/bundles/SmsBundle/Model/SmsModel.php
+++ b/app/bundles/SmsBundle/Model/SmsModel.php
@@ -312,9 +312,7 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface, GlobalSear
                 SmsEvents::TOKEN_REPLACEMENT
             );
 
-            if (!isset($recipientCollections[$translatedSms->getId()])) {
-                $recipientCollections[$translatedSms->getId()] = new RecipientCollection($translatedSms);
-            }
+            $recipientCollections[$translatedSms->getId()] ??= new RecipientCollection($translatedSms);
             $recipientCollections[$translatedSms->getId()]->append(new SmsRecipientDTO($contact, $tokenEvent->getTokens(), $tokenEvent->getContent()));
 
             unset($smsEvent, $tokenEvent);

--- a/app/bundles/StatsBundle/Aggregate/Collection/DAO/StatDAO.php
+++ b/app/bundles/StatsBundle/Aggregate/Collection/DAO/StatDAO.php
@@ -10,9 +10,7 @@ final class StatDAO
 
     public function addStat($key, $value): static
     {
-        if (!isset($this->stats[$key])) {
-            $this->stats[$key] = 0;
-        }
+        $this->stats[$key] ??= 0;
 
         $this->stats[$key] += $value;
 

--- a/app/bundles/StatsBundle/Aggregate/Collection/DAO/StatsDAO.php
+++ b/app/bundles/StatsBundle/Aggregate/Collection/DAO/StatsDAO.php
@@ -21,9 +21,7 @@ final class StatsDAO
      */
     public function getYear($year)
     {
-        if (!isset($this->years[$year])) {
-            $this->years[$year] = new YearStat($year);
-        }
+        $this->years[$year] ??= new YearStat($year);
 
         return $this->years[$year];
     }

--- a/app/bundles/StatsBundle/Aggregate/Collection/StatCollection.php
+++ b/app/bundles/StatsBundle/Aggregate/Collection/StatCollection.php
@@ -85,9 +85,7 @@ final class StatCollection
 
     public function getCalculator(\DateTime $fromDateTime, \DateTime $toDateTime): Calculator
     {
-        if (null === $this->calculator) {
-            $this->calculator = new Calculator($this->stats, $fromDateTime, $toDateTime);
-        }
+        $this->calculator ??= new Calculator($this->stats, $fromDateTime, $toDateTime);
 
         return $this->calculator;
     }

--- a/app/bundles/StatsBundle/Aggregate/Collection/Stats/DayStat.php
+++ b/app/bundles/StatsBundle/Aggregate/Collection/Stats/DayStat.php
@@ -28,9 +28,7 @@ final class DayStat implements StatInterface
     {
         $key = new \DateTime("{$this->day} {$hour}:00:00")->format('Y-m-d H');
 
-        if (!isset($this->stats[$key])) {
-            $this->stats[$key] = new HourStat($key);
-        }
+        $this->stats[$key] ??= new HourStat($key);
 
         return $this->stats[$key];
     }

--- a/app/bundles/StatsBundle/Aggregate/Collection/Stats/MonthStat.php
+++ b/app/bundles/StatsBundle/Aggregate/Collection/Stats/MonthStat.php
@@ -28,9 +28,7 @@ final class MonthStat implements StatInterface
     {
         $key = new \DateTime("{$this->month}-{$day} 00:00:00")->format('Y-m-d');
 
-        if (!isset($this->stats[$key])) {
-            $this->stats[$key] = new DayStat($key);
-        }
+        $this->stats[$key] ??= new DayStat($key);
 
         return $this->stats[$key];
     }

--- a/app/bundles/StatsBundle/Aggregate/Collection/Stats/YearStat.php
+++ b/app/bundles/StatsBundle/Aggregate/Collection/Stats/YearStat.php
@@ -30,9 +30,7 @@ final class YearStat implements StatInterface
     {
         $key = new \DateTime("{$this->year}-{$month}-01 00:00:00")->format('Y-m');
 
-        if (!isset($this->stats[$key])) {
-            $this->stats[$key] = new MonthStat($key);
-        }
+        $this->stats[$key] ??= new MonthStat($key);
 
         return $this->stats[$key];
     }

--- a/app/bundles/StatsBundle/Aggregate/Collector.php
+++ b/app/bundles/StatsBundle/Aggregate/Collector.php
@@ -20,9 +20,7 @@ final readonly class Collector
      */
     public function fetchStats($statName, \DateTime $fromDateTime, \DateTime $toDateTime, ?FetchOptions $fetchOptions = null): StatCollection
     {
-        if (null === $fetchOptions) {
-            $fetchOptions = new FetchOptions();
-        }
+        $fetchOptions ??= new FetchOptions();
 
         $event = new AggregateStatRequestEvent($statName, $fromDateTime, $toDateTime, $fetchOptions);
 

--- a/app/bundles/UserBundle/Entity/RoleRepository.php
+++ b/app/bundles/UserBundle/Entity/RoleRepository.php
@@ -161,9 +161,7 @@ class RoleRepository extends CommonRepository
 
         // Ensure lists without leads have a value
         foreach ($roleIds as $r) {
-            if (!isset($return[$r])) {
-                $return[$r] = 0;
-            }
+            $return[$r] ??= 0;
         }
 
         return ($returnArray) ? $return : $return[$roleIds[0]];

--- a/app/bundles/UserBundle/EventListener/ApiUserSubscriber.php
+++ b/app/bundles/UserBundle/EventListener/ApiUserSubscriber.php
@@ -57,9 +57,7 @@ final readonly class ApiUserSubscriber implements EventSubscriberInterface
             }
 
             $accessToken = $accessTokenBadge->getAccessToken();
-            if (null === $user) {
-                $user = $this->tokenPermissions->setActivePermissionsOnAuthToken($accessToken);
-            }
+            $user ??= $this->tokenPermissions->setActivePermissionsOnAuthToken($accessToken);
 
             if (null === $user) {
                 return null;

--- a/app/bundles/UserBundle/Security/Authentication/Token/Permissions/TokenPermissions.php
+++ b/app/bundles/UserBundle/Security/Authentication/Token/Permissions/TokenPermissions.php
@@ -29,9 +29,7 @@ class TokenPermissions
      */
     public function setActivePermissionsOnAuthToken(TokenInterface|OAuthTokenInterface|null $token = null): ?UserInterface
     {
-        if (null === $token) {
-            $token = $this->tokenStorage->getToken();
-        }
+        $token ??= $this->tokenStorage->getToken();
 
         if (null === $token) {
             return null;

--- a/app/bundles/UserBundle/Tests/Model/RoleModelTest.php
+++ b/app/bundles/UserBundle/Tests/Model/RoleModelTest.php
@@ -70,9 +70,7 @@ final class RoleModelTest extends TestCase
 
     private function createRoleModel(CorePermissions $security, ?Translator $translator = null): RoleModel
     {
-        if (null === $translator) {
-            $translator = $this->createMock(Translator::class);
-        }
+        $translator ??= $this->createMock(Translator::class);
 
         return new RoleModel(
             $this->createStub(EntityManagerInterface::class),

--- a/app/bundles/WebhookBundle/Model/WebhookModel.php
+++ b/app/bundles/WebhookBundle/Model/WebhookModel.php
@@ -507,9 +507,7 @@ class WebhookModel extends FormModel
             $type  = $event->getEventType();
 
             // create new array level for each unique event type
-            if (!isset($payload[$type])) {
-                $payload[$type] = [];
-            }
+            $payload[$type] ??= [];
 
             $queuePayload              = json_decode($queueItem->getPayload(), true);
             $queuePayload['timestamp'] = $queueItem->getDateAdded()->format('c');

--- a/app/middlewares/ConfigAwareTrait.php
+++ b/app/middlewares/ConfigAwareTrait.php
@@ -11,10 +11,7 @@ trait ConfigAwareTrait
      */
     protected $config = [];
 
-    /**
-     * @return array
-     */
-    public function getConfig()
+    public function getConfig(): array
     {
         // Include paths
         $root          = realpath(__DIR__.'/..');

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     "phpstan/phpstan-symfony": "^2.0.20",
     "phpunit/phpunit": "^13.0",
     "rector/type-perfect": "^2.1.4",
-    "rector/rector": "dev-main",
+    "rector/rector": "^2.6.4",
     "symfony/browser-kit": "~7.4.0",
     "symfony/dom-crawler": "~7.4.0",
     "symfony/maker-bundle": "^1.64",

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     "phpstan/phpstan-symfony": "^2.0.20",
     "phpunit/phpunit": "^13.0",
     "rector/type-perfect": "^2.1.4",
-    "rector/rector": "^2.6.4",
+    "rector/rector": "dev-main",
     "symfony/browser-kit": "~7.4.0",
     "symfony/dom-crawler": "~7.4.0",
     "symfony/maker-bundle": "^1.64",

--- a/composer.lock
+++ b/composer.lock
@@ -17868,21 +17868,7 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-<<<<<<< HEAD
                 "reference": "b00041d490deb1ed46f3d370249714ce2cc6d4bc"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/b00041d490deb1ed46f3d370249714ce2cc6d4bc",
-                "reference": "b00041d490deb1ed46f3d370249714ce2cc6d4bc",
-=======
-                "reference": "6ff008471683591224951526247b7a2b86980ba9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/6ff008471683591224951526247b7a2b86980ba9",
-                "reference": "6ff008471683591224951526247b7a2b86980ba9",
->>>>>>> 81e71afc61 (null array)
                 "shasum": ""
             },
             "require": {
@@ -17898,10 +17884,7 @@
             "suggest": {
                 "ext-dom": "To manipulate phpunit.xml via the custom-rule command"
             },
-<<<<<<< HEAD
             "default-branch": true,
-=======
->>>>>>> 81e71afc61 (null array)
             "bin": [
                 "bin/rector"
             ],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7894d4d8ebbbc73913f8bcce85e9cfb6",
+    "content-hash": "0ec718c0df375467259855230e4b618c",
     "packages": [
         {
             "name": "api-platform/core",
@@ -17864,16 +17864,25 @@
         },
         {
             "name": "rector/rector",
-            "version": "dev-main",
+            "version": "2.6.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
+<<<<<<< HEAD
                 "reference": "b00041d490deb1ed46f3d370249714ce2cc6d4bc"
             },
             "dist": {
                 "type": "zip",
                 "url": "https://api.github.com/repos/rectorphp/rector/zipball/b00041d490deb1ed46f3d370249714ce2cc6d4bc",
                 "reference": "b00041d490deb1ed46f3d370249714ce2cc6d4bc",
+=======
+                "reference": "6ff008471683591224951526247b7a2b86980ba9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/6ff008471683591224951526247b7a2b86980ba9",
+                "reference": "6ff008471683591224951526247b7a2b86980ba9",
+>>>>>>> 81e71afc61 (null array)
                 "shasum": ""
             },
             "require": {
@@ -17889,7 +17898,10 @@
             "suggest": {
                 "ext-dom": "To manipulate phpunit.xml via the custom-rule command"
             },
+<<<<<<< HEAD
             "default-branch": true,
+=======
+>>>>>>> 81e71afc61 (null array)
             "bin": [
                 "bin/rector"
             ],
@@ -17913,7 +17925,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/main"
+                "source": "https://github.com/rectorphp/rector/tree/2.6.4"
             },
             "funding": [
                 {
@@ -17921,7 +17933,11 @@
                     "type": "github"
                 }
             ],
+<<<<<<< HEAD
             "time": "2026-08-11T09:33:44+00:00"
+=======
+            "time": "2026-08-27T09:20:34+00:00"
+>>>>>>> 81e71afc61 (null array)
         },
         {
             "name": "rector/type-perfect",
@@ -19780,9 +19796,7 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {
-        "rector/rector": 20
-    },
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {},

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0ec718c0df375467259855230e4b618c",
+    "content-hash": "7894d4d8ebbbc73913f8bcce85e9cfb6",
     "packages": [
         {
             "name": "api-platform/core",
@@ -17864,11 +17864,16 @@
         },
         {
             "name": "rector/rector",
-            "version": "2.6.4",
+            "version": "dev-main",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
                 "reference": "b00041d490deb1ed46f3d370249714ce2cc6d4bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/b00041d490deb1ed46f3d370249714ce2cc6d4bc",
+                "reference": "b00041d490deb1ed46f3d370249714ce2cc6d4bc",
                 "shasum": ""
             },
             "require": {
@@ -17908,7 +17913,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.6.4"
+                "source": "https://github.com/rectorphp/rector/tree/main"
             },
             "funding": [
                 {
@@ -17916,11 +17921,7 @@
                     "type": "github"
                 }
             ],
-<<<<<<< HEAD
             "time": "2026-08-11T09:33:44+00:00"
-=======
-            "time": "2026-08-27T09:20:34+00:00"
->>>>>>> 81e71afc61 (null array)
         },
         {
             "name": "rector/type-perfect",
@@ -19779,7 +19780,9 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {},
+    "stability-flags": {
+        "rector/rector": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {},

--- a/plugins/GrapesJsBuilderBundle/Model/GrapesJsBuilderModel.php
+++ b/plugins/GrapesJsBuilderBundle/Model/GrapesJsBuilderModel.php
@@ -96,9 +96,7 @@ class GrapesJsBuilderModel extends AbstractCommonModel
 
         $emailForm  = $request->request->all('emailform');
         $customHtml = is_array($emailForm) ? ($emailForm['customHtml'] ?? null) : null;
-        if (null === $customHtml) {
-            $customHtml = $request->request->get('customHtml') ?? null;
-        }
+        $customHtml ??= $request->request->get('customHtml') ?? null;
 
         $entity->setCustomHtml($customHtml);
         $this->emailRepository->saveEntity($entity);

--- a/plugins/MauticClearbitBundle/Helper/LookupHelper.php
+++ b/plugins/MauticClearbitBundle/Helper/LookupHelper.php
@@ -174,9 +174,7 @@ final class LookupHelper
         $webhookId = $cacheId.'#'.$user->getId().'#'.$nonce;
 
         $cache = $entity->getSocialCache();
-        if (!isset($cache['clearbit'])) {
-            $cache['clearbit'] = [];
-        }
+        $cache['clearbit'] ??= [];
 
         $cache['clearbit']['nonce'] = $nonce;
 

--- a/plugins/MauticCrmBundle/Api/SalesforceApi.php
+++ b/plugins/MauticCrmBundle/Api/SalesforceApi.php
@@ -419,9 +419,7 @@ final class SalesforceApi extends CrmApi
         // Mautic IntegrationEntity objects
         $this->requestSettings['headers']['Sforce-Query-Options'] = 'batchSize=200';
 
-        if (null === $queryUrl) {
-            $queryUrl = $this->integration->getQueryUrl().'/query';
-        }
+        $queryUrl ??= $this->integration->getQueryUrl().'/query';
 
         $query = "Select CampaignId, ContactId, LeadId, isDeleted from CampaignMember where CampaignId = '".trim($campaignId)."'";
         if ($modifiedSince) {

--- a/plugins/MauticCrmBundle/Api/ZohoApi.php
+++ b/plugins/MauticCrmBundle/Api/ZohoApi.php
@@ -19,9 +19,7 @@ final class ZohoApi extends CrmApi
 
         $url = sprintf('%s/%s', $tokenData['api_domain'].'/crm/v2', $operation);
 
-        if (!isset($settings['headers'])) {
-            $settings['headers'] = [];
-        }
+        $settings['headers'] ??= [];
         $settings['headers']['Authorization'] = 'Zoho-oauthtoken '.$tokenData['access_token'];
 
         if ($json) {
@@ -123,9 +121,7 @@ final class ZohoApi extends CrmApi
      */
     public function getCompanies(array $params, $id = null)
     {
-        if (!isset($params['selectColumns'])) {
-            $params['selectColumns'] = 'All';
-        }
+        $params['selectColumns'] ??= 'All';
 
         $settings = [];
         if ($params['lastModifiedTime']) {

--- a/plugins/MauticCrmBundle/Integration/ConnectwiseIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/ConnectwiseIntegration.php
@@ -763,9 +763,7 @@ class ConnectwiseIntegration extends CrmAbstractIntegration
      */
     protected function cleanPriorityFields(array $fieldsToUpdate, $objects = null)
     {
-        if (null === $objects) {
-            $objects = ['Leads', 'Contacts'];
-        }
+        $objects ??= ['Leads', 'Contacts'];
         if (isset($fieldsToUpdate['leadFields']) && is_array($objects)) {
             // Pass in the whole config
             $fields = $fieldsToUpdate['leadFields'];

--- a/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
@@ -413,9 +413,7 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
         if (!empty($socialCache)) {
             // Update the social cache
             $leadSocialCache = $lead->getSocialCache();
-            if (!isset($leadSocialCache[$this->getName()])) {
-                $leadSocialCache[$this->getName()] = [];
-            }
+            $leadSocialCache[$this->getName()] ??= [];
             $leadSocialCache[$this->getName()] = array_merge($leadSocialCache[$this->getName()], $socialCache);
 
             // Check for activity while here

--- a/plugins/MauticCrmBundle/Integration/HubspotIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/HubspotIntegration.php
@@ -206,9 +206,7 @@ class HubspotIntegration extends CrmAbstractIntegration
      */
     protected function cleanPriorityFields(array $fieldsToUpdate, $objects = null)
     {
-        if (null === $objects) {
-            $objects = ['Leads', 'Contacts'];
-        }
+        $objects ??= ['Leads', 'Contacts'];
 
         if (isset($fieldsToUpdate['leadFields'])) {
             // Pass in the whole config

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -635,9 +635,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
     public function prepareFieldsForSync($fields, $keys, $object = null)
     {
         $leadFields = [];
-        if (null === $object) {
-            $object = 'Lead';
-        }
+        $object ??= 'Lead';
 
         $objects = (!is_array($object)) ? [$object] : $object;
         if (is_string($object) && 'Account' === $object) {
@@ -650,9 +648,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
         }
 
         foreach ($objects as $obj) {
-            if (!isset($leadFields[$obj])) {
-                $leadFields[$obj] = [];
-            }
+            $leadFields[$obj] ??= [];
 
             foreach ($keys as $key) {
                 if (strpos($key, '__'.$obj)) {
@@ -2338,9 +2334,7 @@ class SalesforceIntegration extends CrmAbstractIntegration
      */
     protected function cleanPriorityFields(array $fieldsToUpdate, $objects = null)
     {
-        if (null === $objects) {
-            $objects = ['Lead', 'Contact'];
-        }
+        $objects ??= ['Lead', 'Contact'];
 
         if (isset($fieldsToUpdate['leadFields'])) {
             // Pass in the whole config

--- a/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
@@ -376,10 +376,7 @@ final class SugarcrmIntegration extends CrmAbstractIntegration
 
         $sugarObject           = 'Accounts';
         $params['max_results'] = 100;
-        if (!isset($params['offset'])) {
-            // First call
-            $params['offset'] = 0;
-        }
+        $params['offset'] ??= 0;
 
         $query = $params;
 
@@ -515,10 +512,7 @@ final class SugarcrmIntegration extends CrmAbstractIntegration
     {
         $params['max_results'] = 100;
 
-        if (!isset($params['offset'])) {
-            // First call
-            $params['offset'] = 0;
-        }
+        $params['offset'] ??= 0;
         $query = $params;
 
         try {
@@ -1564,9 +1558,7 @@ final class SugarcrmIntegration extends CrmAbstractIntegration
      */
     protected function cleanPriorityFields(array $fieldsToUpdate, $objects = null)
     {
-        if (null === $objects) {
-            $objects = ['Leads', 'Contacts'];
-        }
+        $objects ??= ['Leads', 'Contacts'];
 
         if (isset($fieldsToUpdate['leadFields'])) {
             // Pass in the whole config
@@ -1588,9 +1580,7 @@ final class SugarcrmIntegration extends CrmAbstractIntegration
     public function prepareFieldsForSync($fields, $keys, $object = null)
     {
         $leadFields = [];
-        if (null === $object) {
-            $object = 'Lead';
-        }
+        $object ??= 'Lead';
 
         $objects = (!is_array($object)) ? [$object] : $object;
         if (is_string($object) && 'Accounts' === $object) {
@@ -1603,9 +1593,7 @@ final class SugarcrmIntegration extends CrmAbstractIntegration
         }
 
         foreach ($objects as $obj) {
-            if (!isset($leadFields[$obj])) {
-                $leadFields[$obj] = [];
-            }
+            $leadFields[$obj] ??= [];
 
             foreach ($keys as $key) {
                 if (strpos($key, '__'.$obj)) {

--- a/plugins/MauticCrmBundle/Integration/VtigerIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/VtigerIntegration.php
@@ -160,9 +160,7 @@ class VtigerIntegration extends CrmAbstractIntegration
                         }
 
                         // Create the array if it doesn't exist to prevent PHP notices
-                        if (!isset($vTigerFields[$object])) {
-                            $vTigerFields[$object] = [];
-                        }
+                        $vTigerFields[$object] ??= [];
 
                         $leadFields = $this->getApiHelper()->getLeadFields($object);
                         if (isset($leadFields['fields'])) {

--- a/plugins/MauticCrmBundle/Integration/ZohoIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/ZohoIntegration.php
@@ -1203,9 +1203,7 @@ final class ZohoIntegration extends CrmAbstractIntegration
      */
     protected function cleanPriorityFields(array $fieldsToUpdate, $objects = null)
     {
-        if (null === $objects) {
-            $objects = ['Leads', 'Contacts'];
-        }
+        $objects ??= ['Leads', 'Contacts'];
 
         if (isset($fieldsToUpdate['leadFields'])) {
             // Pass in the whole config
@@ -1227,9 +1225,7 @@ final class ZohoIntegration extends CrmAbstractIntegration
     public function prepareFieldsForSync($fields, $keys, $object = null)
     {
         $leadFields = [];
-        if (null === $object) {
-            $object = 'Leads';
-        }
+        $object ??= 'Leads';
 
         $objects = (!is_array($object)) ? [$object] : $object;
         if (is_string($object) && 'Accounts' === $object) {
@@ -1242,9 +1238,7 @@ final class ZohoIntegration extends CrmAbstractIntegration
         }
 
         foreach ($objects as $obj) {
-            if (!isset($leadFields[$obj])) {
-                $leadFields[$obj] = [];
-            }
+            $leadFields[$obj] ??= [];
 
             foreach ($keys as $key) {
                 $leadFields[$obj][$key] = $fields[$key];

--- a/plugins/MauticFullContactBundle/Helper/LookupHelper.php
+++ b/plugins/MauticFullContactBundle/Helper/LookupHelper.php
@@ -189,9 +189,7 @@ final class LookupHelper
         $webhookId = $cacheId.'#'.$user->getId().'#'.$nonce;
 
         $cache = $entity->getSocialCache();
-        if (!isset($cache['fullcontact'])) {
-            $cache['fullcontact'] = [];
-        }
+        $cache['fullcontact'] ??= [];
 
         $cache['fullcontact']['nonce'] = $nonce;
 

--- a/plugins/MauticTagManagerBundle/Entity/TagRepository.php
+++ b/plugins/MauticTagManagerBundle/Entity/TagRepository.php
@@ -74,9 +74,7 @@ final class TagRepository extends BaseTagRepository
 
         // Ensure lists without leads have a value
         foreach ($tagIds as $l) {
-            if (!isset($return[$l])) {
-                $return[$l] = 0;
-            }
+            $return[$l] ??= 0;
         }
 
         return ($returnArray) ? $return : $return[$tagIds[0]];

--- a/rector.php
+++ b/rector.php
@@ -26,8 +26,11 @@ return RectorConfig::configure()
     ->withRules([
         Utils\Rector\AssertTrueResponseIsOkToAssertResponseIsSuccessfulRector::class,
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
         Rector\Php74\Rector\If_\IfToNullCoalescingAssignRector::class,
+=======
+>>>>>>> 83ebeeaf52 (cleanup)
 
 >>>>>>> 81788f95a6 ([php 7.4] coal assign)
         Rector\PHPUnit\CodeQuality\Rector\ClassMethod\AssertClassToThisAssertRector::class,

--- a/rector.php
+++ b/rector.php
@@ -25,14 +25,6 @@ return RectorConfig::configure()
     ->withCache(__DIR__.'/var/cache/rector')
     ->withRules([
         Utils\Rector\AssertTrueResponseIsOkToAssertResponseIsSuccessfulRector::class,
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-        Rector\Php74\Rector\If_\IfToNullCoalescingAssignRector::class,
-=======
->>>>>>> 83ebeeaf52 (cleanup)
-
->>>>>>> 81788f95a6 ([php 7.4] coal assign)
         Rector\PHPUnit\CodeQuality\Rector\ClassMethod\AssertClassToThisAssertRector::class,
         Rector\TypeDeclarationDocblocks\Rector\Property\MergePhpstanDocTagIntoNativeRector::class,
 

--- a/rector.php
+++ b/rector.php
@@ -25,6 +25,11 @@ return RectorConfig::configure()
     ->withCache(__DIR__.'/var/cache/rector')
     ->withRules([
         Utils\Rector\AssertTrueResponseIsOkToAssertResponseIsSuccessfulRector::class,
+<<<<<<< HEAD
+=======
+        Rector\Php74\Rector\If_\IfToNullCoalescingAssignRector::class,
+
+>>>>>>> 81788f95a6 ([php 7.4] coal assign)
         Rector\PHPUnit\CodeQuality\Rector\ClassMethod\AssertClassToThisAssertRector::class,
         Rector\TypeDeclarationDocblocks\Rector\Property\MergePhpstanDocTagIntoNativeRector::class,
 


### PR DESCRIPTION
Enables `IfToNullCoalescingAssignRector` (PHP 7.4 `??=`), applying it across the codebase.

The rule turns verbose `isset()` guards into the null coalescing assignment operator:

```diff
 foreach ($roleIds as $r) {
-    if (!isset($return[$r])) {
-        $return[$r] = 0;
-    }
+    $return[$r] ??= 0;
 }
```
