### PR TITLE
Update import action href to use dynamic object

### DIFF
--- a/app/bundles/LeadBundle/Resources/views/Import/progress.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Import/progress.html.twig
@@ -190,7 +190,7 @@ Variables
                                     {
                                         label: 'mautic.lead.import.import_again',
                                         variant: 'link',
-                                        href: path('mautic_import_action', {'object': 'contacts', 'objectAction': 'new'}),
+                                        href: path('mautic_import_action', {'object': object, 'objectAction': 'new'}),
                                         size: 'xl',
                                         attributes: {
                                             'data-toggle': 'ajax'


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

b = current minor release


* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

<!-- 📄 DOCUMENTATION REVIEW REQUIRED:

After you open this PR, Promptless automatically creates a documentation PR and leaves a comment here with the link. Once your code PR merges, review the documentation PR, request changes if needed, and approve it promptly.

See "Reviewing documentation PRs from Promptless" in the community handbook for more details: https://contribute.mautic.org/en/latest/contributing/developer.html#reviewing-documentation-prs-from-promptless -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️<!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #17220 <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
Fixes the issue described in #17220 , where clicking "Import Another" after importing companies leads to the Contact-Importer page instead of the company one.


<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers. Do not write steps performed by the CI. These steps are for manual testing.
-->
1. Open this PR on GitHub Codespaces or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Go to Companies -> Import
3. Import a Company via CSV
4. After the import, click on "Import Another"
5. Before this PR, you land on the page to import contacts, now you are correctly on the import companies page.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->