### PR TITLE
[symfony] Dispatch Notification, Dashboard, Stage and Sms bundle events by class name (Symfony 4.3 style)

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -356,6 +356,51 @@
     | `PageEvents::REDIRECT_DO_NOT_TRACK` | `UntrackableUrlsEvent` |
     | `PageEvents::ON_REDIRECT_GENERATE` | `RedirectGenerationEvent` |
     | `PageEvents::ON_CONTACT_TRACKED` | `TrackingEvent` |
+- The `Mautic\NotificationBundle\Event\NotificationSendEvent` (`NotificationEvents::NOTIFICATION_ON_SEND`) is now dispatched by the event object alone, so the event name is the event class (Symfony 4.3+) instead of the `mautic.notification_on_send` string constant. Update any listener that keys on `NotificationEvents::NOTIFICATION_ON_SEND` to key on `NotificationSendEvent::class` instead. The constant is kept for backwards compatibility but is no longer used internally. The `NotificationEvent` CRUD events (`NOTIFICATION_PRE_SAVE` / `POST_SAVE` / `PRE_DELETE` / `POST_DELETE`) share one event object and are still dispatched under their string names.
+- DashboardBundle events are now dispatched by the event object alone, so the event name is the event class (Symfony 4.3+) instead of the `Mautic\DashboardBundle\DashboardEvents` string constants. Update any subscriber or listener that keys on one of the converted `DashboardEvents::*` constants to key on the event class instead:
+
+    ```diff
+     public static function getSubscribedEvents(): array
+     {
+         return [
+    -        DashboardEvents::DASHBOARD_ON_MODULE_LIST_GENERATE => ['onWidgetListGenerate', 0],
+    +        WidgetTypeListEvent::class => ['onWidgetListGenerate', 0],
+         ];
+     }
+    ```
+
+    Dispatching drops the redundant second argument, e.g. `$dispatcher->dispatch($event, DashboardEvents::DASHBOARD_ON_MODULE_LIST_GENERATE)` becomes `$dispatcher->dispatch($event)`. The `Mautic\DashboardBundle\DashboardEvents` constants are kept for backwards compatibility but are no longer used internally for the events below. The `DASHBOARD_ON_MODULE_DETAIL_GENERATE` / `DASHBOARD_ON_MODULE_DETAIL_PRE_LOAD` pair share the `WidgetDetailEvent` class and are unchanged.
+
+    Full mapping of the converted constants to their event class (all in the `Mautic\DashboardBundle\Event` namespace):
+
+    | `DashboardEvents` constant | New event class |
+    | --- | --- |
+    | `DashboardEvents::DASHBOARD_ON_MODULE_LIST_GENERATE` | `WidgetTypeListEvent` |
+    | `DashboardEvents::DASHBOARD_ON_MODULE_FORM_GENERATE` | `WidgetFormEvent` |
+- StageBundle now dispatches its stage-builder event by the event object alone, so the event name is the event class (Symfony 4.3+) instead of the `Mautic\StageBundle\StageEvents::STAGE_ON_BUILD` string constant. Update any subscriber or listener that keys on `StageEvents::STAGE_ON_BUILD` (or the raw string `mautic.stage_on_build`) to key on `Mautic\StageBundle\Event\StageBuilderEvent::class` instead, and drop the redundant second argument when dispatching, e.g. `$dispatcher->dispatch($event, StageEvents::STAGE_ON_BUILD)` becomes `$dispatcher->dispatch($event)`. The `StageEvents` constants are kept for backwards compatibility. The `STAGE_PRE_SAVE` / `STAGE_POST_SAVE` / `STAGE_PRE_DELETE` / `STAGE_POST_DELETE` group (all sharing the `StageEvent` class) and `ON_CAMPAIGN_BATCH_ACTION` (a `PendingEvent`) are unchanged.
+- SmsBundle events are now dispatched by the event object alone, so the event name is the event class (Symfony 4.3+) instead of the `Mautic\SmsBundle\SmsEvents` string constants. Update any subscriber or listener that keys on one of the converted `SmsEvents::*` constants to key on the event class instead:
+
+    ```diff
+     public static function getSubscribedEvents(): array
+     {
+         return [
+    -        SmsEvents::DNC_FILTER_CONTACTS_ON_SEND => ['dncFilter', 0],
+    +        DncEvent::class => ['dncFilter', 0],
+         ];
+     }
+    ```
+
+    Dispatching drops the redundant second argument, e.g. `$dispatcher->dispatch($event, SmsEvents::SMS_ON_SEND)` becomes `$dispatcher->dispatch($event)`. The `Mautic\SmsBundle\SmsEvents` constants are kept for backwards compatibility but are no longer used internally for the events below. Constants that share an event class stay unchanged: the `SMS_PRE_SAVE` / `SMS_POST_SAVE` / `SMS_PRE_DELETE` / `SMS_POST_DELETE` group (`SmsEvent`) and the `ON_REPLY` / `ON_CAMPAIGN_REPLY` pair (`ReplyEvent`). The webhook-type identifiers `TOKEN_REPLACEMENT` (shared `CoreBundle` event) and the campaign trigger constants also stay as strings.
+
+    Full mapping of the converted constants to their event class (all in the `Mautic\SmsBundle\Event` namespace):
+
+    | `SmsEvents` constant | New event class |
+    | --- | --- |
+    | `SmsEvents::SMS_ON_SEND` | `SmsSendEvent` |
+    | `SmsEvents::ON_SMS_TOKENS_BUILD` | `TokensBuildEvent` |
+    | `SmsEvents::DNC_FILTER_CONTACTS_ON_SEND` | `DncEvent` |
+    | `SmsEvents::QUEUE_FILTER_CONTACTS_ON_SEND` | `QueueEvent` |
+    | `SmsEvents::FILTER_CONTACTS_ON_SEND` | `FilterEvent` |
 
 - `Mautic\CoreBundle\Factory\ModelFactory` now builds its service locator from a `defaultIndexMethod` on the `mautic.model` tag, replacing the removed `Mautic\CoreBundle\DependencyInjection\Compiler\ModelPass`. Every model (a service implementing `Mautic\CoreBundle\Model\MauticModelInterface`) declares its `ModelFactory::getModel()` lookup key via a static `getName()` method:
 

--- a/app/bundles/DashboardBundle/Controller/Api/WidgetApiController.php
+++ b/app/bundles/DashboardBundle/Controller/Api/WidgetApiController.php
@@ -12,7 +12,6 @@ use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\CoreBundle\Translation\Translator;
-use Mautic\DashboardBundle\DashboardEvents;
 use Mautic\DashboardBundle\Entity\Widget;
 use Mautic\DashboardBundle\Event\WidgetTypeListEvent;
 use Mautic\DashboardBundle\Model\DashboardModel;
@@ -63,7 +62,7 @@ final class WidgetApiController extends CommonApiController
     {
         $event = new WidgetTypeListEvent();
         $event->setTranslator($this->translator);
-        $this->dispatcher->dispatch($event, DashboardEvents::DASHBOARD_ON_MODULE_LIST_GENERATE);
+        $this->dispatcher->dispatch($event);
         $view = $this->view(['success' => 1, 'types' => $event->getTypes()], Response::HTTP_OK);
 
         return $this->handleView($view);

--- a/app/bundles/DashboardBundle/EventListener/DashboardSubscriber.php
+++ b/app/bundles/DashboardBundle/EventListener/DashboardSubscriber.php
@@ -34,8 +34,8 @@ class DashboardSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            DashboardEvents::DASHBOARD_ON_MODULE_LIST_GENERATE   => ['onWidgetListGenerate', 0],
-            DashboardEvents::DASHBOARD_ON_MODULE_FORM_GENERATE   => ['onWidgetFormGenerate', 0],
+            WidgetTypeListEvent::class                           => ['onWidgetListGenerate', 0],
+            WidgetFormEvent::class                               => ['onWidgetFormGenerate', 0],
             DashboardEvents::DASHBOARD_ON_MODULE_DETAIL_PRE_LOAD => ['onWidgetDetailPreLoad', 0],
             DashboardEvents::DASHBOARD_ON_MODULE_DETAIL_GENERATE => ['onWidgetDetailGenerate', 0],
         ];

--- a/app/bundles/DashboardBundle/Form/Type/WidgetType.php
+++ b/app/bundles/DashboardBundle/Form/Type/WidgetType.php
@@ -4,7 +4,6 @@ namespace Mautic\DashboardBundle\Form\Type;
 
 use Mautic\CoreBundle\Form\Type\FormButtonsType;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
-use Mautic\DashboardBundle\DashboardEvents;
 use Mautic\DashboardBundle\Event\WidgetFormEvent;
 use Mautic\DashboardBundle\Event\WidgetTypeListEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -42,7 +41,7 @@ final class WidgetType extends AbstractType
 
         $event = new WidgetTypeListEvent();
         $event->setSecurity($this->security);
-        $this->dispatcher->dispatch($event, DashboardEvents::DASHBOARD_ON_MODULE_LIST_GENERATE);
+        $this->dispatcher->dispatch($event);
 
         $types = array_map(array_flip(...), $event->getTypes());
 
@@ -120,7 +119,7 @@ final class WidgetType extends AbstractType
             }
 
             $event->setType($type);
-            $this->dispatcher->dispatch($event, DashboardEvents::DASHBOARD_ON_MODULE_FORM_GENERATE);
+            $this->dispatcher->dispatch($event);
             $widgetForm = $event->getForm();
             $form->setData($params);
 

--- a/app/bundles/LeadBundle/EventListener/OwnerSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/OwnerSubscriber.php
@@ -36,7 +36,7 @@ final class OwnerSubscriber implements EventSubscriberInterface
             EmailEvents::EMAIL_ON_BUILD    => ['onEmailBuild', 0],
             EmailEvents::EMAIL_ON_SEND     => ['onEmailGenerate', 0],
             EmailEvents::EMAIL_ON_DISPLAY  => ['onEmailDisplay', 0],
-            SmsEvents::ON_SMS_TOKENS_BUILD => ['onSmsTokensBuild', 0],
+            TokensBuildEvent::class        => ['onSmsTokensBuild', 0],
             SmsEvents::TOKEN_REPLACEMENT   => ['onSmsTokenReplacement', 0],
             UrlTokenReplaceEvent::class    => ['onUrlTokenReplace', 0],
         ];

--- a/app/bundles/NotificationBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/NotificationBundle/EventListener/CampaignSubscriber.php
@@ -232,8 +232,7 @@ class CampaignSubscriber implements EventSubscriberInterface
 
         /** @var NotificationSendEvent $sendEvent */
         $sendEvent = $this->dispatcher->dispatch(
-            new NotificationSendEvent($tokenEvent->getContent(), $notification->getHeading(), $lead),
-            NotificationEvents::NOTIFICATION_ON_SEND
+            new NotificationSendEvent($tokenEvent->getContent(), $notification->getHeading(), $lead)
         );
 
         if ($url = $notification->getUrl()) {

--- a/app/bundles/SmsBundle/Controller/AjaxController.php
+++ b/app/bundles/SmsBundle/Controller/AjaxController.php
@@ -10,7 +10,6 @@ use Mautic\EmailBundle\Model\EmailModel;
 use Mautic\SmsBundle\Broadcast\BroadcastQuery;
 use Mautic\SmsBundle\Event\TokensBuildEvent;
 use Mautic\SmsBundle\Model\SmsModel;
-use Mautic\SmsBundle\SmsEvents;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -84,7 +83,7 @@ final class AjaxController extends CommonAjaxController
 
         $tokens = $this->getBuilderTokens($query);
         $event  = new TokensBuildEvent($tokens);
-        $eventDispatcher->dispatch($event, SmsEvents::ON_SMS_TOKENS_BUILD);
+        $eventDispatcher->dispatch($event);
         $sortedTokens = $tokenSorter->sortTokens($event->getTokens());
 
         return $this->sendJsonResponse(['tokens' => $sortedTokens]);

--- a/app/bundles/SmsBundle/EventListener/SendSmsSubscriber.php
+++ b/app/bundles/SmsBundle/EventListener/SendSmsSubscriber.php
@@ -11,7 +11,6 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\SmsBundle\Event\DncEvent;
 use Mautic\SmsBundle\Event\FilterEvent;
 use Mautic\SmsBundle\Event\QueueEvent;
-use Mautic\SmsBundle\SmsEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final readonly class SendSmsSubscriber implements EventSubscriberInterface
@@ -28,9 +27,9 @@ final readonly class SendSmsSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            SmsEvents::DNC_FILTER_CONTACTS_ON_SEND   => ['dncFilter', 0],
-            SmsEvents::QUEUE_FILTER_CONTACTS_ON_SEND => ['queueFilter', 0],
-            SmsEvents::FILTER_CONTACTS_ON_SEND       => ['genericFilter', 0],
+            DncEvent::class    => ['dncFilter', 0],
+            QueueEvent::class  => ['queueFilter', 0],
+            FilterEvent::class => ['genericFilter', 0],
         ];
     }
 

--- a/app/bundles/SmsBundle/EventListener/WebhookSubscriber.php
+++ b/app/bundles/SmsBundle/EventListener/WebhookSubscriber.php
@@ -20,7 +20,7 @@ final readonly class WebhookSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            SmsEvents::SMS_ON_SEND     => 'onSend',
+            SmsSendEvent::class        => 'onSend',
             WebhookBuilderEvent::class => 'onWebhookBuild',
         ];
     }

--- a/app/bundles/SmsBundle/Model/SmsModel.php
+++ b/app/bundles/SmsBundle/Model/SmsModel.php
@@ -230,7 +230,7 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface, GlobalSear
         }
 
         $dncEvent = new DncEvent($contacts);
-        $this->dispatcher->dispatch($dncEvent, SmsEvents::DNC_FILTER_CONTACTS_ON_SEND);
+        $this->dispatcher->dispatch($dncEvent);
 
         foreach ($dncEvent->getRemovedContacts() as $contactId) {
             $results[$contactId] = [
@@ -247,7 +247,7 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface, GlobalSear
         }
 
         $queueEvent = new QueueEvent($contacts, array_merge($options, ['sms_id' => $sms->getId()]));
-        $this->dispatcher->dispatch($queueEvent, SmsEvents::QUEUE_FILTER_CONTACTS_ON_SEND);
+        $this->dispatcher->dispatch($queueEvent);
 
         foreach ($queueEvent->getQueuedContacts() as $contactId) {
             $results[$contactId] = [
@@ -264,7 +264,7 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface, GlobalSear
         }
 
         $filterEvent = new FilterEvent($contacts);
-        $this->dispatcher->dispatch($filterEvent, SmsEvents::FILTER_CONTACTS_ON_SEND);
+        $this->dispatcher->dispatch($filterEvent);
 
         foreach ($filterEvent->getRemovedContacts() as $contactId) {
             $results[$contactId] = [
@@ -294,7 +294,7 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface, GlobalSear
 
             $smsEvent = new SmsSendEvent($translatedSms->getMessage(), $contact);
             $smsEvent->setSmsId($translatedSms->getId());
-            $this->dispatcher->dispatch($smsEvent, SmsEvents::SMS_ON_SEND);
+            $this->dispatcher->dispatch($smsEvent);
 
             $tokenEvent = $this->dispatcher->dispatch(
                 new TokenReplacementEvent(

--- a/app/bundles/StageBundle/Model/StageModel.php
+++ b/app/bundles/StageBundle/Model/StageModel.php
@@ -127,7 +127,7 @@ class StageModel extends CommonFormModel implements GlobalSearchInterface
     }
 
     /**
-     * Gets array of custom actions from bundles subscribed StageEvents::STAGE_ON_BUILD.
+     * Gets array of custom actions from bundles subscribed to StageBuilderEvent.
      *
      * @return mixed
      */
@@ -139,7 +139,7 @@ class StageModel extends CommonFormModel implements GlobalSearchInterface
             // build them
             $actions = [];
             $event   = new StageBuilderEvent($this->translator);
-            $this->dispatcher->dispatch($event, StageEvents::STAGE_ON_BUILD);
+            $this->dispatcher->dispatch($event);
             $actions['actions'] = $event->getActions();
             $actions['list']    = $event->getActionList();
             $actions['choices'] = $event->getActionChoices();


### PR DESCRIPTION
Combines #17194, #17195, #17197 and #17199 into one PR to keep merging easier.

Each bundle now dispatches its events by the event object alone, so the event name is the event class (Symfony 4.3+) instead of the bundle's string constants. The old constants are kept for backwards compatibility but are no longer used internally. Constants whose events share a single event class (CRUD groups etc.) are left unchanged.

- NotificationBundle: `NotificationSendEvent`
- DashboardBundle: `WidgetTypeListEvent`, `WidgetFormEvent`
- StageBundle: `StageBuilderEvent`
- SmsBundle: `SmsSendEvent`, `TokensBuildEvent`, `DncEvent`, `QueueEvent`, `FilterEvent`