### PR TITLE
fix(report): count grouped report totals in strict mode.

### DIFF
--- a/app/bundles/ReportBundle/Model/ReportModel.php
+++ b/app/bundles/ReportBundle/Model/ReportModel.php
@@ -787,10 +787,25 @@ class ReportModel extends FormModel implements GlobalSearchInterface
     private function getTotalCount(QueryBuilder $qb, array &$debugData): int
     {
         $countQb = clone $qb;
+
+        // Total rows must ignore the current page size and sort order.
+        $countQb->setFirstResult(0)
+            ->setMaxResults(null)
+            ->resetQueryPart('orderBy');
+
+        if ($countQb->getQueryPart('groupBy')) {
+            // For grouped reports, the count query only needs one row per group.
+            // Keeping the report's display SELECT list can select non-grouped,
+            // non-aggregated columns and fail under MySQL's ONLY_FULL_GROUP_BY mode.
+            $countQb->resetQueryPart('select')
+                ->select('1');
+        }
+
+        $countSql = $countQb->getSQL();
         $countQb->resetQueryParts();
 
         $countQb->select('count(*)')
-            ->from('('.$qb->getSQL().')', 'c');
+            ->from('('.$countSql.')', 'c');
 
         if ($this->isDebugMode()) {
             $debugData['count_query'] = $countQb->getSQL();

--- a/app/bundles/ReportBundle/Tests/Unit/Model/ReportModelTest.php
+++ b/app/bundles/ReportBundle/Tests/Unit/Model/ReportModelTest.php
@@ -147,6 +147,54 @@ final class ReportModelTest extends MauticMysqlTestCase
         $this->assertSame(3, $this->invokeGetTotalCount($reportModel, $queryBuilder, $debugData));
     }
 
+    public function testGetTotalCountPreservesHavingForGroupedReports(): void
+    {
+        $form = new Form();
+        $form->setName('Grouped Report Having Test Form');
+        $form->setAlias('grouped_report_having_test_form');
+
+        $ip = new IpAddress('127.0.0.4');
+
+        $this->em->persist($ip);
+        $this->em->persist($form);
+        $this->em->flush();
+
+        $timezone = new \DateTimeZone('UTC');
+        $this->em->persist($this->makeSubmission($form, $ip, new \DateTime('2026-03-01 10:00:00', $timezone)));
+        $this->em->persist($this->makeSubmission($form, $ip, new \DateTime('2026-03-01 11:00:00', $timezone)));
+        $this->em->persist($this->makeSubmission($form, $ip, new \DateTime('2026-03-02 10:00:00', $timezone)));
+        $this->em->flush();
+
+        $connection      = $this->em->getConnection();
+        $originalSqlMode = (string) $connection->executeQuery('SELECT @@SESSION.sql_mode')->fetchOne();
+
+        try {
+            $sqlModes = array_filter(explode(',', $originalSqlMode));
+            if (!in_array('ONLY_FULL_GROUP_BY', $sqlModes, true)) {
+                $sqlModes[] = 'ONLY_FULL_GROUP_BY';
+                $connection->executeStatement('SET SESSION sql_mode = ?', [implode(',', $sqlModes)]);
+            }
+
+            $queryBuilder = $connection->createQueryBuilder();
+            $queryBuilder->select('fs.id', 'fs.date_submitted')
+                ->from(MAUTIC_TABLE_PREFIX.'form_submissions', 'fs')
+                ->where('fs.form_id = :formId')
+                ->setParameter('formId', $form->getId())
+                ->groupBy('DATE(fs.date_submitted)')
+                ->having('COUNT(fs.id) > 1')
+                ->orderBy('fs.id', 'DESC')
+                ->setMaxResults(1);
+
+            /** @var ReportModel $reportModel */
+            $reportModel = self::getContainer()->get(ReportModel::class);
+            $debugData   = [];
+
+            $this->assertSame(1, $this->invokeGetTotalCount($reportModel, $queryBuilder, $debugData));
+        } finally {
+            $connection->executeStatement('SET SESSION sql_mode = ?', [$originalSqlMode]);
+        }
+    }
+
     private function makeSubmission(Form $form, IpAddress $ipAddress, \DateTime $dateSubmitted): Submission
     {
         $submission = new Submission();

--- a/app/bundles/ReportBundle/Tests/Unit/Model/ReportModelTest.php
+++ b/app/bundles/ReportBundle/Tests/Unit/Model/ReportModelTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\ReportBundle\Tests\Unit\Model;
 
+use Doctrine\DBAL\Query\QueryBuilder;
 use Mautic\CoreBundle\Entity\IpAddress;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\FormBundle\Entity\Form;
@@ -66,6 +67,86 @@ final class ReportModelTest extends MauticMysqlTestCase
         $this->assertCount(1, $reportData['data']);
     }
 
+    public function testGetTotalCountUsesStrictModeCompatibleQueryForGroupedReports(): void
+    {
+        $form = new Form();
+        $form->setName('Grouped Report Test Form');
+        $form->setAlias('grouped_report_test_form');
+
+        $ip = new IpAddress('127.0.0.2');
+
+        $this->em->persist($ip);
+        $this->em->persist($form);
+        $this->em->flush();
+
+        $timezone = new \DateTimeZone('UTC');
+        $this->em->persist($this->makeSubmission($form, $ip, new \DateTime('2026-01-01 10:00:00', $timezone)));
+        $this->em->persist($this->makeSubmission($form, $ip, new \DateTime('2026-01-01 11:00:00', $timezone)));
+        $this->em->persist($this->makeSubmission($form, $ip, new \DateTime('2026-01-02 10:00:00', $timezone)));
+        $this->em->flush();
+
+        $connection      = $this->em->getConnection();
+        $originalSqlMode = (string) $connection->executeQuery('SELECT @@SESSION.sql_mode')->fetchOne();
+
+        try {
+            $sqlModes = array_filter(explode(',', $originalSqlMode));
+            if (!in_array('ONLY_FULL_GROUP_BY', $sqlModes, true)) {
+                $sqlModes[] = 'ONLY_FULL_GROUP_BY';
+                $connection->executeStatement('SET SESSION sql_mode = ?', [implode(',', $sqlModes)]);
+            }
+
+            $queryBuilder = $connection->createQueryBuilder();
+            $queryBuilder->select('fs.id', 'fs.date_submitted')
+                ->from(MAUTIC_TABLE_PREFIX.'form_submissions', 'fs')
+                ->where('fs.form_id = :formId')
+                ->setParameter('formId', $form->getId())
+                ->groupBy('DATE(fs.date_submitted)')
+                ->orderBy('fs.id', 'DESC')
+                ->setMaxResults(1);
+
+            /** @var ReportModel $reportModel */
+            $reportModel = self::getContainer()->get(ReportModel::class);
+            $debugData   = [];
+
+            $this->assertSame(2, $this->invokeGetTotalCount($reportModel, $queryBuilder, $debugData));
+        } finally {
+            $connection->executeStatement('SET SESSION sql_mode = ?', [$originalSqlMode]);
+        }
+    }
+
+    public function testGetTotalCountSupportsNonGroupedReports(): void
+    {
+        $form = new Form();
+        $form->setName('Non Grouped Report Test Form');
+        $form->setAlias('non_grouped_report_test_form');
+
+        $ip = new IpAddress('127.0.0.3');
+
+        $this->em->persist($ip);
+        $this->em->persist($form);
+        $this->em->flush();
+
+        $timezone = new \DateTimeZone('UTC');
+        $this->em->persist($this->makeSubmission($form, $ip, new \DateTime('2026-02-01 10:00:00', $timezone)));
+        $this->em->persist($this->makeSubmission($form, $ip, new \DateTime('2026-02-01 11:00:00', $timezone)));
+        $this->em->persist($this->makeSubmission($form, $ip, new \DateTime('2026-02-02 10:00:00', $timezone)));
+        $this->em->flush();
+
+        $queryBuilder = $this->em->getConnection()->createQueryBuilder();
+        $queryBuilder->select('fs.id', 'fs.date_submitted')
+            ->from(MAUTIC_TABLE_PREFIX.'form_submissions', 'fs')
+            ->where('fs.form_id = :formId')
+            ->setParameter('formId', $form->getId())
+            ->orderBy('fs.id', 'DESC')
+            ->setMaxResults(1);
+
+        /** @var ReportModel $reportModel */
+        $reportModel = self::getContainer()->get(ReportModel::class);
+        $debugData   = [];
+
+        $this->assertSame(3, $this->invokeGetTotalCount($reportModel, $queryBuilder, $debugData));
+    }
+
     private function makeSubmission(Form $form, IpAddress $ipAddress, \DateTime $dateSubmitted): Submission
     {
         $submission = new Submission();
@@ -75,5 +156,14 @@ final class ReportModelTest extends MauticMysqlTestCase
         $submission->setReferer('');
 
         return $submission;
+    }
+
+    private function invokeGetTotalCount(ReportModel $reportModel, QueryBuilder $queryBuilder, array &$debugData): int
+    {
+        $method = new \ReflectionMethod($reportModel, 'getTotalCount');
+        $result = $method->invokeArgs($reportModel, [$queryBuilder, &$debugData]);
+        \assert(is_int($result));
+
+        return $result;
     }
 }

--- a/app/bundles/ReportBundle/Tests/Unit/Model/ReportModelTest.php
+++ b/app/bundles/ReportBundle/Tests/Unit/Model/ReportModelTest.php
@@ -11,6 +11,7 @@ use Mautic\FormBundle\Entity\Form;
 use Mautic\FormBundle\Entity\Submission;
 use Mautic\ReportBundle\Entity\Report;
 use Mautic\ReportBundle\Model\ReportModel;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Session;
@@ -67,132 +68,80 @@ final class ReportModelTest extends MauticMysqlTestCase
         $this->assertCount(1, $reportData['data']);
     }
 
-    public function testGetTotalCountUsesStrictModeCompatibleQueryForGroupedReports(): void
-    {
-        $form = new Form();
-        $form->setName('Grouped Report Test Form');
-        $form->setAlias('grouped_report_test_form');
-
-        $ip = new IpAddress('127.0.0.2');
-
-        $this->em->persist($ip);
-        $this->em->persist($form);
-        $this->em->flush();
-
-        $timezone = new \DateTimeZone('UTC');
-        $this->em->persist($this->makeSubmission($form, $ip, new \DateTime('2026-01-01 10:00:00', $timezone)));
-        $this->em->persist($this->makeSubmission($form, $ip, new \DateTime('2026-01-01 11:00:00', $timezone)));
-        $this->em->persist($this->makeSubmission($form, $ip, new \DateTime('2026-01-02 10:00:00', $timezone)));
-        $this->em->flush();
-
-        $connection      = $this->em->getConnection();
-        $originalSqlMode = (string) $connection->executeQuery('SELECT @@SESSION.sql_mode')->fetchOne();
-
-        try {
-            $sqlModes = array_filter(explode(',', $originalSqlMode));
-            if (!in_array('ONLY_FULL_GROUP_BY', $sqlModes, true)) {
-                $sqlModes[] = 'ONLY_FULL_GROUP_BY';
-                $connection->executeStatement('SET SESSION sql_mode = ?', [implode(',', $sqlModes)]);
-            }
-
-            $queryBuilder = $connection->createQueryBuilder();
-            $queryBuilder->select('fs.id', 'fs.date_submitted')
-                ->from(MAUTIC_TABLE_PREFIX.'form_submissions', 'fs')
-                ->where('fs.form_id = :formId')
-                ->setParameter('formId', $form->getId())
-                ->groupBy('DATE(fs.date_submitted)')
-                ->orderBy('fs.id', 'DESC')
-                ->setMaxResults(1);
-
+    /**
+     * @param list<string> $submittedAt
+     */
+    #[DataProvider('totalCountQueryProvider')]
+    public function testGetTotalCountBuildsCompatibleCountQuery(
+        string $alias,
+        string $ipAddress,
+        array $submittedAt,
+        bool $useOnlyFullGroupBy,
+        bool $grouped,
+        ?string $having,
+        int $expectedTotal,
+    ): void {
+        $form = $this->createFormWithSubmissions('Report Count Test Form', $alias, $ipAddress, $submittedAt);
+        $test = function () use ($form, $grouped, $having, $expectedTotal): void {
             /** @var ReportModel $reportModel */
             $reportModel = self::getContainer()->get(ReportModel::class);
             $debugData   = [];
+            $query       = $this->createReportQuery($form, $grouped, $having);
 
-            $this->assertSame(2, $this->invokeGetTotalCount($reportModel, $queryBuilder, $debugData));
-        } finally {
-            $connection->executeStatement('SET SESSION sql_mode = ?', [$originalSqlMode]);
+            $this->assertSame($expectedTotal, $this->invokeGetTotalCount($reportModel, $query, $debugData));
+        };
+
+        if ($useOnlyFullGroupBy) {
+            $this->withOnlyFullGroupBy($test);
+
+            return;
         }
+
+        $test();
     }
 
-    public function testGetTotalCountSupportsNonGroupedReports(): void
+    /**
+     * @return iterable<string, array{
+     *     alias: string,
+     *     ipAddress: string,
+     *     submittedAt: list<string>,
+     *     useOnlyFullGroupBy: bool,
+     *     grouped: bool,
+     *     having: string|null,
+     *     expectedTotal: int
+     * }>
+     */
+    public static function totalCountQueryProvider(): iterable
     {
-        $form = new Form();
-        $form->setName('Non Grouped Report Test Form');
-        $form->setAlias('non_grouped_report_test_form');
+        yield 'grouped report with strict group-by mode' => [
+            'alias'              => 'grouped_report_test_form',
+            'ipAddress'          => '127.0.0.2',
+            'submittedAt'        => ['2026-01-01 10:00:00', '2026-01-01 11:00:00', '2026-01-02 10:00:00'],
+            'useOnlyFullGroupBy' => true,
+            'grouped'            => true,
+            'having'             => null,
+            'expectedTotal'      => 2,
+        ];
 
-        $ip = new IpAddress('127.0.0.3');
+        yield 'non-grouped report' => [
+            'alias'              => 'non_grouped_report_test_form',
+            'ipAddress'          => '127.0.0.3',
+            'submittedAt'        => ['2026-02-01 10:00:00', '2026-02-01 11:00:00', '2026-02-02 10:00:00'],
+            'useOnlyFullGroupBy' => false,
+            'grouped'            => false,
+            'having'             => null,
+            'expectedTotal'      => 3,
+        ];
 
-        $this->em->persist($ip);
-        $this->em->persist($form);
-        $this->em->flush();
-
-        $timezone = new \DateTimeZone('UTC');
-        $this->em->persist($this->makeSubmission($form, $ip, new \DateTime('2026-02-01 10:00:00', $timezone)));
-        $this->em->persist($this->makeSubmission($form, $ip, new \DateTime('2026-02-01 11:00:00', $timezone)));
-        $this->em->persist($this->makeSubmission($form, $ip, new \DateTime('2026-02-02 10:00:00', $timezone)));
-        $this->em->flush();
-
-        $queryBuilder = $this->em->getConnection()->createQueryBuilder();
-        $queryBuilder->select('fs.id', 'fs.date_submitted')
-            ->from(MAUTIC_TABLE_PREFIX.'form_submissions', 'fs')
-            ->where('fs.form_id = :formId')
-            ->setParameter('formId', $form->getId())
-            ->orderBy('fs.id', 'DESC')
-            ->setMaxResults(1);
-
-        /** @var ReportModel $reportModel */
-        $reportModel = self::getContainer()->get(ReportModel::class);
-        $debugData   = [];
-
-        $this->assertSame(3, $this->invokeGetTotalCount($reportModel, $queryBuilder, $debugData));
-    }
-
-    public function testGetTotalCountPreservesHavingForGroupedReports(): void
-    {
-        $form = new Form();
-        $form->setName('Grouped Report Having Test Form');
-        $form->setAlias('grouped_report_having_test_form');
-
-        $ip = new IpAddress('127.0.0.4');
-
-        $this->em->persist($ip);
-        $this->em->persist($form);
-        $this->em->flush();
-
-        $timezone = new \DateTimeZone('UTC');
-        $this->em->persist($this->makeSubmission($form, $ip, new \DateTime('2026-03-01 10:00:00', $timezone)));
-        $this->em->persist($this->makeSubmission($form, $ip, new \DateTime('2026-03-01 11:00:00', $timezone)));
-        $this->em->persist($this->makeSubmission($form, $ip, new \DateTime('2026-03-02 10:00:00', $timezone)));
-        $this->em->flush();
-
-        $connection      = $this->em->getConnection();
-        $originalSqlMode = (string) $connection->executeQuery('SELECT @@SESSION.sql_mode')->fetchOne();
-
-        try {
-            $sqlModes = array_filter(explode(',', $originalSqlMode));
-            if (!in_array('ONLY_FULL_GROUP_BY', $sqlModes, true)) {
-                $sqlModes[] = 'ONLY_FULL_GROUP_BY';
-                $connection->executeStatement('SET SESSION sql_mode = ?', [implode(',', $sqlModes)]);
-            }
-
-            $queryBuilder = $connection->createQueryBuilder();
-            $queryBuilder->select('fs.id', 'fs.date_submitted')
-                ->from(MAUTIC_TABLE_PREFIX.'form_submissions', 'fs')
-                ->where('fs.form_id = :formId')
-                ->setParameter('formId', $form->getId())
-                ->groupBy('DATE(fs.date_submitted)')
-                ->having('COUNT(fs.id) > 1')
-                ->orderBy('fs.id', 'DESC')
-                ->setMaxResults(1);
-
-            /** @var ReportModel $reportModel */
-            $reportModel = self::getContainer()->get(ReportModel::class);
-            $debugData   = [];
-
-            $this->assertSame(1, $this->invokeGetTotalCount($reportModel, $queryBuilder, $debugData));
-        } finally {
-            $connection->executeStatement('SET SESSION sql_mode = ?', [$originalSqlMode]);
-        }
+        yield 'grouped report with having and strict group-by mode' => [
+            'alias'              => 'grouped_report_having_test_form',
+            'ipAddress'          => '127.0.0.4',
+            'submittedAt'        => ['2026-03-01 10:00:00', '2026-03-01 11:00:00', '2026-03-02 10:00:00'],
+            'useOnlyFullGroupBy' => true,
+            'grouped'            => true,
+            'having'             => 'COUNT(fs.id) > 1',
+            'expectedTotal'      => 1,
+        ];
     }
 
     private function makeSubmission(Form $form, IpAddress $ipAddress, \DateTime $dateSubmitted): Submission
@@ -204,6 +153,70 @@ final class ReportModelTest extends MauticMysqlTestCase
         $submission->setReferer('');
 
         return $submission;
+    }
+
+    /**
+     * @param list<string> $submittedAt
+     */
+    private function createFormWithSubmissions(string $name, string $alias, string $ipAddress, array $submittedAt): Form
+    {
+        $form = new Form();
+        $form->setName($name);
+        $form->setAlias($alias);
+
+        $ip = new IpAddress($ipAddress);
+
+        $this->em->persist($ip);
+        $this->em->persist($form);
+        $this->em->flush();
+
+        $timezone = new \DateTimeZone('UTC');
+        foreach ($submittedAt as $dateSubmitted) {
+            $this->em->persist($this->makeSubmission($form, $ip, new \DateTime($dateSubmitted, $timezone)));
+        }
+
+        $this->em->flush();
+
+        return $form;
+    }
+
+    private function withOnlyFullGroupBy(callable $callback): void
+    {
+        $connection      = $this->em->getConnection();
+        $originalSqlMode = (string) $connection->executeQuery('SELECT @@SESSION.sql_mode')->fetchOne();
+
+        try {
+            $sqlModes = array_filter(explode(',', $originalSqlMode));
+            if (!in_array('ONLY_FULL_GROUP_BY', $sqlModes, true)) {
+                $sqlModes[] = 'ONLY_FULL_GROUP_BY';
+                $connection->executeStatement('SET SESSION sql_mode = ?', [implode(',', $sqlModes)]);
+            }
+
+            $callback();
+        } finally {
+            $connection->executeStatement('SET SESSION sql_mode = ?', [$originalSqlMode]);
+        }
+    }
+
+    private function createReportQuery(Form $form, bool $grouped = false, ?string $having = null): QueryBuilder
+    {
+        $queryBuilder = $this->em->getConnection()->createQueryBuilder();
+        $queryBuilder->select('fs.id', 'fs.date_submitted')
+            ->from(MAUTIC_TABLE_PREFIX.'form_submissions', 'fs')
+            ->where('fs.form_id = :formId')
+            ->setParameter('formId', $form->getId())
+            ->orderBy('fs.id', 'DESC')
+            ->setMaxResults(1);
+
+        if ($grouped) {
+            $queryBuilder->groupBy('DATE(fs.date_submitted)');
+        }
+
+        if (null !== $having) {
+            $queryBuilder->having($having);
+        }
+
+        return $queryBuilder;
     }
 
     private function invokeGetTotalCount(ReportModel $reportModel, QueryBuilder $queryBuilder, array &$debugData): int


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️
| Related user documentation PR URL      | Not required
| Related developer documentation PR URL | Not required
| Issue(s) addressed                     | No related issue. This ports the intent of #11825 to 7.x.

## Description

### What changed

Report total counting now removes pagination and ordering before building the count query. For grouped reports, the count query wraps a minimal grouped subquery instead of the full report SELECT list.

### Why this is needed

Grouped report count queries can fail on MySQL/MariaDB installations using `ONLY_FULL_GROUP_BY` when the inner count subquery selects columns that are not part of the `GROUP BY` clause.

### How it works

The total-count query is built from a cloned report query. The clone has pagination and ordering removed. When the report query contains `GROUP BY`, its select list is replaced with a constant before the outer `COUNT(*)` query is generated.

When debug mode is enabled, the report page shows the generated count query. For grouped reports, the count query should now use a minimal inner select, for example:

```sql
SELECT count(*) FROM (
    SELECT 1
    FROM form_submissions fs
    ...
    GROUP BY DATE(fs.date_submitted), fs.referer
) c
```

The important part is that the inner query no longer selects the full report column list, so MySQL does not reject the count query when `ONLY_FULL_GROUP_BY` is enabled.

### Impact

This is backward compatible. It only affects report total-count generation for paginated reports. Non-grouped reports continue to use the existing count behavior, and grouped reports should be more compatible with strict SQL mode.

---
### 📋 Steps to test this PR:

1. Open this PR on GitHub Codespaces or pull down for testing locally.
2. Check the current database SQL mode:
```bash
ddev mysql -N -e "SELECT @@GLOBAL.sql_mode, @@SESSION.sql_mode;"
```
3. Enable `ONLY_FULL_GROUP_BY` for new database connections:
```bash
ddev mysql -e "SET GLOBAL sql_mode = IF(@@GLOBAL.sql_mode LIKE '%ONLY_FULL_GROUP_BY%', @@GLOBAL.sql_mode, CONCAT_WS(',', @@GLOBAL.sql_mode, 'ONLY_FULL_GROUP_BY'));"
```
4. Confirm it is enabled:
```bash
ddev mysql -N -e "SELECT @@GLOBAL.sql_mode;"
```
5. In Mautic, create or use a report based on **Form Submissions**.
6. Add **Date submitted** and **Referer** as report columns.
7. Group the report by **Date submitted**.
8. View the report with pagination enabled.
9. Confirm the report loads without a SQL error.
10. Confirm the report shows the expected total, for example `3 items, 1 page in total`.
11. If debug mode is enabled, confirm the grouped report count query uses `SELECT 1` inside the subquery instead of selecting the full report column list.
12. Also confirm that a normal non-grouped report still loads and shows the correct total.
13. Run the targeted automated test:
```bash
ddev exec php bin/phpunit -c app/phpunit.xml.dist app/bundles/ReportBundle/Tests/Unit/Model/ReportModelTest.php
```
14. Optional: restore the local SQL mode if you do not want to keep `ONLY_FULL_GROUP_BY` enabled:
```bash
ddev mysql -e "SET GLOBAL sql_mode = REPLACE(REPLACE(@@GLOBAL.sql_mode, ',ONLY_FULL_GROUP_BY', ''), 'ONLY_FULL_GROUP_BY,', '');"
```