### PR TITLE
[routes] move custom API and catch-all routes to native #[Route] attributes

### DIFF
--- a/app/bundles/CampaignBundle/Config/config.php
+++ b/app/bundles/CampaignBundle/Config/config.php
@@ -31,55 +31,6 @@ return [
                 'path'                => '/campaigns/events',
                 'controller'          => Mautic\CampaignBundle\Controller\Api\EventApiController::class,
             ],
-            'mautic_api_campaigns_events_contact'     => [
-                'path'       => '/campaigns/events/contact/{contactId}',
-                'controller' => 'Mautic\CampaignBundle\Controller\Api\EventLogApiController::getContactEventsAction',
-                'method'     => 'GET',
-            ],
-            'mautic_api_campaigns_edit_contact_event' => [
-                'path'       => '/campaigns/events/{eventId}/contact/{contactId}/edit',
-                'controller' => 'Mautic\CampaignBundle\Controller\Api\EventLogApiController::editContactEventAction',
-                'method'     => 'PUT',
-            ],
-            'mautic_api_campaigns_batchedit_events'   => [
-                'path'       => '/campaigns/events/batch/edit',
-                'controller' => 'Mautic\CampaignBundle\Controller\Api\EventLogApiController::editEventsAction',
-                'method'     => 'PUT',
-            ],
-            'mautic_api_campaign_contact_events'      => [
-                'path'       => '/campaigns/{campaignId}/events/contact/{contactId}',
-                'controller' => 'Mautic\CampaignBundle\Controller\Api\EventLogApiController::getContactEventsAction',
-                'method'     => 'GET',
-            ],
-            'mautic_api_campaigngetcontacts'          => [
-                'path'       => '/campaigns/{id}/contacts',
-                'controller' => 'Mautic\CampaignBundle\Controller\Api\CampaignApiController::getContactsAction',
-            ],
-            'mautic_api_campaignaddcontact'           => [
-                'path'       => '/campaigns/{id}/contact/{leadId}/add',
-                'controller' => 'Mautic\CampaignBundle\Controller\Api\CampaignApiController::addLeadAction',
-                'method'     => 'POST',
-            ],
-            'mautic_api_campaignremovecontact'        => [
-                'path'       => '/campaigns/{id}/contact/{leadId}/remove',
-                'controller' => 'Mautic\CampaignBundle\Controller\Api\CampaignApiController::removeLeadAction',
-                'method'     => 'POST',
-            ],
-            'mautic_api_contact_clone_campaign' => [
-                'path'       => '/campaigns/clone/{campaignId}',
-                'controller' => 'Mautic\CampaignBundle\Controller\Api\CampaignApiController::cloneCampaignAction',
-                'method'     => 'POST',
-            ],
-            'mautic_api_export_campaign' => [
-                'path'       => '/campaigns/export/{campaignId}',
-                'controller' => 'Mautic\CampaignBundle\Controller\Api\CampaignApiController::exportCampaignAction',
-                'method'     => 'GET',
-            ],
-            'mautic_api_import_campaign' => [
-                'path'       => '/campaigns/import',
-                'controller' => 'Mautic\CampaignBundle\Controller\Api\CampaignApiController::importCampaignAction',
-                'method'     => 'POST',
-            ],
         ],
     ],
 

--- a/app/bundles/CampaignBundle/Controller/Api/CampaignApiController.php
+++ b/app/bundles/CampaignBundle/Controller/Api/CampaignApiController.php
@@ -29,6 +29,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Validator\ConstraintViolationInterface;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
@@ -120,6 +121,13 @@ final class CampaignApiController extends CommonApiController
      *
      * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      */
+    #[Route(
+        '/api/campaigns/{id}/contact/{leadId}/add',
+        name: 'mautic_api_campaignaddcontact',
+        requirements: ['id' => '\d+', 'leadId' => '\d+'],
+        defaults: ['_format' => 'json'],
+        methods: ['POST']
+    )]
     public function addLeadAction($id, $leadId): Response
     {
         $entity = $this->model->getEntity($id);
@@ -151,6 +159,13 @@ final class CampaignApiController extends CommonApiController
      *
      * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      */
+    #[Route(
+        '/api/campaigns/{id}/contact/{leadId}/remove',
+        name: 'mautic_api_campaignremovecontact',
+        requirements: ['id' => '\d+', 'leadId' => '\d+'],
+        defaults: ['_format' => 'json'],
+        methods: ['POST']
+    )]
     public function removeLeadAction($id, $leadId): Response
     {
         $entity = $this->model->getEntity($id);
@@ -321,6 +336,13 @@ final class CampaignApiController extends CommonApiController
     /**
      * Obtains a list of campaign contacts.
      */
+    #[Route(
+        '/api/campaigns/{id}/contacts',
+        name: 'mautic_api_campaigngetcontacts',
+        requirements: ['id' => '\d+'],
+        defaults: ['_format' => 'json'],
+        methods: ['GET']
+    )]
     public function getContactsAction(Request $request, $id): Response
     {
         $entity = $this->model->getEntity($id);
@@ -363,6 +385,13 @@ final class CampaignApiController extends CommonApiController
         );
     }
 
+    #[Route(
+        '/api/campaigns/clone/{campaignId}',
+        name: 'mautic_api_contact_clone_campaign',
+        requirements: ['campaignId' => '\d+'],
+        defaults: ['_format' => 'json'],
+        methods: ['POST']
+    )]
     public function cloneCampaignAction($campaignId): Response
     {
         if (empty($campaignId) || false == intval($campaignId)) {
@@ -401,6 +430,13 @@ final class CampaignApiController extends CommonApiController
     /**
      * Get a list of events.
      */
+    #[Route(
+        '/api/campaigns/export/{campaignId}',
+        name: 'mautic_api_export_campaign',
+        requirements: ['campaignId' => '\d+'],
+        defaults: ['_format' => 'json'],
+        methods: ['GET']
+    )]
     public function exportCampaignAction(int $campaignId): Response
     {
         // Check if the campaign exists
@@ -426,6 +462,12 @@ final class CampaignApiController extends CommonApiController
         return $this->handleView($view);
     }
 
+    #[Route(
+        '/api/campaigns/import',
+        name: 'mautic_api_import_campaign',
+        defaults: ['_format' => 'json'],
+        methods: ['POST']
+    )]
     public function importCampaignAction(Request $request, UserHelper $userHelper, ImportHelper $importHelper): Response
     {
         // Check if user has permission to import campaigns

--- a/app/bundles/CampaignBundle/Controller/Api/EventLogApiController.php
+++ b/app/bundles/CampaignBundle/Controller/Api/EventLogApiController.php
@@ -26,6 +26,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
 
 /**
  * @extends FetchCommonApiController<LeadEventLog>
@@ -89,6 +90,20 @@ final class EventLogApiController extends FetchCommonApiController
     /**
      * Get a list of events.
      */
+    #[Route(
+        '/api/campaigns/events/contact/{contactId}',
+        name: 'mautic_api_campaigns_events_contact',
+        requirements: ['contactId' => '\d+'],
+        defaults: ['_format' => 'json'],
+        methods: ['GET']
+    )]
+    #[Route(
+        '/api/campaigns/{campaignId}/events/contact/{contactId}',
+        name: 'mautic_api_campaign_contact_events',
+        requirements: ['campaignId' => '\d+', 'contactId' => '\d+'],
+        defaults: ['_format' => 'json'],
+        methods: ['GET']
+    )]
     public function getContactEventsAction(Request $request, UserHelper $userHelper, $contactId, $campaignId = null): Response
     {
         // Ensure contact exists and user has access
@@ -136,6 +151,13 @@ final class EventLogApiController extends FetchCommonApiController
         return $this->getEntitiesAction($request, $userHelper);
     }
 
+    #[Route(
+        '/api/campaigns/events/{eventId}/contact/{contactId}/edit',
+        name: 'mautic_api_campaigns_edit_contact_event',
+        requirements: ['eventId' => '\d+', 'contactId' => '\d+'],
+        defaults: ['_format' => 'json'],
+        methods: ['PUT']
+    )]
     public function editContactEventAction(Request $request, $eventId, $contactId): Response
     {
         $parameters = $request->request->all();
@@ -178,6 +200,12 @@ final class EventLogApiController extends FetchCommonApiController
         return $this->handleView($view);
     }
 
+    #[Route(
+        '/api/campaigns/events/batch/edit',
+        name: 'mautic_api_campaigns_batchedit_events',
+        defaults: ['_format' => 'json'],
+        methods: ['PUT']
+    )]
     public function editEventsAction(Request $request): Response
     {
         $parameters = $request->request->all();

--- a/app/bundles/CoreBundle/Config/config.php
+++ b/app/bundles/CoreBundle/Config/config.php
@@ -22,47 +22,6 @@ return [
                 'method'       => 'GET',
             ],
         ],
-        'api' => [
-            'mautic_core_api_file_list' => [
-                'path'       => '/files/{dir}',
-                'controller' => 'Mautic\CoreBundle\Controller\Api\FileApiController::listAction',
-            ],
-            'mautic_core_api_file_create' => [
-                'path'       => '/files/{dir}/new',
-                'controller' => 'Mautic\CoreBundle\Controller\Api\FileApiController::createAction',
-                'method'     => 'POST',
-            ],
-            'mautic_core_api_file_delete' => [
-                'path'       => '/files/{dir}/{file}/delete',
-                'controller' => 'Mautic\CoreBundle\Controller\Api\FileApiController::deleteAction',
-                'method'     => 'DELETE',
-            ],
-            'mautic_core_api_theme_list' => [
-                'path'       => '/themes',
-                'controller' => 'Mautic\CoreBundle\Controller\Api\ThemeApiController::listAction',
-            ],
-            'mautic_core_api_theme_get' => [
-                'path'       => '/themes/{theme}',
-                'controller' => 'Mautic\CoreBundle\Controller\Api\ThemeApiController::getAction',
-            ],
-            'mautic_core_api_theme_create' => [
-                'path'       => '/themes/new',
-                'controller' => 'Mautic\CoreBundle\Controller\Api\ThemeApiController::newAction',
-                'method'     => 'POST',
-            ],
-            'mautic_core_api_theme_delete' => [
-                'path'       => '/themes/{theme}/delete',
-                'controller' => 'Mautic\CoreBundle\Controller\Api\ThemeApiController::deleteAction',
-                'method'     => 'DELETE',
-            ],
-            'mautic_core_api_stats' => [
-                'path'       => '/stats/{table}',
-                'controller' => 'Mautic\CoreBundle\Controller\Api\StatsApiController::listAction',
-                'defaults'   => [
-                    'table' => '',
-                ],
-            ],
-        ],
         'main' => [
             'mautic_core_ajax' => [
                 'path'       => '/ajax',

--- a/app/bundles/CoreBundle/Controller/Api/FileApiController.php
+++ b/app/bundles/CoreBundle/Controller/Api/FileApiController.php
@@ -18,6 +18,7 @@ use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\RouterInterface;
 
 /**
@@ -56,6 +57,12 @@ final class FileApiController extends CommonApiController
     /**
      * Uploads a file.
      */
+    #[Route(
+        '/api/files/{dir}/new',
+        name: 'mautic_core_api_file_create',
+        defaults: ['_format' => 'json'],
+        methods: ['POST']
+    )]
     public function createAction(Request $request, PathsHelper $pathsHelper, $dir): Response
     {
         try {
@@ -93,6 +100,12 @@ final class FileApiController extends CommonApiController
     /**
      * List the files in /media directory.
      */
+    #[Route(
+        '/api/files/{dir}',
+        name: 'mautic_core_api_file_list',
+        defaults: ['_format' => 'json'],
+        methods: ['GET']
+    )]
     public function listAction(Request $request, PathsHelper $pathsHelper, $dir): Response
     {
         try {
@@ -122,6 +135,12 @@ final class FileApiController extends CommonApiController
     /**
      * Delete a file from /media directory.
      */
+    #[Route(
+        '/api/files/{dir}/{file}/delete',
+        name: 'mautic_core_api_file_delete',
+        defaults: ['_format' => 'json'],
+        methods: ['DELETE']
+    )]
     public function deleteAction(Request $request, PathsHelper $pathsHelper, $dir, $file): Response
     {
         $response = ['success' => false];

--- a/app/bundles/CoreBundle/Controller/Api/StatsApiController.php
+++ b/app/bundles/CoreBundle/Controller/Api/StatsApiController.php
@@ -8,6 +8,7 @@ use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\CoreBundle\Helper\UserHelper;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
 
 /**
  * @extends CommonApiController<object>
@@ -21,6 +22,12 @@ final class StatsApiController extends CommonApiController
      * @param array  $order
      * @param array  $where
      */
+    #[Route(
+        '/api/stats/{table}',
+        name: 'mautic_core_api_stats',
+        defaults: ['table' => '', '_format' => 'json'],
+        methods: ['GET']
+    )]
     public function listAction(Request $request, UserHelper $userHelper, $table = null, string $itemsName = 'stats', $order = [], $where = [], int $start = 0, int $limit = 100): Response
     {
         $response = [];

--- a/app/bundles/CoreBundle/Controller/Api/ThemeApiController.php
+++ b/app/bundles/CoreBundle/Controller/Api/ThemeApiController.php
@@ -10,6 +10,7 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Contracts\Service\Attribute\Required;
 
 /**
@@ -29,6 +30,12 @@ final class ThemeApiController extends CommonApiController
     /**
      * Accepts the zip file and installs the theme from it.
      */
+    #[Route(
+        '/api/themes/new',
+        name: 'mautic_core_api_theme_create',
+        defaults: ['_format' => 'json'],
+        methods: ['POST']
+    )]
     public function newAction(Request $request, PathsHelper $pathsHelper): Response
     {
         if (!$this->security->isGranted('core:themes:create')) {
@@ -73,6 +80,12 @@ final class ThemeApiController extends CommonApiController
      *
      * @param string $theme dir name
      */
+    #[Route(
+        '/api/themes/{theme}',
+        name: 'mautic_core_api_theme_get',
+        defaults: ['_format' => 'json'],
+        methods: ['GET']
+    )]
     public function getAction($theme): Response
     {
         if (!$this->security->isGranted('core:themes:view')) {
@@ -103,6 +116,12 @@ final class ThemeApiController extends CommonApiController
     /**
      * List the folders (themes) in the /themes directory.
      */
+    #[Route(
+        '/api/themes',
+        name: 'mautic_core_api_theme_list',
+        defaults: ['_format' => 'json'],
+        methods: ['GET']
+    )]
     public function listAction(): Response
     {
         if (!$this->security->isGranted('core:themes:view')) {
@@ -125,6 +144,12 @@ final class ThemeApiController extends CommonApiController
      *
      * @param string $theme
      */
+    #[Route(
+        '/api/themes/{theme}/delete',
+        name: 'mautic_core_api_theme_delete',
+        defaults: ['_format' => 'json'],
+        methods: ['DELETE']
+    )]
     public function deleteAction($theme): Response
     {
         if (!$this->security->isGranted('core:themes:delete')) {

--- a/app/bundles/CoreBundle/Tests/Functional/route-map.json
+++ b/app/bundles/CoreBundle/Tests/Functional/route-map.json
@@ -181,7 +181,8 @@
         ],
         "defaults": {
             "_controller": "Mautic\\CampaignBundle\\Controller\\Api\\EventLogApiController::getContactEventsAction",
-            "_format": "json"
+            "_format": "json",
+            "campaignId": null
         },
         "requirements": {
             "campaignId": "\\d+",
@@ -199,7 +200,7 @@
         },
         "requirements": {
             "id": "\\d+",
-            "id}/contact/{leadId": "\\d+"
+            "leadId": "\\d+"
         }
     },
     "mautic_api_campaigngetcontacts": {
@@ -226,7 +227,7 @@
         },
         "requirements": {
             "id": "\\d+",
-            "id}/contact/{leadId": "\\d+"
+            "leadId": "\\d+"
         }
     },
     "mautic_api_campaigns_batchedit_events": {
@@ -1392,7 +1393,9 @@
         ],
         "defaults": {
             "_controller": "Mautic\\FormBundle\\Controller\\Api\\SubmissionApiController::getEntityAction",
-            "_format": "json"
+            "_format": "json",
+            "formId": null,
+            "submissionId": null
         },
         "requirements": {
             "formId": "\\d+",
@@ -1406,7 +1409,8 @@
         ],
         "defaults": {
             "_controller": "Mautic\\FormBundle\\Controller\\Api\\SubmissionApiController::getEntitiesAction",
-            "_format": "json"
+            "_format": "json",
+            "formId": null
         },
         "requirements": {
             "formId": "\\d+"
@@ -3067,7 +3071,7 @@
         },
         "requirements": {
             "id": "\\d+",
-            "id}/contact/{leadId": "\\d+"
+            "leadId": "\\d+"
         }
     },
     "mautic_api_segmentaddcontacts": {
@@ -3094,7 +3098,7 @@
         },
         "requirements": {
             "id": "\\d+",
-            "id}/contact/{leadId": "\\d+"
+            "leadId": "\\d+"
         }
     },
     "mautic_api_sendcontactemail": {
@@ -3108,7 +3112,7 @@
         },
         "requirements": {
             "id": "\\d+",
-            "id}/contact/{leadId": "\\d+"
+            "leadId": "\\d+"
         }
     },
     "mautic_api_sendemail": {
@@ -3252,8 +3256,8 @@
             "_format": "json"
         },
         "requirements": {
-            "id": "\\d+",
-            "id}/contact/{contactId": "\\d+"
+            "contactId": "\\d+",
+            "id": "\\d+"
         }
     },
     "mautic_api_stageddcontact": {
@@ -3266,8 +3270,8 @@
             "_format": "json"
         },
         "requirements": {
-            "id": "\\d+",
-            "id}/contact/{contactId": "\\d+"
+            "contactId": "\\d+",
+            "id": "\\d+"
         }
     },
     "mautic_api_stageremovecontact": {
@@ -3280,8 +3284,8 @@
             "_format": "json"
         },
         "requirements": {
-            "id": "\\d+",
-            "id}/contact/{contactId": "\\d+"
+            "contactId": "\\d+",
+            "id": "\\d+"
         }
     },
     "mautic_api_stages_delete": {

--- a/app/bundles/DashboardBundle/Config/config.php
+++ b/app/bundles/DashboardBundle/Config/config.php
@@ -3,19 +3,6 @@
 declare(strict_types=1);
 
 return [
-    'routes' => [
-        'api' => [
-            'mautic_widget_types' => [
-                'path'       => '/data',
-                'controller' => 'Mautic\DashboardBundle\Controller\Api\WidgetApiController::getTypesAction',
-            ],
-            'mautic_widget_data' => [
-                'path'       => '/data/{type}',
-                'controller' => 'Mautic\DashboardBundle\Controller\Api\WidgetApiController::getDataAction',
-            ],
-        ],
-    ],
-
     'menu' => [
         'main' => [
             'priority' => 100,

--- a/app/bundles/DashboardBundle/Controller/Api/WidgetApiController.php
+++ b/app/bundles/DashboardBundle/Controller/Api/WidgetApiController.php
@@ -20,6 +20,7 @@ use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\RouterInterface;
 
 /**
@@ -58,6 +59,12 @@ final class WidgetApiController extends CommonApiController
     /**
      * Obtains a list of available widget types.
      */
+    #[Route(
+        '/api/data',
+        name: 'mautic_widget_types',
+        defaults: ['_format' => 'json'],
+        methods: ['GET']
+    )]
     public function getTypesAction(): Response
     {
         $event = new WidgetTypeListEvent();
@@ -73,6 +80,12 @@ final class WidgetApiController extends CommonApiController
      *
      * @param string $type of the widget
      */
+    #[Route(
+        '/api/data/{type}',
+        name: 'mautic_widget_data',
+        defaults: ['_format' => 'json'],
+        methods: ['GET']
+    )]
     public function getDataAction(Request $request, string $type): Response
     {
         $start      = microtime(true);

--- a/app/bundles/EmailBundle/Config/config.php
+++ b/app/bundles/EmailBundle/Config/config.php
@@ -11,21 +11,6 @@ return [
                 'path'            => '/emails',
                 'controller'      => Mautic\EmailBundle\Controller\Api\EmailApiController::class,
             ],
-            'mautic_api_sendemail' => [
-                'path'       => '/emails/{id}/send',
-                'controller' => 'Mautic\EmailBundle\Controller\Api\EmailApiController::sendAction',
-                'method'     => 'POST',
-            ],
-            'mautic_api_sendcontactemail' => [
-                'path'       => '/emails/{id}/contact/{leadId}/send',
-                'controller' => 'Mautic\EmailBundle\Controller\Api\EmailApiController::sendLeadAction',
-                'method'     => 'POST',
-            ],
-            'mautic_api_reply' => [
-                'path'       => '/emails/reply/{trackingHash}',
-                'controller' => 'Mautic\EmailBundle\Controller\Api\EmailApiController::replyAction',
-                'method'     => 'POST',
-            ],
         ],
     ],
     'menu' => [

--- a/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
+++ b/app/bundles/EmailBundle/Controller/Api/EmailApiController.php
@@ -25,6 +25,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\RouterInterface;
 
 /**
@@ -104,6 +105,13 @@ final class EmailApiController extends CommonApiController
      *
      * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      */
+    #[Route(
+        '/api/emails/{id}/send',
+        name: 'mautic_api_sendemail',
+        requirements: ['id' => '\d+'],
+        defaults: ['_format' => 'json'],
+        methods: ['POST']
+    )]
     public function sendAction(Request $request, $id): Response
     {
         $entity = $this->model->getEntity($id);
@@ -142,6 +150,13 @@ final class EmailApiController extends CommonApiController
      *
      * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      */
+    #[Route(
+        '/api/emails/{id}/contact/{leadId}/send',
+        name: 'mautic_api_sendcontactemail',
+        requirements: ['id' => '\d+', 'leadId' => '\d+'],
+        defaults: ['_format' => 'json'],
+        methods: ['POST']
+    )]
     public function sendLeadAction(Request $request, $id, $leadId): Response
     {
         $entity = $this->model->getEntity($id);
@@ -208,6 +223,12 @@ final class EmailApiController extends CommonApiController
     /**
      * @param string $trackingHash
      */
+    #[Route(
+        '/api/emails/reply/{trackingHash}',
+        name: 'mautic_api_reply',
+        defaults: ['_format' => 'json'],
+        methods: ['POST']
+    )]
     public function replyAction(Reply $replyService, RandomHelperInterface $randomHelper, $trackingHash): Response
     {
         try {

--- a/app/bundles/FormBundle/Config/config.php
+++ b/app/bundles/FormBundle/Config/config.php
@@ -13,28 +13,6 @@ return [
                 'path'            => '/forms',
                 'controller'      => Mautic\FormBundle\Controller\Api\FormApiController::class,
             ],
-            'mautic_api_formresults' => [
-                'path'       => '/forms/{formId}/submissions',
-                'controller' => 'Mautic\FormBundle\Controller\Api\SubmissionApiController::getEntitiesAction',
-            ],
-            'mautic_api_formresult' => [
-                'path'       => '/forms/{formId}/submissions/{submissionId}',
-                'controller' => 'Mautic\FormBundle\Controller\Api\SubmissionApiController::getEntityAction',
-            ],
-            'mautic_api_contactformresults' => [
-                'path'       => '/forms/{formId}/submissions/contact/{contactId}',
-                'controller' => 'Mautic\FormBundle\Controller\Api\SubmissionApiController::getEntitiesForContactAction',
-            ],
-            'mautic_api_formdeletefields' => [
-                'path'       => '/forms/{formId}/fields/delete',
-                'controller' => 'Mautic\FormBundle\Controller\Api\FormApiController::deleteFieldsAction',
-                'method'     => 'DELETE',
-            ],
-            'mautic_api_formdeleteactions' => [
-                'path'       => '/forms/{formId}/actions/delete',
-                'controller' => 'Mautic\FormBundle\Controller\Api\FormApiController::deleteActionsAction',
-                'method'     => 'DELETE',
-            ],
         ],
     ],
 

--- a/app/bundles/FormBundle/Controller/Api/FormApiController.php
+++ b/app/bundles/FormBundle/Controller/Api/FormApiController.php
@@ -24,6 +24,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\RouterInterface;
 
 /**
@@ -70,6 +71,13 @@ final class FormApiController extends CommonApiController
     /**
      * Delete fields from a form.
      */
+    #[Route(
+        '/api/forms/{formId}/fields/delete',
+        name: 'mautic_api_formdeletefields',
+        requirements: ['formId' => '\d+'],
+        defaults: ['_format' => 'json'],
+        methods: ['DELETE']
+    )]
     public function deleteFieldsAction(Request $request, $formId): Response
     {
         if (!$this->security->isGranted(['form:forms:editown', 'form:forms:editother'], 'MATCH_ONE')) {
@@ -98,6 +106,13 @@ final class FormApiController extends CommonApiController
     /**
      * Delete fields from a form.
      */
+    #[Route(
+        '/api/forms/{formId}/actions/delete',
+        name: 'mautic_api_formdeleteactions',
+        requirements: ['formId' => '\d+'],
+        defaults: ['_format' => 'json'],
+        methods: ['DELETE']
+    )]
     public function deleteActionsAction(Request $request, $formId): Response
     {
         if (!$this->security->isGranted(['form:forms:editown', 'form:forms:editother'], 'MATCH_ONE')) {

--- a/app/bundles/FormBundle/Controller/Api/SubmissionApiController.php
+++ b/app/bundles/FormBundle/Controller/Api/SubmissionApiController.php
@@ -20,6 +20,7 @@ use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\RouterInterface;
 
 /**
@@ -57,6 +58,13 @@ final class SubmissionApiController extends CommonApiController
      *
      * @param int $formId
      */
+    #[Route(
+        '/api/forms/{formId}/submissions',
+        name: 'mautic_api_formresults',
+        requirements: ['formId' => '\d+'],
+        defaults: ['_format' => 'json'],
+        methods: ['GET']
+    )]
     public function getEntitiesAction(Request $request, UserHelper $userHelper, $formId = null): Response
     {
         $form = $this->getFormOrResponseWithError($formId);
@@ -83,6 +91,13 @@ final class SubmissionApiController extends CommonApiController
      * @param int $formId
      * @param int $contactId
      */
+    #[Route(
+        '/api/forms/{formId}/submissions/contact/{contactId}',
+        name: 'mautic_api_contactformresults',
+        requirements: ['formId' => '\d+', 'contactId' => '\d+'],
+        defaults: ['_format' => 'json'],
+        methods: ['GET']
+    )]
     public function getEntitiesForContactAction(Request $request, UserHelper $userHelper, $formId, $contactId): Response
     {
         $filter = [
@@ -105,6 +120,13 @@ final class SubmissionApiController extends CommonApiController
     /**
      * Obtains a specific entity as defined by the API URL.
      */
+    #[Route(
+        '/api/forms/{formId}/submissions/{submissionId}',
+        name: 'mautic_api_formresult',
+        requirements: ['formId' => '\d+', 'submissionId' => '\d+'],
+        defaults: ['_format' => 'json'],
+        methods: ['GET']
+    )]
     public function getEntityAction(Request $request, $formId = null, $submissionId = null): Response
     {
         $form = $this->getFormOrResponseWithError($formId);

--- a/app/bundles/LeadBundle/Config/config.php
+++ b/app/bundles/LeadBundle/Config/config.php
@@ -11,105 +11,17 @@ return [
                 'path'            => '/contacts',
                 'controller'      => Mautic\LeadBundle\Controller\Api\LeadApiController::class,
             ],
-            'mautic_api_dncaddcontact' => [
-                'path'       => '/contacts/{id}/dnc/{channel}/add',
-                'controller' => 'Mautic\LeadBundle\Controller\Api\LeadApiController::addDncAction',
-                'method'     => 'POST',
-                'defaults'   => [
-                    'channel' => 'email',
-                ],
-            ],
-            'mautic_api_dncremovecontact' => [
-                'path'       => '/contacts/{id}/dnc/{channel}/remove',
-                'controller' => 'Mautic\LeadBundle\Controller\Api\LeadApiController::removeDncAction',
-                'method'     => 'POST',
-            ],
-            'mautic_api_getcontactevents' => [
-                'path'       => '/contacts/{id}/activity',
-                'controller' => 'Mautic\LeadBundle\Controller\Api\LeadApiController::getActivityAction',
-            ],
-            'mautic_api_getcontactsevents' => [
-                'path'       => '/contacts/activity',
-                'controller' => 'Mautic\LeadBundle\Controller\Api\LeadApiController::getAllActivityAction',
-            ],
-            'mautic_api_getcontactnotes' => [
-                'path'       => '/contacts/{id}/notes',
-                'controller' => 'Mautic\LeadBundle\Controller\Api\LeadApiController::getNotesAction',
-            ],
-            'mautic_api_getcontactdevices' => [
-                'path'       => '/contacts/{id}/devices',
-                'controller' => 'Mautic\LeadBundle\Controller\Api\LeadApiController::getDevicesAction',
-            ],
-            'mautic_api_getcontactcampaigns' => [
-                'path'       => '/contacts/{id}/campaigns',
-                'controller' => 'Mautic\LeadBundle\Controller\Api\LeadApiController::getCampaignsAction',
-            ],
-            'mautic_api_getcontactssegments' => [
-                'path'       => '/contacts/{id}/segments',
-                'controller' => 'Mautic\LeadBundle\Controller\Api\LeadApiController::getListsAction',
-            ],
-            'mautic_api_getcontactscompanies' => [
-                'path'       => '/contacts/{id}/companies',
-                'controller' => 'Mautic\LeadBundle\Controller\Api\LeadApiController::getCompaniesAction',
-            ],
-            'mautic_api_utmcreateevent' => [
-                'path'       => '/contacts/{id}/utm/add',
-                'controller' => 'Mautic\LeadBundle\Controller\Api\LeadApiController::addUtmTagsAction',
-                'method'     => 'POST',
-            ],
-            'mautic_api_utmremoveevent' => [
-                'path'       => '/contacts/{id}/utm/{utmid}/remove',
-                'controller' => 'Mautic\LeadBundle\Controller\Api\LeadApiController::removeUtmTagsAction',
-                'method'     => 'POST',
-            ],
-            'mautic_api_getcontactowners' => [
-                'path'       => '/contacts/list/owners',
-                'controller' => 'Mautic\LeadBundle\Controller\Api\LeadApiController::getOwnersAction',
-            ],
-            'mautic_api_getcontactfields' => [
-                'path'       => '/contacts/list/fields',
-                'controller' => 'Mautic\LeadBundle\Controller\Api\LeadApiController::getFieldsAction',
-            ],
-            'mautic_api_getcontactsegments' => [
-                'path'       => '/contacts/list/segments',
-                'controller' => 'Mautic\LeadBundle\Controller\Api\ListApiController::getListsAction',
-            ],
             'mautic_api_segmentsstandard' => [
                 'standard_entity' => true,
                 'name'            => 'lists',
                 'path'            => '/segments',
                 'controller'      => Mautic\LeadBundle\Controller\Api\ListApiController::class,
             ],
-            'mautic_api_segmentaddcontact' => [
-                'path'       => '/segments/{id}/contact/{leadId}/add',
-                'controller' => 'Mautic\LeadBundle\Controller\Api\ListApiController::addLeadAction',
-                'method'     => 'POST',
-            ],
-            'mautic_api_segmentaddcontacts' => [
-                'path'       => '/segments/{id}/contacts/add',
-                'controller' => 'Mautic\LeadBundle\Controller\Api\ListApiController::addLeadsAction',
-                'method'     => 'POST',
-            ],
-            'mautic_api_segmentremovecontact' => [
-                'path'       => '/segments/{id}/contact/{leadId}/remove',
-                'controller' => 'Mautic\LeadBundle\Controller\Api\ListApiController::removeLeadAction',
-                'method'     => 'POST',
-            ],
             'mautic_api_companiesstandard' => [
                 'standard_entity' => true,
                 'name'            => 'companies',
                 'path'            => '/companies',
                 'controller'      => Mautic\LeadBundle\Controller\Api\CompanyApiController::class,
-            ],
-            'mautic_api_companyaddcontact' => [
-                'path'       => '/companies/{companyId}/contact/{contactId}/add',
-                'controller' => 'Mautic\LeadBundle\Controller\Api\CompanyApiController::addContactAction',
-                'method'     => 'POST',
-            ],
-            'mautic_api_companyremovecontact' => [
-                'path'       => '/companies/{companyId}/contact/{contactId}/remove',
-                'controller' => 'Mautic\LeadBundle\Controller\Api\CompanyApiController::removeContactAction',
-                'method'     => 'POST',
             ],
             'mautic_api_fieldsstandard' => [
                 'standard_entity' => true,

--- a/app/bundles/LeadBundle/Controller/Api/CompanyApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/CompanyApiController.php
@@ -21,6 +21,7 @@ use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\RouterInterface;
 
 /**
@@ -89,6 +90,13 @@ final class CompanyApiController extends CommonApiController
      *
      * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      */
+    #[Route(
+        '/api/companies/{companyId}/contact/{contactId}/add',
+        name: 'mautic_api_companyaddcontact',
+        requirements: ['companyId' => '\d+', 'contactId' => '\d+'],
+        defaults: ['_format' => 'json'],
+        methods: ['POST']
+    )]
     public function addContactAction($companyId, $contactId): Response
     {
         $company = $this->model->getEntity($companyId);
@@ -116,6 +124,13 @@ final class CompanyApiController extends CommonApiController
      *
      * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      */
+    #[Route(
+        '/api/companies/{companyId}/contact/{contactId}/remove',
+        name: 'mautic_api_companyremovecontact',
+        requirements: ['companyId' => '\d+', 'contactId' => '\d+'],
+        defaults: ['_format' => 'json'],
+        methods: ['POST']
+    )]
     public function removeContactAction($companyId, $contactId): Response
     {
         $company = $this->model->getEntity($companyId);

--- a/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/LeadApiController.php
@@ -36,6 +36,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\RouterInterface;
 
 /**
@@ -92,6 +93,12 @@ final class LeadApiController extends CommonApiController
     /**
      * Obtains a list of users for lead owner edits.
      */
+    #[Route(
+        '/api/contacts/list/owners',
+        name: 'mautic_api_getcontactowners',
+        defaults: ['_format' => 'json'],
+        methods: ['GET']
+    )]
     public function getOwnersAction(Request $request): Response
     {
         if (!$this->security->isGranted(
@@ -121,6 +128,12 @@ final class LeadApiController extends CommonApiController
     /**
      * Obtains a list of custom fields.
      */
+    #[Route(
+        '/api/contacts/list/fields',
+        name: 'mautic_api_getcontactfields',
+        defaults: ['_format' => 'json'],
+        methods: ['GET']
+    )]
     public function getFieldsAction(): Response
     {
         if (!$this->security->isGranted(['lead:leads:editown', 'lead:leads:editother'], 'MATCH_ONE')) {
@@ -152,6 +165,13 @@ final class LeadApiController extends CommonApiController
     /**
      * Obtains a list of notes on a specific lead.
      */
+    #[Route(
+        '/api/contacts/{id}/notes',
+        name: 'mautic_api_getcontactnotes',
+        requirements: ['id' => '\d+'],
+        defaults: ['_format' => 'json'],
+        methods: ['GET']
+    )]
     public function getNotesAction(Request $request, $id): Response
     {
         $entity = $this->model->getEntity($id);
@@ -204,6 +224,13 @@ final class LeadApiController extends CommonApiController
     /**
      * Obtains a list of devices on a specific lead.
      */
+    #[Route(
+        '/api/contacts/{id}/devices',
+        name: 'mautic_api_getcontactdevices',
+        requirements: ['id' => '\d+'],
+        defaults: ['_format' => 'json'],
+        methods: ['GET']
+    )]
     public function getDevicesAction(Request $request, $id): Response
     {
         $entity = $this->model->getEntity($id);
@@ -256,6 +283,13 @@ final class LeadApiController extends CommonApiController
     /**
      * Obtains a list of contact segments the contact is in.
      */
+    #[Route(
+        '/api/contacts/{id}/segments',
+        name: 'mautic_api_getcontactssegments',
+        requirements: ['id' => '\d+'],
+        defaults: ['_format' => 'json'],
+        methods: ['GET']
+    )]
     public function getListsAction($id): Response
     {
         $entity = $this->model->getEntity($id);
@@ -292,6 +326,13 @@ final class LeadApiController extends CommonApiController
     /**
      * Obtains a list of contact companies the contact is in.
      */
+    #[Route(
+        '/api/contacts/{id}/companies',
+        name: 'mautic_api_getcontactscompanies',
+        requirements: ['id' => '\d+'],
+        defaults: ['_format' => 'json'],
+        methods: ['GET']
+    )]
     public function getCompaniesAction($id): Response
     {
         $entity = $this->model->getEntity($id);
@@ -320,6 +361,13 @@ final class LeadApiController extends CommonApiController
     /**
      * Obtains a list of campaigns the lead is part of.
      */
+    #[Route(
+        '/api/contacts/{id}/campaigns',
+        name: 'mautic_api_getcontactcampaigns',
+        requirements: ['id' => '\d+'],
+        defaults: ['_format' => 'json'],
+        methods: ['GET']
+    )]
     public function getCampaignsAction($id): Response
     {
         $entity = $this->model->getEntity($id);
@@ -361,6 +409,13 @@ final class LeadApiController extends CommonApiController
     /**
      * Obtains a list of contact events.
      */
+    #[Route(
+        '/api/contacts/{id}/activity',
+        name: 'mautic_api_getcontactevents',
+        requirements: ['id' => '\d+'],
+        defaults: ['_format' => 'json'],
+        methods: ['GET']
+    )]
     public function getActivityAction(Request $request, $id): Response
     {
         $entity = $this->model->getEntity($id);
@@ -379,6 +434,12 @@ final class LeadApiController extends CommonApiController
     /**
      * Obtains a list of contact events.
      */
+    #[Route(
+        '/api/contacts/activity',
+        name: 'mautic_api_getcontactsevents',
+        defaults: ['_format' => 'json'],
+        methods: ['GET']
+    )]
     public function getAllActivityAction(Request $request, $lead = null): Response
     {
         $canViewOwn    = $this->security->isGranted('lead:leads:viewown');
@@ -405,6 +466,13 @@ final class LeadApiController extends CommonApiController
     /**
      * Adds a DNC to the contact.
      */
+    #[Route(
+        '/api/contacts/{id}/dnc/{channel}/add',
+        name: 'mautic_api_dncaddcontact',
+        requirements: ['id' => '\d+'],
+        defaults: ['channel' => 'email', '_format' => 'json'],
+        methods: ['POST']
+    )]
     public function addDncAction(Request $request, $id, $channel): Response
     {
         $entity = $this->model->getEntity((int) $id);
@@ -445,6 +513,13 @@ final class LeadApiController extends CommonApiController
     /**
      * Removes a DNC from the contact.
      */
+    #[Route(
+        '/api/contacts/{id}/dnc/{channel}/remove',
+        name: 'mautic_api_dncremovecontact',
+        requirements: ['id' => '\d+'],
+        defaults: ['_format' => 'json'],
+        methods: ['POST']
+    )]
     public function removeDncAction($id, $channel): Response
     {
         $entity = $this->model->getEntity((int) $id);
@@ -513,6 +588,13 @@ final class LeadApiController extends CommonApiController
      *
      * @param int $id
      */
+    #[Route(
+        '/api/contacts/{id}/utm/add',
+        name: 'mautic_api_utmcreateevent',
+        requirements: ['id' => '\d+'],
+        defaults: ['_format' => 'json'],
+        methods: ['POST']
+    )]
     public function addUtmTagsAction(Request $request, $id): Response
     {
         return $this->applyUtmTagsAction($id, 'addUTMTags', $request->request->all());
@@ -524,6 +606,13 @@ final class LeadApiController extends CommonApiController
      * @param int $id
      * @param int $utmid
      */
+    #[Route(
+        '/api/contacts/{id}/utm/{utmid}/remove',
+        name: 'mautic_api_utmremoveevent',
+        requirements: ['id' => '\d+'],
+        defaults: ['_format' => 'json'],
+        methods: ['POST']
+    )]
     public function removeUtmTagsAction($id, $utmid): Response
     {
         return $this->applyUtmTagsAction($id, 'removeUtmTags', (int) $utmid);

--- a/app/bundles/LeadBundle/Controller/Api/ListApiController.php
+++ b/app/bundles/LeadBundle/Controller/Api/ListApiController.php
@@ -21,6 +21,7 @@ use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\RouterInterface;
 
 /**
@@ -130,6 +131,12 @@ final class ListApiController extends CommonApiController
     /**
      * Obtains a list of smart lists for the user.
      */
+    #[Route(
+        '/api/contacts/list/segments',
+        name: 'mautic_api_getcontactsegments',
+        defaults: ['_format' => 'json'],
+        methods: ['GET']
+    )]
     public function getListsAction(): Response
     {
         $lists   = $this->listModel->getUserLists();
@@ -148,6 +155,13 @@ final class ListApiController extends CommonApiController
      *
      * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      */
+    #[Route(
+        '/api/segments/{id}/contact/{leadId}/add',
+        name: 'mautic_api_segmentaddcontact',
+        requirements: ['id' => '\d+', 'leadId' => '\d+'],
+        defaults: ['_format' => 'json'],
+        methods: ['POST']
+    )]
     public function addLeadAction($id, $leadId): Response
     {
         $entity = $this->model->getEntity($id);
@@ -181,6 +195,13 @@ final class ListApiController extends CommonApiController
      *
      * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      */
+    #[Route(
+        '/api/segments/{id}/contacts/add',
+        name: 'mautic_api_segmentaddcontacts',
+        requirements: ['id' => '\d+'],
+        defaults: ['_format' => 'json'],
+        methods: ['POST']
+    )]
     public function addLeadsAction(Request $request, $id): Response
     {
         $contactIds = $request->request->all()['ids'] ?? null;
@@ -224,6 +245,13 @@ final class ListApiController extends CommonApiController
      *
      * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      */
+    #[Route(
+        '/api/segments/{id}/contact/{leadId}/remove',
+        name: 'mautic_api_segmentremovecontact',
+        requirements: ['id' => '\d+', 'leadId' => '\d+'],
+        defaults: ['_format' => 'json'],
+        methods: ['POST']
+    )]
     public function removeLeadAction($id, $leadId): Response
     {
         $entity = $this->model->getEntity($id);

--- a/app/bundles/PageBundle/Config/config.php
+++ b/app/bundles/PageBundle/Config/config.php
@@ -12,15 +12,6 @@ return [
                 'controller'      => Mautic\PageBundle\Controller\Api\PageApiController::class,
             ],
         ],
-        'catchall' => [
-            'mautic_page_public' => [
-                'path'         => '/{slug}',
-                'controller'   => 'Mautic\PageBundle\Controller\PublicController::indexAction',
-                'requirements' => [
-                    'slug' => '^(?!(_(profiler|wdt)|css|images|js|favicon.ico|apps/bundles/|plugins/)).+',
-                ],
-            ],
-        ],
     ],
 
     'menu' => [

--- a/app/bundles/PageBundle/Controller/PublicController.php
+++ b/app/bundles/PageBundle/Controller/PublicController.php
@@ -45,6 +45,11 @@ final class PublicController extends AbstractFormController
      * @throws \Exception
      * @throws FileNotFoundException
      */
+    #[Route(
+        '/{slug}',
+        name: 'mautic_page_public',
+        requirements: ['slug' => '^(?!(_(profiler|wdt)|css|images|js|favicon.ico|apps/bundles/|plugins/)).+'],
+    )]
     public function indexAction(
         Request $request,
         ContactRequestHelper $contactRequestHelper,

--- a/app/bundles/PointBundle/Config/config.php
+++ b/app/bundles/PointBundle/Config/config.php
@@ -11,48 +11,17 @@ return [
                 'path'            => '/points',
                 'controller'      => Mautic\PointBundle\Controller\Api\PointApiController::class,
             ],
-            'mautic_api_getpointactiontypes' => [
-                'path'       => '/points/actions/types',
-                'controller' => 'Mautic\PointBundle\Controller\Api\PointApiController::getPointActionTypesAction',
-            ],
             'mautic_api_pointtriggersstandard' => [
                 'standard_entity' => true,
                 'name'            => 'triggers',
                 'path'            => '/points/triggers',
                 'controller'      => Mautic\PointBundle\Controller\Api\TriggerApiController::class,
             ],
-            'mautic_api_getpointtriggereventtypes' => [
-                'path'       => '/points/triggers/events/types',
-                'controller' => 'Mautic\PointBundle\Controller\Api\TriggerApiController::getPointTriggerEventTypesAction',
-            ],
-            'mautic_api_pointtriggerdeleteevents' => [
-                'path'       => '/points/triggers/{triggerId}/events/delete',
-                'controller' => 'Mautic\PointBundle\Controller\Api\TriggerApiController::deletePointTriggerEventsAction',
-                'method'     => 'DELETE',
-            ],
-            'mautic_api_adjustcontactpoints' => [
-                'path'       => '/contacts/{leadId}/points/{operator}/{delta}',
-                'controller' => 'Mautic\PointBundle\Controller\Api\PointApiController::adjustPointsAction',
-                'method'     => 'POST',
-            ],
             'mautic_api_pointgroupsstandard' => [
                 'standard_entity' => true,
                 'name'            => 'pointGroups',
                 'path'            => '/points/groups',
                 'controller'      => Mautic\PointBundle\Controller\Api\PointGroupsApiController::class,
-            ],
-            'mautic_api_getcontactpointgroups' => [
-                'path'       => '/contacts/{contactId}/points/groups',
-                'controller' => 'Mautic\PointBundle\Controller\Api\PointGroupsApiController::getContactPointGroupsAction',
-            ],
-            'mautic_api_getcontactpointgroup' => [
-                'path'       => '/contacts/{contactId}/points/groups/{groupId}',
-                'controller' => 'Mautic\PointBundle\Controller\Api\PointGroupsApiController::getContactPointGroupAction',
-            ],
-            'mautic_api_adjustcontactgrouppoints' => [
-                'path'       => '/contacts/{contactId}/points/groups/{groupId}/{operator}/{value}',
-                'controller' => 'Mautic\PointBundle\Controller\Api\PointGroupsApiController::adjustGroupPointsAction',
-                'method'     => 'POST',
             ],
             'mautic_api_pointinsightsstandard' => [
                 'standard_entity' => true,

--- a/app/bundles/PointBundle/Controller/Api/PointApiController.php
+++ b/app/bundles/PointBundle/Controller/Api/PointApiController.php
@@ -21,6 +21,7 @@ use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\RouterInterface;
 
 /**
@@ -62,6 +63,12 @@ final class PointApiController extends CommonApiController
     /**
      * Return array of available point action types.
      */
+    #[Route(
+        '/api/points/actions/types',
+        name: 'mautic_api_getpointactiontypes',
+        defaults: ['_format' => 'json'],
+        methods: ['GET']
+    )]
     public function getPointActionTypesAction(): Response
     {
         if (!$this->security->isGranted([$this->permissionBase.':view', $this->permissionBase.':viewown'])) {
@@ -81,6 +88,13 @@ final class PointApiController extends CommonApiController
      * @param string $operator
      * @param int    $delta
      */
+    #[Route(
+        '/api/contacts/{leadId}/points/{operator}/{delta}',
+        name: 'mautic_api_adjustcontactpoints',
+        requirements: ['leadId' => '\d+'],
+        defaults: ['_format' => 'json'],
+        methods: ['POST']
+    )]
     public function adjustPointsAction(Request $request, IpLookupHelper $ipLookupHelper, $leadId, $operator, $delta): Response
     {
         $lead = $this->checkLeadAccess($leadId, 'edit');

--- a/app/bundles/PointBundle/Controller/Api/PointGroupsApiController.php
+++ b/app/bundles/PointBundle/Controller/Api/PointGroupsApiController.php
@@ -22,6 +22,7 @@ use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\RouterInterface;
 
 /**
@@ -58,6 +59,13 @@ final class PointGroupsApiController extends CommonApiController
         parent::__construct($security, $translator, $entityResultHelper, $router, $formFactory, $appVersion, $requestStack, $doctrine, $modelFactory, $dispatcher, $coreParametersHelper);
     }
 
+    #[Route(
+        '/api/contacts/{contactId}/points/groups',
+        name: 'mautic_api_getcontactpointgroups',
+        requirements: ['contactId' => '\d+'],
+        defaults: ['_format' => 'json'],
+        methods: ['GET']
+    )]
     public function getContactPointGroupsAction(int $contactId): Response
     {
         $contact = $this->leadModel->getEntity($contactId);
@@ -85,6 +93,13 @@ final class PointGroupsApiController extends CommonApiController
         return $this->handleView($view);
     }
 
+    #[Route(
+        '/api/contacts/{contactId}/points/groups/{groupId}',
+        name: 'mautic_api_getcontactpointgroup',
+        requirements: ['contactId' => '\d+', 'groupId' => '\d+'],
+        defaults: ['_format' => 'json'],
+        methods: ['GET']
+    )]
     public function getContactPointGroupAction(int $contactId, int $groupId): Response
     {
         $contact = $this->leadModel->getEntity($contactId);
@@ -116,6 +131,13 @@ final class PointGroupsApiController extends CommonApiController
         return $this->handleView($view);
     }
 
+    #[Route(
+        '/api/contacts/{contactId}/points/groups/{groupId}/{operator}/{value}',
+        name: 'mautic_api_adjustcontactgrouppoints',
+        requirements: ['contactId' => '\d+', 'groupId' => '\d+'],
+        defaults: ['_format' => 'json'],
+        methods: ['POST']
+    )]
     public function adjustGroupPointsAction(Request $request, IpLookupHelper $ipLookupHelper, int $contactId, int $groupId, string $operator, int $value): Response
     {
         $contact = $this->leadModel->getEntity($contactId);

--- a/app/bundles/PointBundle/Controller/Api/TriggerApiController.php
+++ b/app/bundles/PointBundle/Controller/Api/TriggerApiController.php
@@ -20,6 +20,7 @@ use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\RouterInterface;
 
 /**
@@ -141,6 +142,12 @@ final class TriggerApiController extends CommonApiController
     /**
      * Return array of available point trigger event types.
      */
+    #[Route(
+        '/api/points/triggers/events/types',
+        name: 'mautic_api_getpointtriggereventtypes',
+        defaults: ['_format' => 'json'],
+        methods: ['GET']
+    )]
     public function getPointTriggerEventTypesAction(): Response
     {
         if (!$this->security->isGranted([$this->permissionBase.':view', $this->permissionBase.':viewown'])) {
@@ -164,6 +171,13 @@ final class TriggerApiController extends CommonApiController
      *
      * @param int $triggerId
      */
+    #[Route(
+        '/api/points/triggers/{triggerId}/events/delete',
+        name: 'mautic_api_pointtriggerdeleteevents',
+        requirements: ['triggerId' => '\d+'],
+        defaults: ['_format' => 'json'],
+        methods: ['DELETE']
+    )]
     public function deletePointTriggerEventsAction($triggerId): Response
     {
         if (!$this->security->isGranted([$this->permissionBase.':editown', $this->permissionBase.':editother'], 'MATCH_ONE')) {

--- a/app/bundles/SmsBundle/Config/config.php
+++ b/app/bundles/SmsBundle/Config/config.php
@@ -11,10 +11,6 @@ return [
                 'path'            => '/smses',
                 'controller'      => Mautic\SmsBundle\Controller\Api\SmsApiController::class,
             ],
-            'mautic_api_smses_send' => [
-                'path'       => '/smses/{id}/contact/{contactId}/send',
-                'controller' => 'Mautic\SmsBundle\Controller\Api\SmsApiController::sendAction',
-            ],
         ],
     ],
     'menu' => [

--- a/app/bundles/SmsBundle/Controller/Api/SmsApiController.php
+++ b/app/bundles/SmsBundle/Controller/Api/SmsApiController.php
@@ -20,6 +20,7 @@ use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\RouterInterface;
 
 /**
@@ -63,6 +64,13 @@ final class SmsApiController extends CommonApiController
         parent::__construct($security, $translator, $entityResultHelper, $router, $formFactory, $appVersion, $requestStack, $doctrine, $modelFactory, $dispatcher, $coreParametersHelper);
     }
 
+    #[Route(
+        '/api/smses/{id}/contact/{contactId}/send',
+        name: 'mautic_api_smses_send',
+        requirements: ['id' => '\d+', 'contactId' => '\d+'],
+        defaults: ['_format' => 'json'],
+        methods: ['GET']
+    )]
     public function sendAction(TransportChain $transportChain, LoggerInterface $mauticLogger, $id, $contactId): JsonResponse|Response
     {
         if (!$transportChain->getEnabledTransports()) {

--- a/app/bundles/StageBundle/Config/config.php
+++ b/app/bundles/StageBundle/Config/config.php
@@ -11,16 +11,6 @@ return [
                 'path'            => '/stages',
                 'controller'      => Mautic\StageBundle\Controller\Api\StageApiController::class,
             ],
-            'mautic_api_stageddcontact' => [
-                'path'       => '/stages/{id}/contact/{contactId}/add',
-                'controller' => 'Mautic\StageBundle\Controller\Api\StageApiController::addContactAction',
-                'method'     => 'POST',
-            ],
-            'mautic_api_stageremovecontact' => [
-                'path'       => '/stages/{id}/contact/{contactId}/remove',
-                'controller' => 'Mautic\StageBundle\Controller\Api\StageApiController::removeContactAction',
-                'method'     => 'POST',
-            ],
         ],
     ],
 

--- a/app/bundles/StageBundle/Controller/Api/StageApiController.php
+++ b/app/bundles/StageBundle/Controller/Api/StageApiController.php
@@ -18,6 +18,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\RouterInterface;
 
 /**
@@ -59,6 +60,13 @@ final class StageApiController extends CommonApiController
      *
      * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      */
+    #[Route(
+        '/api/stages/{id}/contact/{contactId}/add',
+        name: 'mautic_api_stageddcontact',
+        requirements: ['id' => '\d+', 'contactId' => '\d+'],
+        defaults: ['_format' => 'json'],
+        methods: ['POST']
+    )]
     public function addContactAction($id, $contactId): Response
     {
         $stage = $this->model->getEntity($id);
@@ -90,6 +98,13 @@ final class StageApiController extends CommonApiController
      *
      * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
      */
+    #[Route(
+        '/api/stages/{id}/contact/{contactId}/remove',
+        name: 'mautic_api_stageremovecontact',
+        requirements: ['id' => '\d+', 'contactId' => '\d+'],
+        defaults: ['_format' => 'json'],
+        methods: ['POST']
+    )]
     public function removeContactAction($id, $contactId): Response
     {
         $stage = $this->model->getEntity($id);

--- a/app/bundles/UserBundle/Config/config.php
+++ b/app/bundles/UserBundle/Config/config.php
@@ -50,19 +50,6 @@ return [
                 'path'            => '/users',
                 'controller'      => Mautic\UserBundle\Controller\Api\UserApiController::class,
             ],
-            'mautic_api_getself' => [
-                'path'       => '/users/self',
-                'controller' => 'Mautic\UserBundle\Controller\Api\UserApiController::getSelfAction',
-            ],
-            'mautic_api_checkpermission' => [
-                'path'       => '/users/{id}/permissioncheck',
-                'controller' => 'Mautic\UserBundle\Controller\Api\UserApiController::isGrantedAction',
-                'method'     => 'POST',
-            ],
-            'mautic_api_getuserroles' => [
-                'path'       => '/users/list/roles',
-                'controller' => 'Mautic\UserBundle\Controller\Api\UserApiController::getRolesAction',
-            ],
             'mautic_api_rolesstandard' => [
                 'standard_entity' => true,
                 'name'            => 'roles',

--- a/app/bundles/UserBundle/Controller/Api/UserApiController.php
+++ b/app/bundles/UserBundle/Controller/Api/UserApiController.php
@@ -19,6 +19,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
@@ -61,6 +62,12 @@ final class UserApiController extends CommonApiController
      *
      * @throws NotFoundHttpException
      */
+    #[Route(
+        '/api/users/self',
+        name: 'mautic_api_getself',
+        defaults: ['_format' => 'json'],
+        methods: ['GET']
+    )]
     public function getSelfAction(TokenStorageInterface $tokenStorage): Response
     {
         $currentUser = $tokenStorage->getToken()->getUser();
@@ -170,6 +177,13 @@ final class UserApiController extends CommonApiController
      * @throws \Symfony\Component\HttpKernel\Exception\BadRequestHttpException
      * @throws NotFoundHttpException
      */
+    #[Route(
+        '/api/users/{id}/permissioncheck',
+        name: 'mautic_api_checkpermission',
+        requirements: ['id' => '\\d+'],
+        defaults: ['_format' => 'json'],
+        methods: ['POST']
+    )]
     public function isGrantedAction(Request $request, $id): Response
     {
         $entity = $this->model->getEntity($id);
@@ -195,6 +209,12 @@ final class UserApiController extends CommonApiController
     /**
      * Obtains a list of roles for user edits.
      */
+    #[Route(
+        '/api/users/list/roles',
+        name: 'mautic_api_getuserroles',
+        defaults: ['_format' => 'json'],
+        methods: ['GET']
+    )]
     public function getRolesAction(Request $request): Response
     {
         if (!$this->security->isGranted(

--- a/app/bundles/WebhookBundle/Config/config.php
+++ b/app/bundles/WebhookBundle/Config/config.php
@@ -11,10 +11,6 @@ return [
                 'path'            => '/hooks',
                 'controller'      => Mautic\WebhookBundle\Controller\Api\WebhookApiController::class,
             ],
-            'mautic_api_webhookevents' => [
-                'path'       => '/hooks/triggers',
-                'controller' => 'Mautic\WebhookBundle\Controller\Api\WebhookApiController::getTriggersAction',
-            ],
         ],
     ],
 

--- a/app/bundles/WebhookBundle/Controller/Api/WebhookApiController.php
+++ b/app/bundles/WebhookBundle/Controller/Api/WebhookApiController.php
@@ -17,6 +17,7 @@ use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\RouterInterface;
 
 /**
@@ -87,6 +88,12 @@ final class WebhookApiController extends CommonApiController
         }
     }
 
+    #[Route(
+        '/api/hooks/triggers',
+        name: 'mautic_api_webhookevents',
+        defaults: ['_format' => 'json'],
+        methods: ['GET']
+    )]
     public function getTriggersAction(): Response
     {
         return $this->handleView(


### PR DESCRIPTION
Follow-up to #17169.

Moves every bundle's custom API routes (and the PageBundle catch-all) from `Config/config.php` into native Symfony `#[Route]` attributes on the controller actions.

Each attribute reproduces what the config loader used to apply implicitly:
- full `/api` prefix in the path
- `_format: json` default
- `\d+` requirement on `{id}` and every `{XxxId}` placeholder
- explicit HTTP method(s), defaulting to `GET` where config declared none

### Left in config on purpose
- `standard_entity` CRUD routes - they auto-generate the getEntities/getEntity/new/edit/delete routes on inherited `CommonApiController` methods, which map cleanly to config but not to per-controller attributes.
- Plugin routes - the attribute `RouteLoader` scans `app/bundles/*/Controller` only, so plugin controllers are not attribute-scanned.

### Verified
- Router builds; all moved routes present.
- `router:match` confirms literal paths (e.g. `/api/contacts/list/owners`, `/api/contacts/activity`) resolve to the moved routes and are not shadowed by the standard `/api/contacts/{id}` route (digit requirement keeps them distinct).
- Catch-all `/{slug}` remains the last route in the collection.
