### PR TITLE
[dead-code] remove unused AssetEvents consts

### DIFF
--- a/app/bundles/AssetBundle/AssetEvents.php
+++ b/app/bundles/AssetBundle/AssetEvents.php
@@ -4,67 +4,8 @@ declare(strict_types=1);
 
 namespace Mautic\AssetBundle;
 
-/**
- * Events available for AssetBundle.
- */
 final class AssetEvents
 {
-    /**
-     * The mautic.asset_on_load event is dispatched when a public asset is downloaded, publicly viewed, or redirected to (remote).
-     *
-     * The event listener receives a
-     * Mautic\AssetBundle\Event\AssetLoadEvent instance.
-     */
-    public const string ASSET_ON_LOAD = 'mautic.asset_on_load';
-
-    /**
-     * The mautic.asset_on_remote_browse event is dispatched when browsing a remote provider.
-     *
-     * The event listener receives a
-     * Mautic\AssetBundle\Event\RemoteAssetBrowseEvent instance.
-     */
-    public const string ASSET_ON_REMOTE_BROWSE = 'mautic.asset_on_remote_browse';
-
-    /**
-     * The mautic.asset_pre_save event is dispatched right before a asset is persisted.
-     *
-     * The event listener receives a
-     * Mautic\AssetBundle\Event\AssetPreSaveEvent instance.
-     *
-     * @deprecated dispatched by the Mautic\AssetBundle\Event\AssetPreSaveEvent class name
-     */
-    public const string ASSET_PRE_SAVE = 'mautic.asset_pre_save';
-
-    /**
-     * The mautic.asset_post_save event is dispatched right after a asset is persisted.
-     *
-     * The event listener receives a
-     * Mautic\AssetBundle\Event\AssetPostSaveEvent instance.
-     *
-     * @deprecated dispatched by the Mautic\AssetBundle\Event\AssetPostSaveEvent class name
-     */
-    public const string ASSET_POST_SAVE = 'mautic.asset_post_save';
-
-    /**
-     * The mautic.asset_pre_delete event is dispatched prior to when a asset is deleted.
-     *
-     * The event listener receives a
-     * Mautic\AssetBundle\Event\AssetPreDeleteEvent instance.
-     *
-     * @deprecated dispatched by the Mautic\AssetBundle\Event\AssetPreDeleteEvent class name
-     */
-    public const string ASSET_PRE_DELETE = 'mautic.asset_pre_delete';
-
-    /**
-     * The mautic.asset_post_delete event is dispatched after a asset is deleted.
-     *
-     * The event listener receives a
-     * Mautic\AssetBundle\Event\AssetPostDeleteEvent instance.
-     *
-     * @deprecated dispatched by the Mautic\AssetBundle\Event\AssetPostDeleteEvent class name
-     */
-    public const string ASSET_POST_DELETE = 'mautic.asset_post_delete';
-
     /**
      * The mautic.asset.on_campaign_trigger_decision event is fired when the campaign action triggers.
      *


### PR DESCRIPTION
Follow up to https://github.com/mautic/mautic/pull/17196