### PR TITLE
[symfony] Dispatch PageBundle events by class name (Symfony 4.3 style)

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -304,6 +304,30 @@
     | `ChannelEvents::PROCESS_MESSAGE_QUEUE` | `MessageQueueProcessEvent` |
     | `ChannelEvents::PROCESS_MESSAGE_QUEUE_BATCH` | `MessageQueueBatchProcessEvent` |
 - DynamicContentBundle's `ON_CONTACTS_FILTER_EVALUATE` event is now dispatched by the event object alone, so the event name is the event class (Symfony 4.3+) instead of the `Mautic\DynamicContentBundle\DynamicContentEvents::ON_CONTACTS_FILTER_EVALUATE` string constant. Update any subscriber or listener that keys on that constant to key on `Mautic\DynamicContentBundle\Event\ContactFiltersEvaluateEvent::class` instead, e.g. `$dispatcher->dispatch($event, DynamicContentEvents::ON_CONTACTS_FILTER_EVALUATE)` becomes `$dispatcher->dispatch($event)`. The constant is kept for backwards compatibility but is no longer used internally. The `DynamicContentEvent` CRUD group (`PRE_SAVE` / `POST_SAVE` / `PRE_DELETE` / `POST_DELETE`) shares one event class under four names and is unchanged, as are the cross-bundle `CategoryEvent`, `TokenReplacementEvent` and campaign event constants.
+- PageBundle events are now dispatched by the event object alone, so the event name is the event class (Symfony 4.3+) instead of the `Mautic\PageBundle\PageEvents` string constants. Update any subscriber or listener that keys on one of the converted `PageEvents::*` constants (or the raw string name such as `mautic.page_on_hit`) to key on the event class instead:
+
+    ```diff
+     public static function getSubscribedEvents(): array
+     {
+         return [
+    -        PageEvents::PAGE_ON_DISPLAY => ['onPageDisplay', 0],
+    +        PageDisplayEvent::class => ['onPageDisplay', 0],
+         ];
+     }
+    ```
+
+    Dispatching drops the redundant second argument, e.g. `$dispatcher->dispatch($event, PageEvents::PAGE_ON_DISPLAY)` becomes `$dispatcher->dispatch($event)`. The `Mautic\PageBundle\PageEvents` constants are kept for backwards compatibility but are no longer used internally for the events below. Constants that share an event class stay as string constants: the `PageEvent` group (`PAGE_ON_BUILD`, `PAGE_PRE_SAVE`, `PAGE_POST_SAVE`, `PAGE_PRE_DELETE`, `PAGE_POST_DELETE`, `PAGE_ON_TOGGLE_PUBLISH`) and the `DetermineWinnerEvent` pair (`ON_DETERMINE_BOUNCE_RATE_WINNER`, `ON_DETERMINE_DWELL_TIME_WINNER`) are unchanged, as are the campaign constants (`ON_CAMPAIGN_TRIGGER_DECISION`, `ON_CAMPAIGN_BATCH_ACTION`) whose events are shared across bundles.
+
+    Full mapping of the converted constants to their event class (all in the `Mautic\PageBundle\Event` namespace):
+
+    | `PageEvents` constant | New event class |
+    | --- | --- |
+    | `PageEvents::VIDEO_ON_HIT` | `VideoHitEvent` |
+    | `PageEvents::PAGE_ON_HIT` | `PageHitEvent` |
+    | `PageEvents::PAGE_ON_DISPLAY` | `PageDisplayEvent` |
+    | `PageEvents::REDIRECT_DO_NOT_TRACK` | `UntrackableUrlsEvent` |
+    | `PageEvents::ON_REDIRECT_GENERATE` | `RedirectGenerationEvent` |
+    | `PageEvents::ON_CONTACT_TRACKED` | `TrackingEvent` |
 
 - `Mautic\CoreBundle\Factory\ModelFactory` now builds its service locator from a `defaultIndexMethod` on the `mautic.model` tag, replacing the removed `Mautic\CoreBundle\DependencyInjection\Compiler\ModelPass`. Every model (a service implementing `Mautic\CoreBundle\Model\MauticModelInterface`) declares its `ModelFactory::getModel()` lookup key via a static `getName()` method:
 

--- a/app/bundles/AssetBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/BuilderSubscriber.php
@@ -33,7 +33,7 @@ final class BuilderSubscriber implements EventSubscriberInterface
             EmailEvents::EMAIL_ON_SEND    => ['onEmailGenerate', 0],
             EmailEvents::EMAIL_ON_DISPLAY => ['onEmailGenerate', 0],
             PageEvents::PAGE_ON_BUILD     => ['onBuilderBuild', 0],
-            PageEvents::PAGE_ON_DISPLAY   => ['onPageDisplay', 0],
+            PageDisplayEvent::class   => ['onPageDisplay', 0],
         ];
     }
 

--- a/app/bundles/DynamicContentBundle/EventListener/DynamicContentSubscriber.php
+++ b/app/bundles/DynamicContentBundle/EventListener/DynamicContentSubscriber.php
@@ -22,7 +22,6 @@ use Mautic\PageBundle\Entity\Trackable;
 use Mautic\PageBundle\Event\PageDisplayEvent;
 use Mautic\PageBundle\Helper\TokenHelper as PageTokenHelper;
 use Mautic\PageBundle\Model\TrackableModel;
-use Mautic\PageBundle\PageEvents;
 use MauticPlugin\MauticFocusBundle\Helper\TokenHelper as FocusTokenHelper;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -51,7 +50,7 @@ final readonly class DynamicContentSubscriber implements EventSubscriberInterfac
             DynamicContentEvents::POST_SAVE         => ['onPostSave', 0],
             DynamicContentEvents::POST_DELETE       => ['onDelete', 0],
             DynamicContentEvents::TOKEN_REPLACEMENT => ['onTokenReplacement', 0],
-            PageEvents::PAGE_ON_DISPLAY             => ['decodeTokens', 254],
+            PageDisplayEvent::class             => ['decodeTokens', 254],
         ];
     }
 

--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -30,7 +30,6 @@ use Mautic\PageBundle\Entity\Page;
 use Mautic\PageBundle\Event\PageDisplayEvent;
 use Mautic\PageBundle\EventListener\BuilderSubscriber;
 use Mautic\PageBundle\Model\PageModel;
-use Mautic\PageBundle\PageEvents;
 use Mautic\PluginBundle\Helper\IntegrationHelper;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Form\FormView;
@@ -315,7 +314,7 @@ final class PublicController extends CommonFormController
         );
 
         $event = new PageDisplayEvent($html, $prefCenter, $eventParameters);
-        $this->dispatcher->dispatch($event, PageEvents::PAGE_ON_DISPLAY);
+        $this->dispatcher->dispatch($event);
 
         $request->getSession()->remove($successSessionName);
         $pageModel->hitPage($prefCenter, $request, 200, $lead);

--- a/app/bundles/EmailBundle/EventListener/PageSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/PageSubscriber.php
@@ -5,7 +5,6 @@ namespace Mautic\EmailBundle\EventListener;
 use Mautic\CampaignBundle\Executioner\RealTimeExecutioner;
 use Mautic\EmailBundle\Model\EmailModel;
 use Mautic\PageBundle\Event as Events;
-use Mautic\PageBundle\PageEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -21,7 +20,7 @@ final readonly class PageSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            PageEvents::PAGE_ON_HIT => ['onPageHit', 0],
+            Events\PageHitEvent::class => ['onPageHit', 0],
         ];
     }
 

--- a/app/bundles/FormBundle/EventListener/PageSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/PageSubscriber.php
@@ -28,7 +28,7 @@ final class PageSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            PageEvents::PAGE_ON_DISPLAY => ['onPageDisplay', 0],
+            PageDisplayEvent::class => ['onPageDisplay', 0],
             PageEvents::PAGE_ON_BUILD   => ['onPageBuild', 0],
         ];
     }

--- a/app/bundles/NotificationBundle/Controller/PopupController.php
+++ b/app/bundles/NotificationBundle/Controller/PopupController.php
@@ -6,7 +6,6 @@ use Mautic\CoreBundle\Controller\CommonController;
 use Mautic\CoreBundle\Twig\Helper\AssetsHelper;
 use Mautic\PageBundle\Entity\Page;
 use Mautic\PageBundle\Event\PageDisplayEvent;
-use Mautic\PageBundle\PageEvents;
 use Symfony\Component\HttpFoundation\Response;
 
 final class PopupController extends CommonController
@@ -25,7 +24,7 @@ final class PopupController extends CommonController
         $content = $response->getContent();
 
         $event = new PageDisplayEvent($content, new Page());
-        $this->dispatcher->dispatch($event, PageEvents::PAGE_ON_DISPLAY);
+        $this->dispatcher->dispatch($event);
         $content = $event->getContent();
 
         return $response->setContent($content);

--- a/app/bundles/NotificationBundle/EventListener/PageSubscriber.php
+++ b/app/bundles/NotificationBundle/EventListener/PageSubscriber.php
@@ -4,7 +4,6 @@ namespace Mautic\NotificationBundle\EventListener;
 
 use Mautic\CoreBundle\Twig\Helper\AssetsHelper;
 use Mautic\PageBundle\Event\PageDisplayEvent;
-use Mautic\PageBundle\PageEvents;
 use Mautic\PluginBundle\Helper\IntegrationHelper;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -19,7 +18,7 @@ final readonly class PageSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            PageEvents::PAGE_ON_DISPLAY => ['onPageDisplay', 0],
+            PageDisplayEvent::class => ['onPageDisplay', 0],
         ];
     }
 

--- a/app/bundles/PageBundle/Controller/PublicController.php
+++ b/app/bundles/PageBundle/Controller/PublicController.php
@@ -29,7 +29,6 @@ use Mautic\PageBundle\Model\PageModel;
 use Mautic\PageBundle\Model\RedirectModel;
 use Mautic\PageBundle\Model\Tracking404Model;
 use Mautic\PageBundle\Model\VideoModel;
-use Mautic\PageBundle\PageEvents;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -259,7 +258,7 @@ final class PublicController extends AbstractFormController
             );
 
             $event = new PageDisplayEvent((string) $content, $entity);
-            $this->dispatcher->dispatch($event, PageEvents::PAGE_ON_DISPLAY);
+            $this->dispatcher->dispatch($event);
             $content = $event->getContent();
 
             $isHitTrackable = $model->hitPage($entity, $request, Response::HTTP_OK, $lead, $query);
@@ -347,12 +346,12 @@ final class PublicController extends AbstractFormController
             $content = str_replace('</head>', $analytics."\n</head>", $content);
         }
 
-        if ($this->dispatcher->hasListeners(PageEvents::PAGE_ON_DISPLAY)) {
+        if ($this->dispatcher->hasListeners(PageDisplayEvent::class)) {
             $event = new PageDisplayEvent($content, $page, $this->getPreferenceCenterConfig());
             if (isset($contact) && $contact instanceof Lead) {
                 $event->setLead($contact);
             }
-            $this->dispatcher->dispatch($event, PageEvents::PAGE_ON_DISPLAY);
+            $this->dispatcher->dispatch($event);
             $content = $event->getContent();
         }
 
@@ -396,7 +395,7 @@ final class PublicController extends AbstractFormController
         $sessionValue   = $trackingHelper->getCacheItem(true);
 
         $event = new TrackingEvent($lead, $request, $sessionValue);
-        $this->dispatcher->dispatch($event, PageEvents::ON_CONTACT_TRACKED);
+        $this->dispatcher->dispatch($event);
 
         return new JsonResponse(
             [

--- a/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
@@ -73,7 +73,7 @@ final class BuilderSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            PageEvents::PAGE_ON_DISPLAY   => ['onPageDisplay', 0],
+            Events\PageDisplayEvent::class   => ['onPageDisplay', 0],
             PageEvents::PAGE_ON_BUILD     => ['onPageBuild', 0],
             EmailEvents::EMAIL_ON_BUILD   => ['onEmailBuild', 0],
             EmailEvents::EMAIL_ON_SEND    => ['onEmailGenerate', 0],

--- a/app/bundles/PageBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/CampaignSubscriber.php
@@ -30,7 +30,7 @@ final readonly class CampaignSubscriber implements EventSubscriberInterface
     {
         return [
             CampaignBuilderEvent::class => ['onCampaignBuild', 0],
-            PageEvents::PAGE_ON_HIT                  => ['onPageHit', 0],
+            PageHitEvent::class                  => ['onPageHit', 0],
             PageEvents::ON_CAMPAIGN_TRIGGER_DECISION => [
                 ['onCampaignTriggerDecision', 0],
                 ['onCampaignTriggerDecisionDeviceHit', 1],

--- a/app/bundles/PageBundle/EventListener/DateTimeTokenSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/DateTimeTokenSubscriber.php
@@ -25,7 +25,7 @@ final readonly class DateTimeTokenSubscriber implements EventSubscriberInterface
     {
         return [
             PageEvents::PAGE_ON_BUILD                     => ['onPageBuild', 0],
-            PageEvents::PAGE_ON_DISPLAY                   => ['onPageDisplay', 0],
+            PageDisplayEvent::class                   => ['onPageDisplay', 0],
         ];
     }
 

--- a/app/bundles/PageBundle/EventListener/PageSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/PageSubscriber.php
@@ -33,7 +33,7 @@ final readonly class PageSubscriber implements EventSubscriberInterface
         return [
             PageEvents::PAGE_POST_SAVE      => ['onPagePostSave', 0],
             PageEvents::PAGE_POST_DELETE    => ['onPageDelete', 0],
-            PageEvents::PAGE_ON_DISPLAY     => ['onPageDisplay', -255], // We want this to run last
+            Events\PageDisplayEvent::class     => ['onPageDisplay', -255], // We want this to run last
             PageEditSubmitEvent::class      => ['managePageDraft'],
         ];
     }

--- a/app/bundles/PageBundle/EventListener/PointSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/PointSubscriber.php
@@ -6,7 +6,6 @@ use Mautic\PageBundle\Event as Events;
 use Mautic\PageBundle\Form\Type\PointActionPageHitType;
 use Mautic\PageBundle\Form\Type\PointActionUrlHitType;
 use Mautic\PageBundle\Helper\PointActionHelper;
-use Mautic\PageBundle\PageEvents;
 use Mautic\PointBundle\Event\PointBuilderEvent;
 use Mautic\PointBundle\Model\PointModel;
 use Mautic\PointBundle\PointEvents;
@@ -24,7 +23,7 @@ final readonly class PointSubscriber implements EventSubscriberInterface
     {
         return [
             PointEvents::POINT_ON_BUILD => ['onPointBuild', 0],
-            PageEvents::PAGE_ON_HIT     => ['onPageHit', 0],
+            Events\PageHitEvent::class     => ['onPageHit', 0],
         ];
     }
 

--- a/app/bundles/PageBundle/EventListener/TokenSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/TokenSubscriber.php
@@ -3,7 +3,6 @@
 namespace Mautic\PageBundle\EventListener;
 
 use Mautic\PageBundle\Event\PageDisplayEvent;
-use Mautic\PageBundle\PageEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final class TokenSubscriber implements EventSubscriberInterface
@@ -11,7 +10,7 @@ final class TokenSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            PageEvents::PAGE_ON_DISPLAY => ['decodeTokens', 254],
+            PageDisplayEvent::class => ['decodeTokens', 254],
         ];
     }
 

--- a/app/bundles/PageBundle/EventListener/WebhookSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/WebhookSubscriber.php
@@ -22,7 +22,7 @@ final readonly class WebhookSubscriber implements EventSubscriberInterface
     {
         return [
             WebhookEvents::WEBHOOK_ON_BUILD => ['onWebhookBuild', 0],
-            PageEvents::PAGE_ON_HIT         => ['onPageHit', 0],
+            PageHitEvent::class         => ['onPageHit', 0],
         ];
     }
 

--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -710,9 +710,9 @@ class PageModel extends FormModel implements GlobalSearchInterface
             );
         }
 
-        if ($this->dispatcher->hasListeners(PageEvents::PAGE_ON_HIT)) {
+        if ($this->dispatcher->hasListeners(PageHitEvent::class)) {
             $event = new PageHitEvent($hit, $request, $hit->getCode(), $clickthrough, $isUnique);
-            $this->dispatcher->dispatch($event, PageEvents::PAGE_ON_HIT);
+            $this->dispatcher->dispatch($event);
         }
 
         if (null !== $hitDate) {

--- a/app/bundles/PageBundle/Model/RedirectModel.php
+++ b/app/bundles/PageBundle/Model/RedirectModel.php
@@ -8,7 +8,6 @@ use Mautic\CoreBundle\Shortener\Shortener;
 use Mautic\PageBundle\Entity\Redirect;
 use Mautic\PageBundle\Entity\RedirectRepository;
 use Mautic\PageBundle\Event\RedirectGenerationEvent;
-use Mautic\PageBundle\PageEvents;
 use Symfony\Contracts\Service\Attribute\Required;
 
 /**
@@ -58,9 +57,9 @@ class RedirectModel extends FormModel
         Redirect $redirect,
         $clickthrough = [],
     ) {
-        if ($this->dispatcher->hasListeners(PageEvents::ON_REDIRECT_GENERATE)) {
+        if ($this->dispatcher->hasListeners(RedirectGenerationEvent::class)) {
             $event = new RedirectGenerationEvent($redirect, $clickthrough);
-            $this->dispatcher->dispatch($event, PageEvents::ON_REDIRECT_GENERATE);
+            $this->dispatcher->dispatch($event);
 
             $clickthrough = $event->getClickthrough();
         }

--- a/app/bundles/PageBundle/Model/TrackableModel.php
+++ b/app/bundles/PageBundle/Model/TrackableModel.php
@@ -11,7 +11,6 @@ use Mautic\PageBundle\Entity\Redirect;
 use Mautic\PageBundle\Entity\Trackable;
 use Mautic\PageBundle\Entity\TrackableRepository;
 use Mautic\PageBundle\Event\UntrackableUrlsEvent;
-use Mautic\PageBundle\PageEvents;
 use Symfony\Contracts\Service\Attribute\Required;
 
 /**
@@ -221,8 +220,7 @@ class TrackableModel extends AbstractCommonModel
     {
         /** @var UntrackableUrlsEvent $event */
         $event = $this->dispatcher->dispatch(
-            new UntrackableUrlsEvent($content),
-            PageEvents::REDIRECT_DO_NOT_TRACK
+            new UntrackableUrlsEvent($content)
         );
 
         return $event->getDoNotTrackList();

--- a/app/bundles/PageBundle/Model/VideoModel.php
+++ b/app/bundles/PageBundle/Model/VideoModel.php
@@ -9,7 +9,6 @@ use Mautic\LeadBundle\Tracker\ContactTracker;
 use Mautic\PageBundle\Entity\VideoHit;
 use Mautic\PageBundle\Entity\VideoHitRepository;
 use Mautic\PageBundle\Event\VideoHitEvent;
-use Mautic\PageBundle\PageEvents;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Contracts\Service\Attribute\Required;
 
@@ -148,9 +147,9 @@ final class VideoModel extends FormModel
             );
         }
 
-        if ($this->dispatcher->hasListeners(PageEvents::VIDEO_ON_HIT)) {
+        if ($this->dispatcher->hasListeners(VideoHitEvent::class)) {
             $event = new VideoHitEvent($hit, $request, $code);
-            $this->dispatcher->dispatch($event, PageEvents::VIDEO_ON_HIT);
+            $this->dispatcher->dispatch($event);
         }
     }
 }

--- a/app/bundles/PageBundle/Tests/Controller/PublicControllerTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PublicControllerTest.php
@@ -35,7 +35,6 @@ use Mautic\PageBundle\Helper\TrackingHelper;
 use Mautic\PageBundle\Model\PageModel;
 use Mautic\PageBundle\Model\RedirectModel;
 use Mautic\PageBundle\Model\Tracking404Model;
-use Mautic\PageBundle\PageEvents;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -445,7 +444,7 @@ final class PublicControllerTest extends TestCase
         $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
         $eventDispatcher->expects($this->once())
             ->method('dispatch')
-            ->with($event, PageEvents::ON_CONTACT_TRACKED)
+            ->with($event)
             ->willReturnCallback(
                 function (TrackingEvent $event): TrackingEvent {
                     $contact  = $event->getContact()->getEmail();

--- a/app/bundles/PageBundle/Tests/EventListener/PageSubscriberTest.php
+++ b/app/bundles/PageBundle/Tests/EventListener/PageSubscriberTest.php
@@ -22,7 +22,6 @@ use Mautic\PageBundle\Event\PageDisplayEvent;
 use Mautic\PageBundle\EventListener\PageSubscriber;
 use Mautic\PageBundle\Model\PageDraftModel;
 use Mautic\PageBundle\Model\PageModel;
-use Mautic\PageBundle\PageEvents;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Asset\Packages;
@@ -60,7 +59,7 @@ EOF;
 
         $dispatcher->addSubscriber($subscriber);
 
-        $dispatcher->dispatch($event, PageEvents::PAGE_ON_DISPLAY);
+        $dispatcher->dispatch($event);
 
         $this->assertSame(
             <<<EOF

--- a/app/bundles/PageBundle/Tests/EventListener/PointSubscriberTest.php
+++ b/app/bundles/PageBundle/Tests/EventListener/PointSubscriberTest.php
@@ -22,7 +22,7 @@ final class PointSubscriberTest extends TestCase
     {
         $this->assertSame([
             'mautic.point_on_build' => ['onPointBuild', 0],
-            'mautic.page_on_hit'    => ['onPageHit', 0],
+            PageHitEvent::class    => ['onPageHit', 0],
         ], PointSubscriber::getSubscribedEvents());
     }
 

--- a/app/bundles/PageBundle/Tests/EventListener/PreferencePageTest.php
+++ b/app/bundles/PageBundle/Tests/EventListener/PreferencePageTest.php
@@ -12,7 +12,6 @@ use Mautic\LeadBundle\Form\Type\ContactFrequencyType;
 use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\PageBundle\Entity\Page;
 use Mautic\PageBundle\Event\PageDisplayEvent;
-use Mautic\PageBundle\PageEvents;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
@@ -202,7 +201,7 @@ final class PreferencePageTest extends MauticMysqlTestCase
     private function dispatchEvent(Page $page, array $params): string
     {
         $event = new PageDisplayEvent($page->getCustomHtml(), $page, $params);
-        $this->dispatcher->dispatch($event, PageEvents::PAGE_ON_DISPLAY);
+        $this->dispatcher->dispatch($event);
 
         return strip_tags($event->getContent());
     }

--- a/app/bundles/PageBundle/Tests/Model/RedirectModelTest.php
+++ b/app/bundles/PageBundle/Tests/Model/RedirectModelTest.php
@@ -14,7 +14,6 @@ use Mautic\PageBundle\Entity\Redirect;
 use Mautic\PageBundle\Entity\RedirectRepository;
 use Mautic\PageBundle\Event\RedirectGenerationEvent;
 use Mautic\PageBundle\Model\RedirectModel;
-use Mautic\PageBundle\PageEvents;
 use Mautic\PageBundle\Tests\PageTestAbstract;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Routing\Router;
@@ -81,7 +80,7 @@ final class RedirectModelTest extends PageTestAbstract
 
         // Add the listener to append something else to the CT
         $dispatcher->addListener(
-            PageEvents::ON_REDIRECT_GENERATE,
+            RedirectGenerationEvent::class,
             function (RedirectGenerationEvent $event): void {
                 $event->setInClickthrough('bar', 'foo');
             }

--- a/plugins/MauticFocusBundle/EventListener/PageSubscriber.php
+++ b/plugins/MauticFocusBundle/EventListener/PageSubscriber.php
@@ -28,7 +28,7 @@ final class PageSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            PageEvents::PAGE_ON_DISPLAY => ['onPageDisplay', 0],
+            PageDisplayEvent::class => ['onPageDisplay', 0],
             PageEvents::PAGE_ON_BUILD   => ['onPageBuild', 0],
         ];
     }

--- a/plugins/MauticFocusBundle/EventListener/StatSubscriber.php
+++ b/plugins/MauticFocusBundle/EventListener/StatSubscriber.php
@@ -5,7 +5,6 @@ namespace MauticPlugin\MauticFocusBundle\EventListener;
 use Mautic\FormBundle\Event\SubmissionEvent;
 use Mautic\FormBundle\FormEvents;
 use Mautic\PageBundle\Event\PageHitEvent;
-use Mautic\PageBundle\PageEvents;
 use MauticPlugin\MauticFocusBundle\Entity\Stat;
 use MauticPlugin\MauticFocusBundle\Model\FocusModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -22,7 +21,7 @@ final readonly class StatSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            PageEvents::PAGE_ON_HIT    => ['onPageHit', 0],
+            PageHitEvent::class    => ['onPageHit', 0],
             FormEvents::FORM_ON_SUBMIT => ['onFormSubmit', 0],
         ];
     }


### PR DESCRIPTION
Since Symfony 4.3 the dispatched event object's class name is the event name, so the string constant passed as the second argument to `dispatch()` and used as the subscriber array key is redundant. This converts the PageBundle constants whose event class maps 1:1 to a single name.

Transforms applied:
- `$dispatcher->dispatch($event, PageEvents::X)` -> `$dispatcher->dispatch($event)`
- `hasListeners(PageEvents::X)` -> `hasListeners(XEvent::class)`
- subscriber keys `PageEvents::X => [...]` -> `XEvent::class => [...]`

Converted event classes (all in `Mautic\PageBundle\Event`):
- `VideoHitEvent` (`VIDEO_ON_HIT`)
- `PageHitEvent` (`PAGE_ON_HIT`)
- `PageDisplayEvent` (`PAGE_ON_DISPLAY`)
- `UntrackableUrlsEvent` (`REDIRECT_DO_NOT_TRACK`)
- `RedirectGenerationEvent` (`ON_REDIRECT_GENERATE`)
- `TrackingEvent` (`ON_CONTACT_TRACKED`)

Kept as string constants because the event class is shared across multiple names (converting would collapse distinct listeners onto one class):
- the `PageEvent` CRUD/build group dispatched via `PageModel::dispatchEvent()` (`PAGE_ON_BUILD`, `PAGE_PRE_SAVE`, `PAGE_POST_SAVE`, `PAGE_PRE_DELETE`, `PAGE_POST_DELETE`, `PAGE_ON_TOGGLE_PUBLISH`)
- the `DetermineWinnerEvent` pair (`ON_DETERMINE_BOUNCE_RATE_WINNER`, `ON_DETERMINE_DWELL_TIME_WINNER`)
- the campaign constants (`ON_CAMPAIGN_TRIGGER_DECISION`, `ON_CAMPAIGN_BATCH_ACTION`), whose events are shared across every bundle's campaign actions

The `Mautic\PageBundle\PageEvents` constants are kept for backwards compatibility. `UPGRADE-8.0.md` documents the change. Same transform as the merged PluginBundle PR #17162.