### PR TITLE
Prevent unnecessary dashboard widget scrollbars

### DIFF
--- a/app/bundles/CoreBundle/Resources/views/Helper/chart.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Helper/chart.html.twig
@@ -3,7 +3,7 @@
     {% if dataValues|reduce((carry, v) => carry + v) > 0 %}
         <div class="chart-wrapper">
             <div class="pt-sd pr-md pb-md pl-md">
-                <div {% if chartHeight is defined %} style="height: calc({{ chartHeight }}px - 15px)" {% endif %}>
+                <div{% if fitChartToContainer|default(false) %} class="chart-fit-container"{% elseif chartHeight is defined %} style="height: calc({{ chartHeight }}px - 15px)"{% endif %}>
                     <canvas class="chart {{ chartType }}-chart" {{ disableLegend is defined ? 'data-disable-legend' : '' }}>
                         {{ chartData|json_encode }}
                     </canvas>

--- a/app/bundles/DashboardBundle/Assets/css/dashboard.css
+++ b/app/bundles/DashboardBundle/Assets/css/dashboard.css
@@ -52,6 +52,7 @@ body:has(.s-dashboard) {
     transition-timing-function: linear;
     position: relative;
     overflow-y: auto;
+    overflow-x: hidden;
 }
 .dashboard-widgets .ui-sortable-helper .tile {
     box-shadow: rgba(255, 255, 255, 0.1) 0px 1px 1px 0px inset, rgba(50, 50, 93, 0.25) 0px 50px 100px -20px, rgba(0, 0, 0, 0.3) 0px 30px 60px -30px;
@@ -70,8 +71,8 @@ body:has(.s-dashboard) {
 
 .dashboard-widgets .widget-overlay {
     content: '';
-    width: 101%;
-    height: 101%;
+    width: 100%;
+    height: 100%;
     position: absolute;
     top: 0;
     left: 0;
@@ -117,6 +118,18 @@ body:has(.s-dashboard) {
 }
 .dashboard-widgets .tile table td:last-child {
     width: 30px;
+}
+
+.dashboard-widgets .card-body:has(> .chart-wrapper),
+.dashboard-widgets .card-body > .chart-wrapper {
+    min-height: 0;
+}
+.dashboard-widgets .card-body > .chart-wrapper {
+    flex-grow: 1;
+}
+.dashboard-widgets .card-body > .chart-wrapper > div,
+.dashboard-widgets .card-body > .chart-wrapper > div > div {
+    height: 100% !important;
 }
 
 .chart-wrapper {

--- a/app/bundles/DashboardBundle/Assets/css/dashboard.css
+++ b/app/bundles/DashboardBundle/Assets/css/dashboard.css
@@ -128,8 +128,8 @@ body:has(.s-dashboard) {
     flex-grow: 1;
 }
 .dashboard-widgets .card-body > .chart-wrapper > div,
-.dashboard-widgets .card-body > .chart-wrapper > div > div {
-    height: 100% !important;
+.dashboard-widgets .chart-fit-container {
+    height: 100%;
 }
 
 .chart-wrapper {

--- a/app/bundles/DashboardBundle/Resources/views/Widget/detail.html.twig
+++ b/app/bundles/DashboardBundle/Resources/views/Widget/detail.html.twig
@@ -49,7 +49,7 @@
             </div>
         {% elseif widget.template %}
             <!-- start: {{ widget.template }} -->
-            {{ include(widget.template, widget.templateData) }}
+            {{ include(widget.template, widget.templateData|merge({'fitChartToContainer': true})) }}
             <!-- end: {{ widget.template }} -->
         {% endif %}
     </div>


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✅
| New feature/enhancement? (use the a.x branch) | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌
| Related user documentation PR URL      | Not applicable
| Related developer documentation PR URL | Not applicable
| Issue(s) addressed                     | Follow-up to #15888

## Description

PR #15888 made dashboard widgets vertically scrollable when their content exceeds the configured height. However, the drag overlay was sized to 101% of each tile, causing every widget to overflow and display vertical and horizontal scrollbars.

This change keeps the overlay within the tile, prevents horizontal overflow, and sizes standard charts to the available card body. Default widgets no longer display unnecessary scrollbars, while genuinely oversized widgets remain vertically scrollable.

<img width="2538" height="1253" alt="image" src="https://github.com/user-attachments/assets/93e69292-8dd8-4824-af19-b845ef5d5001" />


---
### 📋 Steps to test this PR:

1. Open the dashboard with the default widgets.
2. Confirm that chart widgets such as **Contacts Created**, **Page Visits**, and **Form Submissions** fit within their tiles without horizontal or vertical scrollbars.
3. Confirm that chart legends and axis labels remain visible.
4. Add a **Lifecycle** widget containing enough stage or device data to exceed its configured height.
5. Confirm that the Lifecycle widget has a vertical scrollbar and that dragging a widget still covers the complete tile with the drag overlay.
