### PR TITLE
[events] dispatch LeadBundle events by class name (Symfony 4.3 style)

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -423,6 +423,53 @@
     | `ReportEvents::REPORT_ON_COLUMN_COLLECT` | `ColumnCollectEvent` |
     | `ReportEvents::REPORT_PERMANENT_FILE_CREATED` | `PermanentReportFileCreatedEvent` |
 
+- LeadBundle events are now dispatched by the event object alone, so the event name is the event class (Symfony 4.3+) instead of the `Mautic\LeadBundle\LeadEvents` string constants. Update any subscriber or listener that keys on one of the converted `LeadEvents::*` constants to key on the event class instead:
+
+    ```diff
+     public static function getSubscribedEvents(): array
+     {
+         return [
+    -        LeadEvents::LEAD_BUILD_SEARCH_COMMANDS => ['onBuildSearchCommands', 0],
+    +        LeadBuildSearchEvent::class => ['onBuildSearchCommands', 0],
+         ];
+     }
+    ```
+
+    Dispatching drops the redundant second argument, e.g. `$dispatcher->dispatch($event, LeadEvents::LEAD_BUILD_SEARCH_COMMANDS)` becomes `$dispatcher->dispatch($event)`. The `Mautic\LeadBundle\LeadEvents` constants are kept for backwards compatibility but are no longer used internally for the events below.
+
+    Full mapping of the converted constants to their event class (in `Mautic\LeadBundle\Event`, except the `LEAD_FIELD_PRE_*_COLUMN*` events which live in `Mautic\LeadBundle\Field\Event`):
+
+    | `LeadEvents` constant | New event class |
+    | --- | --- |
+    | `LeadEvents::LEAD_UTMTAGS_ADD` | `LeadUtmTagsEvent` |
+    | `LeadEvents::LEAD_CATEGORY_CHANGE` | `CategoryChangeEvent` |
+    | `LeadEvents::CHANNEL_SUBSCRIPTION_CHANGED` | `ChannelSubscriptionChange` |
+    | `LeadEvents::LEAD_BUILD_SEARCH_COMMANDS` | `LeadBuildSearchEvent` |
+    | `LeadEvents::COMPANY_BUILD_SEARCH_COMMANDS` | `CompanyBuildSearchEvent` |
+    | `LeadEvents::ADJUST_FILTER_FORM_TYPE_FOR_FIELD` | `FormAdjustmentEvent` |
+    | `LeadEvents::COLLECT_OPERATORS_FOR_FIELD_TYPE` | `TypeOperatorsEvent` |
+    | `LeadEvents::COLLECT_OPERATORS_FOR_FIELD` | `FieldOperatorsEvent` |
+    | `LeadEvents::COLLECT_FILTER_CHOICES_FOR_LIST_FIELD_TYPE` | `ListFieldChoicesEvent` |
+    | `LeadEvents::SEGMENT_ON_DECORATOR_DELEGATE` | `LeadListFiltersDecoratorDelegateEvent` |
+    | `LeadEvents::LIST_FILTERS_MERGE` | `LeadListMergeFiltersEvent` |
+    | `LeadEvents::LIST_FILTERS_OPERATORS_ON_GENERATE` | `LeadListFiltersOperatorsEvent` |
+    | `LeadEvents::LIST_FILTERS_OPERATOR_QUERYBUILDER_ON_GENERATE` | `SegmentOperatorQueryBuilderEvent` |
+    | `LeadEvents::LIST_FILTERS_QUERYBUILDER_GENERATED` | `LeadListQueryBuilderGeneratedEvent` |
+    | `LeadEvents::IMPORT_ON_INITIALIZE` | `ImportInitEvent` |
+    | `LeadEvents::IMPORT_ON_FIELD_MAPPING` | `ImportMappingEvent` |
+    | `LeadEvents::IMPORT_ON_PROCESS` | `ImportProcessEvent` |
+    | `LeadEvents::IMPORT_ON_VALIDATE` | `ImportValidateEvent` |
+    | `LeadEvents::LEAD_FIELD_PRE_ADD_COLUMN` | `Field\Event\AddColumnEvent` |
+    | `LeadEvents::LEAD_FIELD_PRE_ADD_COLUMN_BACKGROUND_JOB` | `Field\Event\AddColumnBackgroundEvent` |
+    | `LeadEvents::LEAD_FIELD_PRE_UPDATE_COLUMN` | `Field\Event\UpdateColumnEvent` |
+    | `LeadEvents::LEAD_FIELD_PRE_UPDATE_COLUMN_BACKGROUND_JOB` | `Field\Event\UpdateColumnBackgroundEvent` |
+    | `LeadEvents::LEAD_FIELD_PRE_DELETE_COLUMN` | `Field\Event\DeleteColumnEvent` |
+    | `LeadEvents::LEAD_FIELD_PRE_DELETE_COLUMN_BACKGROUND_JOB` | `Field\Event\DeleteColumnBackgroundEvent` |
+
+    `LeadEvents::CHANNEL_SUBSCRIPTION_CHANGED` is still used as the webhook type identifier (its string value) in `WebhookSubscriber`, so the constant remains referenced there even though the event is dispatched and subscribed by class.
+
+    Constants that share an event class keep their string names and are unchanged. This covers the CRUD/toggle groups that reuse a single event object under several names - the `LeadEvent` group (`LEAD_PRE_SAVE`, `LEAD_POST_SAVE`, `LEAD_PRE_DELETE`, `LEAD_POST_DELETE`, `LEAD_IDENTIFIED`), `LeadListEvent` (`LIST_*`), `LeadFieldEvent` (`FIELD_*`, `NOTE_*`, `DEVICE_*`), `CompanyEvent` (`COMPANY_PRE_SAVE`, `COMPANY_POST_SAVE`, `COMPANY_PRE_DELETE`, `COMPANY_POST_DELETE`, `COMPANY_SOFT_DELETE`), `ImportEvent` (`IMPORT_PRE_SAVE`, `IMPORT_POST_SAVE`, `IMPORT_PRE_DELETE`, `IMPORT_POST_DELETE`, `IMPORT_BATCH_PROCESSED`), `TagEvent` (`TAG_*`), `ContactExportSchedulerEvent` (the `*_CONTACT_EXPORT*` group) - and the before/after pairs `LeadMergeEvent`, `CompanyMergeEvent`, `TagMergeEvent` and `SaveBatchLeadsEvent`. The `LeadListFilteringEvent` shared by `LIST_FILTERS_ON_FILTERING` and `LIST_PRE_PROCESS_LIST` also stays a string. Constants dispatched or subscribed outside LeadBundle (e.g. `LEAD_POINTS_CHANGE`, `LEAD_COMPANY_CHANGE`, `LEAD_LIST_CHANGE`, `LEAD_LIST_BATCH_CHANGE`, `CURRENT_LEAD_CHANGED`, `TIMELINE_ON_GENERATE`, `LIST_FILTERS_CHOICES_ON_GENERATE`, `SEGMENT_DICTIONARY_ON_GENERATE`, `ON_CLICKTHROUGH_IDENTIFICATION`) and the campaign action/condition constants (whose generic event classes are shared across bundles) are unchanged.
+
 - `Mautic\CoreBundle\Factory\ModelFactory` now builds its service locator from a `defaultIndexMethod` on the `mautic.model` tag, replacing the removed `Mautic\CoreBundle\DependencyInjection\Compiler\ModelPass`. Every model (a service implementing `Mautic\CoreBundle\Model\MauticModelInterface`) declares its `ModelFactory::getModel()` lookup key via a static `getName()` method:
 
     ```php

--- a/app/bundles/LeadBundle/Controller/ImportController.php
+++ b/app/bundles/LeadBundle/Controller/ImportController.php
@@ -14,7 +14,6 @@ use Mautic\LeadBundle\Event\ImportValidateEvent;
 use Mautic\LeadBundle\Form\Type\LeadImportFieldType;
 use Mautic\LeadBundle\Form\Type\LeadImportType;
 use Mautic\LeadBundle\Helper\Progress;
-use Mautic\LeadBundle\LeadEvents;
 use Mautic\LeadBundle\Model\ImportModel;
 use Mautic\UserBundle\Entity\User;
 use Mautic\UserBundle\Entity\UserRepository;
@@ -225,8 +224,7 @@ final class ImportController extends FormController
                 break;
             case self::STEP_MATCH_FIELDS:
                 $mappingEvent = $this->dispatcher->dispatch(
-                    new ImportMappingEvent($request->get('object')),
-                    LeadEvents::IMPORT_ON_FIELD_MAPPING
+                    new ImportMappingEvent($request->get('object'))
                 );
 
                 try {
@@ -382,7 +380,7 @@ final class ImportController extends FormController
                 case self::STEP_MATCH_FIELDS:
                     $validateEvent = new ImportValidateEvent($request->get('object'), $form);
 
-                    $this->dispatcher->dispatch($validateEvent, LeadEvents::IMPORT_ON_VALIDATE);
+                    $this->dispatcher->dispatch($validateEvent);
 
                     if ($validateEvent->hasErrors()) {
                         break;
@@ -732,7 +730,7 @@ final class ImportController extends FormController
         $request = $this->getCurrentRequest();
         $event   = new ImportInitEvent($request->get('object'));
 
-        $this->dispatcher->dispatch($event, LeadEvents::IMPORT_ON_INITIALIZE);
+        $this->dispatcher->dispatch($event);
 
         return $event;
     }

--- a/app/bundles/LeadBundle/Entity/CompanyRepository.php
+++ b/app/bundles/LeadBundle/Entity/CompanyRepository.php
@@ -8,7 +8,6 @@ use Doctrine\DBAL\Query\Expression\CompositeExpression;
 use Doctrine\ORM\QueryBuilder;
 use Mautic\CoreBundle\Entity\CommonRepository;
 use Mautic\LeadBundle\Event\CompanyBuildSearchEvent;
-use Mautic\LeadBundle\LeadEvents;
 use Mautic\ProjectBundle\Entity\ProjectRepositoryTrait;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Service\Attribute\Required;
@@ -197,7 +196,7 @@ class CompanyRepository extends CommonRepository implements CustomFieldRepositor
 
         if ($this->dispatcher) {
             $event = new CompanyBuildSearchEvent($filter->string, $filter->command, $unique, $filter->not, $queryBuilder);
-            $this->dispatcher->dispatch($event, LeadEvents::COMPANY_BUILD_SEARCH_COMMANDS);
+            $this->dispatcher->dispatch($event);
             if ($event->isSearchDone()) {
                 $returnParameter = $event->getReturnParameters();
                 $filter->strict  = $event->getStrict();

--- a/app/bundles/LeadBundle/Entity/LeadRepository.php
+++ b/app/bundles/LeadBundle/Entity/LeadRepository.php
@@ -13,7 +13,6 @@ use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\CoreBundle\Helper\SearchStringHelper;
 use Mautic\LeadBundle\Controller\ListController;
 use Mautic\LeadBundle\Event\LeadBuildSearchEvent;
-use Mautic\LeadBundle\LeadEvents;
 use Mautic\LeadBundle\Segment\OperatorOptions;
 use Mautic\LeadBundle\Segment\Query\QueryBuilder as SegmentQueryBuilder;
 use Mautic\PointBundle\Model\TriggerModel;
@@ -992,7 +991,7 @@ class LeadRepository extends CommonRepository implements CustomFieldRepositoryIn
         }
 
         $event = new LeadBuildSearchEvent($filter->string, $filter->command, $unique, $filter->not, $queryBuilder);
-        $this->dispatcher->dispatch($event, LeadEvents::LEAD_BUILD_SEARCH_COMMANDS);
+        $this->dispatcher->dispatch($event);
         if ($event->isSearchDone()) {
             $returnParameter = $event->getReturnParameters();
             $filter->strict  = $event->getStrict();

--- a/app/bundles/LeadBundle/EventListener/FilterOperatorSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/FilterOperatorSubscriber.php
@@ -69,7 +69,7 @@ final class FilterOperatorSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            LeadEvents::LIST_FILTERS_OPERATORS_ON_GENERATE => ['onListOperatorsGenerate', 0],
+            LeadListFiltersOperatorsEvent::class => ['onListOperatorsGenerate', 0],
             LeadEvents::LIST_FILTERS_CHOICES_ON_GENERATE   => [
                 ['onGenerateSegmentFiltersAddStaticFields', 0],
                 ['onGenerateSegmentFiltersAddCustomFields', 0],

--- a/app/bundles/LeadBundle/EventListener/ImportCompanySubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/ImportCompanySubscriber.php
@@ -11,7 +11,6 @@ use Mautic\LeadBundle\Event\ImportMappingEvent;
 use Mautic\LeadBundle\Event\ImportProcessEvent;
 use Mautic\LeadBundle\Event\ImportValidateEvent;
 use Mautic\LeadBundle\Field\FieldList;
-use Mautic\LeadBundle\LeadEvents;
 use Mautic\LeadBundle\Model\CompanyModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\FormError;
@@ -31,10 +30,10 @@ final readonly class ImportCompanySubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            LeadEvents::IMPORT_ON_INITIALIZE    => ['onImportInit'],
-            LeadEvents::IMPORT_ON_FIELD_MAPPING => ['onFieldMapping'],
-            LeadEvents::IMPORT_ON_PROCESS       => ['onImportProcess'],
-            LeadEvents::IMPORT_ON_VALIDATE      => ['onValidateImport'],
+            ImportInitEvent::class => ['onImportInit'],
+            ImportMappingEvent::class => ['onFieldMapping'],
+            ImportProcessEvent::class => ['onImportProcess'],
+            ImportValidateEvent::class => ['onValidateImport'],
         ];
     }
 

--- a/app/bundles/LeadBundle/EventListener/ImportContactSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/ImportContactSubscriber.php
@@ -13,7 +13,6 @@ use Mautic\LeadBundle\Event\ImportMappingEvent;
 use Mautic\LeadBundle\Event\ImportProcessEvent;
 use Mautic\LeadBundle\Event\ImportValidateEvent;
 use Mautic\LeadBundle\Field\FieldList;
-use Mautic\LeadBundle\LeadEvents;
 use Mautic\LeadBundle\Model\LeadModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\FormError;
@@ -33,10 +32,10 @@ final readonly class ImportContactSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            LeadEvents::IMPORT_ON_INITIALIZE    => 'onImportInit',
-            LeadEvents::IMPORT_ON_FIELD_MAPPING => 'onFieldMapping',
-            LeadEvents::IMPORT_ON_PROCESS       => 'onImportProcess',
-            LeadEvents::IMPORT_ON_VALIDATE      => 'onValidateImport',
+            ImportInitEvent::class => 'onImportInit',
+            ImportMappingEvent::class => 'onFieldMapping',
+            ImportProcessEvent::class => 'onImportProcess',
+            ImportValidateEvent::class => 'onValidateImport',
         ];
     }
 

--- a/app/bundles/LeadBundle/EventListener/ImportDateValidationSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/ImportDateValidationSubscriber.php
@@ -8,7 +8,6 @@ use Mautic\CoreBundle\Cache\ResultCacheOptions;
 use Mautic\LeadBundle\Entity\LeadField;
 use Mautic\LeadBundle\Event\ImportProcessEvent;
 use Mautic\LeadBundle\Exception\ImportRowFailedException;
-use Mautic\LeadBundle\LeadEvents;
 use Mautic\LeadBundle\Model\FieldModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -31,7 +30,7 @@ final class ImportDateValidationSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            LeadEvents::IMPORT_ON_PROCESS => ['onImportProcess', 100],
+            ImportProcessEvent::class => ['onImportProcess', 100],
         ];
     }
 

--- a/app/bundles/LeadBundle/EventListener/ImportUrlValidationSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/ImportUrlValidationSubscriber.php
@@ -8,7 +8,6 @@ use Mautic\CoreBundle\Cache\ResultCacheOptions;
 use Mautic\LeadBundle\Entity\LeadField;
 use Mautic\LeadBundle\Event\ImportProcessEvent;
 use Mautic\LeadBundle\Exception\ImportRowFailedException;
-use Mautic\LeadBundle\LeadEvents;
 use Mautic\LeadBundle\Model\FieldModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -31,7 +30,7 @@ final class ImportUrlValidationSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            LeadEvents::IMPORT_ON_PROCESS => ['onImportProcess', 210],
+            ImportProcessEvent::class => ['onImportProcess', 210],
         ];
     }
 

--- a/app/bundles/LeadBundle/EventListener/SearchSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/SearchSubscriber.php
@@ -14,7 +14,6 @@ use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Entity\EmailRepository;
 use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Event\LeadBuildSearchEvent;
-use Mautic\LeadBundle\LeadEvents;
 use Mautic\LeadBundle\Model\CompanyModel;
 use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\LeadBundle\Model\ListModel;
@@ -48,7 +47,7 @@ final readonly class SearchSubscriber implements EventSubscriberInterface
                 ['onGlobalSearchForSegments', 0],
             ],
             CommandListEvent::class                => ['onBuildCommandList', 0],
-            LeadEvents::LEAD_BUILD_SEARCH_COMMANDS => ['onBuildSearchCommands', 0],
+            LeadBuildSearchEvent::class => ['onBuildSearchCommands', 0],
         ];
     }
 

--- a/app/bundles/LeadBundle/EventListener/SegmentOperatorQuerySubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/SegmentOperatorQuerySubscriber.php
@@ -7,7 +7,6 @@ namespace Mautic\LeadBundle\EventListener;
 use Doctrine\DBAL\Query\Expression\CompositeExpression;
 use Doctrine\ORM\Query\Expr;
 use Mautic\LeadBundle\Event\SegmentOperatorQueryBuilderEvent;
-use Mautic\LeadBundle\LeadEvents;
 use Mautic\LeadBundle\Segment\OperatorOptions;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -16,7 +15,7 @@ final class SegmentOperatorQuerySubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            LeadEvents::LIST_FILTERS_OPERATOR_QUERYBUILDER_ON_GENERATE => [
+            SegmentOperatorQueryBuilderEvent::class => [
                 ['onEmptyOperator', 0],
                 ['onNotEmptyOperator', 0],
                 ['onNegativeOperators', 0],

--- a/app/bundles/LeadBundle/EventListener/TypeOperatorSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/TypeOperatorSubscriber.php
@@ -19,7 +19,6 @@ use Mautic\LeadBundle\Event\TypeOperatorsEvent;
 use Mautic\LeadBundle\Form\Type\GlobalCategoryType;
 use Mautic\LeadBundle\Form\Validator\Constraints\DbRegex;
 use Mautic\LeadBundle\Helper\FormFieldHelper;
-use Mautic\LeadBundle\LeadEvents;
 use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\LeadBundle\Model\ListModel;
 use Mautic\LeadBundle\Segment\OperatorOptions;
@@ -52,9 +51,9 @@ final class TypeOperatorSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            LeadEvents::COLLECT_OPERATORS_FOR_FIELD_TYPE           => ['onTypeOperatorsCollect', 0],
-            LeadEvents::COLLECT_FILTER_CHOICES_FOR_LIST_FIELD_TYPE => ['onTypeListCollect', 0],
-            LeadEvents::ADJUST_FILTER_FORM_TYPE_FOR_FIELD          => [
+            TypeOperatorsEvent::class => ['onTypeOperatorsCollect', 0],
+            ListFieldChoicesEvent::class => ['onTypeListCollect', 0],
+            FormAdjustmentEvent::class => [
                 ['onSegmentFilterFormHandleTags', 1000],
                 ['onSegmentFilterFormHandleLookupId', 800],
                 ['onSegmentFilterFormHandleLookup', 600],

--- a/app/bundles/LeadBundle/EventListener/WebhookSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/WebhookSubscriber.php
@@ -31,7 +31,7 @@ final readonly class WebhookSubscriber implements EventSubscriberInterface
             LeadEvents::LEAD_POST_SAVE               => ['onLeadNewUpdate', 0],
             LeadEvents::LEAD_POINTS_CHANGE           => ['onLeadPointChange', 0],
             LeadEvents::LEAD_POST_DELETE             => ['onLeadDelete', 0],
-            LeadEvents::CHANNEL_SUBSCRIPTION_CHANGED => ['onChannelSubscriptionChange', 0],
+            ChannelSubscriptionChange::class => ['onChannelSubscriptionChange', 0],
             LeadEvents::LEAD_COMPANY_CHANGE          => ['onLeadCompanyChange', 0],
             LeadEvents::COMPANY_POST_SAVE            => ['onCompanySave', 0],
             LeadEvents::COMPANY_POST_DELETE          => ['onCompanyDelete', 0],

--- a/app/bundles/LeadBundle/Field/Dispatcher/FieldColumnBackgroundJobDispatcher.php
+++ b/app/bundles/LeadBundle/Field/Dispatcher/FieldColumnBackgroundJobDispatcher.php
@@ -11,7 +11,6 @@ use Mautic\LeadBundle\Field\Event\DeleteColumnBackgroundEvent;
 use Mautic\LeadBundle\Field\Event\UpdateColumnBackgroundEvent;
 use Mautic\LeadBundle\Field\Exception\AbortColumnCreateException;
 use Mautic\LeadBundle\Field\Exception\AbortColumnUpdateException;
-use Mautic\LeadBundle\LeadEvents;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class FieldColumnBackgroundJobDispatcher
@@ -27,15 +26,13 @@ class FieldColumnBackgroundJobDispatcher
      */
     public function dispatchPreAddColumnEvent(LeadField $leadField): void
     {
-        $action = LeadEvents::LEAD_FIELD_PRE_ADD_COLUMN_BACKGROUND_JOB;
-
-        if (!$this->dispatcher->hasListeners($action)) {
+        if (!$this->dispatcher->hasListeners(AddColumnBackgroundEvent::class)) {
             throw new NoListenerException('There is no Listener for this event');
         }
 
         $event = new AddColumnBackgroundEvent($leadField);
 
-        $this->dispatcher->dispatch($event, $action);
+        $this->dispatcher->dispatch($event);
 
         if ($event->isPropagationStopped()) {
             throw new AbortColumnCreateException('Column cannot be created now');
@@ -48,15 +45,13 @@ class FieldColumnBackgroundJobDispatcher
      */
     public function dispatchPreUpdateColumnEvent(LeadField $leadField): void
     {
-        $action = LeadEvents::LEAD_FIELD_PRE_UPDATE_COLUMN_BACKGROUND_JOB;
-
-        if (!$this->dispatcher->hasListeners($action)) {
+        if (!$this->dispatcher->hasListeners(UpdateColumnBackgroundEvent::class)) {
             throw new NoListenerException('There is no Listener for this event');
         }
 
         $event = new UpdateColumnBackgroundEvent($leadField);
 
-        $this->dispatcher->dispatch($event, $action);
+        $this->dispatcher->dispatch($event);
 
         if ($event->isPropagationStopped()) {
             throw new AbortColumnUpdateException('Column cannot be updated now');
@@ -69,15 +64,13 @@ class FieldColumnBackgroundJobDispatcher
      */
     public function dispatchPreDeleteColumnEvent(LeadField $leadField): void
     {
-        $action = LeadEvents::LEAD_FIELD_PRE_DELETE_COLUMN_BACKGROUND_JOB;
-
-        if (!$this->dispatcher->hasListeners($action)) {
+        if (!$this->dispatcher->hasListeners(DeleteColumnBackgroundEvent::class)) {
             throw new NoListenerException('There is no Listener for this event');
         }
 
         $event = new DeleteColumnBackgroundEvent($leadField);
 
-        $this->dispatcher->dispatch($event, $action);
+        $this->dispatcher->dispatch($event);
 
         if ($event->isPropagationStopped()) {
             throw new AbortColumnUpdateException('Column cannot be deleted now');

--- a/app/bundles/LeadBundle/Field/Dispatcher/FieldColumnDispatcher.php
+++ b/app/bundles/LeadBundle/Field/Dispatcher/FieldColumnDispatcher.php
@@ -12,7 +12,6 @@ use Mautic\LeadBundle\Field\Event\UpdateColumnEvent;
 use Mautic\LeadBundle\Field\Exception\AbortColumnCreateException;
 use Mautic\LeadBundle\Field\Exception\AbortColumnUpdateException;
 use Mautic\LeadBundle\Field\Settings\BackgroundSettings;
-use Mautic\LeadBundle\LeadEvents;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class FieldColumnDispatcher
@@ -31,7 +30,7 @@ class FieldColumnDispatcher
         $shouldProcessInBackground = $this->backgroundSettings->shouldProcessColumnChangeInBackground();
         $event                     = new AddColumnEvent($leadField, $shouldProcessInBackground);
 
-        $this->dispatcher->dispatch($event, LeadEvents::LEAD_FIELD_PRE_ADD_COLUMN);
+        $this->dispatcher->dispatch($event);
 
         if ($shouldProcessInBackground) {
             throw new AbortColumnCreateException('Column change will be processed in background job');
@@ -44,16 +43,14 @@ class FieldColumnDispatcher
      */
     public function dispatchPreUpdateColumnEvent(LeadField $leadField): void
     {
-        $action = LeadEvents::LEAD_FIELD_PRE_UPDATE_COLUMN;
-
-        if (!$this->dispatcher->hasListeners($action)) {
+        if (!$this->dispatcher->hasListeners(UpdateColumnEvent::class)) {
             throw new NoListenerException('There is no Listener for this event');
         }
 
         $shouldProcessInBackground = $this->backgroundSettings->shouldProcessColumnChangeInBackground();
         $event                     = new UpdateColumnEvent($leadField, $shouldProcessInBackground);
 
-        $this->dispatcher->dispatch($event, $action);
+        $this->dispatcher->dispatch($event);
 
         if ($event->shouldProcessInBackground()) {
             throw new AbortColumnUpdateException('Column change will be processed in background job');
@@ -66,9 +63,7 @@ class FieldColumnDispatcher
      */
     public function dispatchPreDeleteColumnEvent(LeadField $leadField): void
     {
-        $action = LeadEvents::LEAD_FIELD_PRE_DELETE_COLUMN;
-
-        if (!$this->dispatcher->hasListeners($action)) {
+        if (!$this->dispatcher->hasListeners(DeleteColumnEvent::class)) {
             throw new NoListenerException('There is no Listener for this event');
         }
 
@@ -76,7 +71,7 @@ class FieldColumnDispatcher
 
         $event = new DeleteColumnEvent($leadField, $shouldProcessInBackground);
 
-        $this->dispatcher->dispatch($event, $action);
+        $this->dispatcher->dispatch($event);
 
         if ($event->shouldProcessInBackground()) {
             throw new AbortColumnUpdateException('Column delete will be processed in background job');

--- a/app/bundles/LeadBundle/Helper/LeadChangeEventDispatcher.php
+++ b/app/bundles/LeadBundle/Helper/LeadChangeEventDispatcher.php
@@ -68,7 +68,7 @@ class LeadChangeEventDispatcher
         }
 
         $utmTagsEvent = new Events\LeadUtmTagsEvent($this->lead, $this->changes['utmtags']);
-        $this->dispatcher->dispatch($utmTagsEvent, LeadEvents::LEAD_UTMTAGS_ADD);
+        $this->dispatcher->dispatch($utmTagsEvent);
     }
 
     private function dispatchDncChangeEvent(): void
@@ -82,7 +82,7 @@ class LeadChangeEventDispatcher
             $newStatus = $status['reason'];
 
             $event = new Events\ChannelSubscriptionChange($this->lead, $channel, $oldStatus, $newStatus);
-            $this->dispatcher->dispatch($event, LeadEvents::CHANNEL_SUBSCRIPTION_CHANGED);
+            $this->dispatcher->dispatch($event);
         }
     }
 }

--- a/app/bundles/LeadBundle/Model/ImportModel.php
+++ b/app/bundles/LeadBundle/Model/ImportModel.php
@@ -325,7 +325,7 @@ class ImportModel extends FormModel
                 $data  = array_combine($headers, $data);
                 $event = new ImportProcessEvent($import, $eventLog, $data);
                 try {
-                    $this->dispatcher->dispatch($event, LeadEvents::IMPORT_ON_PROCESS);
+                    $this->dispatcher->dispatch($event);
 
                     if ($event->wasMerged()) {
                         $this->logDebug('Entity on line '.$lineNumber.' has been updated', $import);

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -1170,8 +1170,8 @@ class LeadModel extends FormModel
             }
 
             if ($dispatchEvent) {
-                if ($this->dispatcher->hasListeners(LeadEvents::LEAD_CATEGORY_CHANGE)) {
-                    $this->dispatcher->dispatch(new CategoryChangeEvent($lead, $category), LeadEvents::LEAD_CATEGORY_CHANGE);
+                if ($this->dispatcher->hasListeners(CategoryChangeEvent::class)) {
+                    $this->dispatcher->dispatch(new CategoryChangeEvent($lead, $category));
                 }
             }
         }
@@ -1198,8 +1198,8 @@ class LeadModel extends FormModel
 
             $unsubscribedCats[] = $category;
 
-            if ($this->dispatcher->hasListeners(LeadEvents::LEAD_CATEGORY_CHANGE)) {
-                $this->dispatcher->dispatch(new CategoryChangeEvent($category->getLead(), $category->getCategory(), false), LeadEvents::LEAD_CATEGORY_CHANGE);
+            if ($this->dispatcher->hasListeners(CategoryChangeEvent::class)) {
+                $this->dispatcher->dispatch(new CategoryChangeEvent($category->getLead(), $category->getCategory(), false));
             }
         }
 
@@ -1217,15 +1217,15 @@ class LeadModel extends FormModel
                 $category     = $this->leadCategoryRepository->getEntity($key);
                 $deleteCats[] = $category;
 
-                if ($this->dispatcher->hasListeners(LeadEvents::LEAD_CATEGORY_CHANGE)) {
-                    $this->dispatcher->dispatch(new CategoryChangeEvent($category->getLead(), $category->getCategory(), false), LeadEvents::LEAD_CATEGORY_CHANGE);
+                if ($this->dispatcher->hasListeners(CategoryChangeEvent::class)) {
+                    $this->dispatcher->dispatch(new CategoryChangeEvent($category->getLead(), $category->getCategory(), false));
                 }
             }
         } elseif ($categories instanceof LeadCategory) {
             $deleteCats[] = $categories;
 
-            if ($this->dispatcher->hasListeners(LeadEvents::LEAD_CATEGORY_CHANGE)) {
-                $this->dispatcher->dispatch(new CategoryChangeEvent($categories->getLead(), $categories->getCategory(), false), LeadEvents::LEAD_CATEGORY_CHANGE);
+            if ($this->dispatcher->hasListeners(CategoryChangeEvent::class)) {
+                $this->dispatcher->dispatch(new CategoryChangeEvent($categories->getLead(), $categories->getCategory(), false));
             }
         }
 

--- a/app/bundles/LeadBundle/Provider/FieldChoicesProvider.php
+++ b/app/bundles/LeadBundle/Provider/FieldChoicesProvider.php
@@ -6,7 +6,6 @@ namespace Mautic\LeadBundle\Provider;
 
 use Mautic\LeadBundle\Event\ListFieldChoicesEvent;
 use Mautic\LeadBundle\Exception\ChoicesNotFoundException;
-use Mautic\LeadBundle\LeadEvents;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 final class FieldChoicesProvider implements FieldChoicesProviderInterface
@@ -70,7 +69,7 @@ final class FieldChoicesProvider implements FieldChoicesProviderInterface
         if ([] === $this->cachedTypeChoices) {
             $event = new ListFieldChoicesEvent();
             $event->setSearchTerm($search);
-            $this->dispatcher->dispatch($event, LeadEvents::COLLECT_FILTER_CHOICES_FOR_LIST_FIELD_TYPE);
+            $this->dispatcher->dispatch($event);
 
             $this->cachedTypeChoices  = $event->getChoicesForAllListFieldTypes();
             $this->cachedAliasChoices = $event->getChoicesForAllListFieldAliases();

--- a/app/bundles/LeadBundle/Provider/FilterOperatorProvider.php
+++ b/app/bundles/LeadBundle/Provider/FilterOperatorProvider.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Mautic\LeadBundle\Provider;
 
 use Mautic\LeadBundle\Event\LeadListFiltersOperatorsEvent;
-use Mautic\LeadBundle\LeadEvents;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -30,7 +29,7 @@ final class FilterOperatorProvider implements FilterOperatorProviderInterface
         if ([] === $this->cachedOperators) {
             $event = new LeadListFiltersOperatorsEvent();
 
-            $this->dispatcher->dispatch($event, LeadEvents::LIST_FILTERS_OPERATORS_ON_GENERATE);
+            $this->dispatcher->dispatch($event);
 
             $this->cachedOperators = $this->translateOperatorLabels($event->getOperators());
         }

--- a/app/bundles/LeadBundle/Provider/FormAdjustmentsProvider.php
+++ b/app/bundles/LeadBundle/Provider/FormAdjustmentsProvider.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Mautic\LeadBundle\Provider;
 
 use Mautic\LeadBundle\Event\FormAdjustmentEvent;
-use Mautic\LeadBundle\LeadEvents;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormInterface;
 
@@ -25,7 +24,7 @@ final readonly class FormAdjustmentsProvider implements FormAdjustmentsProviderI
     public function adjustForm(FormInterface $form, string $fieldAlias, string $fieldObject, string $operator, array $fieldDetails): FormInterface
     {
         $event = new FormAdjustmentEvent($form, $fieldAlias, $fieldObject, $operator, $fieldDetails);
-        $this->dispatcher->dispatch($event, LeadEvents::ADJUST_FILTER_FORM_TYPE_FOR_FIELD);
+        $this->dispatcher->dispatch($event);
 
         return $event->getForm();
     }

--- a/app/bundles/LeadBundle/Provider/TypeOperatorProvider.php
+++ b/app/bundles/LeadBundle/Provider/TypeOperatorProvider.php
@@ -7,7 +7,6 @@ namespace Mautic\LeadBundle\Provider;
 use Mautic\LeadBundle\Entity\OperatorListTrait;
 use Mautic\LeadBundle\Event\FieldOperatorsEvent;
 use Mautic\LeadBundle\Event\TypeOperatorsEvent;
-use Mautic\LeadBundle\LeadEvents;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 final class TypeOperatorProvider implements TypeOperatorProviderInterface
@@ -79,7 +78,7 @@ final class TypeOperatorProvider implements TypeOperatorProviderInterface
         if ([] === $this->cachedTypeOperators) {
             $event = new TypeOperatorsEvent($this->context);
 
-            $this->dispatcher->dispatch($event, LeadEvents::COLLECT_OPERATORS_FOR_FIELD_TYPE);
+            $this->dispatcher->dispatch($event);
 
             $this->cachedTypeOperators = $event->getOperatorsForAllFieldTypes();
         }
@@ -102,7 +101,7 @@ final class TypeOperatorProvider implements TypeOperatorProviderInterface
             $this->getOperatorsForFieldType($type)
         );
 
-        $this->dispatcher->dispatch($event, LeadEvents::COLLECT_OPERATORS_FOR_FIELD);
+        $this->dispatcher->dispatch($event);
 
         return $event->getOperators();
     }

--- a/app/bundles/LeadBundle/Segment/ContactSegmentFilterFactory.php
+++ b/app/bundles/LeadBundle/Segment/ContactSegmentFilterFactory.php
@@ -4,7 +4,6 @@ namespace Mautic\LeadBundle\Segment;
 
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Event\LeadListMergeFiltersEvent;
-use Mautic\LeadBundle\LeadEvents;
 use Mautic\LeadBundle\Segment\Decorator\DecoratorFactory;
 use Mautic\LeadBundle\Segment\Decorator\FilterDecoratorInterface;
 use Mautic\LeadBundle\Segment\Query\Filter\FilterQueryBuilderInterface;
@@ -39,7 +38,7 @@ final class ContactSegmentFilterFactory
 
         $filters = $this->mergeFilters($leadList->getFilters());
         $event   = new LeadListMergeFiltersEvent($filters);
-        $this->eventDispatcher->dispatch($event, LeadEvents::LIST_FILTERS_MERGE);
+        $this->eventDispatcher->dispatch($event);
         $filters = $event->getFilters();
 
         foreach ($filters as $filter) {

--- a/app/bundles/LeadBundle/Segment/Decorator/DecoratorFactory.php
+++ b/app/bundles/LeadBundle/Segment/Decorator/DecoratorFactory.php
@@ -4,7 +4,6 @@ namespace Mautic\LeadBundle\Segment\Decorator;
 
 use Mautic\LeadBundle\Event\LeadListFiltersDecoratorDelegateEvent;
 use Mautic\LeadBundle\Exception\FilterNotFoundException;
-use Mautic\LeadBundle\LeadEvents;
 use Mautic\LeadBundle\Segment\ContactSegmentFilterCrate;
 use Mautic\LeadBundle\Segment\Decorator\Date\DateOptionFactory;
 use Mautic\LeadBundle\Services\ContactSegmentFilterDictionary;
@@ -26,7 +25,7 @@ class DecoratorFactory
     {
         $decoratorEvent = new LeadListFiltersDecoratorDelegateEvent($contactSegmentFilterCrate);
 
-        $this->eventDispatcher->dispatch($decoratorEvent, LeadEvents::SEGMENT_ON_DECORATOR_DELEGATE);
+        $this->eventDispatcher->dispatch($decoratorEvent);
         if ($decorator = $decoratorEvent->getDecorator()) {
             return $decorator;
         }

--- a/app/bundles/LeadBundle/Segment/Query/ContactSegmentQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/ContactSegmentQueryBuilder.php
@@ -204,12 +204,12 @@ final class ContactSegmentQueryBuilder
 
     public function queryBuilderGenerated(LeadList $segment, QueryBuilder $queryBuilder): void
     {
-        if (!$this->dispatcher->hasListeners(LeadEvents::LIST_FILTERS_QUERYBUILDER_GENERATED)) {
+        if (!$this->dispatcher->hasListeners(LeadListQueryBuilderGeneratedEvent::class)) {
             return;
         }
 
         $event = new LeadListQueryBuilderGeneratedEvent($segment, $queryBuilder);
-        $this->dispatcher->dispatch($event, LeadEvents::LIST_FILTERS_QUERYBUILDER_GENERATED);
+        $this->dispatcher->dispatch($event);
     }
 
     /**

--- a/app/bundles/LeadBundle/Segment/Query/Filter/BaseFilterQueryBuilder.php
+++ b/app/bundles/LeadBundle/Segment/Query/Filter/BaseFilterQueryBuilder.php
@@ -3,7 +3,6 @@
 namespace Mautic\LeadBundle\Segment\Query\Filter;
 
 use Mautic\LeadBundle\Event\SegmentOperatorQueryBuilderEvent;
-use Mautic\LeadBundle\LeadEvents;
 use Mautic\LeadBundle\Segment\ContactSegmentFilter;
 use Mautic\LeadBundle\Segment\Query\QueryBuilder;
 use Mautic\LeadBundle\Segment\RandomParameterName;
@@ -39,7 +38,7 @@ class BaseFilterQueryBuilder implements FilterQueryBuilderInterface
         }
 
         $event = new SegmentOperatorQueryBuilderEvent($queryBuilder, $filter, $filter->getParameterHolder($parameters));
-        $this->dispatcher->dispatch($event, LeadEvents::LIST_FILTERS_OPERATOR_QUERYBUILDER_ON_GENERATE);
+        $this->dispatcher->dispatch($event);
 
         if (!$event->wasOperatorHandled()) {
             throw new \Exception('Dunno how to handle operator "'.$filter->getOperator().'"');

--- a/app/bundles/LeadBundle/Tests/EventListener/SearchSubscriberFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/SearchSubscriberFunctionalTest.php
@@ -12,7 +12,6 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\ListLead;
 use Mautic\LeadBundle\Event\LeadBuildSearchEvent;
-use Mautic\LeadBundle\LeadEvents;
 use Ramsey\Uuid\Uuid;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -33,7 +32,7 @@ final class SearchSubscriberFunctionalTest extends MauticMysqlTestCase
         $dispatcher = self::getContainer()->get(EventDispatcherInterface::class);
         $this->assertInstanceOf(EventDispatcherInterface::class, $dispatcher);
 
-        $dispatcher->dispatch($event, LeadEvents::LEAD_BUILD_SEARCH_COMMANDS);
+        $dispatcher->dispatch($event);
         $expectedQuery = 'l.id IN (SELECT l.id FROM '.MAUTIC_TABLE_PREFIX.'leads l WHERE (l.id IN (SELECT ll.lead_id FROM '.MAUTIC_TABLE_PREFIX.'lead_lists_leads ll WHERE (ll.lead_id = l.id) AND (ll.leadlist_id IN (:listIds)) AND (ll.manually_removed = :false))) AND (l.id NOT IN (SELECT dnc.lead_id FROM '.MAUTIC_TABLE_PREFIX."lead_donotcontact dnc WHERE (dnc.lead_id = l.id) AND (dnc.channel = 'email'))) AND (NOT EXISTS (SELECT null FROM ".MAUTIC_TABLE_PREFIX.'email_stats stat WHERE (stat.lead_id = l.id) AND (stat.lead_id IS NOT NULL) AND (stat.email_id IN (:variantIds)))) AND (l.id NOT IN (SELECT mq.lead_id FROM '.MAUTIC_TABLE_PREFIX."message_queue mq WHERE (mq.lead_id = l.id) AND (mq.status <> 'sent') AND (mq.channel = 'email') AND (mq.channel_id IN (:variantIds)))) AND (l.id NOT IN (SELECT lc.lead_id FROM ".MAUTIC_TABLE_PREFIX.'lead_categories lc INNER JOIN '.MAUTIC_TABLE_PREFIX."emails e ON e.category_id = lc.category_id WHERE (e.id = {$this->email->getId()}) AND (lc.manually_removed = 1))) AND ((l.email IS NOT NULL) AND (l.email <> '')))";
         $this->assertSame($expectedQuery, $event->getSubQuery());
     }

--- a/app/bundles/LeadBundle/Tests/EventListener/SearchSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/SearchSubscriberTest.php
@@ -14,7 +14,6 @@ use Mautic\EmailBundle\Entity\EmailRepository;
 use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Event\LeadBuildSearchEvent;
 use Mautic\LeadBundle\EventListener\SearchSubscriber;
-use Mautic\LeadBundle\LeadEvents;
 use Mautic\LeadBundle\Model\CompanyModel;
 use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\LeadBundle\Model\ListModel;
@@ -114,7 +113,7 @@ final class SearchSubscriberTest extends TestCase
 
         // test email read
         $event = new LeadBuildSearchEvent('1', 'email_read', $alias, false, $qb);
-        $dispatcher->dispatch($event, LeadEvents::LEAD_BUILD_SEARCH_COMMANDS);
+        $dispatcher->dispatch($event);
         $sql = preg_replace('/:\w+/', '?', $event->getQueryBuilder()->getSQL());
         $this->assertSame('SELECT  FROM lead l INNER JOIN test_email_stats es ON l.id = es.lead_id WHERE (es.email_id = ?) AND (es.is_read = ?) GROUP BY l.id', $sql);
 
@@ -123,7 +122,7 @@ final class SearchSubscriberTest extends TestCase
         $qb->from('lead', 'l');
 
         $event = new LeadBuildSearchEvent('1', 'email_sent', $alias, false, $qb);
-        $dispatcher->dispatch($event, LeadEvents::LEAD_BUILD_SEARCH_COMMANDS);
+        $dispatcher->dispatch($event);
         $sql = preg_replace('/:\w+/', '?', $event->getQueryBuilder()->getSQL());
         $this->assertSame('SELECT  FROM lead l INNER JOIN test_email_stats es ON l.id = es.lead_id WHERE es.email_id = ? GROUP BY l.id', $sql);
 
@@ -132,7 +131,7 @@ final class SearchSubscriberTest extends TestCase
         $qb->from('lead', 'l');
 
         $event = new LeadBuildSearchEvent('1', 'email_pending', $alias, false, $qb);
-        $dispatcher->dispatch($event, LeadEvents::LEAD_BUILD_SEARCH_COMMANDS);
+        $dispatcher->dispatch($event);
         $sql = preg_replace('/:\w+/', '?', $event->getQueryBuilder()->getSQL());
         $this->assertSame('SELECT  FROM lead l INNER JOIN test_message_queue mq ON l.id = mq.lead_id WHERE (mq.channel_id = ?) AND (mq.channel = ?) AND (mq.status = ?) GROUP BY l.id', $sql);
 
@@ -141,7 +140,7 @@ final class SearchSubscriberTest extends TestCase
         $qb->from('lead', 'l');
 
         $event = new LeadBuildSearchEvent('1', 'email_queued', $alias, false, $qb);
-        $dispatcher->dispatch($event, LeadEvents::LEAD_BUILD_SEARCH_COMMANDS);
+        $dispatcher->dispatch($event);
         $sql = preg_replace('/:\w+/', '?', $event->getQueryBuilder()->getSQL());
         $this->assertSame('SELECT  FROM lead l INNER JOIN test_message_queue mq ON l.id = mq.lead_id WHERE (mq.channel_id = ?) AND (mq.channel = ?) AND (mq.status IN (?, ?)) GROUP BY l.id', $sql);
 
@@ -150,7 +149,7 @@ final class SearchSubscriberTest extends TestCase
         $qb->from('lead', 'l');
 
         $event = new LeadBuildSearchEvent('1', 'sms_sent', $alias, false, $qb);
-        $dispatcher->dispatch($event, LeadEvents::LEAD_BUILD_SEARCH_COMMANDS);
+        $dispatcher->dispatch($event);
         $sql = preg_replace('/:\w+/', '?', $event->getQueryBuilder()->getSQL());
         $this->assertSame('SELECT  FROM lead l INNER JOIN test_sms_message_stats ss ON l.id = ss.lead_id WHERE ss.sms_id = ? GROUP BY l.id', $sql);
 
@@ -159,7 +158,7 @@ final class SearchSubscriberTest extends TestCase
         $qb->from('lead', 'l');
 
         $event = new LeadBuildSearchEvent('1', 'web_sent', $alias, false, $qb);
-        $dispatcher->dispatch($event, LeadEvents::LEAD_BUILD_SEARCH_COMMANDS);
+        $dispatcher->dispatch($event);
         $sql = preg_replace('/:\w+/', '?', $event->getQueryBuilder()->getSQL());
         $this->assertSame('SELECT  FROM lead l INNER JOIN test_push_notification_stats ns ON l.id = ns.lead_id INNER JOIN test_push_notifications pn ON pn.id = ns.notification_id WHERE (pn.id = ?) AND (pn.mobile = ?) GROUP BY l.id', $sql);
 
@@ -168,7 +167,7 @@ final class SearchSubscriberTest extends TestCase
         $qb->from('lead', 'l');
 
         $event = new LeadBuildSearchEvent('1', 'mobile_sent', $alias, false, $qb);
-        $dispatcher->dispatch($event, LeadEvents::LEAD_BUILD_SEARCH_COMMANDS);
+        $dispatcher->dispatch($event);
         $sql = preg_replace('/:\w+/', '?', $event->getQueryBuilder()->getSQL());
         $this->assertSame('SELECT  FROM lead l INNER JOIN test_push_notification_stats ns ON l.id = ns.lead_id INNER JOIN test_push_notifications pn ON pn.id = ns.notification_id WHERE (pn.id = ?) AND (pn.mobile = ?) GROUP BY l.id', $sql);
 
@@ -177,7 +176,7 @@ final class SearchSubscriberTest extends TestCase
         $qb->from('lead', 'l');
 
         $event = new LeadBuildSearchEvent('1', 'import_id', $alias, false, $qb);
-        $dispatcher->dispatch($event, LeadEvents::LEAD_BUILD_SEARCH_COMMANDS);
+        $dispatcher->dispatch($event);
         $sql = preg_replace('/:\w+/', '?', $event->getQueryBuilder()->getSQL());
         $this->assertSame('SELECT  FROM lead l INNER JOIN test_lead_event_log lel ON l.id = lel.lead_id WHERE (lel.object_id = ?) AND (lel.object = ?) GROUP BY l.id', $sql);
 
@@ -186,7 +185,7 @@ final class SearchSubscriberTest extends TestCase
         $qb->from('lead', 'l');
 
         $event = new LeadBuildSearchEvent('1', 'import_action', $alias, false, $qb);
-        $dispatcher->dispatch($event, LeadEvents::LEAD_BUILD_SEARCH_COMMANDS);
+        $dispatcher->dispatch($event);
         $sql = preg_replace('/:\w+/', '?', $event->getQueryBuilder()->getSQL());
         $this->assertSame('SELECT  FROM lead l INNER JOIN test_lead_event_log lel ON l.id = lel.lead_id WHERE lel.action = ? GROUP BY l.id', $sql);
     }

--- a/app/bundles/LeadBundle/Tests/EventListener/WebhookSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/WebhookSubscriberTest.php
@@ -146,7 +146,7 @@ final class WebhookSubscriberTest extends \PHPUnit\Framework\TestCase
         $this->dispatcher->addSubscriber($webhookSubscriber);
 
         $event = new ChannelSubscriptionChange($lead, $channel, DoNotContact::IS_CONTACTABLE, DoNotContact::UNSUBSCRIBED);
-        $this->dispatcher->dispatch($event, LeadEvents::CHANNEL_SUBSCRIPTION_CHANGED);
+        $this->dispatcher->dispatch($event);
     }
 
     #[TestDox('Test that webhook is queued for lead company changes')]

--- a/app/bundles/LeadBundle/Tests/Field/Dispatcher/FieldColumnBackgroundJobDispatcherTest.php
+++ b/app/bundles/LeadBundle/Tests/Field/Dispatcher/FieldColumnBackgroundJobDispatcherTest.php
@@ -12,7 +12,6 @@ use Mautic\LeadBundle\Field\Event\DeleteColumnBackgroundEvent;
 use Mautic\LeadBundle\Field\Event\UpdateColumnBackgroundEvent;
 use Mautic\LeadBundle\Field\Exception\AbortColumnCreateException;
 use Mautic\LeadBundle\Field\Exception\AbortColumnUpdateException;
-use Mautic\LeadBundle\LeadEvents;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -74,7 +73,6 @@ final class FieldColumnBackgroundJobDispatcherTest extends \PHPUnit\Framework\Te
         $this->dispatcher->expects($this->once())->method('hasListeners')->willReturn(true);
         $this->dispatcher->expects($this->once())->method('dispatch')->with(
             $this->isInstanceOf(AddColumnBackgroundEvent::class),
-            LeadEvents::LEAD_FIELD_PRE_ADD_COLUMN_BACKGROUND_JOB,
         );
 
         $fieldColumnBackgroundJobDispatcher = new FieldColumnBackgroundJobDispatcher($this->dispatcher);
@@ -86,7 +84,6 @@ final class FieldColumnBackgroundJobDispatcherTest extends \PHPUnit\Framework\Te
         $this->dispatcher->expects($this->once())->method('hasListeners')->willReturn(true);
         $this->dispatcher->expects($this->once())->method('dispatch')->with(
             $this->isInstanceOf(UpdateColumnBackgroundEvent::class),
-            LeadEvents::LEAD_FIELD_PRE_UPDATE_COLUMN_BACKGROUND_JOB,
         );
 
         $fieldColumnBackgroundJobDispatcher = new FieldColumnBackgroundJobDispatcher($this->dispatcher);
@@ -98,7 +95,6 @@ final class FieldColumnBackgroundJobDispatcherTest extends \PHPUnit\Framework\Te
         $this->dispatcher->expects($this->once())->method('hasListeners')->willReturn(true);
         $this->dispatcher->expects($this->once())->method('dispatch')->with(
             $this->isInstanceOf(DeleteColumnBackgroundEvent::class),
-            LeadEvents::LEAD_FIELD_PRE_DELETE_COLUMN_BACKGROUND_JOB,
         );
 
         $fieldColumnBackgroundJobDispatcher = new FieldColumnBackgroundJobDispatcher($this->dispatcher);
@@ -114,7 +110,6 @@ final class FieldColumnBackgroundJobDispatcherTest extends \PHPUnit\Framework\Te
 
                 return true;
             }),
-            LeadEvents::LEAD_FIELD_PRE_ADD_COLUMN_BACKGROUND_JOB,
         );
 
         $fieldColumnBackgroundJobDispatcher = new FieldColumnBackgroundJobDispatcher($this->dispatcher);
@@ -134,7 +129,6 @@ final class FieldColumnBackgroundJobDispatcherTest extends \PHPUnit\Framework\Te
 
                 return true;
             }),
-            LeadEvents::LEAD_FIELD_PRE_UPDATE_COLUMN_BACKGROUND_JOB,
         );
 
         $fieldColumnBackgroundJobDispatcher = new FieldColumnBackgroundJobDispatcher($this->dispatcher);
@@ -154,7 +148,6 @@ final class FieldColumnBackgroundJobDispatcherTest extends \PHPUnit\Framework\Te
 
                 return true;
             }),
-            LeadEvents::LEAD_FIELD_PRE_DELETE_COLUMN_BACKGROUND_JOB,
         );
 
         $fieldColumnBackgroundJobDispatcher = new FieldColumnBackgroundJobDispatcher($this->dispatcher);

--- a/app/bundles/LeadBundle/Tests/Field/Dispatcher/FieldColumnDispatcherTest.php
+++ b/app/bundles/LeadBundle/Tests/Field/Dispatcher/FieldColumnDispatcherTest.php
@@ -30,7 +30,6 @@ final class FieldColumnDispatcherTest extends \PHPUnit\Framework\TestCase
             ->method('dispatch')
             ->with(
                 $this->isInstanceOf(AddColumnEvent::class),
-                'mautic.lead_field_pre_add_column',
             );
 
         $fieldColumnDispatcher = new FieldColumnDispatcher($dispatcher, $backgroundSettings);
@@ -52,7 +51,6 @@ final class FieldColumnDispatcherTest extends \PHPUnit\Framework\TestCase
             ->method('dispatch')
             ->with(
                 $this->isInstanceOf(AddColumnEvent::class),
-                'mautic.lead_field_pre_add_column'
             );
 
         $fieldColumnDispatcher = new FieldColumnDispatcher($dispatcher, $backgroundSettings);
@@ -85,7 +83,6 @@ final class FieldColumnDispatcherTest extends \PHPUnit\Framework\TestCase
             ->method('dispatch')
             ->with(
                 $this->isInstanceOf(UpdateColumnEvent::class),
-                'mautic.lead_field_pre_update_column'
             );
 
         $fieldColumnDispatcher = new FieldColumnDispatcher($dispatcher, $backgroundSettings);
@@ -114,7 +111,6 @@ final class FieldColumnDispatcherTest extends \PHPUnit\Framework\TestCase
             ->method('dispatch')
             ->with(
                 $this->isInstanceOf(DeleteColumnEvent::class),
-                'mautic.lead_field_pre_delete_column',
             );
 
         $fieldColumnDispatcher = new FieldColumnDispatcher($dispatcher, $backgroundSettings);

--- a/app/bundles/LeadBundle/Tests/Helper/LeadChangeEventDispatcherTest.php
+++ b/app/bundles/LeadBundle/Tests/Helper/LeadChangeEventDispatcherTest.php
@@ -138,8 +138,7 @@ final class LeadChangeEventDispatcherTest extends \PHPUnit\Framework\TestCase
         $dispatcher->expects($this->once())
             ->method('dispatch')
             ->with(
-                $utmTagsEvent,
-                LeadEvents::LEAD_UTMTAGS_ADD
+                $utmTagsEvent
             );
 
         $leadEventDispatcher = new LeadChangeEventDispatcher($dispatcher);
@@ -160,8 +159,7 @@ final class LeadChangeEventDispatcherTest extends \PHPUnit\Framework\TestCase
         $dispatcher->expects($this->once())
             ->method('dispatch')
             ->with(
-                $dncEvent,
-                LeadEvents::CHANNEL_SUBSCRIPTION_CHANGED
+                $dncEvent
             );
 
         $leadEventDispatcher = new LeadChangeEventDispatcher($dispatcher);

--- a/app/bundles/LeadBundle/Tests/Model/ImportModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/ImportModelTest.php
@@ -17,7 +17,6 @@ use Mautic\LeadBundle\Event\ImportProcessEvent;
 use Mautic\LeadBundle\Exception\ImportDelayedException;
 use Mautic\LeadBundle\Exception\ImportFailedException;
 use Mautic\LeadBundle\Helper\Progress;
-use Mautic\LeadBundle\LeadEvents;
 use Mautic\LeadBundle\Model\CompanyModel;
 use Mautic\LeadBundle\Model\ImportModel;
 use Mautic\LeadBundle\Model\LeadModel;
@@ -65,8 +64,7 @@ final class ImportModelTest extends StandardImportTestHelper
                     $event->setWasMerged(false);
 
                     return true;
-                }),
-                LeadEvents::IMPORT_ON_PROCESS
+                })
             );
 
         $entity->start();
@@ -398,8 +396,7 @@ final class ImportModelTest extends StandardImportTestHelper
                     $event->addWarning('test warning message');
 
                     return true;
-                }),
-                LeadEvents::IMPORT_ON_PROCESS
+                })
             );
 
         $entity->start();
@@ -465,8 +462,7 @@ final class ImportModelTest extends StandardImportTestHelper
                     $event->setWasMerged(false);
 
                     return true;
-                }),
-                LeadEvents::IMPORT_ON_PROCESS,
+                })
             );
 
         $importModel = new ImportModel(

--- a/app/bundles/LeadBundle/Tests/Provider/FieldChoicesProviderTest.php
+++ b/app/bundles/LeadBundle/Tests/Provider/FieldChoicesProviderTest.php
@@ -6,7 +6,6 @@ namespace Mautic\LeadBundle\Tests\Provider;
 
 use Mautic\LeadBundle\Event\ListFieldChoicesEvent;
 use Mautic\LeadBundle\Exception\ChoicesNotFoundException;
-use Mautic\LeadBundle\LeadEvents;
 use Mautic\LeadBundle\Provider\FieldChoicesProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -33,8 +32,7 @@ final class FieldChoicesProviderTest extends \PHPUnit\Framework\TestCase
         $this->dispatcher->expects($this->once())
             ->method('dispatch')
             ->with(
-                $this->callback($this->setSomeChoicesLikeASubscriber()),
-                LeadEvents::COLLECT_FILTER_CHOICES_FOR_LIST_FIELD_TYPE
+                $this->callback($this->setSomeChoicesLikeASubscriber())
             );
 
         $this->expectException(ChoicesNotFoundException::class);
@@ -46,8 +44,7 @@ final class FieldChoicesProviderTest extends \PHPUnit\Framework\TestCase
         $this->dispatcher->expects($this->once())
             ->method('dispatch')
             ->with(
-                $this->callback($this->setSomeChoicesLikeASubscriber()),
-                LeadEvents::COLLECT_FILTER_CHOICES_FOR_LIST_FIELD_TYPE
+                $this->callback($this->setSomeChoicesLikeASubscriber())
             );
 
         // Calling it twice to ensure the cache is working and the event is triggered only once.
@@ -62,8 +59,7 @@ final class FieldChoicesProviderTest extends \PHPUnit\Framework\TestCase
         $this->dispatcher->expects($this->once())
             ->method('dispatch')
             ->with(
-                $this->callback($this->setSomeChoicesLikeASubscriber()),
-                LeadEvents::COLLECT_FILTER_CHOICES_FOR_LIST_FIELD_TYPE
+                $this->callback($this->setSomeChoicesLikeASubscriber())
             );
 
         // Calling it twice to ensure the cache is working and the event is triggered only once.

--- a/app/bundles/LeadBundle/Tests/Provider/FilterOperatorProviderTest.php
+++ b/app/bundles/LeadBundle/Tests/Provider/FilterOperatorProviderTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Mautic\LeadBundle\Tests\Provider;
 
 use Mautic\LeadBundle\Event\LeadListFiltersOperatorsEvent;
-use Mautic\LeadBundle\LeadEvents;
 use Mautic\LeadBundle\Provider\FilterOperatorProvider;
 use Mautic\LeadBundle\Segment\OperatorOptions;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -55,8 +54,7 @@ final class FilterOperatorProviderTest extends \PHPUnit\Framework\TestCase
                     );
 
                     return true;
-                }),
-                LeadEvents::LIST_FILTERS_OPERATORS_ON_GENERATE
+                })
             );
 
         $this->translator->expects($this->once())

--- a/app/bundles/LeadBundle/Tests/Provider/FormAdjustmentsProviderTest.php
+++ b/app/bundles/LeadBundle/Tests/Provider/FormAdjustmentsProviderTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Mautic\LeadBundle\Tests\Provider;
 
 use Mautic\LeadBundle\Event\FormAdjustmentEvent;
-use Mautic\LeadBundle\LeadEvents;
 use Mautic\LeadBundle\Provider\FormAdjustmentsProvider;
 use Mautic\LeadBundle\Segment\OperatorOptions;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -48,8 +47,7 @@ final class FormAdjustmentsProviderTest extends \PHPUnit\Framework\TestCase
                     $this->assertSame('text', $event->getFieldType());
 
                     return true;
-                }),
-                LeadEvents::ADJUST_FILTER_FORM_TYPE_FOR_FIELD
+                })
             );
 
         $this->provider->adjustForm(

--- a/app/bundles/LeadBundle/Tests/Provider/TypeOperatorProviderTest.php
+++ b/app/bundles/LeadBundle/Tests/Provider/TypeOperatorProviderTest.php
@@ -6,7 +6,6 @@ namespace Mautic\LeadBundle\Tests\Provider;
 
 use Mautic\LeadBundle\Event\FieldOperatorsEvent;
 use Mautic\LeadBundle\Event\TypeOperatorsEvent;
-use Mautic\LeadBundle\LeadEvents;
 use Mautic\LeadBundle\Provider\FilterOperatorProviderInterface;
 use Mautic\LeadBundle\Provider\TypeOperatorProvider;
 use Mautic\LeadBundle\Segment\OperatorOptions;
@@ -121,8 +120,7 @@ final class TypeOperatorProviderTest extends \PHPUnit\Framework\TestCase
                     ]);
 
                     return true;
-                }),
-                LeadEvents::COLLECT_OPERATORS_FOR_FIELD_TYPE
+                })
             );
 
         $this->assertSame(
@@ -170,7 +168,6 @@ final class TypeOperatorProviderTest extends \PHPUnit\Framework\TestCase
                         ]);
                     };
                     $callback($parameters[0]);
-                    $this->assertSame(LeadEvents::COLLECT_OPERATORS_FOR_FIELD_TYPE, $parameters[1]);
                 }
                 if (2 === $matcher->numberOfInvocations()) {
                     $callback = function (FieldOperatorsEvent $event): void {
@@ -182,7 +179,6 @@ final class TypeOperatorProviderTest extends \PHPUnit\Framework\TestCase
                         $event->addOperator(OperatorOptions::STARTS_WITH);
                     };
                     $callback($parameters[0]);
-                    $this->assertSame(LeadEvents::COLLECT_OPERATORS_FOR_FIELD, $parameters[1]);
                 }
 
                 return $parameters[0];

--- a/app/bundles/LeadBundle/Tests/Segment/Decorator/DecoratorFactoryTest.php
+++ b/app/bundles/LeadBundle/Tests/Segment/Decorator/DecoratorFactoryTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Mautic\LeadBundle\Tests\Segment\Decorator;
 
 use Mautic\LeadBundle\Event\LeadListFiltersDecoratorDelegateEvent;
-use Mautic\LeadBundle\LeadEvents;
 use Mautic\LeadBundle\Segment\ContactSegmentFilterCrate;
 use Mautic\LeadBundle\Segment\Decorator\BaseDecorator;
 use Mautic\LeadBundle\Segment\Decorator\CompanyDecorator;
@@ -94,8 +93,7 @@ final class DecoratorFactoryTest extends \PHPUnit\Framework\TestCase
 
                         return true;
                     }
-                ),
-                LeadEvents::SEGMENT_ON_DECORATOR_DELEGATE
+                )
             );
 
         $this->assertSame(
@@ -124,8 +122,7 @@ final class DecoratorFactoryTest extends \PHPUnit\Framework\TestCase
 
                         return true;
                     }
-                ),
-                LeadEvents::SEGMENT_ON_DECORATOR_DELEGATE
+                )
             );
 
         $this->assertSame(


### PR DESCRIPTION
Continues the migration of bundle `*Events` string constants to native Symfony 4.3+ class-name event dispatch, following the already-merged Asset/Channel/Core/Page/Webhook/Plugin bundles. LeadBundle is the largest remaining bundle, so it gets its own PR.

Only events that map 1:1 to a single event class, with all dispatch and subscriber sites inside LeadBundle, are converted. Constants whose event object is shared across several names (CRUD / pre-post groups, merge pairs) or whose events cross bundle boundaries are left as string constants. All `LeadEvents` constants and the class are kept for backwards compatibility.

## Converted (24 constants)

UTM / category / channel: `LEAD_UTMTAGS_ADD` -> `LeadUtmTagsEvent`, `LEAD_CATEGORY_CHANGE` -> `CategoryChangeEvent`, `CHANNEL_SUBSCRIPTION_CHANGED` -> `ChannelSubscriptionChange`.

Search / filter / operators: `LEAD_BUILD_SEARCH_COMMANDS` -> `LeadBuildSearchEvent`, `COMPANY_BUILD_SEARCH_COMMANDS` -> `CompanyBuildSearchEvent`, `ADJUST_FILTER_FORM_TYPE_FOR_FIELD` -> `FormAdjustmentEvent`, `COLLECT_OPERATORS_FOR_FIELD_TYPE` -> `TypeOperatorsEvent`, `COLLECT_OPERATORS_FOR_FIELD` -> `FieldOperatorsEvent`, `COLLECT_FILTER_CHOICES_FOR_LIST_FIELD_TYPE` -> `ListFieldChoicesEvent`.

Segment filters: `SEGMENT_ON_DECORATOR_DELEGATE` -> `LeadListFiltersDecoratorDelegateEvent`, `LIST_FILTERS_MERGE` -> `LeadListMergeFiltersEvent`, `LIST_FILTERS_OPERATORS_ON_GENERATE` -> `LeadListFiltersOperatorsEvent`, `LIST_FILTERS_OPERATOR_QUERYBUILDER_ON_GENERATE` -> `SegmentOperatorQueryBuilderEvent`, `LIST_FILTERS_QUERYBUILDER_GENERATED` -> `LeadListQueryBuilderGeneratedEvent`.

Import: `IMPORT_ON_INITIALIZE` / `IMPORT_ON_FIELD_MAPPING` / `IMPORT_ON_PROCESS` / `IMPORT_ON_VALIDATE` -> `ImportInitEvent` / `ImportMappingEvent` / `ImportProcessEvent` / `ImportValidateEvent`.

Lead field columns: the six `LEAD_FIELD_PRE_*_COLUMN` / `*_BACKGROUND_JOB` -> `Field\Event\{Add,Update,Delete}Column{,Background}Event`.

## Notes

- `CHANNEL_SUBSCRIPTION_CHANGED` also doubles as a webhook type identifier (its string value) in `WebhookSubscriber`; only its event dispatch + `getSubscribedEvents` key were converted, the webhook-type-id usages stay as the constant.
- Shared-event-object groups (Lead/LeadList/LeadField/Company/Import/Tag CRUD and merge pairs) and cross-bundle constants (points/company/list change, timeline, clickthrough, campaign action/condition) are intentionally left as string constants.
- Affected unit tests updated to the new single-argument dispatch signature.

`UPGRADE-8.0.md` documents the full mapping and skip rationale.
