### PR TITLE
[symfony] Dispatch ChannelBundle events by class name (Symfony 4.3 style)

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -280,6 +280,30 @@
     | `PluginEvents::ON_PLUGIN_INSTALL` | `PluginInstallEvent` |
     | `PluginEvents::PLUGIN_IS_PUBLISHED_STATE_CHANGING` | `PluginIsPublishedEvent` |
 
+- ChannelBundle events are now dispatched by the event object alone, so the event name is the event class (Symfony 4.3+) instead of the `Mautic\ChannelBundle\ChannelEvents` string constants. Update any subscriber or listener that keys on one of the converted `ChannelEvents::*` constants to key on the event class instead:
+
+    ```diff
+     public static function getSubscribedEvents(): array
+     {
+         return [
+    -        ChannelEvents::ADD_CHANNEL => ['onAddChannel', 0],
+    +        ChannelEvent::class => ['onAddChannel', 0],
+         ];
+     }
+    ```
+
+    Dispatching drops the redundant second argument, e.g. `$dispatcher->dispatch($event, ChannelEvents::CHANNEL_BROADCAST)` becomes `$dispatcher->dispatch($event)`. The `Mautic\ChannelBundle\ChannelEvents` constants are kept for backwards compatibility but are no longer used internally for the events below. Constants that share an event class are unchanged: the `MESSAGE_PRE_SAVE` / `MESSAGE_POST_SAVE` / `MESSAGE_PRE_DELETE` / `MESSAGE_POST_DELETE` group on `MessageEvent`, and `ON_CAMPAIGN_BATCH_ACTION` on the shared `Mautic\CampaignBundle\Event\PendingEvent`.
+
+    Full mapping of the converted constants to their event class (all in the `Mautic\ChannelBundle\Event` namespace):
+
+    | `ChannelEvents` constant | New event class |
+    | --- | --- |
+    | `ChannelEvents::ADD_CHANNEL` | `ChannelEvent` |
+    | `ChannelEvents::CHANNEL_BROADCAST` | `ChannelBroadcastEvent` |
+    | `ChannelEvents::MESSAGE_QUEUED` | `MessageQueueEvent` |
+    | `ChannelEvents::PROCESS_MESSAGE_QUEUE` | `MessageQueueProcessEvent` |
+    | `ChannelEvents::PROCESS_MESSAGE_QUEUE_BATCH` | `MessageQueueBatchProcessEvent` |
+
 - `Mautic\CoreBundle\Factory\ModelFactory` now builds its service locator from a `defaultIndexMethod` on the `mautic.model` tag, replacing the removed `Mautic\CoreBundle\DependencyInjection\Compiler\ModelPass`. Every model (a service implementing `Mautic\CoreBundle\Model\MauticModelInterface`) declares its `ModelFactory::getModel()` lookup key via a static `getName()` method:
 
     ```php

--- a/app/bundles/ChannelBundle/Command/SendChannelBroadcastCommand.php
+++ b/app/bundles/ChannelBundle/Command/SendChannelBroadcastCommand.php
@@ -2,7 +2,6 @@
 
 namespace Mautic\ChannelBundle\Command;
 
-use Mautic\ChannelBundle\ChannelEvents;
 use Mautic\ChannelBundle\Event\ChannelBroadcastEvent;
 use Mautic\CoreBundle\Command\ModeratedCommand;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
@@ -159,7 +158,7 @@ final class SendChannelBroadcastCommand extends ModeratedCommand
             $event->setMaxThreads((int) $maxThreads);
         }
 
-        $this->dispatcher->dispatch($event, ChannelEvents::CHANNEL_BROADCAST);
+        $this->dispatcher->dispatch($event);
 
         $results = $event->getResults();
 

--- a/app/bundles/ChannelBundle/Controller/Api/MessageApiController.php
+++ b/app/bundles/ChannelBundle/Controller/Api/MessageApiController.php
@@ -5,7 +5,6 @@ namespace Mautic\ChannelBundle\Controller\Api;
 use Doctrine\Persistence\ManagerRegistry;
 use Mautic\ApiBundle\Controller\CommonApiController;
 use Mautic\ApiBundle\Helper\EntityResultHelper;
-use Mautic\ChannelBundle\ChannelEvents;
 use Mautic\ChannelBundle\Entity\Message;
 use Mautic\ChannelBundle\Event\ChannelEvent;
 use Mautic\ChannelBundle\Model\MessageModel;
@@ -79,7 +78,7 @@ final class MessageApiController extends CommonApiController
      */
     protected function preSerializeEntity(object $entity, string $action = 'view'): void
     {
-        $event = $this->dispatcher->dispatch(new ChannelEvent(), ChannelEvents::ADD_CHANNEL);
+        $event = $this->dispatcher->dispatch(new ChannelEvent());
 
         foreach ($entity->getChannels() as $channel) {
             $repository = $event->getRepositoryName($channel->getChannel());

--- a/app/bundles/ChannelBundle/Helper/ChannelListHelper.php
+++ b/app/bundles/ChannelBundle/Helper/ChannelListHelper.php
@@ -2,7 +2,6 @@
 
 namespace Mautic\ChannelBundle\Helper;
 
-use Mautic\ChannelBundle\ChannelEvents;
 use Mautic\ChannelBundle\Event\ChannelEvent;
 use Mautic\CoreBundle\Translation\Translator;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -105,7 +104,7 @@ class ChannelListHelper
             return;
         }
 
-        $event                 = $this->dispatcher->dispatch(new ChannelEvent(), ChannelEvents::ADD_CHANNEL);
+        $event                 = $this->dispatcher->dispatch(new ChannelEvent());
         $this->channels        = $event->getChannelConfigs();
         $this->featureChannels = $event->getFeatureChannels();
         unset($event);

--- a/app/bundles/ChannelBundle/Model/MessageQueueModel.php
+++ b/app/bundles/ChannelBundle/Model/MessageQueueModel.php
@@ -2,7 +2,6 @@
 
 namespace Mautic\ChannelBundle\Model;
 
-use Mautic\ChannelBundle\ChannelEvents;
 use Mautic\ChannelBundle\Entity\MessageQueue;
 use Mautic\ChannelBundle\Entity\MessageQueueRepository;
 use Mautic\ChannelBundle\Event\MessageQueueBatchProcessEvent;
@@ -324,13 +323,13 @@ class MessageQueueModel extends FormModel
     {
         switch ($action) {
             case 'process_message_queue':
-                $name = ChannelEvents::PROCESS_MESSAGE_QUEUE;
+                $name = MessageQueueProcessEvent::class;
                 break;
             case 'process_batch_message_queue':
-                $name = ChannelEvents::PROCESS_MESSAGE_QUEUE_BATCH;
+                $name = MessageQueueBatchProcessEvent::class;
                 break;
             case 'post_save':
-                $name = ChannelEvents::MESSAGE_QUEUED;
+                $name = MessageQueueEvent::class;
                 break;
             default:
                 return null;
@@ -341,7 +340,7 @@ class MessageQueueModel extends FormModel
                 $event = new MessageQueueEvent($entity, $isNew);
                 $event->setEntityManager($this->em);
             }
-            $this->dispatcher->dispatch($event, $name);
+            $this->dispatcher->dispatch($event);
 
             return $event;
         }

--- a/app/bundles/DynamicContentBundle/EventListener/ChannelSubscriber.php
+++ b/app/bundles/DynamicContentBundle/EventListener/ChannelSubscriber.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\DynamicContentBundle\EventListener;
 
-use Mautic\ChannelBundle\ChannelEvents;
 use Mautic\ChannelBundle\Event\ChannelEvent;
 use Mautic\ReportBundle\Model\ReportModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -14,7 +13,7 @@ final class ChannelSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            ChannelEvents::ADD_CHANNEL => ['onAddChannel', 0],
+            ChannelEvent::class => ['onAddChannel', 0],
         ];
     }
 

--- a/app/bundles/EmailBundle/EventListener/BroadcastSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/BroadcastSubscriber.php
@@ -3,7 +3,6 @@
 namespace Mautic\EmailBundle\EventListener;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Mautic\ChannelBundle\ChannelEvents;
 use Mautic\ChannelBundle\Event\ChannelBroadcastEvent;
 use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\EmailBundle\Entity\Email;
@@ -25,7 +24,7 @@ final readonly class BroadcastSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            ChannelEvents::CHANNEL_BROADCAST => ['onBroadcast', 0],
+            ChannelBroadcastEvent::class => ['onBroadcast', 0],
         ];
     }
 

--- a/app/bundles/EmailBundle/EventListener/ChannelSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/ChannelSubscriber.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\EmailBundle\EventListener;
 
-use Mautic\ChannelBundle\ChannelEvents;
 use Mautic\ChannelBundle\Event\ChannelEvent;
 use Mautic\ChannelBundle\Model\MessageModel;
 use Mautic\EmailBundle\Form\Type\EmailListType;
@@ -24,7 +23,7 @@ final class ChannelSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            ChannelEvents::ADD_CHANNEL => ['onAddChannel', 100],
+            ChannelEvent::class => ['onAddChannel', 100],
         ];
     }
 

--- a/app/bundles/EmailBundle/EventListener/MessageQueueSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/MessageQueueSubscriber.php
@@ -2,7 +2,6 @@
 
 namespace Mautic\EmailBundle\EventListener;
 
-use Mautic\ChannelBundle\ChannelEvents;
 use Mautic\ChannelBundle\Entity\MessageQueue;
 use Mautic\ChannelBundle\Event\MessageQueueBatchProcessEvent;
 use Mautic\EmailBundle\Helper\MailHelper;
@@ -19,7 +18,7 @@ final readonly class MessageQueueSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            ChannelEvents::PROCESS_MESSAGE_QUEUE_BATCH => ['onProcessMessageQueueBatch', 0],
+            MessageQueueBatchProcessEvent::class => ['onProcessMessageQueueBatch', 0],
         ];
     }
 

--- a/app/bundles/NotificationBundle/EventListener/ChannelSubscriber.php
+++ b/app/bundles/NotificationBundle/EventListener/ChannelSubscriber.php
@@ -2,7 +2,6 @@
 
 namespace Mautic\NotificationBundle\EventListener;
 
-use Mautic\ChannelBundle\ChannelEvents;
 use Mautic\ChannelBundle\Event\ChannelEvent;
 use Mautic\ChannelBundle\Model\MessageModel;
 use Mautic\NotificationBundle\Entity\Notification;
@@ -21,7 +20,7 @@ final readonly class ChannelSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            ChannelEvents::ADD_CHANNEL => ['onAddChannel', 70],
+            ChannelEvent::class => ['onAddChannel', 70],
         ];
     }
 

--- a/app/bundles/SmsBundle/EventListener/BroadcastSubscriber.php
+++ b/app/bundles/SmsBundle/EventListener/BroadcastSubscriber.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\SmsBundle\EventListener;
 
-use Mautic\ChannelBundle\ChannelEvents;
 use Mautic\ChannelBundle\Event\ChannelBroadcastEvent;
 use Mautic\SmsBundle\Broadcast\BroadcastExecutioner;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -19,7 +18,7 @@ final readonly class BroadcastSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            ChannelEvents::CHANNEL_BROADCAST => ['onBroadcast', 0],
+            ChannelBroadcastEvent::class => ['onBroadcast', 0],
         ];
     }
 

--- a/app/bundles/SmsBundle/EventListener/ChannelSubscriber.php
+++ b/app/bundles/SmsBundle/EventListener/ChannelSubscriber.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\SmsBundle\EventListener;
 
-use Mautic\ChannelBundle\ChannelEvents;
 use Mautic\ChannelBundle\Event\ChannelEvent;
 use Mautic\ChannelBundle\Model\MessageModel;
 use Mautic\LeadBundle\Model\LeadModel;
@@ -24,7 +23,7 @@ final readonly class ChannelSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            ChannelEvents::ADD_CHANNEL => ['onAddChannel', 90],
+            ChannelEvent::class => ['onAddChannel', 90],
         ];
     }
 

--- a/app/bundles/SmsBundle/EventListener/MessageQueueSubscriber.php
+++ b/app/bundles/SmsBundle/EventListener/MessageQueueSubscriber.php
@@ -2,7 +2,6 @@
 
 namespace Mautic\SmsBundle\EventListener;
 
-use Mautic\ChannelBundle\ChannelEvents;
 use Mautic\ChannelBundle\Entity\MessageQueue;
 use Mautic\ChannelBundle\Event\MessageQueueBatchProcessEvent;
 use Mautic\SmsBundle\Model\SmsModel;
@@ -18,7 +17,7 @@ final readonly class MessageQueueSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            ChannelEvents::PROCESS_MESSAGE_QUEUE_BATCH => ['onProcessMessageQueueBatch', 0],
+            MessageQueueBatchProcessEvent::class => ['onProcessMessageQueueBatch', 0],
         ];
     }
 

--- a/plugins/MauticSocialBundle/EventListener/ChannelSubscriber.php
+++ b/plugins/MauticSocialBundle/EventListener/ChannelSubscriber.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace MauticPlugin\MauticSocialBundle\EventListener;
 
-use Mautic\ChannelBundle\ChannelEvents;
 use Mautic\ChannelBundle\Event\ChannelEvent;
 use Mautic\ChannelBundle\Model\MessageModel;
 use Mautic\PluginBundle\Helper\IntegrationHelper;
@@ -21,7 +20,7 @@ final readonly class ChannelSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            ChannelEvents::ADD_CHANNEL => ['onAddChannel', 80],
+            ChannelEvent::class => ['onAddChannel', 80],
         ];
     }
 


### PR DESCRIPTION
Since Symfony 4.3 the event object alone identifies the event, its class name being the event name. This converts every convertible `ChannelEvents::*` string constant to the corresponding event class:

- `dispatch($event, ChannelEvents::X)` -> `dispatch($event)`
- `hasListeners(ChannelEvents::X)` -> `hasListeners(XEvent::class)`
- subscriber key `ChannelEvents::X => [...]` -> `XEvent::class => [...]`

Only the constants whose event object class maps to exactly one event name are converted, so dropping the second dispatch argument is behaviour preserving:

| `ChannelEvents` constant | New event class |
| --- | --- |
| `ADD_CHANNEL` | `ChannelEvent` |
| `CHANNEL_BROADCAST` | `ChannelBroadcastEvent` |
| `MESSAGE_QUEUED` | `MessageQueueEvent` |
| `PROCESS_MESSAGE_QUEUE` | `MessageQueueProcessEvent` |
| `PROCESS_MESSAGE_QUEUE_BATCH` | `MessageQueueBatchProcessEvent` |

Constants that share an event class are kept as string constants:

- the `MESSAGE_PRE_SAVE` / `MESSAGE_POST_SAVE` / `MESSAGE_PRE_DELETE` / `MESSAGE_POST_DELETE` group, which dispatch one shared `MessageEvent` object under four names (`MessageModel::dispatchEvent()`)
- `ON_CAMPAIGN_BATCH_ACTION`, which routes to the shared CampaignBundle `PendingEvent`

The `Mautic\ChannelBundle\ChannelEvents` constants are kept for backwards compatibility; `UPGRADE-8.0.md` documents the change.