### PR TITLE
Restore normal line spacing in CodeMirror editors

### DIFF
--- a/app/bundles/CoreBundle/Assets/css/app/scss/components/_type.scss
+++ b/app/bundles/CoreBundle/Assets/css/app/scss/components/_type.scss
@@ -399,8 +399,11 @@ code {
 }
 
 pre {
-  min-height: 40px;
   overflow: auto;
+}
+
+.code-snippet--multi pre.code-snippet__code {
+  min-height: 40px;
 }
 
 .code-snippet--multi pre.code-snippet__code:before {


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch) | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌
| Related user documentation PR URL      | Not applicable
| Related developer documentation PR URL | Not applicable
| Issue(s) addressed                     | Not applicable

## Description

The global `pre` minimum height also applies to CodeMirror, which renders each editor line as a `<pre>` element. This makes every line at least 40 pixels high.

Scope the minimum height to multiline code snippets so they retain their intended appearance without affecting code editors.

<img width="2171" height="920" alt="image" src="https://github.com/user-attachments/assets/a56bb371-3acc-4a4b-b0e8-54b2c008d416" />


---
### 📋 Steps to test this PR:

1. Edit an email that uses the GrapesJS Builder and launch the builder.
2. Click **Edit code** in the builder toolbar.
3. Verify that the HTML and MJML editor lines have normal, compact spacing.
4. Add and remove lines and verify that the cursor and line content remain aligned.
5. Go to **Configuration > Tracking Settings** and verify that the multiline tracking code snippets still display normally.
