### PR TITLE
[symfony] Dispatch ReportBundle events by class name (Symfony 4.3 style)

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -356,6 +356,32 @@
     | `PageEvents::REDIRECT_DO_NOT_TRACK` | `UntrackableUrlsEvent` |
     | `PageEvents::ON_REDIRECT_GENERATE` | `RedirectGenerationEvent` |
     | `PageEvents::ON_CONTACT_TRACKED` | `TrackingEvent` |
+- ReportBundle events are now dispatched by the event object alone, so the event name is the event class (Symfony 4.3+) instead of the `Mautic\ReportBundle\ReportEvents` string constants. Update any subscriber or listener that keys on one of the converted `ReportEvents::*` constants to key on the event class instead:
+
+    ```diff
+     public static function getSubscribedEvents(): array
+     {
+         return [
+    -        ReportEvents::REPORT_ON_BUILD => ['onReportBuilder', 0],
+    +        ReportBuilderEvent::class => ['onReportBuilder', 0],
+         ];
+     }
+    ```
+
+    Dispatching drops the redundant second argument, e.g. `$dispatcher->dispatch($event, ReportEvents::REPORT_ON_BUILD)` becomes `$dispatcher->dispatch($event)`. The `Mautic\ReportBundle\ReportEvents` constants are kept for backwards compatibility but are no longer used internally for the events below. The CRUD constants that share one `ReportEvent` object (`REPORT_PRE_SAVE` / `REPORT_POST_SAVE` / `REPORT_PRE_DELETE` / `REPORT_POST_DELETE`) are unchanged.
+
+    Full mapping of the converted constants to their event class (all in the `Mautic\ReportBundle\Event` namespace):
+
+    | `ReportEvents` constant | New event class |
+    | --- | --- |
+    | `ReportEvents::REPORT_ON_BUILD` | `ReportBuilderEvent` |
+    | `ReportEvents::REPORT_ON_GENERATE` | `ReportGeneratorEvent` |
+    | `ReportEvents::REPORT_QUERY_PRE_EXECUTE` | `ReportQueryEvent` |
+    | `ReportEvents::REPORT_ON_DISPLAY` | `ReportDataEvent` |
+    | `ReportEvents::REPORT_ON_GRAPH_GENERATE` | `ReportGraphEvent` |
+    | `ReportEvents::REPORT_SCHEDULE_SEND` | `ReportScheduleSendEvent` |
+    | `ReportEvents::REPORT_ON_COLUMN_COLLECT` | `ColumnCollectEvent` |
+    | `ReportEvents::REPORT_PERMANENT_FILE_CREATED` | `PermanentReportFileCreatedEvent` |
 
 - `Mautic\CoreBundle\Factory\ModelFactory` now builds its service locator from a `defaultIndexMethod` on the `mautic.model` tag, replacing the removed `Mautic\CoreBundle\DependencyInjection\Compiler\ModelPass`. Every model (a service implementing `Mautic\CoreBundle\Model\MauticModelInterface`) declares its `ModelFactory::getModel()` lookup key via a static `getName()` method:
 

--- a/app/bundles/AssetBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/ReportSubscriber.php
@@ -10,7 +10,6 @@ use Mautic\ReportBundle\Event\ReportBuilderEvent;
 use Mautic\ReportBundle\Event\ReportDataEvent;
 use Mautic\ReportBundle\Event\ReportGeneratorEvent;
 use Mautic\ReportBundle\Event\ReportGraphEvent;
-use Mautic\ReportBundle\ReportEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final readonly class ReportSubscriber implements EventSubscriberInterface
@@ -29,10 +28,10 @@ final readonly class ReportSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            ReportEvents::REPORT_ON_BUILD          => ['onReportBuilder', 0],
-            ReportEvents::REPORT_ON_GENERATE       => ['onReportGenerate', 0],
-            ReportEvents::REPORT_ON_GRAPH_GENERATE => ['onReportGraphGenerate', 0],
-            ReportEvents::REPORT_ON_DISPLAY        => ['onReportDisplay', 0],
+            ReportBuilderEvent::class   => ['onReportBuilder', 0],
+            ReportGeneratorEvent::class => ['onReportGenerate', 0],
+            ReportGraphEvent::class     => ['onReportGraphGenerate', 0],
+            ReportDataEvent::class      => ['onReportDisplay', 0],
         ];
     }
 

--- a/app/bundles/CampaignBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/ReportSubscriber.php
@@ -11,7 +11,6 @@ use Mautic\ReportBundle\Event\ReportBuilderEvent;
 use Mautic\ReportBundle\Event\ReportDataEvent;
 use Mautic\ReportBundle\Event\ReportGeneratorEvent;
 use Mautic\ReportBundle\Event\ReportGraphEvent;
-use Mautic\ReportBundle\ReportEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final readonly class ReportSubscriber implements EventSubscriberInterface
@@ -27,10 +26,10 @@ final readonly class ReportSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            ReportEvents::REPORT_ON_BUILD          => ['onReportBuilder', 0],
-            ReportEvents::REPORT_ON_GENERATE       => ['onReportGenerate', 0],
-            ReportEvents::REPORT_ON_GRAPH_GENERATE => ['onReportGraphGenerate', 0],
-            ReportEvents::REPORT_ON_DISPLAY        => ['onReportDisplay', 0],
+            ReportBuilderEvent::class   => ['onReportBuilder', 0],
+            ReportGeneratorEvent::class => ['onReportGenerate', 0],
+            ReportGraphEvent::class     => ['onReportGraphGenerate', 0],
+            ReportDataEvent::class      => ['onReportDisplay', 0],
         ];
     }
 

--- a/app/bundles/ChannelBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/ChannelBundle/EventListener/ReportSubscriber.php
@@ -8,7 +8,6 @@ use Mautic\LeadBundle\Model\CompanyReportData;
 use Mautic\ReportBundle\Event\ReportBuilderEvent;
 use Mautic\ReportBundle\Event\ReportDataEvent;
 use Mautic\ReportBundle\Event\ReportGeneratorEvent;
-use Mautic\ReportBundle\ReportEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Routing\RouterInterface;
 
@@ -25,9 +24,9 @@ final readonly class ReportSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            ReportEvents::REPORT_ON_BUILD    => ['onReportBuilder', 0],
-            ReportEvents::REPORT_ON_GENERATE => ['onReportGenerate', 0],
-            ReportEvents::REPORT_ON_DISPLAY  => ['onReportDisplay', 0],
+            ReportBuilderEvent::class   => ['onReportBuilder', 0],
+            ReportGeneratorEvent::class => ['onReportGenerate', 0],
+            ReportDataEvent::class      => ['onReportDisplay', 0],
         ];
     }
 

--- a/app/bundles/CoreBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/ReportSubscriber.php
@@ -10,7 +10,6 @@ use Mautic\ReportBundle\Event\AbstractReportEvent;
 use Mautic\ReportBundle\Event\ReportBuilderEvent;
 use Mautic\ReportBundle\Event\ReportDataEvent;
 use Mautic\ReportBundle\Event\ReportGeneratorEvent;
-use Mautic\ReportBundle\ReportEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final readonly class ReportSubscriber implements EventSubscriberInterface
@@ -25,9 +24,9 @@ final readonly class ReportSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            ReportEvents::REPORT_ON_BUILD    => ['onReportBuilder', 0],
-            ReportEvents::REPORT_ON_GENERATE => ['onReportGenerate', 0],
-            ReportEvents::REPORT_ON_DISPLAY  => ['onReportDisplay', 0],
+            ReportBuilderEvent::class   => ['onReportBuilder', 0],
+            ReportGeneratorEvent::class => ['onReportGenerate', 0],
+            ReportDataEvent::class      => ['onReportDisplay', 0],
         ];
     }
 

--- a/app/bundles/CoreBundle/Tests/Functional/DependencyInjection/EventSubscriberSmokeTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/DependencyInjection/EventSubscriberSmokeTest.php
@@ -33,6 +33,7 @@ use Mautic\LeadBundle\EventListener\ReportDNCSubscriber;
 use Mautic\LeadBundle\EventListener\ReportUtmTagSubscriber;
 use Mautic\LeadBundle\EventListener\SegmentLogReportSubscriber;
 use Mautic\LeadBundle\EventListener\SegmentReportSubscriber;
+use Mautic\ReportBundle\Event\ReportBuilderEvent;
 use Mautic\SmsBundle\EventListener\CampaignReplySubscriber;
 use Mautic\SmsBundle\EventListener\CampaignSendSubscriber;
 use Mautic\UserBundle\Controller\SecurityController;
@@ -123,7 +124,7 @@ final class EventSubscriberSmokeTest extends AbstractContainerSmokeTestCase
             \Mautic\StageBundle\EventListener\CampaignSubscriber::class,
             \Mautic\WebhookBundle\EventListener\CampaignSubscriber::class,
         ],
-        'mautic.report_on_build' => [
+        ReportBuilderEvent::class => [
             FocusSubscriber::class,
             \MauticPlugin\MauticFocusBundle\EventListener\ReportSubscriber::class,
             \Mautic\AssetBundle\EventListener\ReportSubscriber::class,

--- a/app/bundles/EmailBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/ReportSubscriber.php
@@ -21,7 +21,6 @@ use Mautic\ReportBundle\Event\ReportBuilderEvent;
 use Mautic\ReportBundle\Event\ReportDataEvent;
 use Mautic\ReportBundle\Event\ReportGeneratorEvent;
 use Mautic\ReportBundle\Event\ReportGraphEvent;
-use Mautic\ReportBundle\ReportEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final readonly class ReportSubscriber implements EventSubscriberInterface
@@ -177,10 +176,10 @@ final readonly class ReportSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            ReportEvents::REPORT_ON_BUILD          => ['onReportBuilder', 0],
-            ReportEvents::REPORT_ON_GENERATE       => ['onReportGenerate', 0],
-            ReportEvents::REPORT_ON_GRAPH_GENERATE => ['onReportGraphGenerate', 0],
-            ReportEvents::REPORT_ON_DISPLAY        => ['onReportDisplay', 0],
+            ReportBuilderEvent::class   => ['onReportBuilder', 0],
+            ReportGeneratorEvent::class => ['onReportGenerate', 0],
+            ReportGraphEvent::class     => ['onReportGraphGenerate', 0],
+            ReportDataEvent::class      => ['onReportDisplay', 0],
         ];
     }
 

--- a/app/bundles/FormBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/ReportSubscriber.php
@@ -15,7 +15,6 @@ use Mautic\ReportBundle\Event\ReportDataEvent;
 use Mautic\ReportBundle\Event\ReportGeneratorEvent;
 use Mautic\ReportBundle\Event\ReportGraphEvent;
 use Mautic\ReportBundle\Helper\ReportHelper;
-use Mautic\ReportBundle\ReportEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -42,10 +41,10 @@ final readonly class ReportSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            ReportEvents::REPORT_ON_BUILD          => ['onReportBuilder', 0],
-            ReportEvents::REPORT_ON_GENERATE       => ['onReportGenerate', 0],
-            ReportEvents::REPORT_ON_GRAPH_GENERATE => ['onReportGraphGenerate', 0],
-            ReportEvents::REPORT_ON_DISPLAY        => ['onReportDisplay', 0],
+            ReportBuilderEvent::class   => ['onReportBuilder', 0],
+            ReportGeneratorEvent::class => ['onReportGenerate', 0],
+            ReportGraphEvent::class     => ['onReportGraphGenerate', 0],
+            ReportDataEvent::class      => ['onReportDisplay', 0],
         ];
     }
 

--- a/app/bundles/LeadBundle/EventListener/ReportDNCSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/ReportDNCSubscriber.php
@@ -9,7 +9,6 @@ use Mautic\LeadBundle\Report\FieldsBuilder;
 use Mautic\ReportBundle\Event\ReportBuilderEvent;
 use Mautic\ReportBundle\Event\ReportDataEvent;
 use Mautic\ReportBundle\Event\ReportGeneratorEvent;
-use Mautic\ReportBundle\ReportEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Routing\RouterInterface;
 
@@ -29,9 +28,9 @@ final readonly class ReportDNCSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            ReportEvents::REPORT_ON_BUILD    => ['onReportBuilder', 0],
-            ReportEvents::REPORT_ON_GENERATE => ['onReportGenerate', 0],
-            ReportEvents::REPORT_ON_DISPLAY  => ['onReportDisplay', 0],
+            ReportBuilderEvent::class   => ['onReportBuilder', 0],
+            ReportGeneratorEvent::class => ['onReportGenerate', 0],
+            ReportDataEvent::class      => ['onReportDisplay', 0],
         ];
     }
 

--- a/app/bundles/LeadBundle/EventListener/ReportDevicesSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/ReportDevicesSubscriber.php
@@ -9,7 +9,6 @@ use Mautic\LeadBundle\Report\FieldsBuilder;
 use Mautic\ReportBundle\Event\ReportBuilderEvent;
 use Mautic\ReportBundle\Event\ReportDataEvent;
 use Mautic\ReportBundle\Event\ReportGeneratorEvent;
-use Mautic\ReportBundle\ReportEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final readonly class ReportDevicesSubscriber implements EventSubscriberInterface
@@ -25,9 +24,9 @@ final readonly class ReportDevicesSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            ReportEvents::REPORT_ON_BUILD    => ['onReportBuilder', 0],
-            ReportEvents::REPORT_ON_GENERATE => ['onReportGenerate', 0],
-            ReportEvents::REPORT_ON_DISPLAY  => ['onReportDisplay', 0],
+            ReportBuilderEvent::class   => ['onReportBuilder', 0],
+            ReportGeneratorEvent::class => ['onReportGenerate', 0],
+            ReportDataEvent::class      => ['onReportDisplay', 0],
         ];
     }
 

--- a/app/bundles/LeadBundle/EventListener/ReportNormalizeSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/ReportNormalizeSubscriber.php
@@ -5,7 +5,6 @@ namespace Mautic\LeadBundle\EventListener;
 use Mautic\LeadBundle\Entity\LeadFieldRepository;
 use Mautic\LeadBundle\Helper\CustomFieldValueHelper;
 use Mautic\ReportBundle\Event\ReportDataEvent;
-use Mautic\ReportBundle\ReportEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final readonly class ReportNormalizeSubscriber implements EventSubscriberInterface
@@ -18,7 +17,7 @@ final readonly class ReportNormalizeSubscriber implements EventSubscriberInterfa
     public static function getSubscribedEvents(): array
     {
         return [
-            ReportEvents::REPORT_ON_DISPLAY => ['onReportDisplay', 0],
+            ReportDataEvent::class => ['onReportDisplay', 0],
         ];
     }
 

--- a/app/bundles/LeadBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/ReportSubscriber.php
@@ -19,7 +19,6 @@ use Mautic\ReportBundle\Event\ReportBuilderEvent;
 use Mautic\ReportBundle\Event\ReportDataEvent;
 use Mautic\ReportBundle\Event\ReportGeneratorEvent;
 use Mautic\ReportBundle\Event\ReportGraphEvent;
-use Mautic\ReportBundle\ReportEvents;
 use Mautic\StageBundle\Model\StageModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -81,11 +80,11 @@ final class ReportSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            ReportEvents::REPORT_ON_BUILD          => ['onReportBuilder', 0],
-            ReportEvents::REPORT_ON_GENERATE       => ['onReportGenerate', 0],
-            ReportEvents::REPORT_ON_GRAPH_GENERATE => ['onReportGraphGenerate', 0],
-            ReportEvents::REPORT_ON_DISPLAY        => ['onReportDisplay', 0],
-            ReportEvents::REPORT_ON_COLUMN_COLLECT => ['onReportColumnCollect', 0],
+            ReportBuilderEvent::class   => ['onReportBuilder', 0],
+            ReportGeneratorEvent::class => ['onReportGenerate', 0],
+            ReportGraphEvent::class     => ['onReportGraphGenerate', 0],
+            ReportDataEvent::class      => ['onReportDisplay', 0],
+            ColumnCollectEvent::class   => ['onReportColumnCollect', 0],
         ];
     }
 

--- a/app/bundles/LeadBundle/EventListener/ReportUtmTagSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/ReportUtmTagSubscriber.php
@@ -8,7 +8,6 @@ use Mautic\LeadBundle\Model\CompanyReportData;
 use Mautic\LeadBundle\Report\FieldsBuilder;
 use Mautic\ReportBundle\Event\ReportBuilderEvent;
 use Mautic\ReportBundle\Event\ReportGeneratorEvent;
-use Mautic\ReportBundle\ReportEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final readonly class ReportUtmTagSubscriber implements EventSubscriberInterface
@@ -24,8 +23,8 @@ final readonly class ReportUtmTagSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            ReportEvents::REPORT_ON_BUILD    => ['onReportBuilder', 0],
-            ReportEvents::REPORT_ON_GENERATE => ['onReportGenerate', 0],
+            ReportBuilderEvent::class   => ['onReportBuilder', 0],
+            ReportGeneratorEvent::class => ['onReportGenerate', 0],
         ];
     }
 

--- a/app/bundles/LeadBundle/EventListener/SegmentLogReportSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/SegmentLogReportSubscriber.php
@@ -5,7 +5,6 @@ namespace Mautic\LeadBundle\EventListener;
 use Mautic\LeadBundle\Report\FieldsBuilder;
 use Mautic\ReportBundle\Event\ReportBuilderEvent;
 use Mautic\ReportBundle\Event\ReportGeneratorEvent;
-use Mautic\ReportBundle\ReportEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final readonly class SegmentLogReportSubscriber implements EventSubscriberInterface
@@ -20,8 +19,8 @@ final readonly class SegmentLogReportSubscriber implements EventSubscriberInterf
     public static function getSubscribedEvents(): array
     {
         return [
-            ReportEvents::REPORT_ON_BUILD    => ['onReportBuilder', 0],
-            ReportEvents::REPORT_ON_GENERATE => ['onReportGenerate', 0],
+            ReportBuilderEvent::class   => ['onReportBuilder', 0],
+            ReportGeneratorEvent::class => ['onReportGenerate', 0],
         ];
     }
 

--- a/app/bundles/LeadBundle/EventListener/SegmentReportSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/SegmentReportSubscriber.php
@@ -7,7 +7,6 @@ namespace Mautic\LeadBundle\EventListener;
 use Mautic\LeadBundle\Report\FieldsBuilder;
 use Mautic\ReportBundle\Event\ReportBuilderEvent;
 use Mautic\ReportBundle\Event\ReportGeneratorEvent;
-use Mautic\ReportBundle\ReportEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final readonly class SegmentReportSubscriber implements EventSubscriberInterface
@@ -22,8 +21,8 @@ final readonly class SegmentReportSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            ReportEvents::REPORT_ON_BUILD    => ['onReportBuilder', 0],
-            ReportEvents::REPORT_ON_GENERATE => ['onReportGenerate', 0],
+            ReportBuilderEvent::class   => ['onReportBuilder', 0],
+            ReportGeneratorEvent::class => ['onReportGenerate', 0],
         ];
     }
 

--- a/app/bundles/NotificationBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/NotificationBundle/EventListener/ReportSubscriber.php
@@ -9,7 +9,6 @@ use Mautic\NotificationBundle\Entity\StatRepository;
 use Mautic\ReportBundle\Event\ReportBuilderEvent;
 use Mautic\ReportBundle\Event\ReportGeneratorEvent;
 use Mautic\ReportBundle\Event\ReportGraphEvent;
-use Mautic\ReportBundle\ReportEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final readonly class ReportSubscriber implements EventSubscriberInterface
@@ -28,9 +27,9 @@ final readonly class ReportSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            ReportEvents::REPORT_ON_BUILD          => ['onReportBuilder', 0],
-            ReportEvents::REPORT_ON_GENERATE       => ['onReportGenerate', 0],
-            ReportEvents::REPORT_ON_GRAPH_GENERATE => ['onReportGraphGenerate', 0],
+            ReportBuilderEvent::class   => ['onReportBuilder', 0],
+            ReportGeneratorEvent::class => ['onReportGenerate', 0],
+            ReportGraphEvent::class     => ['onReportGraphGenerate', 0],
         ];
     }
 

--- a/app/bundles/PageBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/ReportSubscriber.php
@@ -12,7 +12,6 @@ use Mautic\ReportBundle\Event\ReportBuilderEvent;
 use Mautic\ReportBundle\Event\ReportDataEvent;
 use Mautic\ReportBundle\Event\ReportGeneratorEvent;
 use Mautic\ReportBundle\Event\ReportGraphEvent;
-use Mautic\ReportBundle\ReportEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -35,10 +34,10 @@ final readonly class ReportSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            ReportEvents::REPORT_ON_BUILD          => ['onReportBuilder', 0],
-            ReportEvents::REPORT_ON_GENERATE       => ['onReportGenerate', 0],
-            ReportEvents::REPORT_ON_GRAPH_GENERATE => ['onReportGraphGenerate', 0],
-            ReportEvents::REPORT_ON_DISPLAY        => ['onReportDisplay', 0],
+            ReportBuilderEvent::class   => ['onReportBuilder', 0],
+            ReportGeneratorEvent::class => ['onReportGenerate', 0],
+            ReportGraphEvent::class     => ['onReportGraphGenerate', 0],
+            ReportDataEvent::class      => ['onReportDisplay', 0],
         ];
     }
 

--- a/app/bundles/PointBundle/EventListener/ReportSubscriber.php
+++ b/app/bundles/PointBundle/EventListener/ReportSubscriber.php
@@ -9,7 +9,6 @@ use Mautic\PointBundle\Entity\Group;
 use Mautic\PointBundle\Entity\GroupContactScore;
 use Mautic\ReportBundle\Event\ReportBuilderEvent;
 use Mautic\ReportBundle\Event\ReportGeneratorEvent;
-use Mautic\ReportBundle\ReportEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final class ReportSubscriber implements EventSubscriberInterface
@@ -53,8 +52,8 @@ final class ReportSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            ReportEvents::REPORT_ON_BUILD          => ['onReportBuilder', -10],
-            ReportEvents::REPORT_ON_GENERATE       => ['onReportGenerate', -10],
+            ReportBuilderEvent::class   => ['onReportBuilder', -10],
+            ReportGeneratorEvent::class => ['onReportGenerate', -10],
         ];
     }
 

--- a/app/bundles/ReportBundle/Builder/MauticReportBuilder.php
+++ b/app/bundles/ReportBundle/Builder/MauticReportBuilder.php
@@ -9,7 +9,6 @@ use Mautic\ChannelBundle\Helper\ChannelListHelper;
 use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\ReportBundle\Entity\Report;
 use Mautic\ReportBundle\Event\ReportGeneratorEvent;
-use Mautic\ReportBundle\ReportEvents;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 final class MauticReportBuilder implements ReportBuilderInterface
@@ -124,7 +123,7 @@ final class MauticReportBuilder implements ReportBuilderInterface
         $event = new ReportGeneratorEvent($this->entity, $options, $this->db->createQueryBuilder(), $this->channelListHelper);
 
         // Trigger the REPORT_ON_GENERATE event to initialize the QueryBuilder
-        $this->dispatcher->dispatch($event, ReportEvents::REPORT_ON_GENERATE);
+        $this->dispatcher->dispatch($event);
 
         // Build the QUERY
         $queryBuilder = $event->getQueryBuilder();

--- a/app/bundles/ReportBundle/EventListener/SchedulerSubscriber.php
+++ b/app/bundles/ReportBundle/EventListener/SchedulerSubscriber.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Mautic\ReportBundle\EventListener;
 
 use Mautic\ReportBundle\Event\ReportScheduleSendEvent;
-use Mautic\ReportBundle\ReportEvents;
 use Mautic\ReportBundle\Scheduler\Model\SendSchedule;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -19,7 +18,7 @@ final readonly class SchedulerSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            ReportEvents::REPORT_SCHEDULE_SEND => ['onScheduleSend', 0],
+            ReportScheduleSendEvent::class => ['onScheduleSend', 0],
         ];
     }
 

--- a/app/bundles/ReportBundle/Helper/ReportHelper.php
+++ b/app/bundles/ReportBundle/Helper/ReportHelper.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Mautic\ReportBundle\Helper;
 
 use Mautic\ReportBundle\Event\ColumnCollectEvent;
-use Mautic\ReportBundle\ReportEvents;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 final readonly class ReportHelper
@@ -117,7 +116,7 @@ final readonly class ReportHelper
     public function getMappedObjectColumns(string $object, array $properties = []): array
     {
         $event = new ColumnCollectEvent($object, $properties);
-        $this->dispatcher->dispatch($event, ReportEvents::REPORT_ON_COLUMN_COLLECT);
+        $this->dispatcher->dispatch($event);
 
         return array_map(
             function (array $item): array {

--- a/app/bundles/ReportBundle/Model/ReportExporter.php
+++ b/app/bundles/ReportBundle/Model/ReportExporter.php
@@ -7,7 +7,6 @@ use Mautic\ReportBundle\Adapter\ReportDataAdapter;
 use Mautic\ReportBundle\Entity\Scheduler;
 use Mautic\ReportBundle\Event\ReportScheduleSendEvent;
 use Mautic\ReportBundle\Exception\FileIOException;
-use Mautic\ReportBundle\ReportEvents;
 use Mautic\ReportBundle\Scheduler\Enum\SchedulerEnum;
 use Mautic\ReportBundle\Scheduler\Option\ExportOption;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -84,7 +83,7 @@ final readonly class ReportExporter
 
             $file  = $this->reportFileWriter->getFilePath($scheduler);
             $event = new ReportScheduleSendEvent($scheduler, $file);
-            $this->eventDispatcher->dispatch($event, ReportEvents::REPORT_SCHEDULE_SEND);
+            $this->eventDispatcher->dispatch($event);
         }
 
         $this->schedulerModel->reportWasScheduled($report);

--- a/app/bundles/ReportBundle/Model/ReportModel.php
+++ b/app/bundles/ReportBundle/Model/ReportModel.php
@@ -201,7 +201,7 @@ class ReportModel extends FormModel implements GlobalSearchInterface
                 $eventContext = ('all' == $context) ? '' : $context;
 
                 $event = new ReportBuilderEvent($this->translator, $this->channelListHelper, $eventContext, $this->fieldModel->getPublishedFieldArrays(), $this->reportHelper, $reportSource);
-                $this->dispatcher->dispatch($event, ReportEvents::REPORT_ON_BUILD);
+                $this->dispatcher->dispatch($event);
 
                 $tables = $event->getTables();
                 $graphs = $event->getGraphs();
@@ -564,7 +564,7 @@ class ReportModel extends FormModel implements GlobalSearchInterface
                 }
 
                 $event = new ReportGraphEvent($entity, $eventGraphs, $query);
-                $this->dispatcher->dispatch($event, ReportEvents::REPORT_ON_GRAPH_GENERATE);
+                $this->dispatcher->dispatch($event);
                 $graphs = $event->getGraphs();
 
                 unset($defaultGraphOptions);
@@ -579,7 +579,7 @@ class ReportModel extends FormModel implements GlobalSearchInterface
 
         // Allow plugin to manipulate the query
         $event = new ReportQueryEvent($entity, $query, $totalResults, $dataOptions);
-        $this->dispatcher->dispatch($event, ReportEvents::REPORT_QUERY_PRE_EXECUTE);
+        $this->dispatcher->dispatch($event);
         $query = $event->getQuery();
 
         if (empty($options['ignoreTableData']) && !empty($selectedColumns)) {
@@ -627,7 +627,7 @@ class ReportModel extends FormModel implements GlobalSearchInterface
 
             // Allow plugin to manipulate the data
             $event = new ReportDataEvent($entity, $data, $totalResults, $dataOptions);
-            $this->dispatcher->dispatch($event, ReportEvents::REPORT_ON_DISPLAY);
+            $this->dispatcher->dispatch($event);
             $data        = $event->getData();
             $dataOptions = $event->getOptions();
         }

--- a/app/bundles/ReportBundle/Scheduler/Model/SendSchedule.php
+++ b/app/bundles/ReportBundle/Scheduler/Model/SendSchedule.php
@@ -7,7 +7,6 @@ use Mautic\EmailBundle\Helper\MailHelper;
 use Mautic\ReportBundle\Entity\Scheduler;
 use Mautic\ReportBundle\Event\PermanentReportFileCreatedEvent;
 use Mautic\ReportBundle\Exception\FileTooBigException;
-use Mautic\ReportBundle\ReportEvents;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class SendSchedule
@@ -48,7 +47,7 @@ class SendSchedule
                 $this->fileHandler->moveZipToPermanentLocation($report, $zipFilePath);
                 $message = $this->messageSchedule->getMessageForLinkedFile($report);
                 $event   = new PermanentReportFileCreatedEvent($report);
-                $this->eventDispatcher->dispatch($event, ReportEvents::REPORT_PERMANENT_FILE_CREATED);
+                $this->eventDispatcher->dispatch($event);
             }
         }
 

--- a/app/bundles/ReportBundle/Tests/Model/ReportExporterTest.php
+++ b/app/bundles/ReportBundle/Tests/Model/ReportExporterTest.php
@@ -15,7 +15,6 @@ use Mautic\ReportBundle\Model\ReportExporter;
 use Mautic\ReportBundle\Model\ReportExportOptions;
 use Mautic\ReportBundle\Model\ReportFileWriter;
 use Mautic\ReportBundle\Model\ScheduleModel;
-use Mautic\ReportBundle\ReportEvents;
 use Mautic\ReportBundle\Scheduler\Enum\SchedulerEnum;
 use Mautic\ReportBundle\Scheduler\Option\ExportOption;
 use Mautic\ReportBundle\Tests\Fixtures;
@@ -119,12 +118,11 @@ final class ReportExporterTest extends \PHPUnit\Framework\TestCase
         $matcher = $this->atLeast(3);
 
         $eventDispatcher->expects($matcher)
-            ->method('dispatch')->willReturnCallback(function (ReportScheduleSendEvent|JobExtendTimeEvent $event, ?string $eventName) use ($matcher, $scheduler1, $scheduler2, $schedulerNow): JobExtendTimeEvent|\Mautic\ReportBundle\Event\ReportScheduleSendEvent {
+            ->method('dispatch')->willReturnCallback(function (ReportScheduleSendEvent|JobExtendTimeEvent $event) use ($matcher, $scheduler1, $scheduler2, $schedulerNow): JobExtendTimeEvent|\Mautic\ReportBundle\Event\ReportScheduleSendEvent {
                 if ($event instanceof JobExtendTimeEvent) {
                     return $event;
                 }
 
-                $this->assertSame(ReportEvents::REPORT_SCHEDULE_SEND, $eventName);
                 $this->assertSame('my-path', $event->getFile());
                 if (1 === $matcher->numberOfInvocations()) {
                     $this->assertSame($event->getScheduler(), $scheduler1);

--- a/plugins/MauticFocusBundle/EventListener/FocusSubscriber.php
+++ b/plugins/MauticFocusBundle/EventListener/FocusSubscriber.php
@@ -13,7 +13,6 @@ use Mautic\PageBundle\Entity\Trackable;
 use Mautic\PageBundle\Helper\TokenHelper as PageTokenHelper;
 use Mautic\PageBundle\Model\TrackableModel;
 use Mautic\ReportBundle\Event\ReportBuilderEvent;
-use Mautic\ReportBundle\ReportEvents;
 use MauticPlugin\MauticFocusBundle\Event\FocusEvent;
 use MauticPlugin\MauticFocusBundle\FocusEvents;
 use MauticPlugin\MauticFocusBundle\Model\FocusModel;
@@ -45,7 +44,7 @@ final readonly class FocusSubscriber implements EventSubscriberInterface
             FocusEvents::POST_SAVE         => ['onFocusPostSave', 0],
             FocusEvents::POST_DELETE       => ['onFocusDelete', 0],
             FocusEvents::TOKEN_REPLACEMENT => ['onTokenReplacement', 0],
-            ReportEvents::REPORT_ON_BUILD  => ['onReportBuild', -10],
+            ReportBuilderEvent::class => ['onReportBuild', -10],
         ];
     }
 

--- a/plugins/MauticFocusBundle/EventListener/ReportSubscriber.php
+++ b/plugins/MauticFocusBundle/EventListener/ReportSubscriber.php
@@ -6,7 +6,6 @@ namespace MauticPlugin\MauticFocusBundle\EventListener;
 
 use Mautic\ReportBundle\Event\ReportBuilderEvent;
 use Mautic\ReportBundle\Event\ReportGeneratorEvent;
-use Mautic\ReportBundle\ReportEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final class ReportSubscriber implements EventSubscriberInterface
@@ -32,8 +31,8 @@ final class ReportSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            ReportEvents::REPORT_ON_BUILD    => ['onReportBuilder', 0],
-            ReportEvents::REPORT_ON_GENERATE => ['onReportGenerate', 0],
+            ReportBuilderEvent::class   => ['onReportBuilder', 0],
+            ReportGeneratorEvent::class => ['onReportGenerate', 0],
         ];
     }
 


### PR DESCRIPTION
Since Symfony 4.3 the event object alone identifies the event, its class name being the event name. This converts every convertible `ReportEvents::*` string constant usage to the corresponding event class:

- `dispatch($event, ReportEvents::X)` -> `dispatch($event)`
- subscriber key `ReportEvents::X` -> `XEvent::class`

The 8 constants whose event class maps 1:1 to a single name are converted:

| `ReportEvents` constant | Event class |
| --- | --- |
| `REPORT_ON_BUILD` | `ReportBuilderEvent` |
| `REPORT_ON_GENERATE` | `ReportGeneratorEvent` |
| `REPORT_QUERY_PRE_EXECUTE` | `ReportQueryEvent` |
| `REPORT_ON_DISPLAY` | `ReportDataEvent` |
| `REPORT_ON_GRAPH_GENERATE` | `ReportGraphEvent` |
| `REPORT_SCHEDULE_SEND` | `ReportScheduleSendEvent` |
| `REPORT_ON_COLUMN_COLLECT` | `ColumnCollectEvent` |
| `REPORT_PERMANENT_FILE_CREATED` | `PermanentReportFileCreatedEvent` |

The CRUD constants that share one `ReportEvent` object (`REPORT_PRE_SAVE` / `REPORT_POST_SAVE` / `REPORT_PRE_DELETE` / `REPORT_POST_DELETE`, dispatched under four names by `ReportModel::dispatchEvent()`) stay as string constants. The `ReportEvents` constants are kept for backwards compatibility. UPGRADE-8.0.md documents the change.