### PR TITLE
[events] dispatch Form, Integrations and Focus bundle events by class name

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -233,6 +233,8 @@
     | `IntegrationEvents::INTEGRATION_FIND_INTERNAL_RECORD` | `InternalObjectFindByIdEvent` |
     | `IntegrationEvents::INTEGRATION_BUILD_INTERNAL_OBJECT_ROUTE` | `InternalObjectRouteEvent` |
     | `IntegrationEvents::INTEGRATION_OBJECT_TOKEN_EVENT` | `MappedIntegrationObjectTokenEvent` |
+    | `IntegrationEvents::INTEGRATION_FIND_INTERNAL_RECORDS` | `InternalObjectFindEvent` |
+    | `IntegrationEvents::INTEGRATION_FIND_OWNER_IDS` | `InternalObjectOwnerEvent` |
     Dispatching drops the redundant second argument, e.g. `$dispatcher->dispatch($event, CoreEvents::BUILD_MENU)` becomes `$dispatcher->dispatch($event)`. The `Mautic\CoreBundle\CoreEvents` constants are kept for backwards compatibility but are no longer used internally. Note that listeners for the icon event (`Mautic\CoreBundle\Event\IconEvent`) must now be keyed on `IconEvent::class`, as that event was already dispatched by object.
 
     Full mapping of old event name to new event class (all in the `Mautic\CoreBundle\Event` namespace):
@@ -484,6 +486,33 @@
     `LeadEvents::CHANNEL_SUBSCRIPTION_CHANGED` is still used as the webhook type identifier (its string value) in `WebhookSubscriber`, so the constant remains referenced there even though the event is dispatched and subscribed by class.
 
     Constants that share an event class keep their string names and are unchanged. This covers the CRUD/toggle groups that reuse a single event object under several names - the `LeadEvent` group (`LEAD_PRE_SAVE`, `LEAD_POST_SAVE`, `LEAD_PRE_DELETE`, `LEAD_POST_DELETE`, `LEAD_IDENTIFIED`), `LeadListEvent` (`LIST_*`), `LeadFieldEvent` (`FIELD_*`, `NOTE_*`, `DEVICE_*`), `CompanyEvent` (`COMPANY_PRE_SAVE`, `COMPANY_POST_SAVE`, `COMPANY_PRE_DELETE`, `COMPANY_POST_DELETE`, `COMPANY_SOFT_DELETE`), `ImportEvent` (`IMPORT_PRE_SAVE`, `IMPORT_POST_SAVE`, `IMPORT_PRE_DELETE`, `IMPORT_POST_DELETE`, `IMPORT_BATCH_PROCESSED`), `TagEvent` (`TAG_*`), `ContactExportSchedulerEvent` (the `*_CONTACT_EXPORT*` group) - and the before/after pairs `LeadMergeEvent`, `CompanyMergeEvent`, `TagMergeEvent` and `SaveBatchLeadsEvent`. The `LeadListFilteringEvent` shared by `LIST_FILTERS_ON_FILTERING` and `LIST_PRE_PROCESS_LIST` also stays a string. Constants dispatched or subscribed outside LeadBundle (e.g. `LEAD_POINTS_CHANGE`, `LEAD_COMPANY_CHANGE`, `LEAD_LIST_CHANGE`, `LEAD_LIST_BATCH_CHANGE`, `CURRENT_LEAD_CHANGED`, `TIMELINE_ON_GENERATE`, `LIST_FILTERS_CHOICES_ON_GENERATE`, `SEGMENT_DICTIONARY_ON_GENERATE`, `ON_CLICKTHROUGH_IDENTIFICATION`) and the campaign action/condition constants (whose generic event classes are shared across bundles) are unchanged.
+
+- FormBundle events are now dispatched by the event object alone, so the event name is the event class (Symfony 4.3+) instead of the `Mautic\FormBundle\FormEvents` string constants. Update any subscriber or listener that keys on one of the converted `FormEvents::*` constants to key on the event class instead:
+
+    ```diff
+     public static function getSubscribedEvents(): array
+     {
+         return [
+    -        FormEvents::FORM_ON_BUILD => ['onFormBuilder', 0],
+    +        FormBuilderEvent::class   => ['onFormBuilder', 0],
+         ];
+     }
+    ```
+
+    Dispatching drops the redundant second argument, e.g. `$dispatcher->dispatch($event, FormEvents::FORM_ON_BUILD)` becomes `$dispatcher->dispatch($event)`. The `Mautic\FormBundle\FormEvents` constants are kept for backwards compatibility but are no longer used internally for the events below.
+
+    Full mapping of the converted constants to their event class (all in the `Mautic\FormBundle\Event` namespace):
+
+    | `FormEvents` constant | New event class |
+    | --- | --- |
+    | `FormEvents::FORM_ON_SUBMIT` | `SubmissionEvent` |
+    | `FormEvents::FORM_ON_BUILD` | `FormBuilderEvent` |
+    | `FormEvents::ON_OBJECT_COLLECT` | `ObjectCollectEvent` |
+    | `FormEvents::ON_FIELD_COLLECT` | `FieldCollectEvent` |
+
+    `FormEvents::FORM_ON_SUBMIT` is still used as the webhook type identifier (its string value) in `WebhookSubscriber`, so the constant remains referenced there even though the event is dispatched and subscribed by class. Constants that share an event object across several names (the `FORM_*` CRUD group, `ON_EXECUTE_SUBMIT_ACTION`, `ON_FORM_VALIDATE`, and the campaign action/condition constants whose generic event classes are shared across bundles) are unchanged.
+
+- MauticFocusBundle events are now dispatched by the event object alone, so the event name is the event class (Symfony 4.3+) instead of the `MauticPlugin\MauticFocusBundle\FocusEvents` string constant. The `FOCUS_ON_VIEW` event now dispatches and is subscribed by `MauticPlugin\MauticFocusBundle\Event\FocusViewEvent`; update any listener keyed on `FocusEvents::FOCUS_ON_VIEW` to key on `FocusViewEvent::class`. Dispatching drops the redundant second argument, e.g. `$dispatcher->dispatch($event, FocusEvents::FOCUS_ON_VIEW)` becomes `$dispatcher->dispatch($event)`. The `FocusEvents` constant is kept for backwards compatibility. Note `MauticPlugin\MauticFocusBundle\FocusEventTypes::FOCUS_ON_VIEW` is a separate stat-type identifier and is unchanged.
 
 - `Mautic\CoreBundle\Factory\ModelFactory` now builds its service locator from a `defaultIndexMethod` on the `mautic.model` tag, replacing the removed `Mautic\CoreBundle\DependencyInjection\Compiler\ModelPass`. Every model (a service implementing `Mautic\CoreBundle\Model\MauticModelInterface`) declares its `ModelFactory::getModel()` lookup key via a static `getName()` method:
 

--- a/app/bundles/AssetBundle/EventListener/FormSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/FormSubscriber.php
@@ -36,7 +36,7 @@ final readonly class FormSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            FormEvents::FORM_ON_BUILD                 => ['onFormBuilder', 0],
+            FormBuilderEvent::class                   => ['onFormBuilder', 0],
             FormEvents::ON_EXECUTE_SUBMIT_ACTION      => [
                 ['onFormSubmitActionAssetDownload', 0],
                 ['onFormSubmitActionDownloadFile', 0],

--- a/app/bundles/CoreBundle/Tests/Functional/DependencyInjection/EventSubscriberSmokeTest.php
+++ b/app/bundles/CoreBundle/Tests/Functional/DependencyInjection/EventSubscriberSmokeTest.php
@@ -184,7 +184,7 @@ final class EventSubscriberSmokeTest extends AbstractContainerSmokeTestCase
             OwnerSubscriber::class,
             \Mautic\PageBundle\EventListener\BuilderSubscriber::class,
         ],
-        'mautic.form_on_build' => [
+        \Mautic\FormBundle\Event\FormBuilderEvent::class => [
             \MauticPlugin\MauticSocialBundle\EventListener\FormSubscriber::class,
             \Mautic\AssetBundle\EventListener\FormSubscriber::class,
             \Mautic\EmailBundle\EventListener\FormSubscriber::class,

--- a/app/bundles/EmailBundle/EventListener/FormSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/FormSubscriber.php
@@ -24,7 +24,7 @@ final readonly class FormSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            FormEvents::FORM_ON_BUILD            => ['onFormBuilder', 0],
+            FormBuilderEvent::class             => ['onFormBuilder', 0],
             FormEvents::ON_EXECUTE_SUBMIT_ACTION => [
                 ['onFormSubmitActionSendEmail', 0],
             ],

--- a/app/bundles/FormBundle/Collector/FieldCollector.php
+++ b/app/bundles/FormBundle/Collector/FieldCollector.php
@@ -6,7 +6,6 @@ namespace Mautic\FormBundle\Collector;
 
 use Mautic\FormBundle\Collection\FieldCollection;
 use Mautic\FormBundle\Event\FieldCollectEvent;
-use Mautic\FormBundle\FormEvents;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Service\ResetInterface;
 
@@ -39,7 +38,7 @@ final class FieldCollector implements FieldCollectorInterface, ResetInterface
     private function collect(string $object): void
     {
         $event = new FieldCollectEvent($object);
-        $this->dispatcher->dispatch($event, FormEvents::ON_FIELD_COLLECT);
+        $this->dispatcher->dispatch($event);
         $this->fieldCollections[$object] = $event->getFields();
     }
 }

--- a/app/bundles/FormBundle/Collector/ObjectCollector.php
+++ b/app/bundles/FormBundle/Collector/ObjectCollector.php
@@ -6,7 +6,6 @@ namespace Mautic\FormBundle\Collector;
 
 use Mautic\FormBundle\Collection\ObjectCollection;
 use Mautic\FormBundle\Event\ObjectCollectEvent;
-use Mautic\FormBundle\FormEvents;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 final class ObjectCollector implements ObjectCollectorInterface
@@ -30,7 +29,7 @@ final class ObjectCollector implements ObjectCollectorInterface
     private function collect(): void
     {
         $event = new ObjectCollectEvent();
-        $this->dispatcher->dispatch($event, FormEvents::ON_OBJECT_COLLECT);
+        $this->dispatcher->dispatch($event);
         $this->objects = $event->getObjects();
     }
 }

--- a/app/bundles/FormBundle/Controller/FieldController.php
+++ b/app/bundles/FormBundle/Controller/FieldController.php
@@ -14,7 +14,6 @@ use Mautic\FormBundle\Collector\AlreadyMappedFieldCollectorInterface;
 use Mautic\FormBundle\Collector\MappedObjectCollectorInterface;
 use Mautic\FormBundle\Entity\Field;
 use Mautic\FormBundle\Event\FormBuilderEvent;
-use Mautic\FormBundle\FormEvents;
 use Mautic\FormBundle\Helper\FormFieldHelper;
 use Mautic\FormBundle\Model\FieldModel;
 use Mautic\FormBundle\Model\FormModel;
@@ -441,7 +440,7 @@ final class FieldController extends CommonFormController
         $form->get('formId')->setData($formId);
 
         $event      = new FormBuilderEvent($this->translator);
-        $this->dispatcher->dispatch($event, FormEvents::FORM_ON_BUILD);
+        $this->dispatcher->dispatch($event);
         $event->addValidatorsToBuilder($form);
 
         return $form;

--- a/app/bundles/FormBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/CampaignSubscriber.php
@@ -33,7 +33,7 @@ final readonly class CampaignSubscriber implements EventSubscriberInterface
     {
         return [
             CampaignBuilderEvent::class => ['onCampaignBuild', 0],
-            FormEvents::FORM_ON_SUBMIT                => ['onFormSubmit', 0],
+            SubmissionEvent::class                    => ['onFormSubmit', 0],
             FormEvents::ON_CAMPAIGN_TRIGGER_DECISION  => ['onCampaignTriggerDecision', 0],
             FormEvents::ON_CAMPAIGN_TRIGGER_CONDITION => ['onCampaignTriggerCondition', 0],
         ];

--- a/app/bundles/FormBundle/EventListener/FormSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/FormSubscriber.php
@@ -43,7 +43,7 @@ final readonly class FormSubscriber implements EventSubscriberInterface
         return [
             FormEvents::FORM_POST_SAVE           => ['onFormPostSave', 0],
             FormEvents::FORM_POST_DELETE         => ['onFormDelete', 0],
-            FormEvents::FORM_ON_BUILD            => ['onFormBuilder', 0],
+            Events\FormBuilderEvent::class       => ['onFormBuilder', 0],
             FormEvents::ON_EXECUTE_SUBMIT_ACTION => [
                 ['onFormSubmitActionSendEmail', 0],
                 ['onFormSubmitActionRepost', 0],

--- a/app/bundles/FormBundle/EventListener/FormValidationSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/FormValidationSubscriber.php
@@ -24,8 +24,8 @@ final readonly class FormValidationSubscriber implements EventSubscriberInterfac
     public static function getSubscribedEvents(): array
     {
         return [
-            FormEvents::FORM_ON_BUILD    => ['onFormBuilder', 0],
-            FormEvents::ON_FORM_VALIDATE => ['onFormValidate', 0],
+            Events\FormBuilderEvent::class => ['onFormBuilder', 0],
+            FormEvents::ON_FORM_VALIDATE   => ['onFormValidate', 0],
         ];
     }
 

--- a/app/bundles/FormBundle/EventListener/PointSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/PointSubscriber.php
@@ -6,7 +6,6 @@ namespace Mautic\FormBundle\EventListener;
 
 use Mautic\FormBundle\Event\SubmissionEvent;
 use Mautic\FormBundle\Form\Type\PointActionFormSubmitType;
-use Mautic\FormBundle\FormEvents;
 use Mautic\FormBundle\Helper\PointActionHelper;
 use Mautic\PointBundle\Event\PointBuilderEvent;
 use Mautic\PointBundle\Model\PointModel;
@@ -24,7 +23,7 @@ final readonly class PointSubscriber implements EventSubscriberInterface
     {
         return [
             PointEvents::POINT_ON_BUILD => ['onPointBuild', 0],
-            FormEvents::FORM_ON_SUBMIT  => ['onFormSubmit', 0],
+            SubmissionEvent::class      => ['onFormSubmit', 0],
         ];
     }
 

--- a/app/bundles/FormBundle/EventListener/WebhookSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/WebhookSubscriber.php
@@ -21,7 +21,7 @@ final readonly class WebhookSubscriber implements EventSubscriberInterface
     {
         return [
             WebhookBuilderEvent::class => ['onWebhookBuild', 0],
-            FormEvents::FORM_ON_SUBMIT => ['onFormSubmit', 0],
+            SubmissionEvent::class     => ['onFormSubmit', 0],
         ];
     }
 

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -641,7 +641,7 @@ class FormModel extends CommonFormModel implements GlobalSearchInterface
         if (empty($customComponents)) {
             // build them
             $event = new FormBuilderEvent($this->translator);
-            $this->dispatcher->dispatch($event, FormEvents::FORM_ON_BUILD);
+            $this->dispatcher->dispatch($event);
             $customComponents['fields']     = $event->getFormFields();
             $customComponents['actions']    = $event->getSubmitActions();
             $customComponents['choices']    = $event->getSubmitActionGroups();

--- a/app/bundles/FormBundle/Model/SubmissionModel.php
+++ b/app/bundles/FormBundle/Model/SubmissionModel.php
@@ -34,7 +34,6 @@ use Mautic\FormBundle\Event\ValidationEvent;
 use Mautic\FormBundle\Exception\FileValidationException;
 use Mautic\FormBundle\Exception\NoFileGivenException;
 use Mautic\FormBundle\Exception\ValidationException;
-use Mautic\FormBundle\FormEvents;
 use Mautic\FormBundle\Helper\FormFieldHelper;
 use Mautic\FormBundle\Helper\FormUploader;
 use Mautic\FormBundle\ProgressiveProfiling\DisplayManager;
@@ -391,12 +390,12 @@ final class SubmissionModel extends CommonFormModel
             }
         }
 
-        if ($this->dispatcher->hasListeners(FormEvents::FORM_ON_SUBMIT)) {
+        if ($this->dispatcher->hasListeners(SubmissionEvent::class)) {
             // Reset action config from executeFormActions()
             $submissionEvent->setAction();
 
             // Dispatch to on submit listeners
-            $this->dispatcher->dispatch($submissionEvent, FormEvents::FORM_ON_SUBMIT);
+            $this->dispatcher->dispatch($submissionEvent);
         }
 
         // get callback commands from the submit action

--- a/app/bundles/IntegrationsBundle/EventListener/CompanyObjectSubscriber.php
+++ b/app/bundles/IntegrationsBundle/EventListener/CompanyObjectSubscriber.php
@@ -11,7 +11,6 @@ use Mautic\IntegrationsBundle\Event\InternalObjectFindEvent;
 use Mautic\IntegrationsBundle\Event\InternalObjectOwnerEvent;
 use Mautic\IntegrationsBundle\Event\InternalObjectRouteEvent;
 use Mautic\IntegrationsBundle\Event\InternalObjectUpdateEvent;
-use Mautic\IntegrationsBundle\IntegrationEvents;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\Object\Company;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\ObjectHelper\CompanyObjectHelper;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -28,17 +27,17 @@ final readonly class CompanyObjectSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            InternalObjectEvent::class                           => ['collectInternalObjects', 0],
-            InternalObjectUpdateEvent::class                     => ['updateCompanies', 0],
-            InternalObjectCreateEvent::class                     => ['createCompanies', 0],
-            IntegrationEvents::INTEGRATION_FIND_INTERNAL_RECORDS => [
+            InternalObjectEvent::class         => ['collectInternalObjects', 0],
+            InternalObjectUpdateEvent::class   => ['updateCompanies', 0],
+            InternalObjectCreateEvent::class   => ['createCompanies', 0],
+            InternalObjectFindEvent::class     => [
                 ['findCompaniesByIds', 0],
                 ['findCompaniesByDateRange', 0],
                 ['findCompaniesByFieldValues', 0],
             ],
-            IntegrationEvents::INTEGRATION_FIND_OWNER_IDS        => ['findOwnerIdsForCompanies', 0],
-            InternalObjectRouteEvent::class                      => ['buildCompanyRoute', 0],
-            InternalObjectFindByIdEvent::class                   => ['findCompanyById', 0],
+            InternalObjectOwnerEvent::class    => ['findOwnerIdsForCompanies', 0],
+            InternalObjectRouteEvent::class    => ['buildCompanyRoute', 0],
+            InternalObjectFindByIdEvent::class => ['findCompanyById', 0],
         ];
     }
 

--- a/app/bundles/IntegrationsBundle/EventListener/ContactObjectSubscriber.php
+++ b/app/bundles/IntegrationsBundle/EventListener/ContactObjectSubscriber.php
@@ -11,7 +11,6 @@ use Mautic\IntegrationsBundle\Event\InternalObjectFindEvent;
 use Mautic\IntegrationsBundle\Event\InternalObjectOwnerEvent;
 use Mautic\IntegrationsBundle\Event\InternalObjectRouteEvent;
 use Mautic\IntegrationsBundle\Event\InternalObjectUpdateEvent;
-use Mautic\IntegrationsBundle\IntegrationEvents;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\Object\Contact;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\ObjectHelper\ContactObjectHelper;
 use Mautic\LeadBundle\Exception\ImportFailedException;
@@ -29,17 +28,17 @@ final readonly class ContactObjectSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            InternalObjectEvent::class                           => ['collectInternalObjects', 0],
-            InternalObjectUpdateEvent::class                     => ['updateContacts', 0],
-            InternalObjectCreateEvent::class                     => ['createContacts', 0],
-            IntegrationEvents::INTEGRATION_FIND_INTERNAL_RECORDS => [
+            InternalObjectEvent::class         => ['collectInternalObjects', 0],
+            InternalObjectUpdateEvent::class   => ['updateContacts', 0],
+            InternalObjectCreateEvent::class   => ['createContacts', 0],
+            InternalObjectFindEvent::class     => [
                 ['findContactsByIds', 0],
                 ['findContactsByDateRange', 0],
                 ['findContactsByFieldValues', 0],
             ],
-            IntegrationEvents::INTEGRATION_FIND_OWNER_IDS        => ['findOwnerIdsForContacts', 0],
-            InternalObjectRouteEvent::class                      => ['buildContactRoute', 0],
-            InternalObjectFindByIdEvent::class                   => ['findContactById', 0],
+            InternalObjectOwnerEvent::class    => ['findOwnerIdsForContacts', 0],
+            InternalObjectRouteEvent::class    => ['buildContactRoute', 0],
+            InternalObjectFindByIdEvent::class => ['findContactById', 0],
         ];
     }
 

--- a/app/bundles/IntegrationsBundle/Sync/Helper/MappingHelper.php
+++ b/app/bundles/IntegrationsBundle/Sync/Helper/MappingHelper.php
@@ -7,7 +7,6 @@ namespace Mautic\IntegrationsBundle\Sync\Helper;
 use Mautic\IntegrationsBundle\Entity\ObjectMapping;
 use Mautic\IntegrationsBundle\Entity\ObjectMappingRepository;
 use Mautic\IntegrationsBundle\Event\InternalObjectFindEvent;
-use Mautic\IntegrationsBundle\IntegrationEvents;
 use Mautic\IntegrationsBundle\Sync\DAO\Mapping\MappingManualDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Mapping\RemappedObjectDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Mapping\UpdatedObjectMappingDAO;
@@ -86,10 +85,7 @@ class MappingHelper
 
         $event->setFieldValues($identifiers);
 
-        $this->dispatcher->dispatch(
-            $event,
-            IntegrationEvents::INTEGRATION_FIND_INTERNAL_RECORDS,
-        );
+        $this->dispatcher->dispatch($event);
 
         $foundObjects = $event->getFoundObjects();
 

--- a/app/bundles/IntegrationsBundle/Sync/Notification/Helper/OwnerProvider.php
+++ b/app/bundles/IntegrationsBundle/Sync/Notification/Helper/OwnerProvider.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Mautic\IntegrationsBundle\Sync\Notification\Helper;
 
 use Mautic\IntegrationsBundle\Event\InternalObjectOwnerEvent;
-use Mautic\IntegrationsBundle\IntegrationEvents;
 use Mautic\IntegrationsBundle\Sync\Exception\ObjectNotFoundException;
 use Mautic\IntegrationsBundle\Sync\Exception\ObjectNotSupportedException;
 use Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\ObjectProvider;
@@ -40,7 +39,7 @@ class OwnerProvider
 
         $event = new InternalObjectOwnerEvent($object, $objectIds);
 
-        $this->dispatcher->dispatch($event, IntegrationEvents::INTEGRATION_FIND_OWNER_IDS);
+        $this->dispatcher->dispatch($event);
 
         return $event->getOwners();
     }

--- a/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ReportBuilder/FullObjectReportBuilder.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ReportBuilder/FullObjectReportBuilder.php
@@ -74,10 +74,7 @@ class FullObjectReportBuilder
                     $event->setLimit($limit);
                 }
 
-                $this->dispatcher->dispatch(
-                    $event,
-                    IntegrationEvents::INTEGRATION_FIND_INTERNAL_RECORDS
-                );
+                $this->dispatcher->dispatch($event);
 
                 $foundObjects = $event->getFoundObjects();
 

--- a/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ReportBuilder/PartialObjectReportBuilder.php
+++ b/app/bundles/IntegrationsBundle/Sync/SyncDataExchange/Internal/ReportBuilder/PartialObjectReportBuilder.php
@@ -6,7 +6,6 @@ namespace Mautic\IntegrationsBundle\Sync\SyncDataExchange\Internal\ReportBuilder
 
 use Mautic\IntegrationsBundle\Entity\FieldChangeRepository;
 use Mautic\IntegrationsBundle\Event\InternalObjectFindEvent;
-use Mautic\IntegrationsBundle\IntegrationEvents;
 use Mautic\IntegrationsBundle\Sync\DAO\Sync\Report\FieldDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Sync\Report\ObjectDAO as ReportObjectDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Sync\Report\ReportDAO;
@@ -154,7 +153,7 @@ class PartialObjectReportBuilder
 
         $event = new InternalObjectFindEvent($this->objectProvider->getObjectByName($objectName));
         $event->setIds(array_keys($this->objectsWithMissingFields));
-        $this->dispatcher->dispatch($event, IntegrationEvents::INTEGRATION_FIND_INTERNAL_RECORDS);
+        $this->dispatcher->dispatch($event);
 
         return $event->getFoundObjects();
     }

--- a/app/bundles/IntegrationsBundle/Tests/Unit/EventListener/CompanyObjectSubscriberTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/EventListener/CompanyObjectSubscriberTest.php
@@ -13,7 +13,6 @@ use Mautic\IntegrationsBundle\Event\InternalObjectOwnerEvent;
 use Mautic\IntegrationsBundle\Event\InternalObjectRouteEvent;
 use Mautic\IntegrationsBundle\Event\InternalObjectUpdateEvent;
 use Mautic\IntegrationsBundle\EventListener\CompanyObjectSubscriber;
-use Mautic\IntegrationsBundle\IntegrationEvents;
 use Mautic\IntegrationsBundle\Sync\DAO\DateRange;
 use Mautic\IntegrationsBundle\Sync\DAO\Mapping\UpdatedObjectMappingDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Sync\Order\ObjectChangeDAO;
@@ -56,17 +55,17 @@ final class CompanyObjectSubscriberTest extends TestCase
     {
         $this->assertSame(
             [
-                InternalObjectEvent::class                           => ['collectInternalObjects', 0],
-                InternalObjectUpdateEvent::class                     => ['updateCompanies', 0],
-                InternalObjectCreateEvent::class                     => ['createCompanies', 0],
-                IntegrationEvents::INTEGRATION_FIND_INTERNAL_RECORDS => [
+                InternalObjectEvent::class         => ['collectInternalObjects', 0],
+                InternalObjectUpdateEvent::class   => ['updateCompanies', 0],
+                InternalObjectCreateEvent::class   => ['createCompanies', 0],
+                InternalObjectFindEvent::class     => [
                     ['findCompaniesByIds', 0],
                     ['findCompaniesByDateRange', 0],
                     ['findCompaniesByFieldValues', 0],
                 ],
-                IntegrationEvents::INTEGRATION_FIND_OWNER_IDS => ['findOwnerIdsForCompanies', 0],
-                InternalObjectRouteEvent::class               => ['buildCompanyRoute', 0],
-                InternalObjectFindByIdEvent::class            => ['findCompanyById', 0],
+                InternalObjectOwnerEvent::class    => ['findOwnerIdsForCompanies', 0],
+                InternalObjectRouteEvent::class    => ['buildCompanyRoute', 0],
+                InternalObjectFindByIdEvent::class => ['findCompanyById', 0],
             ],
             CompanyObjectSubscriber::getSubscribedEvents()
         );

--- a/app/bundles/IntegrationsBundle/Tests/Unit/EventListener/ContactObjectSubscriberTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/EventListener/ContactObjectSubscriberTest.php
@@ -13,7 +13,6 @@ use Mautic\IntegrationsBundle\Event\InternalObjectOwnerEvent;
 use Mautic\IntegrationsBundle\Event\InternalObjectRouteEvent;
 use Mautic\IntegrationsBundle\Event\InternalObjectUpdateEvent;
 use Mautic\IntegrationsBundle\EventListener\ContactObjectSubscriber;
-use Mautic\IntegrationsBundle\IntegrationEvents;
 use Mautic\IntegrationsBundle\Sync\DAO\DateRange;
 use Mautic\IntegrationsBundle\Sync\DAO\Mapping\UpdatedObjectMappingDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Sync\Order\ObjectChangeDAO;
@@ -56,17 +55,17 @@ final class ContactObjectSubscriberTest extends TestCase
     {
         $this->assertSame(
             [
-                InternalObjectEvent::class                           => ['collectInternalObjects', 0],
-                InternalObjectUpdateEvent::class                     => ['updateContacts', 0],
-                InternalObjectCreateEvent::class                     => ['createContacts', 0],
-                IntegrationEvents::INTEGRATION_FIND_INTERNAL_RECORDS => [
+                InternalObjectEvent::class         => ['collectInternalObjects', 0],
+                InternalObjectUpdateEvent::class   => ['updateContacts', 0],
+                InternalObjectCreateEvent::class   => ['createContacts', 0],
+                InternalObjectFindEvent::class     => [
                     ['findContactsByIds', 0],
                     ['findContactsByDateRange', 0],
                     ['findContactsByFieldValues', 0],
                 ],
-                IntegrationEvents::INTEGRATION_FIND_OWNER_IDS => ['findOwnerIdsForContacts', 0],
-                InternalObjectRouteEvent::class               => ['buildContactRoute', 0],
-                InternalObjectFindByIdEvent::class            => ['findContactById', 0],
+                InternalObjectOwnerEvent::class    => ['findOwnerIdsForContacts', 0],
+                InternalObjectRouteEvent::class    => ['buildContactRoute', 0],
+                InternalObjectFindByIdEvent::class => ['findContactById', 0],
             ],
             ContactObjectSubscriber::getSubscribedEvents()
         );

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/Helper/MappingHelperTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/Helper/MappingHelperTest.php
@@ -7,7 +7,6 @@ namespace Mautic\IntegrationsBundle\Tests\Unit\Sync\Helper;
 use Mautic\IntegrationsBundle\Entity\ObjectMapping;
 use Mautic\IntegrationsBundle\Entity\ObjectMappingRepository;
 use Mautic\IntegrationsBundle\Event\InternalObjectFindEvent;
-use Mautic\IntegrationsBundle\IntegrationEvents;
 use Mautic\IntegrationsBundle\Sync\DAO\Mapping\MappingManualDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Mapping\UpdatedObjectMappingDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Sync\Report\FieldDAO;
@@ -137,8 +136,7 @@ final class MappingHelperTest extends TestCase
 
                         return true;
                     }
-                ),
-                IntegrationEvents::INTEGRATION_FIND_INTERNAL_RECORDS
+                )
             );
 
         $foundInternalObject = $this->mappingHelper->findMauticObject($mappingManual, $internalObjectName, $integrationObjectDAO);
@@ -196,8 +194,7 @@ final class MappingHelperTest extends TestCase
 
                         return true;
                     }
-                ),
-                IntegrationEvents::INTEGRATION_FIND_INTERNAL_RECORDS
+                )
             );
 
         $foundInternalObject = $this->mappingHelper->findMauticObject($mappingManual, $internalObjectName, $integrationObjectDAO);
@@ -255,8 +252,7 @@ final class MappingHelperTest extends TestCase
 
                         return true;
                     }
-                ),
-                IntegrationEvents::INTEGRATION_FIND_INTERNAL_RECORDS
+                )
             );
 
         $foundInternalObject = $this->mappingHelper->findMauticObject(

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/Notification/Helper/OwnerProviderTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/Notification/Helper/OwnerProviderTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Mautic\IntegrationsBundle\Tests\Unit\Sync\Notification\Helper;
 
 use Mautic\IntegrationsBundle\Event\InternalObjectOwnerEvent;
-use Mautic\IntegrationsBundle\IntegrationEvents;
 use Mautic\IntegrationsBundle\Sync\Exception\ObjectNotFoundException;
 use Mautic\IntegrationsBundle\Sync\Exception\ObjectNotSupportedException;
 use Mautic\IntegrationsBundle\Sync\Notification\Helper\OwnerProvider;
@@ -75,8 +74,7 @@ final class OwnerProviderTest extends TestCase
                     $event->setOwners([$event->getObjectIds()[0] => 456]);
 
                     return true;
-                }),
-                IntegrationEvents::INTEGRATION_FIND_OWNER_IDS
+                })
             );
 
         $this->assertSame([123 => 456], $this->ownerProvider->getOwnersForObjectIds(Contact::NAME, [123]));

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ReportBuilder/FullObjectReportBuilderTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ReportBuilder/FullObjectReportBuilderTest.php
@@ -105,8 +105,7 @@ final class FullObjectReportBuilderTest extends TestCase
                     ]);
 
                     return true;
-                }),
-                IntegrationEvents::INTEGRATION_FIND_INTERNAL_RECORDS
+                })
             );
 
         $report  = $this->reportBuilder->buildReport($requestDAO);
@@ -159,8 +158,7 @@ final class FullObjectReportBuilderTest extends TestCase
                     ]);
 
                     return true;
-                }),
-                IntegrationEvents::INTEGRATION_FIND_INTERNAL_RECORDS
+                })
             );
 
         $report  = $this->reportBuilder->buildReport($requestDAO);
@@ -244,7 +242,6 @@ final class FullObjectReportBuilderTest extends TestCase
                         );
                     };
                     $callback($parameters[0]);
-                    $this->assertSame(IntegrationEvents::INTEGRATION_FIND_INTERNAL_RECORDS, $parameters[1]);
                 }
                 if (2 === $matcher->numberOfInvocations()) {
                     $callback = function (InternalObjectFindByIdEvent $event) use ($internalObject, $contactEntity): void {
@@ -349,7 +346,6 @@ final class FullObjectReportBuilderTest extends TestCase
                         );
                     };
                     $callback($parameters[0]);
-                    $this->assertSame(IntegrationEvents::INTEGRATION_FIND_INTERNAL_RECORDS, $parameters[1]);
                 }
                 if (2 === $matcher->numberOfInvocations()) {
                     $callback = function (InternalObjectFindByIdEvent $event) use ($internalObject, $companyEntity): void {

--- a/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ReportBuilder/PartialObjectReportBuilderTest.php
+++ b/app/bundles/IntegrationsBundle/Tests/Unit/Sync/SyncDataExchange/Internal/ReportBuilder/PartialObjectReportBuilderTest.php
@@ -6,7 +6,6 @@ namespace Mautic\IntegrationsBundle\Tests\Unit\Sync\SyncDataExchange\Internal\Re
 
 use Mautic\IntegrationsBundle\Entity\FieldChangeRepository;
 use Mautic\IntegrationsBundle\Event\InternalObjectFindEvent;
-use Mautic\IntegrationsBundle\IntegrationEvents;
 use Mautic\IntegrationsBundle\Sync\DAO\Sync\InputOptionsDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Sync\Report\FieldDAO;
 use Mautic\IntegrationsBundle\Sync\DAO\Sync\Request\ObjectDAO;
@@ -158,8 +157,7 @@ final class PartialObjectReportBuilderTest extends TestCase
                     ]);
 
                     return true;
-                }),
-                IntegrationEvents::INTEGRATION_FIND_INTERNAL_RECORDS
+                })
             );
 
         $report  = $this->reportBuilder->buildReport($requestDAO);
@@ -249,8 +247,7 @@ final class PartialObjectReportBuilderTest extends TestCase
                     ]);
 
                     return true;
-                }),
-                IntegrationEvents::INTEGRATION_FIND_INTERNAL_RECORDS
+                })
             );
 
         $report  = $this->reportBuilder->buildReport($requestDAO);
@@ -387,8 +384,7 @@ final class PartialObjectReportBuilderTest extends TestCase
                     ]);
 
                     return true;
-                }),
-                IntegrationEvents::INTEGRATION_FIND_INTERNAL_RECORDS
+                })
             );
 
         $report  = $this->reportBuilder->buildReport($requestDAO);

--- a/app/bundles/LeadBundle/EventListener/FormSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/FormSubscriber.php
@@ -46,9 +46,9 @@ final readonly class FormSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            FormEvents::FORM_ON_BUILD                    => ['onFormBuilder', 0],
-            FormEvents::ON_OBJECT_COLLECT                => ['onObjectCollect', 0],
-            FormEvents::ON_FIELD_COLLECT                 => ['onFieldCollect', 0],
+            FormBuilderEvent::class                      => ['onFormBuilder', 0],
+            ObjectCollectEvent::class                    => ['onObjectCollect', 0],
+            FieldCollectEvent::class                     => ['onFieldCollect', 0],
             LeadEvents::LEAD_ON_SEGMENTS_CHANGE          => ['onLeadSegmentsChange', 0],
             FormEvents::ON_EXECUTE_SUBMIT_ACTION         => [
                 ['onFormSubmitActionChangePoints', 0],

--- a/app/bundles/LeadBundle/EventListener/SetContactAvatarFormSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/SetContactAvatarFormSubscriber.php
@@ -5,7 +5,6 @@ namespace Mautic\LeadBundle\EventListener;
 use Mautic\FormBundle\Entity\Field;
 use Mautic\FormBundle\Event\SubmissionEvent;
 use Mautic\FormBundle\Form\Type\FormFieldFileType;
-use Mautic\FormBundle\FormEvents;
 use Mautic\FormBundle\Helper\FormUploader;
 use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\LeadBundle\Twig\Helper\AvatarHelper;
@@ -23,7 +22,7 @@ final readonly class SetContactAvatarFormSubscriber implements EventSubscriberIn
     public static function getSubscribedEvents(): array
     {
         return [
-            FormEvents::FORM_ON_SUBMIT => ['onFormSubmit', 0],
+            SubmissionEvent::class => ['onFormSubmit', 0],
         ];
     }
 

--- a/app/bundles/PluginBundle/EventListener/FormSubscriber.php
+++ b/app/bundles/PluginBundle/EventListener/FormSubscriber.php
@@ -15,7 +15,7 @@ final class FormSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            FormEvents::FORM_ON_BUILD            => ['onFormBuild', 0],
+            FormBuilderEvent::class             => ['onFormBuild', 0],
             FormEvents::ON_EXECUTE_SUBMIT_ACTION => ['onFormSubmitActionTriggered', 0],
         ];
     }

--- a/plugins/MauticFocusBundle/Controller/PublicController.php
+++ b/plugins/MauticFocusBundle/Controller/PublicController.php
@@ -7,7 +7,6 @@ use Mautic\CoreBundle\Helper\TrackingPixelHelper;
 use Mautic\LeadBundle\Tracker\ContactTracker;
 use MauticPlugin\MauticFocusBundle\Entity\Stat;
 use MauticPlugin\MauticFocusBundle\Event\FocusViewEvent;
-use MauticPlugin\MauticFocusBundle\FocusEvents;
 use MauticPlugin\MauticFocusBundle\Model\FocusModel;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -53,9 +52,9 @@ final class PublicController extends CommonController
 
             if ($focus && $focus->isPublished() && $lead) {
                 $stat = $this->focusModel->addStat($focus, Stat::TYPE_NOTIFICATION, $request, $lead);
-                if ($stat && $this->dispatcher->hasListeners(FocusEvents::FOCUS_ON_VIEW)) {
+                if ($stat && $this->dispatcher->hasListeners(FocusViewEvent::class)) {
                     $event = new FocusViewEvent($stat);
-                    $this->dispatcher->dispatch($event, FocusEvents::FOCUS_ON_VIEW);
+                    $this->dispatcher->dispatch($event);
                     unset($event);
                 }
             }

--- a/plugins/MauticFocusBundle/EventListener/StatSubscriber.php
+++ b/plugins/MauticFocusBundle/EventListener/StatSubscriber.php
@@ -3,7 +3,6 @@
 namespace MauticPlugin\MauticFocusBundle\EventListener;
 
 use Mautic\FormBundle\Event\SubmissionEvent;
-use Mautic\FormBundle\FormEvents;
 use Mautic\PageBundle\Event\PageHitEvent;
 use MauticPlugin\MauticFocusBundle\Entity\Stat;
 use MauticPlugin\MauticFocusBundle\Model\FocusModel;
@@ -22,7 +21,7 @@ final readonly class StatSubscriber implements EventSubscriberInterface
     {
         return [
             PageHitEvent::class    => ['onPageHit', 0],
-            FormEvents::FORM_ON_SUBMIT => ['onFormSubmit', 0],
+            SubmissionEvent::class => ['onFormSubmit', 0],
         ];
     }
 

--- a/plugins/MauticSocialBundle/EventListener/FormSubscriber.php
+++ b/plugins/MauticSocialBundle/EventListener/FormSubscriber.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace MauticPlugin\MauticSocialBundle\EventListener;
 
 use Mautic\FormBundle\Event\FormBuilderEvent;
-use Mautic\FormBundle\FormEvents;
 use MauticPlugin\MauticSocialBundle\Form\Type\SocialLoginType;
 use MauticPlugin\MauticSocialBundle\Integration\Config;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -20,7 +19,7 @@ final readonly class FormSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            FormEvents::FORM_ON_BUILD => ['onFormBuild', 0],
+            FormBuilderEvent::class => ['onFormBuild', 0],
         ];
     }
 


### PR DESCRIPTION
Continues the migration of bundle `*Events` string constants to native Symfony 4.3+ class-name event dispatch, following the pattern of the already-merged Asset/Campaign/Channel/Core/Dashboard/Lead/Page/Plugin/Report/Sms/Stage/Webhook bundles.

Only events that map 1:1 to a single event class, with all dispatch and subscriber sites in-repo, are converted. Constants whose event object is shared across several names (CRUD / pre-post groups) or whose events cross bundle boundaries are left as string constants. All `*Events` classes and their constants are kept for backwards compatibility.

## Converted

| Bundle | Constant | Event class |
| --- | --- | --- |
| FormBundle | `FORM_ON_SUBMIT` | `SubmissionEvent` |
| FormBundle | `FORM_ON_BUILD` | `FormBuilderEvent` |
| FormBundle | `ON_OBJECT_COLLECT` | `ObjectCollectEvent` |
| FormBundle | `ON_FIELD_COLLECT` | `FieldCollectEvent` |
| IntegrationsBundle | `INTEGRATION_FIND_INTERNAL_RECORDS` | `InternalObjectFindEvent` |
| IntegrationsBundle | `INTEGRATION_FIND_OWNER_IDS` | `InternalObjectOwnerEvent` |
| MauticFocusBundle | `FOCUS_ON_VIEW` | `FocusViewEvent` |

## Notes

- FormBundle: `FORM_ON_SUBMIT` also doubles as a persisted webhook event-type identifier in `WebhookSubscriber`; only its event-dispatch subscription was switched to the class, the webhook-type-id string usages were left intact.
- IntegrationsBundle: completes the earlier partial conversion of `IntegrationEvents` - the two remaining find-events (dispatched from `PartialObjectReportBuilder`, `FullObjectReportBuilder`, `MappingHelper` and `OwnerProvider`) now dispatch by class. The `INTEGRATION_CONFIG_*` before/after-save pair reuses one `ConfigEvent` object under two names and stays a string.
- MauticFocusBundle: `FocusEvents::FOCUS_ON_VIEW` is an in-repo extension point with no shared object. `FocusEventTypes::FOCUS_ON_VIEW` is a separate stat-type identifier and is untouched.

`UPGRADE-8.0.md` documents the mapping.

Tests, php-cs-fixer and PHPStan pass locally.