### PR TITLE
[symfony] Dispatch SmsBundle events by class name (Symfony 4.3 style)

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -356,6 +356,29 @@
     | `PageEvents::REDIRECT_DO_NOT_TRACK` | `UntrackableUrlsEvent` |
     | `PageEvents::ON_REDIRECT_GENERATE` | `RedirectGenerationEvent` |
     | `PageEvents::ON_CONTACT_TRACKED` | `TrackingEvent` |
+- SmsBundle events are now dispatched by the event object alone, so the event name is the event class (Symfony 4.3+) instead of the `Mautic\SmsBundle\SmsEvents` string constants. Update any subscriber or listener that keys on one of the converted `SmsEvents::*` constants to key on the event class instead:
+
+    ```diff
+     public static function getSubscribedEvents(): array
+     {
+         return [
+    -        SmsEvents::DNC_FILTER_CONTACTS_ON_SEND => ['dncFilter', 0],
+    +        DncEvent::class => ['dncFilter', 0],
+         ];
+     }
+    ```
+
+    Dispatching drops the redundant second argument, e.g. `$dispatcher->dispatch($event, SmsEvents::SMS_ON_SEND)` becomes `$dispatcher->dispatch($event)`. The `Mautic\SmsBundle\SmsEvents` constants are kept for backwards compatibility but are no longer used internally for the events below. Constants that share an event class stay unchanged: the `SMS_PRE_SAVE` / `SMS_POST_SAVE` / `SMS_PRE_DELETE` / `SMS_POST_DELETE` group (`SmsEvent`) and the `ON_REPLY` / `ON_CAMPAIGN_REPLY` pair (`ReplyEvent`). The webhook-type identifiers `TOKEN_REPLACEMENT` (shared `CoreBundle` event) and the campaign trigger constants also stay as strings.
+
+    Full mapping of the converted constants to their event class (all in the `Mautic\SmsBundle\Event` namespace):
+
+    | `SmsEvents` constant | New event class |
+    | --- | --- |
+    | `SmsEvents::SMS_ON_SEND` | `SmsSendEvent` |
+    | `SmsEvents::ON_SMS_TOKENS_BUILD` | `TokensBuildEvent` |
+    | `SmsEvents::DNC_FILTER_CONTACTS_ON_SEND` | `DncEvent` |
+    | `SmsEvents::QUEUE_FILTER_CONTACTS_ON_SEND` | `QueueEvent` |
+    | `SmsEvents::FILTER_CONTACTS_ON_SEND` | `FilterEvent` |
 
 - `Mautic\CoreBundle\Factory\ModelFactory` now builds its service locator from a `defaultIndexMethod` on the `mautic.model` tag, replacing the removed `Mautic\CoreBundle\DependencyInjection\Compiler\ModelPass`. Every model (a service implementing `Mautic\CoreBundle\Model\MauticModelInterface`) declares its `ModelFactory::getModel()` lookup key via a static `getName()` method:
 

--- a/app/bundles/LeadBundle/EventListener/OwnerSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/OwnerSubscriber.php
@@ -36,7 +36,7 @@ final class OwnerSubscriber implements EventSubscriberInterface
             EmailEvents::EMAIL_ON_BUILD    => ['onEmailBuild', 0],
             EmailEvents::EMAIL_ON_SEND     => ['onEmailGenerate', 0],
             EmailEvents::EMAIL_ON_DISPLAY  => ['onEmailDisplay', 0],
-            SmsEvents::ON_SMS_TOKENS_BUILD => ['onSmsTokensBuild', 0],
+            TokensBuildEvent::class        => ['onSmsTokensBuild', 0],
             SmsEvents::TOKEN_REPLACEMENT   => ['onSmsTokenReplacement', 0],
             UrlTokenReplaceEvent::class    => ['onUrlTokenReplace', 0],
         ];

--- a/app/bundles/SmsBundle/Controller/AjaxController.php
+++ b/app/bundles/SmsBundle/Controller/AjaxController.php
@@ -10,7 +10,6 @@ use Mautic\EmailBundle\Model\EmailModel;
 use Mautic\SmsBundle\Broadcast\BroadcastQuery;
 use Mautic\SmsBundle\Event\TokensBuildEvent;
 use Mautic\SmsBundle\Model\SmsModel;
-use Mautic\SmsBundle\SmsEvents;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -84,7 +83,7 @@ final class AjaxController extends CommonAjaxController
 
         $tokens = $this->getBuilderTokens($query);
         $event  = new TokensBuildEvent($tokens);
-        $eventDispatcher->dispatch($event, SmsEvents::ON_SMS_TOKENS_BUILD);
+        $eventDispatcher->dispatch($event);
         $sortedTokens = $tokenSorter->sortTokens($event->getTokens());
 
         return $this->sendJsonResponse(['tokens' => $sortedTokens]);

--- a/app/bundles/SmsBundle/EventListener/SendSmsSubscriber.php
+++ b/app/bundles/SmsBundle/EventListener/SendSmsSubscriber.php
@@ -11,7 +11,6 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\SmsBundle\Event\DncEvent;
 use Mautic\SmsBundle\Event\FilterEvent;
 use Mautic\SmsBundle\Event\QueueEvent;
-use Mautic\SmsBundle\SmsEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final readonly class SendSmsSubscriber implements EventSubscriberInterface
@@ -28,9 +27,9 @@ final readonly class SendSmsSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            SmsEvents::DNC_FILTER_CONTACTS_ON_SEND   => ['dncFilter', 0],
-            SmsEvents::QUEUE_FILTER_CONTACTS_ON_SEND => ['queueFilter', 0],
-            SmsEvents::FILTER_CONTACTS_ON_SEND       => ['genericFilter', 0],
+            DncEvent::class    => ['dncFilter', 0],
+            QueueEvent::class  => ['queueFilter', 0],
+            FilterEvent::class => ['genericFilter', 0],
         ];
     }
 

--- a/app/bundles/SmsBundle/EventListener/WebhookSubscriber.php
+++ b/app/bundles/SmsBundle/EventListener/WebhookSubscriber.php
@@ -20,7 +20,7 @@ final readonly class WebhookSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            SmsEvents::SMS_ON_SEND     => 'onSend',
+            SmsSendEvent::class        => 'onSend',
             WebhookBuilderEvent::class => 'onWebhookBuild',
         ];
     }

--- a/app/bundles/SmsBundle/Model/SmsModel.php
+++ b/app/bundles/SmsBundle/Model/SmsModel.php
@@ -230,7 +230,7 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface, GlobalSear
         }
 
         $dncEvent = new DncEvent($contacts);
-        $this->dispatcher->dispatch($dncEvent, SmsEvents::DNC_FILTER_CONTACTS_ON_SEND);
+        $this->dispatcher->dispatch($dncEvent);
 
         foreach ($dncEvent->getRemovedContacts() as $contactId) {
             $results[$contactId] = [
@@ -247,7 +247,7 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface, GlobalSear
         }
 
         $queueEvent = new QueueEvent($contacts, array_merge($options, ['sms_id' => $sms->getId()]));
-        $this->dispatcher->dispatch($queueEvent, SmsEvents::QUEUE_FILTER_CONTACTS_ON_SEND);
+        $this->dispatcher->dispatch($queueEvent);
 
         foreach ($queueEvent->getQueuedContacts() as $contactId) {
             $results[$contactId] = [
@@ -264,7 +264,7 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface, GlobalSear
         }
 
         $filterEvent = new FilterEvent($contacts);
-        $this->dispatcher->dispatch($filterEvent, SmsEvents::FILTER_CONTACTS_ON_SEND);
+        $this->dispatcher->dispatch($filterEvent);
 
         foreach ($filterEvent->getRemovedContacts() as $contactId) {
             $results[$contactId] = [
@@ -294,7 +294,7 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface, GlobalSear
 
             $smsEvent = new SmsSendEvent($translatedSms->getMessage(), $contact);
             $smsEvent->setSmsId($translatedSms->getId());
-            $this->dispatcher->dispatch($smsEvent, SmsEvents::SMS_ON_SEND);
+            $this->dispatcher->dispatch($smsEvent);
 
             $tokenEvent = $this->dispatcher->dispatch(
                 new TokenReplacementEvent(


### PR DESCRIPTION
Since Symfony 4.3 the event object alone identifies the event, its class name being the event name. This converts every convertible `SmsEvents::*` string constant usage in SmsBundle to the corresponding event class, following the same approach as #17162 (PluginBundle).

- `dispatch($event, SmsEvents::X)` -> `dispatch($event)`
- subscriber key `SmsEvents::X` -> `XEvent::class`

## Converted constants

Only the 5 constants whose event object class maps to exactly one event name are converted, so dropping the second dispatch argument is behaviour preserving (all in the `Mautic\SmsBundle\Event` namespace):

| `SmsEvents` constant | Event class |
| --- | --- |
| `SMS_ON_SEND` | `SmsSendEvent` |
| `ON_SMS_TOKENS_BUILD` | `TokensBuildEvent` |
| `DNC_FILTER_CONTACTS_ON_SEND` | `DncEvent` |
| `QUEUE_FILTER_CONTACTS_ON_SEND` | `QueueEvent` |
| `FILTER_CONTACTS_ON_SEND` | `FilterEvent` |

## Kept as string constants

- The SMS CRUD group `SMS_PRE_SAVE` / `SMS_POST_SAVE` / `SMS_PRE_DELETE` / `SMS_POST_DELETE` share one `SmsEvent` object dispatched under multiple names via `SmsModel::dispatchEvent()`.
- The `ON_REPLY` / `ON_CAMPAIGN_REPLY` pair share the `ReplyEvent` class.
- `TOKEN_REPLACEMENT` uses the shared CoreBundle `TokenReplacementEvent`, dispatched under many names across bundles.
- The campaign trigger constants use CampaignBundle's `CampaignExecutionEvent`.
- `SMS_ON_SEND` remains as a string where it is used as a persisted webhook-type identifier (registering and looking up webhooks), not as a dispatch name.

The `Mautic\SmsBundle\SmsEvents` constants are kept for backwards compatibility.