### PR TITLE
[routes] Remove 3 dead routes, move campaign preview to #[Route]

### DIFF
--- a/UPGRADE-8.0.md
+++ b/UPGRADE-8.0.md
@@ -172,6 +172,7 @@
 ```
 
   Non-model services that happen to live under the same `mautic.<bundle>.model.*` namespace (e.g. `mautic.lead.model.dnc` was a model but `mautic.report.model.report_exporter` is a helper) are unaffected — only aliases pointing at `MauticModelInterface` models were removed.
+- Dead routes removed from bundle route config. `mautic_receive_notification` (`/notification/receive`), `mautic_campaign_import_index` (`/s/campaign/import`) and `mautic_integration_companies` (`/plugin/{integration}/company_data`, CRM plugin) pointed at controller actions that do not exist (`NotificationApiController::receiveAction`, `ImportController::indexAction`, `MauticCrmBundle\Controller\PublicController::companyDataAction`), so they returned an error on every request.
 
 ## Changed code
 

--- a/app/bundles/CampaignBundle/Config/config.php
+++ b/app/bundles/CampaignBundle/Config/config.php
@@ -4,16 +4,6 @@ declare(strict_types=1);
 
 return [
     'routes' => [
-        'main' => [
-            'mautic_campaign_preview'      => [
-                'path'       => '/campaign/preview/{objectId}',
-                'controller' => 'Mautic\EmailBundle\Controller\PublicController::previewAction',
-            ],
-            'mautic_campaign_import_index' => [
-                'path'       => '/campaign/import',
-                'controller' => 'Mautic\CampaignBundle\Controller\ImportController::indexAction',
-            ],
-        ],
         'api'  => [
             'mautic_api_campaignsstandard'            => [
                 'standard_entity' => true,

--- a/app/bundles/CoreBundle/Tests/Functional/route-map.json
+++ b/app/bundles/CoreBundle/Tests/Functional/route-map.json
@@ -3906,14 +3906,6 @@
         },
         "requirements": []
     },
-    "mautic_campaign_import_index": {
-        "path": "/s/campaign/import",
-        "methods": [],
-        "defaults": {
-            "_controller": "Mautic\\CampaignBundle\\Controller\\ImportController::indexAction"
-        },
-        "requirements": []
-    },
     "mautic_campaign_index": {
         "path": "/s/campaigns/{page}",
         "methods": [],
@@ -5439,14 +5431,6 @@
         "requirements": {
             "page": "\\d+"
         }
-    },
-    "mautic_receive_notification": {
-        "path": "/notification/receive",
-        "methods": [],
-        "defaults": {
-            "_controller": "Mautic\\NotificationBundle\\Controller\\Api\\NotificationApiController::receiveAction"
-        },
-        "requirements": []
     },
     "mautic_remove_trailing_slash": {
         "path": "/{url}",

--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -476,6 +476,12 @@ final class PublicController extends CommonFormController
         requirements: ['objectId' => '[a-zA-Z0-9_-]+'],
         defaults: ['objectType' => null, 'objectId' => 0],
     )]
+    #[Route(
+        '/s/campaign/preview/{objectId}',
+        name: 'mautic_campaign_preview',
+        requirements: ['objectId' => '[a-zA-Z0-9_-]+'],
+        defaults: ['objectId' => 0],
+    )]
     public function previewAction(
         AnalyticsHelper $analyticsHelper,
         ThemeHelper $themeHelper,

--- a/app/bundles/NotificationBundle/Config/config.php
+++ b/app/bundles/NotificationBundle/Config/config.php
@@ -4,12 +4,6 @@ declare(strict_types=1);
 
 return [
     'routes' => [
-        'public' => [
-            'mautic_receive_notification' => [
-                'path'       => '/notification/receive',
-                'controller' => 'Mautic\NotificationBundle\Controller\Api\NotificationApiController::receiveAction',
-            ],
-        ],
         'api' => [
             'mautic_api_notificationsstandard' => [
                 'standard_entity' => true,

--- a/plugins/MauticCrmBundle/Config/config.php
+++ b/plugins/MauticCrmBundle/Config/config.php
@@ -16,13 +16,6 @@ return [
                     'integration' => '.+',
                 ],
             ],
-            'mautic_integration_companies' => [
-                'path'         => '/plugin/{integration}/company_data',
-                'controller'   => 'MauticPlugin\MauticCrmBundle\Controller\PublicController::companyDataAction',
-                'requirements' => [
-                    'integration' => '.+',
-                ],
-            ],
         ],
     ],
 ];


### PR DESCRIPTION
Follow-up to #17135 / #17222 (moving Mautic config routes to native `#[Route]`). Reviewing the config routes not yet migrated, then auditing **every** config route action for existence.

## Dead routes removed

Each points at a controller action that does not exist (no method in the controller or its base chain, no `__call` dispatch), so it returned an error on every request:

| Route | Path | Missing action |
|---|---|---|
| `mautic_receive_notification` | `/notification/receive` | `NotificationApiController::receiveAction` |
| `mautic_campaign_import_index` | `/s/campaign/import` | `ImportController::indexAction` |
| `mautic_integration_companies` | `/plugin/{integration}/company_data` | `MauticCrmBundle\Controller\PublicController::companyDataAction` (sibling `contactDataAction` is real) |

## Moved to `#[Route]`

`mautic_campaign_preview` (`/s/campaign/preview/{objectId}`) is a live route on `EmailBundle\PublicController::previewAction` (`objectId` optional), but it was still declared in `CampaignBundle` config pointing across bundles. It is now a native `#[Route]` stacked on `previewAction` alongside `mautic_email_preview`. Path, name and requirements are unchanged, so the URL keeps working.

## Audit

Reflection-checked all 33 explicit `Class::method` config-route controllers (inheritance-aware). Besides the three above, all resolve. Notable non-issue: `SecurityController::loginCheckAction` has no method but is the `form_login` `check_path` route (`/login_check`) - the firewall intercepts before any controller runs, and the name is used in the login form and `MainEntryPoint`, so it stays. `standard_entity` `::class` routes map to real inherited `CommonApiController` CRUD; vendor routes (FOSOAuth/LightSaml) are external.

Confirmed `objectType` (an optional non-path arg on `previewAction`) is not promoted to a route default: Symfony's `AttributeClassLoader` only promotes an arg whose name matches a `{placeholder}` in the path, so the resolved `mautic_campaign_preview` route is identical to the old config one.

## Changes

- Remove the three dead entries from `NotificationBundle` / `CampaignBundle` / `MauticCrmBundle` route config (and the now-empty `public` / `main` groups).
- Add the `mautic_campaign_preview` `#[Route]` on `PublicController::previewAction`.
- `RouteMapTest` fixture updated (two dead app routes dropped, `mautic_campaign_preview` kept; the CRM plugin route is not in the fixture).
- `UPGRADE-8.0.md` note for the three removed routes.