### PR TITLE
Restore the entity fields the import was silently dropping

### DIFF
--- a/app/bundles/AssetBundle/EventListener/AssetImportExportSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/AssetImportExportSubscriber.php
@@ -15,8 +15,8 @@ use Mautic\CoreBundle\Event\EntityImportUndoEvent;
 use Mautic\CoreBundle\EventListener\ImportExportTrait;
 use Mautic\CoreBundle\Helper\IpLookupHelper;
 use Mautic\CoreBundle\Model\AuditLogModel;
+use Mautic\CoreBundle\Serializer\ImportEntityDenormalizer;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
 final class AssetImportExportSubscriber implements EventSubscriberInterface
 {
@@ -28,7 +28,7 @@ final class AssetImportExportSubscriber implements EventSubscriberInterface
         private AssetRepository $assetRepository,
         private AuditLogModel $auditLogModel,
         private IpLookupHelper $ipLookupHelper,
-        private DenormalizerInterface $serializer,
+        private ImportEntityDenormalizer $serializer,
     ) {
     }
 

--- a/app/bundles/CoreBundle/Serializer/ImportEntityDenormalizer.php
+++ b/app/bundles/CoreBundle/Serializer/ImportEntityDenormalizer.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CoreBundle\Serializer;
+
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+/**
+ * The export subscribers write their payloads with snake_case keys while the entities expose
+ * camelCase properties. The default denormalizer silently discards any key it cannot map, so
+ * every multi-word field was dropped on import: email bodies, form styling, page HTML. This
+ * wrapper restores the mapping before delegating to the real denormalizer.
+ *
+ * Mapped keys are added alongside the originals rather than replacing them, so payloads that
+ * already use the canonical form keep working unchanged.
+ *
+ * Deliberately not a DenormalizerInterface implementation: that would register it inside the
+ * serializer's own normalizer chain and create a circular reference back onto itself.
+ */
+final readonly class ImportEntityDenormalizer
+{
+    /**
+     * Export keys whose camelCase form still does not match the entity property.
+     *
+     * @var array<string, string>
+     */
+    private const ALIASES = [
+        'lang'           => 'language',
+        'form_attr'      => 'formAttributes',
+        'container_attr' => 'containerAttributes',
+        'input_attr'     => 'inputAttributes',
+        'label_attr'     => 'labelAttributes',
+        'field_order'    => 'order',
+        'field_group'    => 'group',
+    ];
+
+    /**
+     * Exported keys that describe the state of the source install rather than the entity itself.
+     * They were dropped before this class existed, and they should stay dropped: a copy starts
+     * with its own traffic counters, and the schema flag belongs to the database it came from.
+     *
+     * @var array<int, string>
+     */
+    private const NOT_IMPORTABLE = [
+        'unique_hits',
+        'variant_hits',
+        'column_is_not_created',
+    ];
+
+    public function __construct(
+        private DenormalizerInterface $decorated,
+    ) {
+    }
+
+    /**
+     * @param array<mixed>         $data
+     * @param class-string         $type
+     * @param array<string, mixed> $context
+     */
+    public function denormalize(array $data, string $type, ?string $format = null, array $context = []): mixed
+    {
+        return $this->decorated->denormalize($this->mapKeys($data), $type, $format, $context);
+    }
+
+    /**
+     * @param array<mixed> $data
+     *
+     * @return array<mixed>
+     */
+    public function mapKeys(array $data): array
+    {
+        foreach ($data as $key => $value) {
+            if (!is_string($key) || in_array($key, self::NOT_IMPORTABLE, true)) {
+                continue;
+            }
+
+            $mapped = self::ALIASES[$key] ?? $this->toCamelCase($key);
+
+            if ($mapped === $key || array_key_exists($mapped, $data)) {
+                continue;
+            }
+
+            $data[$mapped] = $value;
+        }
+
+        return $data;
+    }
+
+    private function toCamelCase(string $key): string
+    {
+        if (!str_contains($key, '_')) {
+            return $key;
+        }
+
+        return lcfirst(str_replace('_', '', ucwords($key, '_')));
+    }
+}

--- a/app/bundles/CoreBundle/Tests/Unit/Serializer/ImportEntityDenormalizerTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Serializer/ImportEntityDenormalizerTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CoreBundle\Tests\Unit\Serializer;
+
+use Mautic\CoreBundle\Serializer\ImportEntityDenormalizer;
+use Mautic\EmailBundle\Entity\Email;
+use Mautic\FormBundle\Entity\Field;
+use Mautic\FormBundle\Entity\Form;
+use Mautic\LeadBundle\Entity\LeadField;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+final class ImportEntityDenormalizerTest extends TestCase
+{
+    private DenormalizerInterface&MockObject $decorated;
+
+    private ImportEntityDenormalizer $denormalizer;
+
+    protected function setUp(): void
+    {
+        $this->decorated    = $this->createMock(DenormalizerInterface::class);
+        $this->denormalizer = new ImportEntityDenormalizer($this->decorated);
+    }
+
+    public function testSnakeCaseKeysAreMappedToTheEntityProperty(): void
+    {
+        $mapped = $this->denormalizer->mapKeys([
+            'custom_html'    => '<p>Body</p>',
+            'plain_text'     => 'Body',
+            'preheader_text' => 'Preheader',
+            'email_type'     => 'transactional',
+        ]);
+
+        $this->assertSame('<p>Body</p>', $mapped['customHtml']);
+        $this->assertSame('Body', $mapped['plainText']);
+        $this->assertSame('Preheader', $mapped['preheaderText']);
+        $this->assertSame('transactional', $mapped['emailType']);
+    }
+
+    public function testOriginalKeysArePreserved(): void
+    {
+        $mapped = $this->denormalizer->mapKeys(['custom_html' => '<p>Body</p>']);
+
+        $this->assertArrayHasKey('custom_html', $mapped, 'Callers may still read the exported key.');
+        $this->assertSame('<p>Body</p>', $mapped['custom_html']);
+    }
+
+    public function testSingleWordKeysAreLeftAlone(): void
+    {
+        $data   = ['name' => 'Newsletter', 'subject' => 'Hello', 'uuid' => 'abc'];
+        $mapped = $this->denormalizer->mapKeys($data);
+
+        $this->assertSame($data, $mapped);
+    }
+
+    /**
+     * @return \Iterator<string, array{string, string}>
+     */
+    public static function aliasProvider(): \Iterator
+    {
+        yield 'language is not a case conversion' => ['lang', 'language'];
+        yield 'form attributes' => ['form_attr', 'formAttributes'];
+        yield 'field container attributes' => ['container_attr', 'containerAttributes'];
+        yield 'field input attributes' => ['input_attr', 'inputAttributes'];
+        yield 'field label attributes' => ['label_attr', 'labelAttributes'];
+        yield 'form field order' => ['field_order', 'order'];
+        yield 'custom field group' => ['field_group', 'group'];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('aliasProvider')]
+    public function testExplicitAliases(string $exported, string $property): void
+    {
+        $mapped = $this->denormalizer->mapKeys([$exported => 'value']);
+
+        $this->assertSame('value', $mapped[$property]);
+    }
+
+    public function testAnExistingCanonicalKeyIsNotOverwritten(): void
+    {
+        $mapped = $this->denormalizer->mapKeys([
+            'custom_html' => 'exported',
+            'customHtml'  => 'canonical',
+        ]);
+
+        $this->assertSame('canonical', $mapped['customHtml']);
+    }
+
+    public function testNonStringKeysAreIgnored(): void
+    {
+        $mapped = $this->denormalizer->mapKeys([0 => 'first', 'custom_html' => '<p>Body</p>']);
+
+        $this->assertSame('first', $mapped[0]);
+        $this->assertSame('<p>Body</p>', $mapped['customHtml']);
+    }
+
+    /**
+     * @return \Iterator<string, array{string, class-string}>
+     */
+    public static function aliasTargetProvider(): \Iterator
+    {
+        yield 'lang on an email' => ['lang', Email::class];
+        yield 'form attributes' => ['form_attr', Form::class];
+        yield 'field container attribute' => ['container_attr', Field::class];
+        yield 'field input attribute' => ['input_attr', Field::class];
+        yield 'field label attribute' => ['label_attr', Field::class];
+        yield 'form field order' => ['field_order', Field::class];
+        yield 'custom field order' => ['field_order', LeadField::class];
+        yield 'custom field group' => ['field_group', LeadField::class];
+    }
+
+    /**
+     * The alias list is maintained by hand, which is exactly how the original bug slipped in.
+     * If an entity property is ever renamed, this fails instead of silently dropping the field
+     * again.
+     *
+     * @param class-string $entityClass
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('aliasTargetProvider')]
+    public function testEveryAliasPointsAtAnExistingSetter(string $exported, string $entityClass): void
+    {
+        $mapped = array_keys($this->denormalizer->mapKeys([$exported => 'value']));
+        $target = end($mapped);
+
+        $this->assertTrue(
+            method_exists($entityClass, 'set'.ucfirst((string) $target)),
+            sprintf('%s::set%s() does not exist, so "%s" would be dropped on import.', $entityClass, ucfirst((string) $target), $exported)
+        );
+    }
+
+    /**
+     * These describe the install the export came from, not the entity, so a copy must not
+     * inherit them.
+     */
+    public function testStateOfTheSourceInstallIsNotMapped(): void
+    {
+        $mapped = $this->denormalizer->mapKeys([
+            'unique_hits'           => 1234,
+            'variant_hits'          => 567,
+            'column_is_not_created' => true,
+        ]);
+
+        $this->assertArrayNotHasKey('uniqueHits', $mapped);
+        $this->assertArrayNotHasKey('variantHits', $mapped);
+        $this->assertArrayNotHasKey('columnIsNotCreated', $mapped);
+    }
+
+    public function testDenormalizePassesTheMappedPayloadToTheDecoratedService(): void
+    {
+        $email = new Email();
+
+        $received = [];
+
+        $this->decorated->expects($this->once())
+            ->method('denormalize')
+            ->willReturnCallback(static function (array $data) use (&$received, $email): Email {
+                $received = $data;
+
+                return $email;
+            });
+
+        $result = $this->denormalizer->denormalize(
+            ['email_type' => 'transactional'],
+            Email::class,
+            null,
+            ['object_to_populate' => $email]
+        );
+
+        $this->assertSame($email, $result);
+        $this->assertSame('transactional', $received['emailType'] ?? null);
+    }
+}

--- a/app/bundles/DynamicContentBundle/EventListener/DynamicContentImportExportSubscriber.php
+++ b/app/bundles/DynamicContentBundle/EventListener/DynamicContentImportExportSubscriber.php
@@ -12,11 +12,11 @@ use Mautic\CoreBundle\Event\EntityImportUndoEvent;
 use Mautic\CoreBundle\EventListener\ImportExportTrait;
 use Mautic\CoreBundle\Helper\IpLookupHelper;
 use Mautic\CoreBundle\Model\AuditLogModel;
+use Mautic\CoreBundle\Serializer\ImportEntityDenormalizer;
 use Mautic\DynamicContentBundle\Entity\DynamicContent;
 use Mautic\DynamicContentBundle\Entity\DynamicContentRepository;
 use Mautic\DynamicContentBundle\Model\DynamicContentModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
 final class DynamicContentImportExportSubscriber implements EventSubscriberInterface
 {
@@ -28,7 +28,7 @@ final class DynamicContentImportExportSubscriber implements EventSubscriberInter
         private DynamicContentRepository $dynamicContentRepository,
         private AuditLogModel $auditLogModel,
         private IpLookupHelper $ipLookupHelper,
-        private DenormalizerInterface $serializer,
+        private ImportEntityDenormalizer $serializer,
     ) {
     }
 

--- a/app/bundles/EmailBundle/EventListener/EmailImportExportSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/EmailImportExportSubscriber.php
@@ -13,6 +13,7 @@ use Mautic\CoreBundle\Event\EntityImportUndoEvent;
 use Mautic\CoreBundle\EventListener\ImportExportTrait;
 use Mautic\CoreBundle\Helper\IpLookupHelper;
 use Mautic\CoreBundle\Model\AuditLogModel;
+use Mautic\CoreBundle\Serializer\ImportEntityDenormalizer;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Entity\EmailRepository;
 use Mautic\EmailBundle\Helper\EmailMediaImageHelper;
@@ -23,7 +24,6 @@ use Mautic\PageBundle\Entity\Page;
 use Mautic\PageBundle\Entity\PageRepository;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
 final class EmailImportExportSubscriber implements EventSubscriberInterface
 {
@@ -38,7 +38,7 @@ final class EmailImportExportSubscriber implements EventSubscriberInterface
         private EventDispatcherInterface $dispatcher,
         private AuditLogModel $auditLogModel,
         private IpLookupHelper $ipLookupHelper,
-        private DenormalizerInterface $serializer,
+        private ImportEntityDenormalizer $serializer,
         private EmailMediaImageHelper $mediaImageHelper,
     ) {
     }

--- a/app/bundles/EmailBundle/Resources/views/Email/details.html.twig
+++ b/app/bundles/EmailBundle/Resources/views/Email/details.html.twig
@@ -147,9 +147,7 @@
             {
                 color: 'high-contrast',
                 icon: emailType == 'list' ? 'ri-pie-chart-line' : 'ri-mail-open-line',
-                label: emailType == 'list'
-                    ? 'mautic.email.type.list.header'
-                    : (emailType == 'template' ? 'mautic.email.type.template.header' : type)
+                label: 'mautic.email.type.' ~ emailType ~ '.header'
             }
         ] } %}
 

--- a/app/bundles/EmailBundle/Tests/EventListener/EmailImportExportSubscriberFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/EmailImportExportSubscriberFunctionalTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Mautic\EmailBundle\Tests\EventListener;
 
 use Mautic\CoreBundle\Event\EntityExportEvent;
+use Mautic\CoreBundle\Event\EntityImportEvent;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\EmailBundle\Entity\Email;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -157,5 +158,60 @@ final class EmailImportExportSubscriberFunctionalTest extends MauticMysqlTestCas
         $this->assertIsArray($exportedEmail);
         $this->assertIsArray($exportedEmail['variant_settings']);
         $this->assertSame([], $exportedEmail['variant_settings']);
+    }
+
+    /**
+     * The export writes snake_case keys while the entity exposes camelCase properties. When the
+     * import hydrated straight through the serializer those keys were silently discarded, so an
+     * imported email arrived with no body at all and fell back to the blank theme.
+     */
+    public function testImportKeepsTheFieldsTheExportWrote(): void
+    {
+        $email = new Email();
+        $email->setName('Round Trip Email');
+        $email->setSubject('Round Trip Subject');
+        $email->setCustomHtml('<html><body><p>Original body</p></body></html>');
+        $email->setPlainText('Original body');
+        $email->setPreheaderText('Original preheader');
+        $email->setEmailType('transactional');
+        $email->setLanguage('en');
+        $email->setIsPublished(true);
+        $email->setPublishUp(new \DateTime('2026-01-01 09:00:00'));
+        $email->setPublishDown(new \DateTime('2026-12-31 18:00:00'));
+
+        $this->em->persist($email);
+        $this->em->flush();
+
+        $exportEvent = new EntityExportEvent(Email::ENTITY_NAME, $email->getId());
+        $this->dispatcher->dispatch($exportEvent);
+
+        $exported = reset($exportEvent->getEntities()[Email::ENTITY_NAME]);
+        $this->assertIsArray($exported);
+
+        // A fresh uuid makes the import create a second email rather than update the source one.
+        $exported['uuid'] = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee';
+
+        $importEvent = new EntityImportEvent(Email::ENTITY_NAME, [$exported], 1);
+        $this->dispatcher->dispatch($importEvent);
+
+        $this->em->clear();
+
+        $imported = $this->em->getRepository(Email::class)->findOneBy(['uuid' => $exported['uuid']]);
+        $this->assertInstanceOf(Email::class, $imported);
+
+        $this->assertSame($email->getCustomHtml(), $imported->getCustomHtml());
+        $this->assertSame($email->getPlainText(), $imported->getPlainText());
+        $this->assertSame($email->getPreheaderText(), $imported->getPreheaderText());
+        $this->assertSame($email->getEmailType(), $imported->getEmailType());
+        $this->assertSame($email->getLanguage(), $imported->getLanguage());
+
+        // The export serialises these as DATE_ATOM strings, so the import has to turn them back
+        // into dates rather than storing null and silently republishing the email.
+        $this->assertInstanceOf(\DateTimeInterface::class, $imported->getPublishUp());
+        $this->assertInstanceOf(\DateTimeInterface::class, $imported->getPublishDown());
+        $this->assertSame(
+            $email->getPublishUp()->format('Y-m-d H:i'),
+            $imported->getPublishUp()->format('Y-m-d H:i')
+        );
     }
 }

--- a/app/bundles/FormBundle/EventListener/ActionImportExportSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/ActionImportExportSubscriber.php
@@ -14,6 +14,7 @@ use Mautic\CoreBundle\EventListener\ImportExportTrait;
 use Mautic\CoreBundle\Helper\IpLookupHelper;
 use Mautic\CoreBundle\Helper\UuidHelper;
 use Mautic\CoreBundle\Model\AuditLogModel;
+use Mautic\CoreBundle\Serializer\ImportEntityDenormalizer;
 use Mautic\FormBundle\Entity\Action;
 use Mautic\FormBundle\Entity\ActionRepository;
 use Mautic\FormBundle\Entity\Form;
@@ -21,7 +22,6 @@ use Mautic\FormBundle\Entity\FormRepository;
 use Mautic\FormBundle\Model\ActionModel;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
 final class ActionImportExportSubscriber implements EventSubscriberInterface
 {
@@ -35,7 +35,7 @@ final class ActionImportExportSubscriber implements EventSubscriberInterface
         private AuditLogModel $auditLogModel,
         private IpLookupHelper $ipLookupHelper,
         private EventDispatcherInterface $dispatcher,
-        private DenormalizerInterface $serializer,
+        private ImportEntityDenormalizer $serializer,
     ) {
     }
 

--- a/app/bundles/FormBundle/EventListener/FieldImportExportSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/FieldImportExportSubscriber.php
@@ -13,6 +13,7 @@ use Mautic\CoreBundle\EventListener\ImportExportTrait;
 use Mautic\CoreBundle\Helper\IpLookupHelper;
 use Mautic\CoreBundle\Helper\UuidHelper;
 use Mautic\CoreBundle\Model\AuditLogModel;
+use Mautic\CoreBundle\Serializer\ImportEntityDenormalizer;
 use Mautic\FormBundle\Entity\Field;
 use Mautic\FormBundle\Entity\FieldRepository;
 use Mautic\FormBundle\Entity\Form;
@@ -22,7 +23,6 @@ use Mautic\LeadBundle\Entity\LeadField;
 use Mautic\LeadBundle\Model\FieldModel as LeadFieldModel;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
 final class FieldImportExportSubscriber implements EventSubscriberInterface
 {
@@ -37,7 +37,7 @@ final class FieldImportExportSubscriber implements EventSubscriberInterface
         private FieldModel $fieldModel,
         private LeadFieldModel $leadFieldModel,
         private EventDispatcherInterface $dispatcher,
-        private DenormalizerInterface $serializer,
+        private ImportEntityDenormalizer $serializer,
     ) {
     }
 
@@ -135,7 +135,10 @@ final class FieldImportExportSubscriber implements EventSubscriberInterface
             $isNew = !$field;
             $field ??= new Field();
 
-            foreach (['properties', 'validation', 'custom_parameters', 'conditions', 'label_attr', 'input_attr', 'container_attr'] as $jsonField) {
+            // Only the array and json columns are stored encoded. The *_attr columns are plain
+            // strings ("class=\"btn btn-default\""), and running them through json_decode turned
+            // every one of them into an empty array.
+            foreach (['properties', 'validation', 'custom_parameters', 'conditions'] as $jsonField) {
                 if (isset($fieldData[$jsonField]) && is_string($fieldData[$jsonField])) {
                     $decoded               = json_decode($fieldData[$jsonField], true);
                     $fieldData[$jsonField] = is_array($decoded) ? $decoded : [];

--- a/app/bundles/FormBundle/EventListener/FormImportExportSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/FormImportExportSubscriber.php
@@ -12,6 +12,7 @@ use Mautic\CoreBundle\Event\EntityImportUndoEvent;
 use Mautic\CoreBundle\EventListener\ImportExportTrait;
 use Mautic\CoreBundle\Helper\IpLookupHelper;
 use Mautic\CoreBundle\Model\AuditLogModel;
+use Mautic\CoreBundle\Serializer\ImportEntityDenormalizer;
 use Mautic\FormBundle\Entity\Action;
 use Mautic\FormBundle\Entity\Field;
 use Mautic\FormBundle\Entity\Form;
@@ -19,7 +20,6 @@ use Mautic\FormBundle\Entity\FormRepository;
 use Mautic\FormBundle\Model\FormModel;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
 final class FormImportExportSubscriber implements EventSubscriberInterface
 {
@@ -32,7 +32,7 @@ final class FormImportExportSubscriber implements EventSubscriberInterface
         private AuditLogModel $auditLogModel,
         private IpLookupHelper $ipLookupHelper,
         private EventDispatcherInterface $dispatcher,
-        private DenormalizerInterface $serializer,
+        private ImportEntityDenormalizer $serializer,
     ) {
     }
 

--- a/app/bundles/LeadBundle/EventListener/CustomFieldImportExportSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/CustomFieldImportExportSubscriber.php
@@ -12,11 +12,11 @@ use Mautic\CoreBundle\Event\EntityImportUndoEvent;
 use Mautic\CoreBundle\EventListener\ImportExportTrait;
 use Mautic\CoreBundle\Helper\IpLookupHelper;
 use Mautic\CoreBundle\Model\AuditLogModel;
+use Mautic\CoreBundle\Serializer\ImportEntityDenormalizer;
 use Mautic\LeadBundle\Entity\LeadField;
 use Mautic\LeadBundle\Entity\LeadFieldRepository;
 use Mautic\LeadBundle\Model\FieldModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
 final class CustomFieldImportExportSubscriber implements EventSubscriberInterface
 {
@@ -28,7 +28,7 @@ final class CustomFieldImportExportSubscriber implements EventSubscriberInterfac
         private LeadFieldRepository $leadFieldRepository,
         private AuditLogModel $auditLogModel,
         private IpLookupHelper $ipLookupHelper,
-        private DenormalizerInterface $serializer,
+        private ImportEntityDenormalizer $serializer,
     ) {
     }
 

--- a/app/bundles/LeadBundle/EventListener/SegmentImportExportSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/SegmentImportExportSubscriber.php
@@ -12,6 +12,7 @@ use Mautic\CoreBundle\Event\EntityImportUndoEvent;
 use Mautic\CoreBundle\EventListener\ImportExportTrait;
 use Mautic\CoreBundle\Helper\IpLookupHelper;
 use Mautic\CoreBundle\Model\AuditLogModel;
+use Mautic\CoreBundle\Serializer\ImportEntityDenormalizer;
 use Mautic\LeadBundle\Entity\LeadField;
 use Mautic\LeadBundle\Entity\LeadList;
 use Mautic\LeadBundle\Entity\LeadListRepository;
@@ -20,7 +21,6 @@ use Mautic\LeadBundle\Model\ListModel;
 use Mautic\PluginBundle\Model\PluginModel;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
 final class SegmentImportExportSubscriber implements EventSubscriberInterface
 {
@@ -35,7 +35,7 @@ final class SegmentImportExportSubscriber implements EventSubscriberInterface
         private EventDispatcherInterface $dispatcher,
         private FieldModel $fieldModel,
         private IpLookupHelper $ipLookupHelper,
-        private DenormalizerInterface $serializer,
+        private ImportEntityDenormalizer $serializer,
     ) {
     }
 

--- a/app/bundles/PageBundle/EventListener/PageImportExportSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/PageImportExportSubscriber.php
@@ -12,11 +12,11 @@ use Mautic\CoreBundle\Event\EntityImportUndoEvent;
 use Mautic\CoreBundle\EventListener\ImportExportTrait;
 use Mautic\CoreBundle\Helper\IpLookupHelper;
 use Mautic\CoreBundle\Model\AuditLogModel;
+use Mautic\CoreBundle\Serializer\ImportEntityDenormalizer;
 use Mautic\PageBundle\Entity\Page;
 use Mautic\PageBundle\Entity\PageRepository;
 use Mautic\PageBundle\Model\PageModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
 final class PageImportExportSubscriber implements EventSubscriberInterface
 {
@@ -28,7 +28,7 @@ final class PageImportExportSubscriber implements EventSubscriberInterface
         private PageRepository $pageRepository,
         private AuditLogModel $auditLogModel,
         private IpLookupHelper $ipLookupHelper,
-        private DenormalizerInterface $serializer,
+        private ImportEntityDenormalizer $serializer,
     ) {
     }
 

--- a/app/bundles/PointBundle/EventListener/GroupImportExportSubscriber.php
+++ b/app/bundles/PointBundle/EventListener/GroupImportExportSubscriber.php
@@ -12,11 +12,11 @@ use Mautic\CoreBundle\Event\EntityImportUndoEvent;
 use Mautic\CoreBundle\EventListener\ImportExportTrait;
 use Mautic\CoreBundle\Helper\IpLookupHelper;
 use Mautic\CoreBundle\Model\AuditLogModel;
+use Mautic\CoreBundle\Serializer\ImportEntityDenormalizer;
 use Mautic\PointBundle\Entity\Group;
 use Mautic\PointBundle\Entity\GroupRepository;
 use Mautic\PointBundle\Model\PointGroupModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
 final class GroupImportExportSubscriber implements EventSubscriberInterface
 {
@@ -28,7 +28,7 @@ final class GroupImportExportSubscriber implements EventSubscriberInterface
         private GroupRepository $groupRepository,
         private AuditLogModel $auditLogModel,
         private IpLookupHelper $ipLookupHelper,
-        private DenormalizerInterface $serializer,
+        private ImportEntityDenormalizer $serializer,
     ) {
     }
 


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | No existing issue - steps below

## Description

Importing a campaign silently loses most of its content. Emails arrive with no body and fall back to the blank theme, so you get "Hello World / Lorem ipsum" with the theme's CSS printed as text. Forms arrive unstyled. Pages lose their
HTML.

The export writes snake_case keys (`custom_html`) while entities expose camelCase properties (`$customHtml`). The import hydrates through `serializer->denormalize()` with no name converter, so Symfony discards every key it can't resolve - silently. Only single-word keys survive. 

`ImportEntityDenormalizer` maps the keys before delegating. Seven are aliased explicitly (`lang → language`, `field_order → order`, `*_attr → *Attributes`). Three stay unmapped on purpose - `unique_hits`, `variant_hits` and `column_is_not_created` describe the source install, not the entity.

Also drops the `*_attr` columns from the `json_decode` loop in `FieldImportExportSubscriber`; they're string columns, so decoding turned every value into an empty array.


---
### Steps to test this PR:

1. Open this PR on GitHub Codespaces or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Take any campaign that sends an email and export it
3. Delete that campaign and its email
4. Import the file you just exported
5. Open the imported email - it should show its original content. Before this fix it comes through empty, showing "Hello World / Lorem ipsum" with CSS printed at the top

If the campaign also has a form, the imported form should keep its styling too.