### PR TITLE
Remove the unreachable second null case in getSourceLists

### DIFF
--- a/app/bundles/CampaignBundle/Model/CampaignModel.php
+++ b/app/bundles/CampaignBundle/Model/CampaignModel.php
@@ -542,7 +542,6 @@ class CampaignModel extends CommonFormModel implements GlobalSearchInterface
 
                 // no break
             case 'forms':
-            case null:
                 $choices['forms'] = [];
                 $viewOther        = $this->security->isGranted('form:forms:viewother');
                 $this->formRepository->setCurrentUser($this->userHelper->getUser());


### PR DESCRIPTION
`getSourceLists()` lists `case null:` twice in the same switch, under `'lists'` and again under `'forms'`. PHP matches cases in order, so the second label can never be reached: a null `$sourceType` has already entered at the first one and arrives in the forms block through the `// no break` above it.

That is what makes the label worth removing rather than leaving as documentation. It reads as if null were handled at each level independently, when the fallthrough is the only thing carrying it, and someone tidying up the `// no break` later would have no hint that it is load bearing.

I did not run the ddev suite from AGENTS.md for this one. The change removes an unreachable label and touches nothing else, so there is no behaviour for it to move.
