### PR TITLE
[symfony] Dispatch DynamicContentBundle events by class name (Symfony 4.3 style)

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -280,6 +280,8 @@
     | `PluginEvents::ON_PLUGIN_INSTALL` | `PluginInstallEvent` |
     | `PluginEvents::PLUGIN_IS_PUBLISHED_STATE_CHANGING` | `PluginIsPublishedEvent` |
 
+- DynamicContentBundle's `ON_CONTACTS_FILTER_EVALUATE` event is now dispatched by the event object alone, so the event name is the event class (Symfony 4.3+) instead of the `Mautic\DynamicContentBundle\DynamicContentEvents::ON_CONTACTS_FILTER_EVALUATE` string constant. Update any subscriber or listener that keys on that constant to key on `Mautic\DynamicContentBundle\Event\ContactFiltersEvaluateEvent::class` instead, e.g. `$dispatcher->dispatch($event, DynamicContentEvents::ON_CONTACTS_FILTER_EVALUATE)` becomes `$dispatcher->dispatch($event)`. The constant is kept for backwards compatibility but is no longer used internally. The `DynamicContentEvent` CRUD group (`PRE_SAVE` / `POST_SAVE` / `PRE_DELETE` / `POST_DELETE`) shares one event class under four names and is unchanged, as are the cross-bundle `CategoryEvent`, `TokenReplacementEvent` and campaign event constants.
+
 - `Mautic\CoreBundle\Factory\ModelFactory` now builds its service locator from a `defaultIndexMethod` on the `mautic.model` tag, replacing the removed `Mautic\CoreBundle\DependencyInjection\Compiler\ModelPass`. Every model (a service implementing `Mautic\CoreBundle\Model\MauticModelInterface`) declares its `ModelFactory::getModel()` lookup key via a static `getName()` method:
 
     ```php

--- a/app/bundles/DynamicContentBundle/Helper/DynamicContentHelper.php
+++ b/app/bundles/DynamicContentBundle/Helper/DynamicContentHelper.php
@@ -238,12 +238,12 @@ class DynamicContentHelper
         }
 
         //  We attempt even listeners first
-        if ($this->dispatcher->hasListeners(DynamicContentEvents::ON_CONTACTS_FILTER_EVALUATE)) {
+        if ($this->dispatcher->hasListeners(ContactFiltersEvaluateEvent::class)) {
             /** @var Lead $contact */
             $contact = $this->leadModel->getEntity($contactArray['id']);
 
             $event = new ContactFiltersEvaluateEvent($filters, $contact);
-            $this->dispatcher->dispatch($event, DynamicContentEvents::ON_CONTACTS_FILTER_EVALUATE);
+            $this->dispatcher->dispatch($event);
             if ($event->isMatch()) {
                 return true;
             }

--- a/app/bundles/DynamicContentBundle/Tests/Unit/Helper/DynamicContentHelperTest.php
+++ b/app/bundles/DynamicContentBundle/Tests/Unit/Helper/DynamicContentHelperTest.php
@@ -136,7 +136,6 @@ final class DynamicContentHelperTest extends \PHPUnit\Framework\TestCase
                         $event->setIsMatched(true); // Match found in a subscriber.
                     };
                     $callback($parameters[0]);
-                    $this->assertSame(DynamicContentEvents::ON_CONTACTS_FILTER_EVALUATE, $parameters[1]);
                 }
                 if (2 === $matcher->numberOfInvocations()) {
                     $callback = function (TokenReplacementEvent $event) use ($contact, $slot): void {
@@ -190,7 +189,6 @@ final class DynamicContentHelperTest extends \PHPUnit\Framework\TestCase
                             // Match not found in any subscriber.
                         };
                         $callback($parameters[0]);
-                        $this->assertSame(DynamicContentEvents::ON_CONTACTS_FILTER_EVALUATE, $parameters[1]);
                     }
 
                     return $parameters[0];

--- a/app/bundles/LeadBundle/EventListener/DynamicContentSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/DynamicContentSubscriber.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\LeadBundle\EventListener;
 
-use Mautic\DynamicContentBundle\DynamicContentEvents;
 use Mautic\DynamicContentBundle\Event\ContactFiltersEvaluateEvent;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadListRepository;
@@ -21,7 +20,7 @@ final readonly class DynamicContentSubscriber implements EventSubscriberInterfac
     public static function getSubscribedEvents(): array
     {
         return [
-            DynamicContentEvents::ON_CONTACTS_FILTER_EVALUATE => ['onContactFilterEvaluate', 0],
+            ContactFiltersEvaluateEvent::class => ['onContactFilterEvaluate', 0],
         ];
     }
 

--- a/app/bundles/LeadBundle/Tests/EventListener/DynamicContentSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/DynamicContentSubscriberTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\LeadBundle\Tests\EventListener;
 
-use Mautic\DynamicContentBundle\DynamicContentEvents;
 use Mautic\DynamicContentBundle\Event\ContactFiltersEvaluateEvent;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadListRepository;
@@ -34,7 +33,7 @@ final class DynamicContentSubscriberTest extends TestCase
     public function testGetSubscribedEvents(): void
     {
         $this->assertSame([
-            DynamicContentEvents::ON_CONTACTS_FILTER_EVALUATE => ['onContactFilterEvaluate', 0],
+            ContactFiltersEvaluateEvent::class => ['onContactFilterEvaluate', 0],
         ], DynamicContentSubscriber::getSubscribedEvents());
     }
 


### PR DESCRIPTION
Following the CampaignBundle, CoreBundle, IntegrationsBundle and PluginBundle conversions, this dispatches DynamicContentBundle's own event by the event object alone (Symfony 4.3+ style), so the event name is the event class instead of a `DynamicContentEvents` string constant.

## Converted

- `DynamicContentEvents::ON_CONTACTS_FILTER_EVALUATE` -> `Mautic\DynamicContentBundle\Event\ContactFiltersEvaluateEvent::class`

`$dispatcher->dispatch($event, DynamicContentEvents::ON_CONTACTS_FILTER_EVALUATE)` becomes `$dispatcher->dispatch($event)`, and subscribers/`hasListeners` now key on `ContactFiltersEvaluateEvent::class`.

## Left as strings on purpose

- The `DynamicContentEvent` CRUD group (`PRE_SAVE` / `POST_SAVE` / `PRE_DELETE` / `POST_DELETE`) shares one event object dispatched under four names via the `DynamicContentModel::dispatchEvent()` override, so converting to class-name dispatch is not possible.
- Cross-bundle constants are dispatched by their owning bundles, not here, so they are untouched: `CATEGORY_*` (`CategoryBundle\Event\CategoryEvent`), `TOKEN_REPLACEMENT` (`CoreBundle\Event\TokenReplacementEvent`), `ON_CAMPAIGN_TRIGGER_DECISION` / `ON_CAMPAIGN_BATCH_ACTION` (`CampaignBundle` events).

The `DynamicContentEvents` constants are kept for backwards compatibility.