### PR TITLE
[symfony] Dispatch StageBundle events by class name (Symfony 4.3 style)

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -356,6 +356,7 @@
     | `PageEvents::REDIRECT_DO_NOT_TRACK` | `UntrackableUrlsEvent` |
     | `PageEvents::ON_REDIRECT_GENERATE` | `RedirectGenerationEvent` |
     | `PageEvents::ON_CONTACT_TRACKED` | `TrackingEvent` |
+- StageBundle now dispatches its stage-builder event by the event object alone, so the event name is the event class (Symfony 4.3+) instead of the `Mautic\StageBundle\StageEvents::STAGE_ON_BUILD` string constant. Update any subscriber or listener that keys on `StageEvents::STAGE_ON_BUILD` (or the raw string `mautic.stage_on_build`) to key on `Mautic\StageBundle\Event\StageBuilderEvent::class` instead, and drop the redundant second argument when dispatching, e.g. `$dispatcher->dispatch($event, StageEvents::STAGE_ON_BUILD)` becomes `$dispatcher->dispatch($event)`. The `StageEvents` constants are kept for backwards compatibility. The `STAGE_PRE_SAVE` / `STAGE_POST_SAVE` / `STAGE_PRE_DELETE` / `STAGE_POST_DELETE` group (all sharing the `StageEvent` class) and `ON_CAMPAIGN_BATCH_ACTION` (a `PendingEvent`) are unchanged.
 
 - `Mautic\CoreBundle\Factory\ModelFactory` now builds its service locator from a `defaultIndexMethod` on the `mautic.model` tag, replacing the removed `Mautic\CoreBundle\DependencyInjection\Compiler\ModelPass`. Every model (a service implementing `Mautic\CoreBundle\Model\MauticModelInterface`) declares its `ModelFactory::getModel()` lookup key via a static `getName()` method:
 

--- a/app/bundles/StageBundle/Model/StageModel.php
+++ b/app/bundles/StageBundle/Model/StageModel.php
@@ -127,7 +127,7 @@ class StageModel extends CommonFormModel implements GlobalSearchInterface
     }
 
     /**
-     * Gets array of custom actions from bundles subscribed StageEvents::STAGE_ON_BUILD.
+     * Gets array of custom actions from bundles subscribed to StageBuilderEvent.
      *
      * @return mixed
      */
@@ -139,7 +139,7 @@ class StageModel extends CommonFormModel implements GlobalSearchInterface
             // build them
             $actions = [];
             $event   = new StageBuilderEvent($this->translator);
-            $this->dispatcher->dispatch($event, StageEvents::STAGE_ON_BUILD);
+            $this->dispatcher->dispatch($event);
             $actions['actions'] = $event->getActions();
             $actions['list']    = $event->getActionList();
             $actions['choices'] = $event->getActionChoices();


### PR DESCRIPTION
This follows the same Symfony 4.3+ style as the PluginBundle (#17162) and CampaignBundle conversions: events are dispatched by the event object alone, so the event name is the event class instead of a `StageEvents` string constant.

## Converted

- `STAGE_ON_BUILD` -> `Mautic\StageBundle\Event\StageBuilderEvent`

It is dispatched under a single name with a single event class in `StageModel::getStageActions()`, so the call now passes just the event object:

```diff
-$this->dispatcher->dispatch($event, StageEvents::STAGE_ON_BUILD);
+$this->dispatcher->dispatch($event);
```

Symfony resolves the event name from the `StageBuilderEvent` class.

## Kept as strings

- **`STAGE_PRE_SAVE` / `STAGE_POST_SAVE` / `STAGE_PRE_DELETE` / `STAGE_POST_DELETE`** - these four constants share one `StageEvent` class dispatched under four different names via the `StageModel::dispatchEvent()` override, so they cannot be keyed by class.
- **`ON_CAMPAIGN_BATCH_ACTION`** - dispatches a generic `Mautic\CampaignBundle\Event\PendingEvent` and is consumed as a `batchEventName` config value by the campaign engine.
- **`STAGE_ON_ACTION`** - has no dispatch site and no matching event class.

The `StageEvents` constants are kept for backwards compatibility. `UPGRADE-8.0.md` documents the change.