### PR TITLE
[symfony] Dispatch WebhookBundle events by class name (Symfony 4.3 style)

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -304,6 +304,27 @@
     | `ChannelEvents::PROCESS_MESSAGE_QUEUE` | `MessageQueueProcessEvent` |
     | `ChannelEvents::PROCESS_MESSAGE_QUEUE_BATCH` | `MessageQueueBatchProcessEvent` |
 - DynamicContentBundle's `ON_CONTACTS_FILTER_EVALUATE` event is now dispatched by the event object alone, so the event name is the event class (Symfony 4.3+) instead of the `Mautic\DynamicContentBundle\DynamicContentEvents::ON_CONTACTS_FILTER_EVALUATE` string constant. Update any subscriber or listener that keys on that constant to key on `Mautic\DynamicContentBundle\Event\ContactFiltersEvaluateEvent::class` instead, e.g. `$dispatcher->dispatch($event, DynamicContentEvents::ON_CONTACTS_FILTER_EVALUATE)` becomes `$dispatcher->dispatch($event)`. The constant is kept for backwards compatibility but is no longer used internally. The `DynamicContentEvent` CRUD group (`PRE_SAVE` / `POST_SAVE` / `PRE_DELETE` / `POST_DELETE`) shares one event class under four names and is unchanged, as are the cross-bundle `CategoryEvent`, `TokenReplacementEvent` and campaign event constants.
+- WebhookBundle events are now dispatched by the event object alone, so the event name is the event class (Symfony 4.3+) instead of the `Mautic\WebhookBundle\WebhookEvents` string constants. Update any subscriber or listener that keys on one of the converted `WebhookEvents::*` constants to key on the event class instead:
+
+    ```diff
+     public static function getSubscribedEvents(): array
+     {
+         return [
+    -        WebhookEvents::WEBHOOK_ON_BUILD => ['onWebhookBuild', 0],
+    +        WebhookBuilderEvent::class => ['onWebhookBuild', 0],
+         ];
+     }
+    ```
+
+    Dispatching drops the redundant second argument, e.g. `$dispatcher->dispatch($event, WebhookEvents::WEBHOOK_ON_BUILD)` becomes `$dispatcher->dispatch($event)`. The `Mautic\WebhookBundle\WebhookEvents` constants are kept for backwards compatibility but are no longer used internally for the events below.
+
+    | `WebhookEvents` constant | New event class (in `Mautic\WebhookBundle\Event`) |
+    | --- | --- |
+    | `WebhookEvents::WEBHOOK_ON_BUILD` | `WebhookBuilderEvent` |
+    | `WebhookEvents::WEBHOOK_QUEUE_ON_ADD` | `WebhookQueueEvent` |
+    | `WebhookEvents::WEBHOOK_ON_REQUEST` | `WebhookRequestEvent` |
+
+    The CRUD constants (`WEBHOOK_PRE_SAVE` / `WEBHOOK_POST_SAVE` / `WEBHOOK_PRE_DELETE` / `WEBHOOK_POST_DELETE`) and `WEBHOOK_KILL` all share the `WebhookEvent` class, so they keep their string names and are unchanged.
 
 - `Mautic\CoreBundle\Factory\ModelFactory` now builds its service locator from a `defaultIndexMethod` on the `mautic.model` tag, replacing the removed `Mautic\CoreBundle\DependencyInjection\Compiler\ModelPass`. Every model (a service implementing `Mautic\CoreBundle\Model\MauticModelInterface`) declares its `ModelFactory::getModel()` lookup key via a static `getName()` method:
 

--- a/app/bundles/EmailBundle/EventListener/WebhookSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/WebhookSubscriber.php
@@ -8,7 +8,6 @@ use Mautic\EmailBundle\Event\EmailSendEvent;
 use Mautic\WebhookBundle\Event\WebhookBuilderEvent;
 use Mautic\WebhookBundle\Event\WebhookQueueEvent;
 use Mautic\WebhookBundle\Model\WebhookModel;
-use Mautic\WebhookBundle\WebhookEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final readonly class WebhookSubscriber implements EventSubscriberInterface
@@ -24,8 +23,8 @@ final readonly class WebhookSubscriber implements EventSubscriberInterface
         return [
             EmailEvents::EMAIL_ON_SEND          => ['onEmailSend', 0],
             EmailEvents::EMAIL_ON_OPEN          => ['onEmailOpen', 0],
-            WebhookEvents::WEBHOOK_ON_BUILD     => ['onWebhookBuild', 0],
-            WebhookEvents::WEBHOOK_QUEUE_ON_ADD => ['onWebhookQueueOnAdd', 0],
+            WebhookBuilderEvent::class          => ['onWebhookBuild', 0],
+            WebhookQueueEvent::class            => ['onWebhookQueueOnAdd', 0],
         ];
     }
 

--- a/app/bundles/FormBundle/EventListener/WebhookSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/WebhookSubscriber.php
@@ -8,7 +8,6 @@ use Mautic\FormBundle\Event\SubmissionEvent;
 use Mautic\FormBundle\FormEvents;
 use Mautic\WebhookBundle\Event\WebhookBuilderEvent;
 use Mautic\WebhookBundle\Model\WebhookModel;
-use Mautic\WebhookBundle\WebhookEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final readonly class WebhookSubscriber implements EventSubscriberInterface
@@ -21,8 +20,8 @@ final readonly class WebhookSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            WebhookEvents::WEBHOOK_ON_BUILD => ['onWebhookBuild', 0],
-            FormEvents::FORM_ON_SUBMIT      => ['onFormSubmit', 0],
+            WebhookBuilderEvent::class => ['onWebhookBuild', 0],
+            FormEvents::FORM_ON_SUBMIT => ['onFormSubmit', 0],
         ];
     }
 

--- a/app/bundles/LeadBundle/EventListener/WebhookSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/WebhookSubscriber.php
@@ -13,7 +13,6 @@ use Mautic\LeadBundle\LeadEvents;
 use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\WebhookBundle\Event\WebhookBuilderEvent;
 use Mautic\WebhookBundle\Model\WebhookModel;
-use Mautic\WebhookBundle\WebhookEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final readonly class WebhookSubscriber implements EventSubscriberInterface
@@ -28,7 +27,7 @@ final readonly class WebhookSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            WebhookEvents::WEBHOOK_ON_BUILD          => ['onWebhookBuild', 0],
+            WebhookBuilderEvent::class               => ['onWebhookBuild', 0],
             LeadEvents::LEAD_POST_SAVE               => ['onLeadNewUpdate', 0],
             LeadEvents::LEAD_POINTS_CHANGE           => ['onLeadPointChange', 0],
             LeadEvents::LEAD_POST_DELETE             => ['onLeadDelete', 0],

--- a/app/bundles/PageBundle/EventListener/WebhookSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/WebhookSubscriber.php
@@ -8,7 +8,6 @@ use Mautic\PageBundle\Event\PageHitEvent;
 use Mautic\PageBundle\PageEvents;
 use Mautic\WebhookBundle\Event\WebhookBuilderEvent;
 use Mautic\WebhookBundle\Model\WebhookModel;
-use Mautic\WebhookBundle\WebhookEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final readonly class WebhookSubscriber implements EventSubscriberInterface
@@ -21,8 +20,8 @@ final readonly class WebhookSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            WebhookEvents::WEBHOOK_ON_BUILD => ['onWebhookBuild', 0],
-            PageEvents::PAGE_ON_HIT         => ['onPageHit', 0],
+            WebhookBuilderEvent::class => ['onWebhookBuild', 0],
+            PageEvents::PAGE_ON_HIT    => ['onPageHit', 0],
         ];
     }
 

--- a/app/bundles/SmsBundle/EventListener/WebhookSubscriber.php
+++ b/app/bundles/SmsBundle/EventListener/WebhookSubscriber.php
@@ -8,7 +8,6 @@ use Mautic\SmsBundle\Event\SmsSendEvent;
 use Mautic\SmsBundle\SmsEvents;
 use Mautic\WebhookBundle\Event\WebhookBuilderEvent;
 use Mautic\WebhookBundle\Model\WebhookModel;
-use Mautic\WebhookBundle\WebhookEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final readonly class WebhookSubscriber implements EventSubscriberInterface
@@ -21,8 +20,8 @@ final readonly class WebhookSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            SmsEvents::SMS_ON_SEND          => 'onSend',
-            WebhookEvents::WEBHOOK_ON_BUILD => 'onWebhookBuild',
+            SmsEvents::SMS_ON_SEND     => 'onSend',
+            WebhookBuilderEvent::class => 'onWebhookBuild',
         ];
     }
 

--- a/app/bundles/WebhookBundle/Helper/CampaignHelper.php
+++ b/app/bundles/WebhookBundle/Helper/CampaignHelper.php
@@ -10,7 +10,6 @@ use Mautic\LeadBundle\Entity\CompanyRepository;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Helper\TokenHelper;
 use Mautic\WebhookBundle\Event\WebhookRequestEvent;
-use Mautic\WebhookBundle\WebhookEvents;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 final class CampaignHelper
@@ -37,7 +36,7 @@ final class CampaignHelper
         $url     = rawurldecode(TokenHelper::findLeadTokens($config['url'], $this->getContactValues($contact), true));
 
         $webhookRequestEvent = new WebhookRequestEvent($contact, $url, $headers, $payload);
-        $this->dispatcher->dispatch($webhookRequestEvent, WebhookEvents::WEBHOOK_ON_REQUEST);
+        $this->dispatcher->dispatch($webhookRequestEvent);
 
         $this->makeRequest(
             $webhookRequestEvent->getUrl(),

--- a/app/bundles/WebhookBundle/Model/WebhookModel.php
+++ b/app/bundles/WebhookBundle/Model/WebhookModel.php
@@ -211,7 +211,7 @@ class WebhookModel extends FormModel
             // build them
             $events = [];
             $event  = new Events\WebhookBuilderEvent($this->translator);
-            $this->dispatcher->dispatch($event, WebhookEvents::WEBHOOK_ON_BUILD);
+            $this->dispatcher->dispatch($event);
             $events = $event->getEvents();
         }
 
@@ -274,9 +274,9 @@ class WebhookModel extends FormModel
         $queue->setPayload($serializedPayload);
 
         // fire events for when the queues are created
-        if ($this->dispatcher->hasListeners(WebhookEvents::WEBHOOK_QUEUE_ON_ADD)) {
+        if ($this->dispatcher->hasListeners(Events\WebhookQueueEvent::class)) {
             $webhookQueueEvent = $event = new Events\WebhookQueueEvent($queue, $webhook, true);
-            $this->dispatcher->dispatch($webhookQueueEvent, WebhookEvents::WEBHOOK_QUEUE_ON_ADD);
+            $this->dispatcher->dispatch($webhookQueueEvent);
         }
 
         return $queue;

--- a/app/bundles/WebhookBundle/Tests/Unit/Controller/WebhookControllerTest.php
+++ b/app/bundles/WebhookBundle/Tests/Unit/Controller/WebhookControllerTest.php
@@ -28,10 +28,10 @@ use Mautic\WebhookBundle\Entity\LogRepository;
 use Mautic\WebhookBundle\Entity\Webhook;
 use Mautic\WebhookBundle\Entity\WebhookQueueRepository;
 use Mautic\WebhookBundle\Entity\WebhookRepository;
+use Mautic\WebhookBundle\Event\WebhookQueueEvent;
 use Mautic\WebhookBundle\Http\Client;
 use Mautic\WebhookBundle\Model\WebhookModel;
 use Mautic\WebhookBundle\Service\WebhookService;
-use Mautic\WebhookBundle\WebhookEvents;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -217,7 +217,7 @@ final class WebhookControllerTest extends TestCase
         $dispatcher->expects($this->exactly(3))
             ->method('hasListeners')
             ->willReturnMap([
-                [WebhookEvents::WEBHOOK_QUEUE_ON_ADD, false],
+                [WebhookQueueEvent::class, false],
                 ['mautic.webhook_pre_save', false],
                 ['mautic.webhook_post_save', false],
             ])


### PR DESCRIPTION
## Description

Follow-up to the PluginBundle/CampaignBundle/CoreBundle conversions. This converts the WebhookBundle events that map to exactly one constant and one event class to Symfony 4.3-style dispatch-by-class-name.

Dispatching drops the redundant event-name argument, e.g. `$dispatcher->dispatch($event, WebhookEvents::WEBHOOK_ON_BUILD)` becomes `$dispatcher->dispatch($event)`, and subscribers key on the event class instead of the string constant.

### Converted constants

| `WebhookEvents` constant | Event class (in `Mautic\WebhookBundle\Event`) |
| --- | --- |
| `WEBHOOK_ON_BUILD` | `WebhookBuilderEvent` |
| `WEBHOOK_QUEUE_ON_ADD` | `WebhookQueueEvent` |
| `WEBHOOK_ON_REQUEST` | `WebhookRequestEvent` |

### Left as strings (unchanged)

- The CRUD group `WEBHOOK_PRE_SAVE` / `WEBHOOK_POST_SAVE` / `WEBHOOK_PRE_DELETE` / `WEBHOOK_POST_DELETE` and `WEBHOOK_KILL` all dispatch the **same** `WebhookEvent` class (via the `WebhookModel::dispatchEvent()` override and `killWebhook()`), so they cannot be distinguished by class name.
- `WEBHOOK_PRE_EXECUTE` / `WEBHOOK_POST_EXECUTE` are never dispatched and have no event class.
- `ON_CAMPAIGN_BATCH_ACTION` maps to the shared `Mautic\CampaignBundle\Event\PendingEvent`.

The `Mautic\WebhookBundle\WebhookEvents` constants are kept for backwards compatibility; they are just no longer used internally for the converted events.

An `UPGRADE-8.0.md` note is included.