### PR TITLE
fix: reattach existing tags during background imports

### DIFF
--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -1832,7 +1832,9 @@ class LeadModel extends FormModel
                 if (!array_key_exists($tag, $foundTags)) {
                     $tagToBeAdded = new Tag($tag, false);
                 } elseif (!$leadTags->contains($foundTags[$tag])) {
-                    $tagToBeAdded = $foundTags[$tag];
+                    // Import batches may keep a tag entity after Doctrine has
+                    // detached it. Attach the existing tag to this manager.
+                    $tagToBeAdded = $this->em->getReference(Tag::class, $foundTags[$tag]->getId());
                 }
 
                 if ($tagToBeAdded) {

--- a/app/bundles/LeadBundle/Tests/Model/LeadModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/LeadModelTest.php
@@ -34,6 +34,7 @@ use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Entity\MergeRecordRepository;
 use Mautic\LeadBundle\Entity\PointsChangeLogRepository;
 use Mautic\LeadBundle\Entity\StagesChangeLogRepository;
+use Mautic\LeadBundle\Entity\Tag;
 use Mautic\LeadBundle\Entity\TagRepository;
 use Mautic\LeadBundle\Entity\UtmTagRepository;
 use Mautic\LeadBundle\Event\LeadEvent;
@@ -103,6 +104,11 @@ final class LeadModelTest extends \PHPUnit\Framework\TestCase
     private MockObject $leadRepositoryMock;
 
     /**
+     * @var MockObject&TagRepository
+     */
+    private MockObject $tagRepositoryMock;
+
+    /**
      * @var MockObject&CompanyLeadRepository
      */
     private MockObject $companyLeadRepositoryMock;
@@ -151,6 +157,7 @@ final class LeadModelTest extends \PHPUnit\Framework\TestCase
         $this->coreParametersHelperMock         = $this->createMock(CoreParametersHelper::class);
         $this->emailValidatorMock               = $this->createMock(EmailValidator::class);
         $this->leadRepositoryMock               = $this->createMock(LeadRepository::class);
+        $this->tagRepositoryMock                = $this->createMock(TagRepository::class);
         $this->companyLeadRepositoryMock        = $this->createMock(CompanyLeadRepository::class);
         $this->stagesChangeLogRepositoryMock    = $this->createMock(StagesChangeLogRepository::class);
         $this->stageRepositoryMock              = $this->createMock(StageRepository::class);
@@ -184,7 +191,7 @@ final class LeadModelTest extends \PHPUnit\Framework\TestCase
             $this->userHelperMock,
             $this->createStub(LoggerInterface::class),
             $this->leadRepositoryMock,
-            $this->createStub(TagRepository::class), // $tagRepository
+            $this->tagRepositoryMock,
             $this->createStub(PointsChangeLogRepository::class), // $pointsChangeLogRepository
             $this->createStub(UtmTagRepository::class), // $utmTagRepository
             $this->createStub(LeadDeviceRepository::class), // $leadDeviceRepository
@@ -206,6 +213,28 @@ final class LeadModelTest extends \PHPUnit\Framework\TestCase
         $this->setSecurity($this->leadModel);
 
         $this->companyModelMock->method('getCompanyLeadRepository')->willReturn($this->companyLeadRepositoryMock);
+    }
+
+    public function testModifyTagsReattachesExistingDetachedTag(): void
+    {
+        $lead        = new Lead();
+        $detachedTag = new Tag('import-tag');
+        $managedTag  = new Tag('import-tag');
+
+        ReflectionHelper::setValue($detachedTag, 'id', 123);
+        ReflectionHelper::setValue($managedTag, 'id', 123);
+
+        $this->tagRepositoryMock->expects($this->once())
+            ->method('getTagsByName')
+            ->with(['import-tag'])
+            ->willReturn(['import-tag' => $detachedTag]);
+        $this->entityManagerMock->expects($this->once())
+            ->method('getReference')
+            ->with(Tag::class, 123)
+            ->willReturn($managedTag);
+
+        $this->assertTrue($this->leadModel->modifyTags($lead, ['import-tag'], null, false));
+        $this->assertTrue($lead->getTags()->contains($managedTag));
     }
 
     public function testIpLookupDoesNotAddCompanyIfConfiguredSo(): void


### PR DESCRIPTION
## Target release: 7.2.1

Rebased onto `7.2` at `bd76a5d56e85d5d30da00b041edf61ca7c78e31a`. Current head: `c97b901d962974f3852bdaeb725b3b23cf619ae9`. `git range-diff` confirms that every patch commit is unchanged by the rebase.

Validation repeated on the rebased source with PHP 8.3.32: Detached tag regression: 1 test, 7 assertions. PHP syntax and whitespace checks passed.

Fixes the EntityManager-closed error during background imports with a default tag.

When an import spans batches, Doctrine can detach an existing Tag returned by the repository. The contact is then associated with that detached entity and the next flush closes the EntityManager. This change obtains a managed reference by tag ID before the association.

Regression coverage exercises the detached-tag path.

Validated on Mautic 7.1.3 with an isolated five-contact, three-batch import using a default tag; all contacts were imported and tagged successfully.
