### PR TITLE
[symfony] Dispatch NotificationBundle events by class name (Symfony 4.3 style)

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -356,6 +356,7 @@
     | `PageEvents::REDIRECT_DO_NOT_TRACK` | `UntrackableUrlsEvent` |
     | `PageEvents::ON_REDIRECT_GENERATE` | `RedirectGenerationEvent` |
     | `PageEvents::ON_CONTACT_TRACKED` | `TrackingEvent` |
+- The `Mautic\NotificationBundle\Event\NotificationSendEvent` (`NotificationEvents::NOTIFICATION_ON_SEND`) is now dispatched by the event object alone, so the event name is the event class (Symfony 4.3+) instead of the `mautic.notification_on_send` string constant. Update any listener that keys on `NotificationEvents::NOTIFICATION_ON_SEND` to key on `NotificationSendEvent::class` instead. The constant is kept for backwards compatibility but is no longer used internally. The `NotificationEvent` CRUD events (`NOTIFICATION_PRE_SAVE` / `POST_SAVE` / `PRE_DELETE` / `POST_DELETE`) share one event object and are still dispatched under their string names.
 
 - `Mautic\CoreBundle\Factory\ModelFactory` now builds its service locator from a `defaultIndexMethod` on the `mautic.model` tag, replacing the removed `Mautic\CoreBundle\DependencyInjection\Compiler\ModelPass`. Every model (a service implementing `Mautic\CoreBundle\Model\MauticModelInterface`) declares its `ModelFactory::getModel()` lookup key via a static `getName()` method:
 

--- a/app/bundles/NotificationBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/NotificationBundle/EventListener/CampaignSubscriber.php
@@ -232,8 +232,7 @@ class CampaignSubscriber implements EventSubscriberInterface
 
         /** @var NotificationSendEvent $sendEvent */
         $sendEvent = $this->dispatcher->dispatch(
-            new NotificationSendEvent($tokenEvent->getContent(), $notification->getHeading(), $lead),
-            NotificationEvents::NOTIFICATION_ON_SEND
+            new NotificationSendEvent($tokenEvent->getContent(), $notification->getHeading(), $lead)
         );
 
         if ($url = $notification->getUrl()) {


### PR DESCRIPTION
Following the same pattern as the CampaignBundle, CoreBundle and PluginBundle PRs, this dispatches NotificationBundle events by the event object alone (Symfony 4.3+ style), so the event name is the event class instead of a `NotificationEvents::*` string constant.

## Converted

- `Mautic\NotificationBundle\Event\NotificationSendEvent` - dispatched via `NotificationEvents::NOTIFICATION_ON_SEND` in `CampaignSubscriber`. The redundant second `dispatch()` argument is dropped; the event name is now `NotificationSendEvent::class`.

## Kept as strings (not convertible)

- `NotificationEvent` CRUD group - `NOTIFICATION_PRE_SAVE` / `POST_SAVE` / `PRE_DELETE` / `POST_DELETE` share one event object dispatched under four names via `NotificationModel::dispatchEvent()`, so they cannot be keyed by class.
- `TOKEN_REPLACEMENT` (`Mautic\CoreBundle\Event\TokenReplacementEvent`) and the campaign `ON_CAMPAIGN_BATCH_ACTION` (`PendingEvent`) / `ON_CAMPAIGN_TRIGGER_CONDITION` (`CampaignExecutionEvent`) are shared, cross-bundle events - left unchanged.
- `NOTIFICATION_ON_FORM_ACTION_SEND` (`SendingNotificationEvent`) is not dispatched anywhere in the codebase, so there is nothing to convert.

The `Mautic\NotificationBundle\NotificationEvents` constants are kept for backwards compatibility. An `UPGRADE-8.0.md` note is included.