### PR TITLE
fix: reattach existing tags during background imports

### DIFF
--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -1785,7 +1785,9 @@ class LeadModel extends FormModel
                 if (!array_key_exists($tag, $foundTags)) {
                     $tagToBeAdded = new Tag($tag, false);
                 } elseif (!$leadTags->contains($foundTags[$tag])) {
-                    $tagToBeAdded = $foundTags[$tag];
+                    // Import batches may hold an entity returned before Doctrine
+                    // detached it. Always attach the existing tag to this manager.
+                    $tagToBeAdded = $this->em->getReference(Tag::class, $foundTags[$tag]->getId());
                 }
 
                 if ($tagToBeAdded) {

--- a/app/bundles/LeadBundle/Tests/Model/LeadModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/LeadModelTest.php
@@ -24,6 +24,8 @@ use Mautic\LeadBundle\Entity\LeadField;
 use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Entity\StagesChangeLog;
 use Mautic\LeadBundle\Entity\StagesChangeLogRepository;
+use Mautic\LeadBundle\Entity\Tag;
+use Mautic\LeadBundle\Entity\TagRepository;
 use Mautic\LeadBundle\Event\LeadEvent;
 use Mautic\LeadBundle\Event\SaveBatchLeadsEvent;
 use Mautic\LeadBundle\Exception\ImportFailedException;
@@ -438,6 +440,35 @@ class LeadModelTest extends \PHPUnit\Framework\TestCase
         $mockLeadModel->expects($this->once())->method('modifyTags')->willReturn(true);
 
         $mockLeadModel->import(['tag' => 'tags'], ['tag' => 'Test 1|Test 2|Test 3']);
+    }
+
+    public function testModifyTagsUsesManagedReferenceForExistingTag(): void
+    {
+        $lead        = new Lead();
+        $detachedTag = new Tag('import-tag');
+        $managedTag  = new Tag('import-tag');
+        $this->setProperty($detachedTag, Tag::class, 'id', 123);
+        $this->setProperty($managedTag, Tag::class, 'id', 123);
+
+        $tagRepository = $this->createMock(TagRepository::class);
+        $tagRepository->expects($this->once())
+            ->method('getTagsByName')
+            ->with(['import-tag'])
+            ->willReturn(['import-tag' => $detachedTag]);
+
+        $this->entityManagerMock->expects($this->once())
+            ->method('getRepository')
+            ->with(Tag::class)
+            ->willReturn($tagRepository);
+        $this->entityManagerMock->expects($this->once())
+            ->method('getReference')
+            ->with(Tag::class, 123)
+            ->willReturn($managedTag);
+
+        $this->leadModel->modifyTags($lead, ['import-tag'], null, false);
+
+        $this->assertTrue($lead->getTags()->contains($managedTag));
+        $this->assertFalse($lead->getTags()->contains($detachedTag));
     }
 
     /**


### PR DESCRIPTION
## Description

Reattaches an existing default tag through the current EntityManager before it is added to a contact. This prevents a detached `Tag` object from reaching Doctrine during a background CSV import batch.

Fixes #17207.

## Validation

- Added a unit regression test for an existing detached tag returned by the repository.
- Applied the patch to a Mautic 7.1.3 staging-safe production instance and ran an isolated five-contact CSV import with a default tag and `batchlimit=2` (three batches).
- Result: import completed as `IMPORTED`; all five contacts received the tag; no EntityManager closure occurred.
- Removed the test import, contacts, tag, event rows, and CSV after verification.

The production runtime does not include PHPUnit dev dependencies, so the new PHPUnit case was syntax-checked there; the complete behavioural verification was performed through the real Mautic import command.