### PR TITLE
[symfony] Dispatch DashboardBundle events by class name (Symfony 4.3 style)

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -356,6 +356,26 @@
     | `PageEvents::REDIRECT_DO_NOT_TRACK` | `UntrackableUrlsEvent` |
     | `PageEvents::ON_REDIRECT_GENERATE` | `RedirectGenerationEvent` |
     | `PageEvents::ON_CONTACT_TRACKED` | `TrackingEvent` |
+- DashboardBundle events are now dispatched by the event object alone, so the event name is the event class (Symfony 4.3+) instead of the `Mautic\DashboardBundle\DashboardEvents` string constants. Update any subscriber or listener that keys on one of the converted `DashboardEvents::*` constants to key on the event class instead:
+
+    ```diff
+     public static function getSubscribedEvents(): array
+     {
+         return [
+    -        DashboardEvents::DASHBOARD_ON_MODULE_LIST_GENERATE => ['onWidgetListGenerate', 0],
+    +        WidgetTypeListEvent::class => ['onWidgetListGenerate', 0],
+         ];
+     }
+    ```
+
+    Dispatching drops the redundant second argument, e.g. `$dispatcher->dispatch($event, DashboardEvents::DASHBOARD_ON_MODULE_LIST_GENERATE)` becomes `$dispatcher->dispatch($event)`. The `Mautic\DashboardBundle\DashboardEvents` constants are kept for backwards compatibility but are no longer used internally for the events below. The `DASHBOARD_ON_MODULE_DETAIL_GENERATE` / `DASHBOARD_ON_MODULE_DETAIL_PRE_LOAD` pair share the `WidgetDetailEvent` class and are unchanged.
+
+    Full mapping of the converted constants to their event class (all in the `Mautic\DashboardBundle\Event` namespace):
+
+    | `DashboardEvents` constant | New event class |
+    | --- | --- |
+    | `DashboardEvents::DASHBOARD_ON_MODULE_LIST_GENERATE` | `WidgetTypeListEvent` |
+    | `DashboardEvents::DASHBOARD_ON_MODULE_FORM_GENERATE` | `WidgetFormEvent` |
 
 - `Mautic\CoreBundle\Factory\ModelFactory` now builds its service locator from a `defaultIndexMethod` on the `mautic.model` tag, replacing the removed `Mautic\CoreBundle\DependencyInjection\Compiler\ModelPass`. Every model (a service implementing `Mautic\CoreBundle\Model\MauticModelInterface`) declares its `ModelFactory::getModel()` lookup key via a static `getName()` method:
 

--- a/app/bundles/DashboardBundle/Controller/Api/WidgetApiController.php
+++ b/app/bundles/DashboardBundle/Controller/Api/WidgetApiController.php
@@ -12,7 +12,6 @@ use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\CoreBundle\Translation\Translator;
-use Mautic\DashboardBundle\DashboardEvents;
 use Mautic\DashboardBundle\Entity\Widget;
 use Mautic\DashboardBundle\Event\WidgetTypeListEvent;
 use Mautic\DashboardBundle\Model\DashboardModel;
@@ -63,7 +62,7 @@ final class WidgetApiController extends CommonApiController
     {
         $event = new WidgetTypeListEvent();
         $event->setTranslator($this->translator);
-        $this->dispatcher->dispatch($event, DashboardEvents::DASHBOARD_ON_MODULE_LIST_GENERATE);
+        $this->dispatcher->dispatch($event);
         $view = $this->view(['success' => 1, 'types' => $event->getTypes()], Response::HTTP_OK);
 
         return $this->handleView($view);

--- a/app/bundles/DashboardBundle/EventListener/DashboardSubscriber.php
+++ b/app/bundles/DashboardBundle/EventListener/DashboardSubscriber.php
@@ -34,8 +34,8 @@ class DashboardSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            DashboardEvents::DASHBOARD_ON_MODULE_LIST_GENERATE   => ['onWidgetListGenerate', 0],
-            DashboardEvents::DASHBOARD_ON_MODULE_FORM_GENERATE   => ['onWidgetFormGenerate', 0],
+            WidgetTypeListEvent::class                           => ['onWidgetListGenerate', 0],
+            WidgetFormEvent::class                               => ['onWidgetFormGenerate', 0],
             DashboardEvents::DASHBOARD_ON_MODULE_DETAIL_PRE_LOAD => ['onWidgetDetailPreLoad', 0],
             DashboardEvents::DASHBOARD_ON_MODULE_DETAIL_GENERATE => ['onWidgetDetailGenerate', 0],
         ];

--- a/app/bundles/DashboardBundle/Form/Type/WidgetType.php
+++ b/app/bundles/DashboardBundle/Form/Type/WidgetType.php
@@ -4,7 +4,6 @@ namespace Mautic\DashboardBundle\Form\Type;
 
 use Mautic\CoreBundle\Form\Type\FormButtonsType;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
-use Mautic\DashboardBundle\DashboardEvents;
 use Mautic\DashboardBundle\Event\WidgetFormEvent;
 use Mautic\DashboardBundle\Event\WidgetTypeListEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -42,7 +41,7 @@ final class WidgetType extends AbstractType
 
         $event = new WidgetTypeListEvent();
         $event->setSecurity($this->security);
-        $this->dispatcher->dispatch($event, DashboardEvents::DASHBOARD_ON_MODULE_LIST_GENERATE);
+        $this->dispatcher->dispatch($event);
 
         $types = array_map(array_flip(...), $event->getTypes());
 
@@ -120,7 +119,7 @@ final class WidgetType extends AbstractType
             }
 
             $event->setType($type);
-            $this->dispatcher->dispatch($event, DashboardEvents::DASHBOARD_ON_MODULE_FORM_GENERATE);
+            $this->dispatcher->dispatch($event);
             $widgetForm = $event->getForm();
             $form->setData($params);
 


### PR DESCRIPTION
This converts the DashboardBundle events that are named by a unique event class to Symfony 4.3-style dispatch, where the event object alone identifies the event (its class name is the event name), following the same pattern as the PluginBundle PR #17162.

### Converted

| `DashboardEvents` constant | Event class |
| --- | --- |
| `DASHBOARD_ON_MODULE_LIST_GENERATE` | `WidgetTypeListEvent` |
| `DASHBOARD_ON_MODULE_FORM_GENERATE` | `WidgetFormEvent` |

For these, `dispatch($event, DashboardEvents::X)` becomes `dispatch($event)` and subscriber keys use `XEvent::class`.

### Kept as string constants

`DASHBOARD_ON_MODULE_DETAIL_GENERATE` and `DASHBOARD_ON_MODULE_DETAIL_PRE_LOAD` both dispatch the same `WidgetDetailEvent` class under two distinct names, so they cannot be distinguished by class name and are left unchanged.

### Backwards compatibility

The `Mautic\DashboardBundle\DashboardEvents` constants are kept, they are just no longer used internally for the converted events. `UPGRADE-8.0.md` documents the mapping.