### PR TITLE
[cs] Add precise iterable docblock types (Core, Email, Campaign)

### DIFF
--- a/app/bundles/CampaignBundle/Controller/CampaignController.php
+++ b/app/bundles/CampaignBundle/Controller/CampaignController.php
@@ -1282,6 +1282,8 @@ class CampaignController extends AbstractStandardFormController
 
     /**
      * @param bool $isClone
+     *
+     * @return array{}
      */
     protected function prepareCampaignEventsForEdit($entity, $objectId, $isClone = false): array
     {

--- a/app/bundles/CampaignBundle/Entity/Campaign.php
+++ b/app/bundles/CampaignBundle/Entity/Campaign.php
@@ -132,6 +132,9 @@ class Campaign extends FormEntity implements OptimisticLockInterface, UuidInterf
     #[Groups(['campaign:read', 'campaign:write'])]
     private Collection $forms;
 
+    /**
+     * @var array<string, mixed>
+     */
     #[Groups(['campaign:read', 'campaign:write'])]
     private array $canvasSettings = [];
 

--- a/app/bundles/CampaignBundle/Entity/EventRepository.php
+++ b/app/bundles/CampaignBundle/Entity/EventRepository.php
@@ -226,6 +226,8 @@ class EventRepository extends CommonRepository
     /**
      * Get array of events with stats.
      *
+     * @param array<string, mixed> $args
+     *
      * @return array
      */
     public function getEvents(array $args = [])

--- a/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadEventLogRepository.php
@@ -59,7 +59,8 @@ class LeadEventLogRepository extends CommonRepository
     /**
      * Get a lead's page event log.
      *
-     * @param int|null $leadId
+     * @param int|null             $leadId
+     * @param array<string, mixed> $options
      *
      * @return array
      */
@@ -369,6 +370,9 @@ class LeadEventLogRepository extends CommonRepository
         }
     }
 
+    /**
+     * @param array<string, mixed> $options
+     */
     public function getChartQuery(array $options): array
     {
         $chartQuery = new ChartQuery($this->getReplicaConnection(), $options['dateFrom'], $options['dateTo']);

--- a/app/bundles/CampaignBundle/Entity/LeadRepository.php
+++ b/app/bundles/CampaignBundle/Entity/LeadRepository.php
@@ -130,6 +130,7 @@ class LeadRepository extends CommonRepository
      * Check Lead in campaign.
      *
      * @param \Mautic\LeadBundle\Entity\Lead $lead
+     * @param array<string, mixed>           $options
      */
     public function checkLeadInCampaigns($lead, array $options = []): bool
     {

--- a/app/bundles/CampaignBundle/Event/CampaignBuilderEvent.php
+++ b/app/bundles/CampaignBundle/Event/CampaignBuilderEvent.php
@@ -30,22 +30,22 @@ final class CampaignBuilderEvent extends Event
     /**
      * Add an lead decision to the list of available .
      *
-     * @param string $key      a unique identifier; it is recommended that it be namespaced i.e. lead.mytrigger
-     * @param array  $decision can contain the following keys:
-     *                         $decision = [
-     *                         'label'                   => (required) what to display in the list
-     *                         'eventName'               => (required) The event name to fire when this event is triggered.
-     *                         'description'             => (optional) short description of event
-     *                         'formType'                => (optional) name of the form type SERVICE for the action
-     *                         'formTypeOptions'         => (optional) array of options to pass to the formType service
-     *                         'formTheme'               => (optional) form theme
-     *                         'connectionRestrictions'  => (optional) Array of events to restrict this event to. Implicit events
-     *                         [
-     *                         'anchor' => [], // array of anchors this event should _not_ be allowed to connect to in the format of eventType.anchorName, e.g. decision.no
-     *                         'source' => ['action' => [], 'decision' => [], 'condition' => []], // array of event keys allowed to connect into this event
-     *                         'target' => ['action' => [], 'decision' => [], 'condition' => []], // array of event keys allowed to flow from this event
-     *                         ]
-     *                         ]
+     * @param string               $key      a unique identifier; it is recommended that it be namespaced i.e. lead.mytrigger
+     * @param array<string, mixed> $decision can contain the following keys:
+     *                                       $decision = [
+     *                                       'label'                   => (required) what to display in the list
+     *                                       'eventName'               => (required) The event name to fire when this event is triggered.
+     *                                       'description'             => (optional) short description of event
+     *                                       'formType'                => (optional) name of the form type SERVICE for the action
+     *                                       'formTypeOptions'         => (optional) array of options to pass to the formType service
+     *                                       'formTheme'               => (optional) form theme
+     *                                       'connectionRestrictions'  => (optional) Array of events to restrict this event to. Implicit events
+     *                                       [
+     *                                       'anchor' => [], // array of anchors this event should _not_ be allowed to connect to in the format of eventType.anchorName, e.g. decision.no
+     *                                       'source' => ['action' => [], 'decision' => [], 'condition' => []], // array of event keys allowed to connect into this event
+     *                                       'target' => ['action' => [], 'decision' => [], 'condition' => []], // array of event keys allowed to flow from this event
+     *                                       ]
+     *                                       ]
      */
     public function addDecision($key, array $decision): void
     {
@@ -77,22 +77,22 @@ final class CampaignBuilderEvent extends Event
     /**
      * Add an lead condition to the list of available conditions.
      *
-     * @param string $key   a unique identifier; it is recommended that it be namespaced i.e. lead.mytrigger
-     * @param array  $event can contain the following keys:
-     *                      $condition = [
-     *                      'label'                   => (required) what to display in the list
-     *                      'eventName'               => (required) The event name to fire when this event is triggered.
-     *                      'description'             => (optional) short description of event
-     *                      'formType'                => (optional) name of the form type SERVICE for the action
-     *                      'formTypeOptions'         => (optional) array of options to pass to the formType service
-     *                      'formTheme'               => (optional) form theme
-     *                      'connectionRestrictions'  => (optional) Array of events to restrict this event to. Implicit events
-     *                      [
-     *                      'anchor' => [], // array of anchors this event should _not_ be allowed to connect to in the format of eventType.anchorName, e.g. decision.no
-     *                      'source' => ['action' => [], 'decision' => [], 'condition' => []], // array of event keys allowed to connect into this event
-     *                      'target' => ['action' => [], 'decision' => [], 'condition' => []], // array of event keys allowed to flow from this event
-     *                      ]
-     *                      ]
+     * @param string               $key   a unique identifier; it is recommended that it be namespaced i.e. lead.mytrigger
+     * @param array<string, mixed> $event can contain the following keys:
+     *                                    $condition = [
+     *                                    'label'                   => (required) what to display in the list
+     *                                    'eventName'               => (required) The event name to fire when this event is triggered.
+     *                                    'description'             => (optional) short description of event
+     *                                    'formType'                => (optional) name of the form type SERVICE for the action
+     *                                    'formTypeOptions'         => (optional) array of options to pass to the formType service
+     *                                    'formTheme'               => (optional) form theme
+     *                                    'connectionRestrictions'  => (optional) Array of events to restrict this event to. Implicit events
+     *                                    [
+     *                                    'anchor' => [], // array of anchors this event should _not_ be allowed to connect to in the format of eventType.anchorName, e.g. decision.no
+     *                                    'source' => ['action' => [], 'decision' => [], 'condition' => []], // array of event keys allowed to connect into this event
+     *                                    'target' => ['action' => [], 'decision' => [], 'condition' => []], // array of event keys allowed to flow from this event
+     *                                    ]
+     *                                    ]
      */
     public function addCondition($key, array $event): void
     {
@@ -126,23 +126,23 @@ final class CampaignBuilderEvent extends Event
     /**
      * Add an action to the list of available .
      *
-     * @param string $key    a unique identifier; it is recommended that it be namespaced i.e. lead.action
-     * @param array  $action can contain the following keys:
-     *                       $action = [
-     *                       'label'               => (required) what to display in the list
-     *                       'eventName'           => (required) The event to fire when this event is triggered.
-     *                       'description'         => (optional) short description of event
-     *                       'formType'            => (optional) name of the form type SERVICE for the action
-     *                       'formTypeOptions'     => (optional) array of options to pass to the formType service
-     *                       'formTheme'           => (optional) form theme
-     *                       'timelineTemplate'    => (optional) custom template for the lead timeline
-     *                       'connectionRestrictions'  => (optional) Array of events to restrict this event to. Implicit events
-     *                       [
-     *                       'anchor' => [], // array of anchors this event should _not_ be allowed to connect to in the format of eventType.anchorName, e.g. decision.no
-     *                       'source' => ['action' => [], 'decision' => [], 'condition' => []], // array of event keys allowed to connect into this event
-     *                       'target' => ['action' => [], 'decision' => [], 'condition' => []], // array of event keys allowed to flow from this event
-     *                       ]
-     *                       ]
+     * @param string               $key    a unique identifier; it is recommended that it be namespaced i.e. lead.action
+     * @param array<string, mixed> $action can contain the following keys:
+     *                                     $action = [
+     *                                     'label'               => (required) what to display in the list
+     *                                     'eventName'           => (required) The event to fire when this event is triggered.
+     *                                     'description'         => (optional) short description of event
+     *                                     'formType'            => (optional) name of the form type SERVICE for the action
+     *                                     'formTypeOptions'     => (optional) array of options to pass to the formType service
+     *                                     'formTheme'           => (optional) form theme
+     *                                     'timelineTemplate'    => (optional) custom template for the lead timeline
+     *                                     'connectionRestrictions'  => (optional) Array of events to restrict this event to. Implicit events
+     *                                     [
+     *                                     'anchor' => [], // array of anchors this event should _not_ be allowed to connect to in the format of eventType.anchorName, e.g. decision.no
+     *                                     'source' => ['action' => [], 'decision' => [], 'condition' => []], // array of event keys allowed to connect into this event
+     *                                     'target' => ['action' => [], 'decision' => [], 'condition' => []], // array of event keys allowed to flow from this event
+     *                                     ]
+     *                                     ]
      */
     public function addAction($key, array $action): void
     {

--- a/app/bundles/CampaignBundle/Event/CampaignExecutionEvent.php
+++ b/app/bundles/CampaignBundle/Event/CampaignExecutionEvent.php
@@ -61,6 +61,7 @@ class CampaignExecutionEvent extends Event
 
     /**
      * @param bool|mixed[]|string|null $result
+     * @param array<string, mixed>     $args
      */
     public function __construct(
         array $args,

--- a/app/bundles/CampaignBundle/EventCollector/Accessor/EventAccessor.php
+++ b/app/bundles/CampaignBundle/EventCollector/Accessor/EventAccessor.php
@@ -105,6 +105,9 @@ final class EventAccessor
         return $this->decisions;
     }
 
+    /**
+     * @param array<string, mixed> $events
+     */
     private function buildEvents(array $events): void
     {
         if (isset($events[Event::TYPE_ACTION])) {

--- a/app/bundles/CampaignBundle/EventCollector/Builder/ConnectionBuilder.php
+++ b/app/bundles/CampaignBundle/EventCollector/Builder/ConnectionBuilder.php
@@ -6,6 +6,9 @@ final class ConnectionBuilder
 {
     private static array $eventTypes = [];
 
+    /**
+     * @var array<string, mixed>
+     */
     private static array $connectionRestrictions = ['anchor' => []];
 
     /**
@@ -28,9 +31,9 @@ final class ConnectionBuilder
     }
 
     /**
-     * @param string $key
+     * @param array<string, mixed> $event
      */
-    private static function addTypeConnection($key, array $event): void
+    private static function addTypeConnection(string $key, array $event): void
     {
         self::$connectionRestrictions[$key] ??= [
             'source' => self::$eventTypes,
@@ -45,10 +48,9 @@ final class ConnectionBuilder
     }
 
     /**
-     * @param string $key
      * @param string $restrictionType
      */
-    private static function addRestriction($key, $restrictionType, array $restrictions): void
+    private static function addRestriction(string $key, $restrictionType, array $restrictions): void
     {
         switch ($restrictionType) {
             case 'source':

--- a/app/bundles/CampaignBundle/EventListener/CampaignEventImportExportSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/CampaignEventImportExportSubscriber.php
@@ -198,6 +198,8 @@ final readonly class CampaignEventImportExportSubscriber implements EventSubscri
 
     /**
      * @phpstan-ignore-next-line
+     *
+     * @param array<string, mixed> $data
      */
     private function mergeExportData(array &$data, EntityExportEvent $subEvent): void
     {

--- a/app/bundles/CampaignBundle/Executioner/Helper/InactiveHelper.php
+++ b/app/bundles/CampaignBundle/Executioner/Helper/InactiveHelper.php
@@ -132,6 +132,8 @@ class InactiveHelper
     }
 
     /**
+     * @param int[]|string[] $contactIds
+     *
      * @return array<string, \DateTimeInterface>|null
      */
     private function getLastActiveDates(?int $lastActiveEventId, array $contactIds): ?array

--- a/app/bundles/CampaignBundle/Executioner/Logger/EventLogger.php
+++ b/app/bundles/CampaignBundle/Executioner/Logger/EventLogger.php
@@ -192,6 +192,9 @@ class EventLogger
         return $this->persistQueuedLogs();
     }
 
+    /**
+     * @param int[]|string[] $contactIds
+     */
     public function hydrateContactRotationsForNewLogs(array $contactIds, int $campaignId): void
     {
         $this->contactRotations[$campaignId]     = $this->leadRepository->getContactRotations($contactIds, $campaignId);

--- a/app/bundles/CampaignBundle/Form/Type/EventType.php
+++ b/app/bundles/CampaignBundle/Form/Type/EventType.php
@@ -315,6 +315,9 @@ final class EventType extends AbstractType
         $resolver->setRequired(['settings']);
     }
 
+    /**
+     * @param array<string, mixed> $data
+     */
     private function getTimeValue(array $data, string $name): ?\DateTime
     {
         if (empty($data[$name])) {

--- a/app/bundles/CampaignBundle/Helper/CampaignContactCountHelper.php
+++ b/app/bundles/CampaignBundle/Helper/CampaignContactCountHelper.php
@@ -58,7 +58,7 @@ final readonly class CampaignContactCountHelper
     }
 
     /**
-     * @param mixed[] $contactCountDetail
+     * @param array<string, int>|array<string, string> $contactCountDetail
      */
     private function setContactCountInCache(int $campaignId, array $contactCountDetail): void
     {

--- a/app/bundles/CampaignBundle/Helper/CampaignEventHelper.php
+++ b/app/bundles/CampaignBundle/Helper/CampaignEventHelper.php
@@ -8,6 +8,8 @@ final class CampaignEventHelper
 {
     /**
      * Determine if this campaign applies.
+     *
+     * @param array<string, mixed> $event
      */
     public static function validateLeadChangeTrigger(?CampaignLeadChangeEvent $eventDetails = null, array $event = []): bool
     {

--- a/app/bundles/CampaignBundle/Helper/ChannelExtractor.php
+++ b/app/bundles/CampaignBundle/Helper/ChannelExtractor.php
@@ -37,7 +37,8 @@ final class ChannelExtractor
     }
 
     /**
-     * @param string $channelIdField
+     * @param string               $channelIdField
+     * @param array<string, mixed> $properties
      */
     private static function getChannelId(array $properties, $channelIdField): ?int
     {

--- a/app/bundles/CampaignBundle/Model/CampaignModel.php
+++ b/app/bundles/CampaignBundle/Model/CampaignModel.php
@@ -202,7 +202,8 @@ class CampaignModel extends CommonFormModel implements GlobalSearchInterface
     }
 
     /**
-     * @param mixed[] $deletedEvents
+     * @param mixed[]              $deletedEvents
+     * @param array<string, mixed> $sessionConnections
      */
     public function setEvents(Campaign $entity, $sessionEvents, array $sessionConnections, array $deletedEvents): array
     {
@@ -682,8 +683,9 @@ class CampaignModel extends CommonFormModel implements GlobalSearchInterface
     /**
      * Get line chart data of hits.
      *
-     * @param string|null $unit       {@link php.net/manual/en/function.date.php#refsect1-function.date-parameters}
-     * @param string      $dateFormat
+     * @param string|null          $unit       {@link php.net/manual/en/function.date.php#refsect1-function.date-parameters}
+     * @param string               $dateFormat
+     * @param array<string, mixed> $filter
      */
     public function getCampaignMetricsLineChartData($unit, \DateTime $dateFrom, \DateTime $dateTo, $dateFormat = null, array $filter = []): array
     {
@@ -746,6 +748,7 @@ class CampaignModel extends CommonFormModel implements GlobalSearchInterface
      * @param Campaign $entity
      * @param string   $root
      * @param int      $order
+     * @param Event[]  $events
      */
     protected function buildOrder(array $hierarchy, array &$events, $entity, $root = 'null', $order = 1): void
     {

--- a/app/bundles/CampaignBundle/Model/EventLogModel.php
+++ b/app/bundles/CampaignBundle/Model/EventLogModel.php
@@ -82,6 +82,8 @@ final class EventLogModel extends AbstractCommonModel
     }
 
     /**
+     * @param array<string, mixed> $parameters
+     *
      * @return string|mixed[]
      */
     public function updateContactEvent(Event $event, Lead $contact, array $parameters): string|array

--- a/app/bundles/CampaignBundle/Tests/Command/CampaignSummarizationFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Command/CampaignSummarizationFunctionalTest.php
@@ -111,7 +111,7 @@ final class CampaignSummarizationFunctionalTest extends MauticMysqlTestCase
     }
 
     /**
-     * @param mixed[] $properties
+     * @param array<string, int|int[]|string[]|null[]|string|float|null> $properties
      */
     private function createEvent(string $name, Campaign $campaign, array $properties = []): Event
     {

--- a/app/bundles/CampaignBundle/Tests/Functional/EventListener/CampaignSubscriberFunctionalTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/EventListener/CampaignSubscriberFunctionalTest.php
@@ -73,7 +73,7 @@ final class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
     }
 
     /**
-     * @param mixed[] $fieldDetails
+     * @param array<string, string> $fieldDetails
      */
     private function makeField(array $fieldDetails): void
     {
@@ -91,7 +91,7 @@ final class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
     }
 
     /**
-     * @param mixed[] $fieldDetails
+     * @param array<string, string> $fieldDetails
      */
     private function createTestLead(array $fieldDetails): Lead
     {

--- a/app/bundles/CoreBundle/Command/MaxMindDoNotSellPurgeCommand.php
+++ b/app/bundles/CoreBundle/Command/MaxMindDoNotSellPurgeCommand.php
@@ -99,6 +99,9 @@ final class MaxMindDoNotSellPurgeCommand extends Command
         }
     }
 
+    /**
+     * @param string[] $ips
+     */
     private function findContactsFromIPs(array $ips): array
     {
         $in  = "'".implode("','", $ips)."'";

--- a/app/bundles/CoreBundle/Controller/AbstractFormController.php
+++ b/app/bundles/CoreBundle/Controller/AbstractFormController.php
@@ -215,6 +215,8 @@ abstract class AbstractFormController extends CommonController
     /**
      * generate $postActionVars with respect to available referer.
      *
+     * @param array<string, mixed> $vars
+     *
      * @return array
      */
     protected function refererPostActionVars(array $vars)
@@ -244,6 +246,9 @@ abstract class AbstractFormController extends CommonController
         return $vars;
     }
 
+    /**
+     * @param string[] $elements
+     */
     protected function getFormButton(FormInterface $form, array $elements): ClickableInterface
     {
         foreach ($elements as $element) {

--- a/app/bundles/CoreBundle/Controller/AbstractStandardFormController.php
+++ b/app/bundles/CoreBundle/Controller/AbstractStandardFormController.php
@@ -78,7 +78,7 @@ abstract class AbstractStandardFormController extends AbstractFormController
     /**
      * Modify the cloned entity prior to sending through editAction.
      *
-     * @return array of arguments for editAction
+     * @return array<int, mixed> of arguments for editAction
      */
     protected function afterEntityClone($newEntity, $entity)
     {
@@ -562,6 +562,8 @@ abstract class AbstractStandardFormController extends AbstractFormController
 
     /**
      * Get items for index list.
+     *
+     * @return array<int, iterable<object>|\Mautic\CoreBundle\Doctrine\Paginator\SimplePaginator<mixed>|int>
      */
     protected function getIndexItems($start, $limit, $filter, $orderBy, $orderByDir, array $args = [])
     {
@@ -613,6 +615,8 @@ abstract class AbstractStandardFormController extends AbstractFormController
 
     /**
      * Amend the parameters sent through postActionRedirect.
+     *
+     * @param array<array<string, mixed>, mixed> $args
      */
     protected function getPostActionRedirectArguments(array $args, $action): array
     {
@@ -723,6 +727,8 @@ abstract class AbstractStandardFormController extends AbstractFormController
 
     /**
      * Amend the parameters sent through delegateView.
+     *
+     * @param array<array<string, mixed>, mixed> $args
      */
     protected function getViewArguments(array $args, $action): array
     {
@@ -732,7 +738,7 @@ abstract class AbstractStandardFormController extends AbstractFormController
     /**
      * Return array of options for the form when it's being created.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     protected function getEntityFormOptions()
     {
@@ -767,7 +773,7 @@ abstract class AbstractStandardFormController extends AbstractFormController
     /**
      * @param string $timezone
      *
-     * @return array
+     * @return \DateTime[]
      */
     protected function getViewDateRange(Request $request, $objectId, $returnUrl, $timezone = 'local', &$dateRangeForm = null)
     {

--- a/app/bundles/CoreBundle/Controller/AjaxController.php
+++ b/app/bundles/CoreBundle/Controller/AjaxController.php
@@ -34,12 +34,11 @@ class AjaxController extends CommonController
     }
 
     /**
-     * @param int  $statusCode
-     * @param bool $addIgnoreWdt
+     * @param mixed[] $dataArray
      *
      * @throws \Exception
      */
-    protected function sendJsonResponse(array $dataArray, $statusCode = null, $addIgnoreWdt = true): JsonResponse
+    protected function sendJsonResponse(array $dataArray, ?int $statusCode = null, bool $addIgnoreWdt = true): JsonResponse
     {
         $response = new JsonResponse();
 

--- a/app/bundles/CoreBundle/Controller/CommonController.php
+++ b/app/bundles/CoreBundle/Controller/CommonController.php
@@ -102,6 +102,8 @@ class CommonController extends AbstractController implements MauticController
     /**
      * Override this method in your controller
      * for easy access to the permissions.
+     *
+     * @return mixed[]
      */
     protected function getPermissions(): array
     {
@@ -116,10 +118,10 @@ class CommonController extends AbstractController implements MauticController
     /**
      * Forwards the request to another controller and include the POST.
      *
-     * @param string $controller The controller name (a string like BlogBundle:Post:index)
-     * @param array  $request    An array of request parameters
-     * @param array  $path       An array of path parameters
-     * @param array  $query      An array of query parameters
+     * @param string               $controller The controller name (a string like BlogBundle:Post:index)
+     * @param array<string, mixed> $request    An array of request parameters
+     * @param array<string, mixed> $path       An array of path parameters
+     * @param array                $query      An array of query parameters
      *
      * @return Response A Response instance
      */
@@ -245,7 +247,7 @@ class CommonController extends AbstractController implements MauticController
     /**
      * Redirects controller if not ajax or retrieves html output for ajax request.
      *
-     * @param array $args [returnUrl, viewParameters, contentTemplate, passthroughVars, flashes, forwardController]
+     * @param array<string, mixed> $args [returnUrl, viewParameters, contentTemplate, passthroughVars, flashes, forwardController]
      */
     public function postActionRedirect(array $args = []): RedirectResponse|Response
     {
@@ -285,7 +287,7 @@ class CommonController extends AbstractController implements MauticController
     /**
      * Generates html for ajax request.
      *
-     * @param array $args [parameters, contentTemplate, passthroughVars, forwardController]
+     * @param array<string, mixed> $args [parameters, contentTemplate, passthroughVars, forwardController]
      */
     public function ajaxAction(Request $request, array $args = []): Response
     {
@@ -578,6 +580,8 @@ class CommonController extends AbstractController implements MauticController
 
     /**
      * Renders notification info for ajax.
+     *
+     * @return array<string, mixed>
      */
     protected function getNotificationContent(?Request $request = null): array
     {

--- a/app/bundles/CoreBundle/Controller/FileController.php
+++ b/app/bundles/CoreBundle/Controller/FileController.php
@@ -17,6 +17,9 @@ final class FileController extends AjaxController
 {
     public const string EDITOR_CKEDITOR = 'ckeditor';
 
+    /**
+     * @var array<string, mixed>
+     */
     private array $response = [];
 
     private int $statusCode = Response::HTTP_OK;
@@ -72,11 +75,11 @@ final class FileController extends AjaxController
                 if (!is_dir($name)) {
                     try {
                         $fileUploader->validateImage($imageFile);
-                        $this->response[] = [
+                        $this->response = array_merge($this->response, [
                             'url'   => $imageUrl,
                             'thumb' => $imageUrl,
                             'name'  => $name,
-                        ];
+                        ]);
                     } catch (FileUploadException) {
                     }
                 }

--- a/app/bundles/CoreBundle/Controller/ThemeController.php
+++ b/app/bundles/CoreBundle/Controller/ThemeController.php
@@ -307,6 +307,8 @@ final class ThemeController extends FormController
 
     /**
      * A helper method to keep the code DRY.
+     *
+     * @return array<string, string|array<string, string>>
      */
     public function getIndexPostActionVars(): array
     {

--- a/app/bundles/CoreBundle/DependencyInjection/Builder/BundleMetadataBuilder.php
+++ b/app/bundles/CoreBundle/DependencyInjection/Builder/BundleMetadataBuilder.php
@@ -104,6 +104,9 @@ final class BundleMetadataBuilder
         return $metadata->toArray();
     }
 
+    /**
+     * @return array<string, bool|string|null>
+     */
     private function getMetadata(bool $isPlugin, string $namespace, string $symfonyBundle, string $bundleName, string $relativePath): array
     {
         return [

--- a/app/bundles/CoreBundle/Doctrine/AbstractMauticMigration.php
+++ b/app/bundles/CoreBundle/Doctrine/AbstractMauticMigration.php
@@ -167,7 +167,7 @@ abstract class AbstractMauticMigration extends AbstractMigration
     /**
      * Generate index and foreign constraint.
      *
-     * @return array [idx, fk]
+     * @return array<int, string> [idx, fk]
      */
     protected function generateKeys($table, array $columnNames)
     {

--- a/app/bundles/CoreBundle/Doctrine/Connection/ConnectionWrapper.php
+++ b/app/bundles/CoreBundle/Doctrine/Connection/ConnectionWrapper.php
@@ -10,6 +10,8 @@ use Doctrine\DBAL\Exception;
 class ConnectionWrapper extends Connection
 {
     /**
+     * @param array<string, mixed> $dbParams
+     *
      * @throws Exception
      */
     public function initConnection(array $dbParams): void

--- a/app/bundles/CoreBundle/Doctrine/GeneratedColumn/GeneratedColumn.php
+++ b/app/bundles/CoreBundle/Doctrine/GeneratedColumn/GeneratedColumn.php
@@ -16,6 +16,9 @@ final class GeneratedColumn implements GeneratedColumnInterface
 
     private ?string $timeUnit = null;
 
+    /**
+     * @var string[]
+     */
     private array $indexColumns = [];
 
     private ?string $filterDateColumn = null;
@@ -95,6 +98,9 @@ final class GeneratedColumn implements GeneratedColumnInterface
         return "{$this->columnType} AS ({$this->as}){$stored} COMMENT '(DC2Type:generated)'";
     }
 
+    /**
+     * @return string[]
+     */
     public function getIndexColumns(): array
     {
         return $this->indexColumns;

--- a/app/bundles/CoreBundle/Doctrine/Helper/ColumnSchemaHelper.php
+++ b/app/bundles/CoreBundle/Doctrine/Helper/ColumnSchemaHelper.php
@@ -125,7 +125,8 @@ class ColumnSchemaHelper
      *                           ['type']    string (optional) Doctrine type for column; defaults to text
      *                           ['options'] array  (optional) Defining options for column
      *
-     * @param bool $checkExists Check if table exists; pass false if this has already been done
+     * @param bool                 $checkExists Check if table exists; pass false if this has already been done
+     * @param array<string, mixed> $column
      *
      * @throws SchemaException
      */

--- a/app/bundles/CoreBundle/Doctrine/Helper/TableSchemaHelper.php
+++ b/app/bundles/CoreBundle/Doctrine/Helper/TableSchemaHelper.php
@@ -93,6 +93,8 @@ class TableSchemaHelper
      *                     'uniqueIndex' => array()
      *                     )
      *
+     * @param array<string, mixed> $table
+     *
      * @throws SchemaException
      */
     public function addTable(array $table, $checkExists = true, $dropExisting = false): static

--- a/app/bundles/CoreBundle/Doctrine/Paginator/SimplePaginator.php
+++ b/app/bundles/CoreBundle/Doctrine/Paginator/SimplePaginator.php
@@ -27,10 +27,7 @@ final class SimplePaginator implements \IteratorAggregate, \Countable
     ) {
     }
 
-    /**
-     * @return \Traversable<mixed>
-     */
-    public function getIterator(): \Traversable
+    public function getIterator(): \ArrayIterator
     {
         return new \ArrayIterator($this->query->getResult());
     }

--- a/app/bundles/CoreBundle/Entity/CommonRepository.php
+++ b/app/bundles/CoreBundle/Entity/CommonRepository.php
@@ -94,7 +94,8 @@ class CommonRepository extends ServiceEntityRepository
     /**
      * Examines the arguments passed to getEntities and converts ORM properties to dBAL column names.
      *
-     * @param string $entityClass
+     * @param string               $entityClass
+     * @param array<string, mixed> $args
      */
     public function convertOrmProperties($entityClass, array $args): array
     {
@@ -434,6 +435,8 @@ class CommonRepository extends ServiceEntityRepository
 
     /**
      * @param array<mixed> $filter
+     *
+     * @return array<int, mixed>
      */
     public function getFilterExpr(QueryBuilder|DbalQueryBuilder $q, array $filter, ?string $unique = null): array
     {
@@ -622,6 +625,8 @@ class CommonRepository extends ServiceEntityRepository
      *
      * @param int $start
      * @param int $limit
+     *
+     * @return array<string, mixed>
      */
     public function getRows($start = 0, $limit = 100, array $order = [], array $where = [], ?array $select = null, array $allowedJoins = []): array
     {
@@ -961,7 +966,7 @@ class CommonRepository extends ServiceEntityRepository
     /**
      * Validate array for one order by condition.
      *
-     * @param array $clause ['col' => 'column_a', 'dir' => 'ASC']
+     * @param array<string, mixed> $clause ['col' => 'column_a', 'dir' => 'ASC']
      *
      * @throws \InvalidArgumentException
      */
@@ -985,7 +990,7 @@ class CommonRepository extends ServiceEntityRepository
     /**
      * Validate the array for one where condition.
      *
-     * @param array $clause ['expr' => 'expression', 'col' => 'DB column', 'val' => 'value to search for']
+     * @param array<string, mixed> $clause ['expr' => 'expression', 'col' => 'DB column', 'val' => 'value to search for']
      *
      * @throws \InvalidArgumentException
      */
@@ -1019,7 +1024,7 @@ class CommonRepository extends ServiceEntityRepository
     /**
      * @param \stdClass|mixed[] $filters
      *
-     * @return mixed[]
+     * @return array<int, mixed>
      */
     protected function addAdvancedSearchWhereClause(QueryBuilder|DbalQueryBuilder $qb, $filters): array
     {
@@ -1072,6 +1077,8 @@ class CommonRepository extends ServiceEntityRepository
 
     /**
      * Unique handling for $filter->not since dbal does not support the not() function with it's QueryBuilder.
+     *
+     * @return array<int, Query\Expr\Orx|CompositeExpression|Query\Expr\Andx|non-empty-array<string, mixed>>
      */
     protected function addDbalCatchAllWhereClause(QueryBuilder|DbalQueryBuilder &$q, \stdClass $filter, array $columns): array
     {
@@ -1099,6 +1106,9 @@ class CommonRepository extends ServiceEntityRepository
         ];
     }
 
+    /**
+     * @return array<int, Query\Expr\Func|string|mixed[]|bool>
+     */
     protected function addSearchCommandWhereClause(QueryBuilder|DbalQueryBuilder $queryBuilder, \stdClass $filter): array
     {
         $command = $filter->command;
@@ -1117,6 +1127,9 @@ class CommonRepository extends ServiceEntityRepository
         ];
     }
 
+    /**
+     * @return array<int, CompositeExpression|Query\Expr\Orx|Query\Expr\Andx|Query\Expr\Func|non-empty-array<string, mixed>>
+     */
     protected function addStandardCatchAllWhereClause(QueryBuilder|DbalQueryBuilder &$q, \stdClass $filter, array $columns): array
     {
         $unique = $this->generateRandomParameterName(); // ensure that the string has a unique parameter identifier
@@ -1162,6 +1175,9 @@ class CommonRepository extends ServiceEntityRepository
         ];
     }
 
+    /**
+     * @return array<int, Query\Expr\Func|Query\Expr\Comparison|Query\Expr\Orx|CompositeExpression|string|array<string, mixed>|bool>
+     */
     protected function addStandardSearchCommandWhereClause(QueryBuilder|DbalQueryBuilder &$queryBuilder, \stdClass $filter): array
     {
         $command         = $filter->command;
@@ -1309,6 +1325,9 @@ class CommonRepository extends ServiceEntityRepository
         return $joinAdded;
     }
 
+    /**
+     * @param array<string, mixed> $args
+     */
     protected function buildIndexByClause(QueryBuilder|DbalQueryBuilder $q, array $args)
     {
         if (!empty($args['index_by'])) {
@@ -1325,6 +1344,9 @@ class CommonRepository extends ServiceEntityRepository
         }
     }
 
+    /**
+     * @param array<string, mixed> $args
+     */
     protected function buildLimiterClauses(QueryBuilder|DbalQueryBuilder $q, array $args): void
     {
         $start = array_key_exists('start', $args) ? $args['start'] : 0;
@@ -1336,6 +1358,9 @@ class CommonRepository extends ServiceEntityRepository
         }
     }
 
+    /**
+     * @param array<string, mixed> $args
+     */
     protected function buildOrderByClause(QueryBuilder|DbalQueryBuilder $q, array $args): void
     {
         $orderBy = array_key_exists('orderBy', $args) ? $args['orderBy'] : '';
@@ -1376,6 +1401,9 @@ class CommonRepository extends ServiceEntityRepository
         }
     }
 
+    /**
+     * @param array<string, mixed> $args
+     */
     protected function buildSelectClause(QueryBuilder|DbalQueryBuilder $q, array $args)
     {
         $isOrm = $q instanceof QueryBuilder;
@@ -1444,6 +1472,9 @@ class CommonRepository extends ServiceEntityRepository
         }
     }
 
+    /**
+     * @param array<string, mixed> $args
+     */
     protected function buildWhereClause(QueryBuilder|DbalQueryBuilder $q, array $args)
     {
         $filter                    = array_key_exists('filter', $args) ? $args['filter'] : '';
@@ -1670,6 +1701,9 @@ class CommonRepository extends ServiceEntityRepository
         return 'par'.$value;
     }
 
+    /**
+     * @return array<string[]>
+     */
     protected function getDefaultOrder(): array
     {
         return [];

--- a/app/bundles/CoreBundle/ErrorHandler/ErrorHandler.php
+++ b/app/bundles/CoreBundle/ErrorHandler/ErrorHandler.php
@@ -370,7 +370,7 @@ namespace Mautic\CoreBundle\ErrorHandler {
         }
 
         /**
-         * @param mixed[] $context
+         * @param array<string, mixed> $context
          */
         private function log(string $logLevel, string $message, array $context = [], ?array $debugTrace = null): void
         {
@@ -395,7 +395,7 @@ namespace Mautic\CoreBundle\ErrorHandler {
         }
 
         /**
-         * @param mixed[] $error
+         * @param array<string, mixed> $error
          */
         private function generateResponse(array $error, bool $inTemplate = false): string|false
         {

--- a/app/bundles/CoreBundle/Event/BuilderEvent.php
+++ b/app/bundles/CoreBundle/Event/BuilderEvent.php
@@ -87,6 +87,10 @@ class BuilderEvent extends Event
         $this->abTestWinnerCriteria[$key] = $criteria;
     }
 
+    /**
+     * @param string[]              $keys
+     * @param array<string, string> $criteria
+     */
     private function verifyCriteria(array $keys, array $criteria): void
     {
         foreach ($keys as $k) {
@@ -162,6 +166,8 @@ class BuilderEvent extends Event
 
     /**
      * Get text of the search filter.
+     *
+     * @return array<string, string|string[]>
      */
     public function getTokenFilter(): array
     {

--- a/app/bundles/CoreBundle/Event/CustomButtonEvent.php
+++ b/app/bundles/CoreBundle/Event/CustomButtonEvent.php
@@ -56,8 +56,9 @@ final class CustomButtonEvent extends AbstractCustomRequestEvent
     /**
      * Add a single button.
      *
-     * @param string|null $location
-     * @param string|null $route
+     * @param string|null          $location
+     * @param string|null          $route
+     * @param array<string, mixed> $button
      */
     public function addButton(array $button, $location = null, $route = null): static
     {
@@ -104,6 +105,8 @@ final class CustomButtonEvent extends AbstractCustomRequestEvent
 
     /**
      * Generate a button ID that can be overridden by other plugins.
+     *
+     * @param array<string, mixed> $button
      */
     private function generateButtonKey(array $button): string
     {

--- a/app/bundles/CoreBundle/Event/CustomContentEvent.php
+++ b/app/bundles/CoreBundle/Event/CustomContentEvent.php
@@ -8,8 +8,14 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 final class CustomContentEvent extends Event
 {
+    /**
+     * @var string[]
+     */
     private array $content = [];
 
+    /**
+     * @var array<mixed, array<string, string|mixed[]>>
+     */
     private array $templates = [];
 
     /**
@@ -74,11 +80,17 @@ final class CustomContentEvent extends Event
         return $this->vars;
     }
 
+    /**
+     * @return string[]
+     */
     public function getContent(): array
     {
         return $this->content;
     }
 
+    /**
+     * @return array<mixed, array<string, string|mixed[]>>
+     */
     public function getTemplates(): array
     {
         return $this->templates;

--- a/app/bundles/CoreBundle/Event/MenuEvent.php
+++ b/app/bundles/CoreBundle/Event/MenuEvent.php
@@ -25,6 +25,8 @@ final class MenuEvent extends Event
 
     /**
      * Add items to the menu.
+     *
+     * @param array<string, mixed> $menuItems
      */
     public function addMenuItems(array $menuItems): void
     {

--- a/app/bundles/CoreBundle/Event/StatsEvent.php
+++ b/app/bundles/CoreBundle/Event/StatsEvent.php
@@ -176,6 +176,8 @@ class StatsEvent extends Event
 
     /**
      * Add an array of results and if so, stop propagation.
+     *
+     * @param array<string, mixed> $results
      */
     public function setResults(array $results): void
     {

--- a/app/bundles/CoreBundle/EventListener/CommonStatsSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/CommonStatsSubscriber.php
@@ -106,6 +106,9 @@ abstract class CommonStatsSubscriber implements EventSubscriberInterface
         return $this->addRestrictedRepostories($repoNames, ['lead' => 'lead:leads']);
     }
 
+    /**
+     * @param array<string, string> $permissions
+     */
     protected function addRestrictedRepostories(array $repoNames, array $permissions)
     {
         foreach ($repoNames as $repoName) {

--- a/app/bundles/CoreBundle/EventListener/CoreSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/CoreSubscriber.php
@@ -244,6 +244,9 @@ final readonly class CoreSubscriber implements EventSubscriberInterface
         }
     }
 
+    /**
+     * @param array<string, mixed> $details
+     */
     private function addRouteToCollection(RouteCollection $collection, string $type, string $name, array $details): void
     {
         // Set defaults and controller

--- a/app/bundles/CoreBundle/EventListener/DoctrineEventsSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/DoctrineEventsSubscriber.php
@@ -16,6 +16,9 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
 #[AsDoctrineListener(ToolEvents::postGenerateSchema)]
 final class DoctrineEventsSubscriber
 {
+    /**
+     * @var string[]
+     */
     private array $deprecatedEntityTables = [];
 
     public function __construct(

--- a/app/bundles/CoreBundle/Form/ChoiceLoader/EntityLookupChoiceLoader.php
+++ b/app/bundles/CoreBundle/Form/ChoiceLoader/EntityLookupChoiceLoader.php
@@ -170,6 +170,8 @@ final class EntityLookupChoiceLoader implements ChoiceLoaderInterface
     }
 
     /**
+     * @param int[] $data
+     *
      * @return array|mixed
      */
     private function fetchChoices(string $modelName, array $data = [])

--- a/app/bundles/CoreBundle/Form/Type/ContentPreviewSettingsType.php
+++ b/app/bundles/CoreBundle/Form/Type/ContentPreviewSettingsType.php
@@ -89,7 +89,7 @@ final class ContentPreviewSettingsType extends AbstractType
     }
 
     /**
-     * @param mixed[] $variants
+     * @param array<string, mixed> $variants
      */
     private function addTranslationOrVariantChoicesElement(
         FormBuilderInterface $builder,

--- a/app/bundles/CoreBundle/Form/Type/DynamicContentFilterEntryType.php
+++ b/app/bundles/CoreBundle/Form/Type/DynamicContentFilterEntryType.php
@@ -25,22 +25,22 @@ final class DynamicContentFilterEntryType extends AbstractType
     private array $fieldChoices = [];
 
     /**
-     * @var mixed[]
+     * @var array<string, string>
      */
     private readonly array $countryChoices;
 
     /**
-     * @var mixed[]
+     * @var array<string, array<string, string>>
      */
     private readonly array $regionChoices;
 
     /**
-     * @var mixed[]
+     * @var array<string, mixed>
      */
     private readonly array $timezoneChoices;
 
     /**
-     * @var mixed[]
+     * @var array<string, string>
      */
     private readonly array $localeChoices;
 

--- a/app/bundles/CoreBundle/Form/Type/PropertiesTrait.php
+++ b/app/bundles/CoreBundle/Form/Type/PropertiesTrait.php
@@ -9,6 +9,8 @@ trait PropertiesTrait
 {
     /**
      * @param FormBuilderInterface|Form $builder
+     * @param array<string, mixed>      $options
+     * @param array<string, mixed>      $masks
      */
     protected function addPropertiesType($builder, array $options, array &$masks): void
     {

--- a/app/bundles/CoreBundle/Form/Validator/Constraints/CircularDependencyValidator.php
+++ b/app/bundles/CoreBundle/Form/Validator/Constraints/CircularDependencyValidator.php
@@ -52,6 +52,9 @@ final class CircularDependencyValidator extends ConstraintValidator
         return (int) $routeParams['objectId'];
     }
 
+    /**
+     * @param mixed[][] $filters
+     */
     private function reduceToSegmentIds(array $filters): array
     {
         $segmentFilters = array_filter($filters, fn (array $filter): bool => 'leadlist' === $filter['type']
@@ -66,6 +69,9 @@ final class CircularDependencyValidator extends ConstraintValidator
         return $this->flatten($segentIdsInFilter);
     }
 
+    /**
+     * @param mixed[][] $array
+     */
     private function flatten(array $array): array
     {
         return array_unique(array_reduce($array, array_merge(...), []));

--- a/app/bundles/CoreBundle/Helper/AbstractFormFieldHelper.php
+++ b/app/bundles/CoreBundle/Helper/AbstractFormFieldHelper.php
@@ -221,7 +221,7 @@ abstract class AbstractFormFieldHelper
     }
 
     /**
-     * @param mixed[] $choices
+     * @param array<string, mixed> $choices
      *
      * @return mixed[]
      */

--- a/app/bundles/CoreBundle/Helper/AssetGenerationHelper.php
+++ b/app/bundles/CoreBundle/Helper/AssetGenerationHelper.php
@@ -195,7 +195,7 @@ final readonly class AssetGenerationHelper
                                     throw new \ErrorException('These files are missing: '.implode(', ', $missing).'. Have you forgot to install/update modules?');
                                 }
 
-                                if ('css' == $type) {
+                                if ('css' === $type) {
                                     $minifier = new Minify\CSS(...array_column($files, 'fullPath'));
                                     $minifier->minify($assetFile);
                                 } else {
@@ -235,7 +235,7 @@ final readonly class AssetGenerationHelper
     /**
      * Finds directory assets.
      *
-     * @param mixed[] $assets
+     * @param array<string, mixed> $assets
      *
      * @return array<string, false|int>
      */
@@ -322,6 +322,8 @@ final readonly class AssetGenerationHelper
 
     /**
      * Find asset overrides in the template.
+     *
+     * @param array<string, mixed> $assets
      */
     private function findOverrides(string $env, array &$assets): array
     {

--- a/app/bundles/CoreBundle/Helper/Chart/BarChart.php
+++ b/app/bundles/CoreBundle/Helper/Chart/BarChart.php
@@ -51,6 +51,8 @@ final class BarChart extends AbstractChart implements ChartInterface
      * Generate unique color for the dataset.
      *
      * @param int $datasetId
+     *
+     * @return array<string, string|bool>
      */
     public function generateColors($datasetId): array
     {

--- a/app/bundles/CoreBundle/Helper/Chart/ChartQuery.php
+++ b/app/bundles/CoreBundle/Helper/Chart/ChartQuery.php
@@ -292,6 +292,8 @@ class ChartQuery extends AbstractChart
 
     /**
      * Go through the raw data and add the missing times.
+     *
+     * @param array<int, array<string, mixed>> $rawData
      */
     public function completeTimeData(array $rawData, $countAverage = false): array
     {
@@ -433,9 +435,9 @@ class ChartQuery extends AbstractChart
     /**
      * Modify the query to count occurences of a value in a column.
      *
-     * @param string $uniqueColumn name
-     * @param array  $options      for special behavior
-     * @param string $tablePrefix
+     * @param string               $uniqueColumn name
+     * @param array<string, mixed> $options      for special behavior
+     * @param string               $tablePrefix
      */
     public function modifyCountQuery(QueryBuilder &$query, $uniqueColumn, array $options = [], $tablePrefix = 't')
     {

--- a/app/bundles/CoreBundle/Helper/Chart/LineChart.php
+++ b/app/bundles/CoreBundle/Helper/Chart/LineChart.php
@@ -10,6 +10,8 @@ final class LineChart extends AbstractChart implements ChartInterface
     /**
      * Match date/time unit to a humanly readable label
      * {@link php.net/manual/en/function.date.php#refsect1-function.date-parameters}.
+     *
+     * @var array<string, string>
      */
     private array $labelFormats = [
         's' => 'H:i:s',
@@ -106,6 +108,8 @@ final class LineChart extends AbstractChart implements ChartInterface
      * Generate unique color for the dataset.
      *
      * @param int $datasetId
+     *
+     * @return array<string, string>
      */
     public function generateColors($datasetId): array
     {

--- a/app/bundles/CoreBundle/Helper/ColorHelper.php
+++ b/app/bundles/CoreBundle/Helper/ColorHelper.php
@@ -58,6 +58,8 @@ final class ColorHelper
 
     /**
      * Returns array of [R, G, B] of current state.
+     *
+     * @return array<int, int|float>
      */
     public function getColorArray(): array
     {

--- a/app/bundles/CoreBundle/Helper/DataExporterHelper.php
+++ b/app/bundles/CoreBundle/Helper/DataExporterHelper.php
@@ -16,6 +16,8 @@ final class DataExporterHelper
      *
      * @template T of object
      *
+     * @param array<string, mixed> $args
+     *
      * @return mixed[]|null
      */
     public function getDataForExport(
@@ -57,6 +59,9 @@ final class DataExporterHelper
         return $toExport;
     }
 
+    /**
+     * @param string[] $row
+     */
     private function secureAgainstCsvInjection(array $row): array
     {
         foreach ($row as $colNum => $colVal) {

--- a/app/bundles/CoreBundle/Helper/ExportHelper.php
+++ b/app/bundles/CoreBundle/Helper/ExportHelper.php
@@ -42,6 +42,8 @@ readonly class ExportHelper
 
     /**
      * Returns supported export types as an array.
+     *
+     * @return array<int, string>
      */
     public function getSupportedExportTypes(): array
     {

--- a/app/bundles/CoreBundle/Helper/InputHelper.php
+++ b/app/bundles/CoreBundle/Helper/InputHelper.php
@@ -92,7 +92,7 @@ final class InputHelper
     /**
      * Wrapper to InputHelper.
      *
-     * @param mixed[] $arguments
+     * @param array<int, mixed> $arguments
      *
      * @return mixed
      */

--- a/app/bundles/CoreBundle/Helper/PRedisConnectionHelper.php
+++ b/app/bundles/CoreBundle/Helper/PRedisConnectionHelper.php
@@ -53,7 +53,7 @@ final class PRedisConnectionHelper
     /**
      * Transform the redis mautic config to an options array consumable by PRedis.
      *
-     * @param array $redisConfiguration mautic's redis configuration
+     * @param array<string, mixed> $redisConfiguration mautic's redis configuration
      */
     public static function makeRedisOptions(array $redisConfiguration, string $prefix = ''): array
     {
@@ -82,8 +82,8 @@ final class PRedisConnectionHelper
     }
 
     /**
-     * @param mixed[] $endpoints
-     * @param mixed[] $inputOptions
+     * @param mixed[]              $endpoints
+     * @param array<string, mixed> $inputOptions
      */
     public static function createClient(array $endpoints, array $inputOptions): Client
     {

--- a/app/bundles/CoreBundle/Helper/SearchStringHelper.php
+++ b/app/bundles/CoreBundle/Helper/SearchStringHelper.php
@@ -10,17 +10,26 @@ final class SearchStringHelper
 
     public const int COMMAND_NEUTRAL = 2;
 
+    /**
+     * @var string[]
+     */
     private array $needsParsing = [
         ' ',
         '(',
         ')',
     ];
 
+    /**
+     * @var array<string, string>
+     */
     private array $needsClosing = [
         'quote'       => '"',
         'parenthesis' => '(',
     ];
 
+    /**
+     * @var array<string, string>
+     */
     private array $closingChars = [
         'quote'       => '"',
         'parenthesis' => ')',

--- a/app/bundles/CoreBundle/Helper/ThemeHelper.php
+++ b/app/bundles/CoreBundle/Helper/ThemeHelper.php
@@ -594,6 +594,9 @@ class ThemeHelper implements ThemeHelperInterface
         $this->sortThemesInfo($key);
     }
 
+    /**
+     * @param array<string, mixed> $config
+     */
     private function shouldLoadTheme(array $config, string $featureRequested): bool
     {
         if ('all' === $featureRequested) {

--- a/app/bundles/CoreBundle/Helper/Tree/IntNode.php
+++ b/app/bundles/CoreBundle/Helper/Tree/IntNode.php
@@ -56,6 +56,9 @@ final class IntNode implements NodeInterface
         return $this->params[$key] ?? $default;
     }
 
+    /**
+     * @return NodeInterface[]
+     */
     public function getChildrenArray(): array
     {
         return $this->children;

--- a/app/bundles/CoreBundle/Helper/Tree/JsPlumbFormatter.php
+++ b/app/bundles/CoreBundle/Helper/Tree/JsPlumbFormatter.php
@@ -37,7 +37,7 @@ final class JsPlumbFormatter implements NodeFormatterInterface
     }
 
     /**
-     * @param mixed[] $data
+     * @param array<string, mixed[]> $data
      *
      * @return mixed[]
      */

--- a/app/bundles/CoreBundle/Helper/Update/Github/Release.php
+++ b/app/bundles/CoreBundle/Helper/Update/Github/Release.php
@@ -24,6 +24,8 @@ final class Release
     private readonly Metadata $metadata;
 
     /**
+     * @param array<string, mixed> $release
+     *
      * @throws UpdatePackageNotFoundException
      */
     public function __construct(array $release, Metadata $metadata)

--- a/app/bundles/CoreBundle/Helper/UrlHelper.php
+++ b/app/bundles/CoreBundle/Helper/UrlHelper.php
@@ -101,6 +101,8 @@ final class UrlHelper
      * With exception of URLs used as a token default values.
      *
      * @param string $text
+     *
+     * @return string[]
      */
     public static function getUrlsFromPlaintext($text, array $contactUrlFields = []): array
     {

--- a/app/bundles/CoreBundle/IpLookup/AbstractLookup.php
+++ b/app/bundles/CoreBundle/IpLookup/AbstractLookup.php
@@ -75,7 +75,7 @@ abstract class AbstractLookup
     /**
      * Return details of the IP address lookup.
      *
-     * @return array
+     * @return array<string, mixed>
      */
     public function getDetails()
     {

--- a/app/bundles/CoreBundle/IpLookup/AbstractRemoteDataLookup.php
+++ b/app/bundles/CoreBundle/IpLookup/AbstractRemoteDataLookup.php
@@ -27,7 +27,7 @@ abstract class AbstractRemoteDataLookup extends AbstractLookup
     abstract protected function parseResponse($response);
 
     /**
-     * @return array
+     * @return array<string, mixed>
      */
     protected function getHeaders()
     {
@@ -35,7 +35,7 @@ abstract class AbstractRemoteDataLookup extends AbstractLookup
     }
 
     /**
-     * @return array
+     * @return array{}
      */
     protected function getParameters()
     {

--- a/app/bundles/CoreBundle/Menu/MenuHelper.php
+++ b/app/bundles/CoreBundle/Menu/MenuHelper.php
@@ -257,6 +257,8 @@ final class MenuHelper
     /**
      * Handle access check and other checks for menu items.
      *
+     * @param array<string, mixed> $menuItem
+     *
      * @return bool Returns false if the item fails the access check or any other checks
      */
     private function handleChecks(array $menuItem): bool

--- a/app/bundles/CoreBundle/Model/AbstractCommonModel.php
+++ b/app/bundles/CoreBundle/Model/AbstractCommonModel.php
@@ -39,7 +39,7 @@ abstract class AbstractCommonModel implements MauticModelInterface, SearchComman
     /**
      * Retrieve the supported search commands for a repository.
      *
-     * @return array
+     * @return mixed[]
      */
     public function getSupportedSearchCommands()
     {

--- a/app/bundles/CoreBundle/Model/AuditLogModel.php
+++ b/app/bundles/CoreBundle/Model/AuditLogModel.php
@@ -34,7 +34,7 @@ class AuditLogModel extends AbstractCommonModel
     /**
      * Writes an entry to the audit log.
      *
-     * @param array $args [bundle, object, objectId, action, details, ipAddress]
+     * @param array<string, mixed> $args [bundle, object, objectId, action, details, ipAddress]
      */
     public function writeToLog(array $args): void
     {

--- a/app/bundles/CoreBundle/Model/FormModel.php
+++ b/app/bundles/CoreBundle/Model/FormModel.php
@@ -410,7 +410,7 @@ class FormModel extends AbstractCommonModel
     /**
      * Dispatches batch events for child classes.
      *
-     * @param mixed[] $entitiesBatchParams
+     * @param array<int, array<string, object|bool|null>>|array<int, array<string, mixed>> $entitiesBatchParams
      */
     protected function dispatchBatchEvent(string $action, array &$entitiesBatchParams, ?Event $event = null): ?Event
     {

--- a/app/bundles/CoreBundle/Predis/Replication/StrategyConfig.php
+++ b/app/bundles/CoreBundle/Predis/Replication/StrategyConfig.php
@@ -12,7 +12,7 @@ final readonly class StrategyConfig
     }
 
     /**
-     * @param mixed[] $options
+     * @param array<string, mixed> $options
      */
     public static function fromArray(array $options): self
     {

--- a/app/bundles/CoreBundle/Release/Metadata.php
+++ b/app/bundles/CoreBundle/Release/Metadata.php
@@ -38,6 +38,9 @@ final readonly class Metadata implements \JsonSerializable
 
     private string $minSupportedMariaDbVersion;
 
+    /**
+     * @param array<string, mixed> $metadata
+     */
     public function __construct(array $metadata)
     {
         $this->version                      = $metadata['version'];

--- a/app/bundles/CoreBundle/Security/Permissions/AbstractPermissions.php
+++ b/app/bundles/CoreBundle/Security/Permissions/AbstractPermissions.php
@@ -144,7 +144,7 @@ abstract class AbstractPermissions
      * @param string $name
      * @param string $level
      *
-     * @return array
+     * @return array<int, string>
      */
     protected function getSynonym($name, $level)
     {
@@ -188,8 +188,9 @@ abstract class AbstractPermissions
     /**
      * Determines if the user has access to the specified permission.
      *
-     * @param string $name
-     * @param string $level
+     * @param string               $name
+     * @param string               $level
+     * @param array<string, mixed> $userPermissions
      */
     public function isGranted(array $userPermissions, $name, $level): bool
     {
@@ -211,7 +212,8 @@ abstract class AbstractPermissions
     }
 
     /**
-     * @param bool $isSecondRound
+     * @param bool                 $isSecondRound
+     * @param array<string, mixed> $permissions
      *
      * @return bool Return true if a second round is required after all other bundles have analyzed it's permissions
      */
@@ -261,7 +263,7 @@ abstract class AbstractPermissions
     /**
      * Generates an array of granted and total permissions.
      *
-     * @return array
+     * @return array<int, int>
      */
     public function getPermissionRatio(array $data)
     {
@@ -362,6 +364,7 @@ abstract class AbstractPermissions
      * @param string               $level
      * @param FormBuilderInterface $builder
      * @param bool                 $includePublish
+     * @param array<string, mixed> $data
      */
     protected function addStandardFormFields($bundle, $level, &$builder, array $data, $includePublish = true)
     {
@@ -427,6 +430,7 @@ abstract class AbstractPermissions
      * @param string               $bundle
      * @param string               $level
      * @param FormBuilderInterface $builder
+     * @param array<string, mixed> $data
      */
     protected function addManageFormFields($bundle, $level, &$builder, array $data)
     {
@@ -486,6 +490,7 @@ abstract class AbstractPermissions
      * @param string               $level
      * @param FormBuilderInterface $builder
      * @param bool                 $includePublish
+     * @param array<string, mixed> $data
      */
     protected function addExtendedFormFields($bundle, $level, &$builder, array $data, $includePublish = true)
     {

--- a/app/bundles/CoreBundle/Test/AbstractMauticTestCase.php
+++ b/app/bundles/CoreBundle/Test/AbstractMauticTestCase.php
@@ -49,6 +49,9 @@ abstract class AbstractMauticTestCase extends WebTestCase
         'PHP_AUTH_PW'   => 'Maut1cR0cks!',
     ];
 
+    /**
+     * @var array<string, mixed>
+     */
     protected array $configParams = [
         'api_enabled'                       => true,
         'api_enable_basic_auth'             => true,
@@ -108,6 +111,9 @@ abstract class AbstractMauticTestCase extends WebTestCase
         restore_exception_handler();
     }
 
+    /**
+     * @param array<string, mixed> $defaultConfigOptions
+     */
     protected function setUpSymfony(array $defaultConfigOptions = []): void
     {
         putenv('MAUTIC_CONFIG_PARAMETERS='.json_encode($defaultConfigOptions));

--- a/app/bundles/CoreBundle/Test/Doctrine/DBALMocker.php
+++ b/app/bundles/CoreBundle/Test/Doctrine/DBALMocker.php
@@ -23,6 +23,9 @@ final class DBALMocker
 
     private $queryResponse;
 
+    /**
+     * @var array<string, mixed[]>
+     */
     private array $queryParts = [
         'select'     => [],
         'from'       => [],
@@ -40,12 +43,15 @@ final class DBALMocker
         $this->queryResponse = $queryResponse;
     }
 
+    /**
+     * @return array<string, mixed[]>
+     */
     public function getQueryParts(): array
     {
         return $this->queryParts;
     }
 
-    public function getQueryPart($part)
+    public function getQueryPart(string $part): array
     {
         if (array_key_exists($part, $this->queryParts)) {
             return $this->queryParts[$part];

--- a/app/bundles/CoreBundle/Tests/Form/ToBcBccFieldsTraitTest.php
+++ b/app/bundles/CoreBundle/Tests/Form/ToBcBccFieldsTraitTest.php
@@ -20,6 +20,9 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 #[AllowMockObjectsWithoutExpectations]
 final class ToBcBccFieldsTraitTest extends TypeTestCase
 {
+    /**
+     * @return ValidatorExtension[]
+     */
     protected function getExtensions(): array
     {
         $translator = $this->createMock(TranslatorInterface::class);

--- a/app/bundles/CoreBundle/Tests/Unit/Form/Type/ContentPreviewSettingsTypeTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Form/Type/ContentPreviewSettingsTypeTest.php
@@ -39,7 +39,7 @@ final class ContentPreviewSettingsTypeTest extends TestCase
     private MockObject $userHelperMock;
 
     /**
-     * @var mixed[]
+     * @var string[]|array<string, array<string, string>>[]
      */
     private array $contactFieldDefinition = [
         'contact',

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/ThemeHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/ThemeHelperTest.php
@@ -605,6 +605,9 @@ final class ThemeHelperTest extends TestCase
 
 final class ThemeHelperRuntimeBackedFilterExtension extends AbstractExtension
 {
+    /**
+     * @return TwigFilter[]
+     */
     public function getFilters(): array
     {
         return [

--- a/app/bundles/CoreBundle/Tests/Unit/Service/BulkNotificationTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Service/BulkNotificationTest.php
@@ -46,8 +46,8 @@ final class BulkNotificationTest extends TestCase
     }
 
     /**
-     * @param mixed[] $data
-     * @param mixed[] $notification
+     * @param \DateTime[]|User[]|string[] $data
+     * @param array<int, mixed>           $notification
      */
     private function assertNotification(array $data, array $notification, ?\DateTime $deduplicateDateTimeFrom): void
     {

--- a/app/bundles/CoreBundle/Twig/Extension/CoreHelpersExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/CoreHelpersExtension.php
@@ -21,6 +21,9 @@ final class CoreHelpersExtension extends AbstractExtension
     ) {
     }
 
+    /**
+     * @return TwigFunction[]
+     */
     public function getFunctions(): array
     {
         return [

--- a/app/bundles/CoreBundle/Twig/Extension/DeviceExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/DeviceExtension.php
@@ -10,6 +10,9 @@ use Twig\TwigFunction;
 
 final class DeviceExtension extends AbstractExtension
 {
+    /**
+     * @return TwigFunction[]
+     */
     public function getFunctions(): array
     {
         return [

--- a/app/bundles/CoreBundle/Twig/Extension/EnumExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/EnumExtension.php
@@ -10,6 +10,9 @@ use Twig\TwigFunction;
 
 final class EnumExtension extends AbstractExtension
 {
+    /**
+     * @return TwigFunction[]
+     */
     public function getFunctions(): array
     {
         return [

--- a/app/bundles/CoreBundle/Twig/Extension/InputExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/InputExtension.php
@@ -10,6 +10,9 @@ use Twig\TwigFunction;
 
 final class InputExtension extends AbstractExtension
 {
+    /**
+     * @return TwigFunction[]
+     */
     public function getFunctions(): array
     {
         return [

--- a/app/bundles/CoreBundle/Twig/Extension/NumericExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/NumericExtension.php
@@ -10,6 +10,9 @@ use Twig\TwigTest;
 
 final class NumericExtension extends AbstractExtension
 {
+    /**
+     * @return TwigTest[]
+     */
     public function getTests(): array
     {
         return [
@@ -17,6 +20,9 @@ final class NumericExtension extends AbstractExtension
         ];
     }
 
+    /**
+     * @return TwigFilter[]
+     */
     public function getFilters(): array
     {
         return [

--- a/app/bundles/CoreBundle/Twig/Extension/ObjectExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/ObjectExtension.php
@@ -10,6 +10,9 @@ use Twig\TwigTest;
 
 final class ObjectExtension extends AbstractExtension
 {
+    /**
+     * @return TwigFunction[]
+     */
     public function getFunctions(): array
     {
         return [
@@ -17,6 +20,9 @@ final class ObjectExtension extends AbstractExtension
         ];
     }
 
+    /**
+     * @return TwigTest[]
+     */
     public function getTests(): array
     {
         return [

--- a/app/bundles/CoreBundle/Twig/Extension/OverrideIncludeExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/OverrideIncludeExtension.php
@@ -21,6 +21,9 @@ final class OverrideIncludeExtension extends AbstractExtension
     ) {
     }
 
+    /**
+     * @return TwigFunction[]
+     */
     public function getFunctions(): array
     {
         return [

--- a/app/bundles/CoreBundle/Twig/Extension/SerializerExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/SerializerExtension.php
@@ -10,6 +10,9 @@ use Twig\TwigFunction;
 
 final class SerializerExtension extends AbstractExtension
 {
+    /**
+     * @return TwigFunction[]
+     */
     public function getFunctions(): array
     {
         return [

--- a/app/bundles/CoreBundle/Update/StepProvider.php
+++ b/app/bundles/CoreBundle/Update/StepProvider.php
@@ -57,6 +57,8 @@ final class StepProvider
     }
 
     /**
+     * @param StepInterface[] $steps
+     *
      * @return StepInterface[]
      */
     private function orderSteps(array $steps): array

--- a/app/bundles/CoreBundle/Validator/FileUploadValidator.php
+++ b/app/bundles/CoreBundle/Validator/FileUploadValidator.php
@@ -44,7 +44,8 @@ class FileUploadValidator
     }
 
     /**
-     * @param string $extension
+     * @param string             $extension
+     * @param lowercase-string[] $allowedExtensions
      *
      * @throws FileInvalidException
      */

--- a/app/bundles/EmailBundle/Entity/StatRepository.php
+++ b/app/bundles/EmailBundle/Entity/StatRepository.php
@@ -440,7 +440,8 @@ class StatRepository extends CommonRepository
     /**
      * Get a lead's email stat.
      *
-     * @param int $leadId
+     * @param int                  $leadId
+     * @param array<string, mixed> $options
      *
      * @return array
      *

--- a/app/bundles/EmailBundle/Event/EmailSendEvent.php
+++ b/app/bundles/EmailBundle/Event/EmailSendEvent.php
@@ -54,6 +54,9 @@ class EmailSendEvent extends CommonEvent
      */
     private array $errors = [];
 
+    /**
+     * @param array<string, mixed> $args
+     */
     public function __construct(
         private readonly ?MailHelper $helper = null,
         array $args = [],

--- a/app/bundles/EmailBundle/EventListener/FormSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/FormSubscriber.php
@@ -88,6 +88,9 @@ final readonly class FormSubscriber implements EventSubscriberInterface
         }
     }
 
+    /**
+     * @param array<string, mixed> $feedback
+     */
     private function getCurrentLead(array $feedback): ?array
     {
         // Deal with Lead email

--- a/app/bundles/EmailBundle/Helper/FromEmailHelper.php
+++ b/app/bundles/EmailBundle/Helper/FromEmailHelper.php
@@ -122,7 +122,7 @@ class FromEmailHelper
     }
 
     /**
-     * @param mixed[] $owner
+     * @param array<string, mixed> $owner
      */
     private function replaceSignatureTokens(array $owner): string
     {

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -1893,6 +1893,9 @@ class MailHelper
         }
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     private function buildMetadata(?string $name, array $tokens): array
     {
         return [

--- a/app/bundles/EmailBundle/Helper/PlainTextHelper.php
+++ b/app/bundles/EmailBundle/Helper/PlainTextHelper.php
@@ -21,6 +21,8 @@ final class PlainTextHelper
      * used in conjunction with $replace.
      *
      * @see $replace
+     *
+     * @var string[]
      */
     private array $search = [
         "/\r/",                                           // Non-legal carriage return
@@ -51,6 +53,8 @@ final class PlainTextHelper
      * List of pattern replacements corresponding to patterns searched.
      *
      * @see $search
+     *
+     * @var string[]
      */
     private array $replace = [
         '',                              // Non-legal carriage return
@@ -82,6 +86,8 @@ final class PlainTextHelper
      * used in conjunction with $entReplace.
      *
      * @see $entReplace
+     *
+     * @var string[]
      */
     private array $entSearch = [
         '/&#153;/i',                                     // TM symbol in win-1252
@@ -94,6 +100,8 @@ final class PlainTextHelper
      * List of pattern replacements corresponding to patterns searched.
      *
      * @see $entSearch
+     *
+     * @var string[]
      */
     private array $entReplace = [
         '™',         // TM symbol
@@ -105,6 +113,8 @@ final class PlainTextHelper
     /**
      * List of preg* regular expression patterns to search for
      * and replace using callback function.
+     *
+     * @var string[]
      */
     private array $callbackSearch = [
         '/<(h)[123456]( [^>]*)?>(.*?)<\/h[123456]>/i',           // h1 - h6
@@ -119,6 +129,8 @@ final class PlainTextHelper
      * used in conjunction with $preReplace.
      *
      * @see $preReplace
+     *
+     * @var string[]
      */
     private array $preSearch = [
         "/\n/",
@@ -132,6 +144,8 @@ final class PlainTextHelper
      * List of pattern replacements corresponding to patterns searched for PRE body.
      *
      * @see $preSearch
+     *
+     * @var string[]
      */
     private array $preReplace = [
         '<br>',
@@ -157,6 +171,8 @@ final class PlainTextHelper
      * Contains URL addresses from links to be rendered in plain text.
      *
      * @see buildlinkList()
+     *
+     * @var string[]
      */
     private array $linkList = [];
 
@@ -411,7 +427,7 @@ final class PlainTextHelper
     /**
      * Callback function for preg_replace_callback use.
      *
-     * @param array $matches PREG matches
+     * @param array<int, mixed> $matches PREG matches
      *
      * @return string
      */

--- a/app/bundles/EmailBundle/Helper/PointEventHelper.php
+++ b/app/bundles/EmailBundle/Helper/PointEventHelper.php
@@ -12,6 +12,9 @@ final readonly class PointEventHelper
     ) {
     }
 
+    /**
+     * @param array<string, mixed> $action
+     */
     public static function validateEmail($eventDetails, array $action): bool
     {
         if (null === $eventDetails) {
@@ -28,6 +31,9 @@ final readonly class PointEventHelper
         return empty($limitToEmails) || in_array($emailId, $limitToEmails);
     }
 
+    /**
+     * @param array<string, mixed> $event
+     */
     public function sendEmail(array $event, Lead $lead): bool
     {
         $properties = $event['properties'];

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -555,9 +555,10 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
     }
 
     /**
-     * @param int|null $companyId
-     * @param int|null $campaignId
-     * @param int|null $segmentId
+     * @param int|null             $companyId
+     * @param int|null             $campaignId
+     * @param int|null             $segmentId
+     * @param array<string, mixed> $options
      */
     public function getSentEmailToContactData($limit, \DateTime $dateFrom, \DateTime $dateTo, array $options = [], $companyId = null, $campaignId = null, $segmentId = null): array
     {
@@ -614,10 +615,11 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
     }
 
     /**
-     * @param int      $limit
-     * @param int|null $companyId
-     * @param int|null $campaignId
-     * @param int|null $segmentId
+     * @param int                  $limit
+     * @param int|null             $companyId
+     * @param int|null             $campaignId
+     * @param int|null             $segmentId
+     * @param array<string, mixed> $options
      */
     public function getMostHitEmailRedirects($limit, \DateTime $dateFrom, \DateTime $dateTo, array $options = [], $companyId = null, $campaignId = null, $segmentId = null): array
     {
@@ -1323,13 +1325,14 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
     /**
      * Send an email to lead(s).
      *
-     * @param mixed[] $options = array()
-     *                         array source array('model', 'id')
-     *                         array emailSettings
-     *                         int   listId
-     *                         bool  allowResends     If false, exact emails (by id) already sent to the lead will not be resent
-     *                         bool  ignoreDNC        If true, emails listed in the do not contact table will still get the email
-     *                         array assetAttachments Array of optional Asset IDs to attach
+     * @param array<string, mixed>     $options = array()
+     *                                          array source array('model', 'id')
+     *                                          array emailSettings
+     *                                          int   listId
+     *                                          bool  allowResends     If false, exact emails (by id) already sent to the lead will not be resent
+     *                                          bool  ignoreDNC        If true, emails listed in the do not contact table will still get the email
+     *                                          array assetAttachments Array of optional Asset IDs to attach
+     * @param array<string|int, mixed> $leads
      *
      * @return string[]|bool|string|null
      */
@@ -2032,8 +2035,9 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
     /**
      * Get a list of emails in a date range, grouped by a stat date count.
      *
-     * @param int   $limit
-     * @param array $filters
+     * @param int                  $limit
+     * @param array                $filters
+     * @param array<string, mixed> $options
      */
     public function getEmailStatList($limit = 10, ?\DateTime $dateFrom = null, ?\DateTime $dateTo = null, $filters = [], array $options = []): array
     {
@@ -2068,8 +2072,9 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
     /**
      * Get a list of emails in a date range.
      *
-     * @param int   $limit
-     * @param array $filters
+     * @param int                  $limit
+     * @param array                $filters
+     * @param array<string, mixed> $options
      */
     public function getEmailList($limit = 10, ?\DateTime $dateFrom = null, ?\DateTime $dateTo = null, $filters = [], array $options = []): array
     {
@@ -2158,6 +2163,9 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
         return $contact;
     }
 
+    /**
+     * @param array<mixed, array<int|string, int|string|array<int|string, mixed>|null>> $sendTo
+     */
     private function getContactCompanies(array &$sendTo): void
     {
         foreach ($sendTo as $key => $contact) {

--- a/app/bundles/EmailBundle/Model/SendEmailToContact.php
+++ b/app/bundles/EmailBundle/Model/SendEmailToContact.php
@@ -124,6 +124,8 @@ class SendEmailToContact
     }
 
     /**
+     * @param array<string, mixed> $contact
+     *
      * @throws FailedToSendToContactException
      */
     public function setContact(array $contact, array $tokens = []): static
@@ -238,6 +240,9 @@ class SendEmailToContact
         throw new FailedToSendToContactException($errorMessages);
     }
 
+    /**
+     * @param array<string, mixed> $sendFailures
+     */
     protected function processSendFailures(array $sendFailures): void
     {
         $failedEmailAddresses = $sendFailures['failures'];
@@ -316,6 +321,9 @@ class SendEmailToContact
         --$this->emailSentCounts[$emailId];
     }
 
+    /**
+     * @return array<int, mixed>
+     */
     protected function queueTokenizedEmail(): array
     {
         [$queued, $queueErrors] = $this->mailer->queue(true, MailHelper::QUEUE_RETURN_ERRORS);

--- a/app/bundles/EmailBundle/MonitoredEmail/Fetcher.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Fetcher.php
@@ -13,6 +13,9 @@ final class Fetcher
 {
     private ?array $mailboxes = null;
 
+    /**
+     * @var string[]
+     */
     private array $log = [];
 
     private int $processedMessageCounter = 0;
@@ -83,6 +86,9 @@ final class Fetcher
         }
     }
 
+    /**
+     * @return string[]
+     */
     public function getLog(): array
     {
         return $this->log;

--- a/app/bundles/EmailBundle/MonitoredEmail/Mailbox.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Mailbox.php
@@ -258,6 +258,11 @@ class Mailbox
         $this->imapFullPath = $paths['full'];
     }
 
+    /**
+     * @param array<string, mixed> $settings
+     *
+     * @return array<string, string>
+     */
     public function getImapPath(array $settings): array
     {
         $settings['encryption'] ??= (!empty($settings['ssl'])) ? '/ssl' : '';

--- a/app/bundles/EmailBundle/MonitoredEmail/Processor/Bounce/Mapper/CategoryMapper.php
+++ b/app/bundles/EmailBundle/MonitoredEmail/Processor/Bounce/Mapper/CategoryMapper.php
@@ -9,6 +9,9 @@ use Mautic\EmailBundle\MonitoredEmail\Processor\Bounce\Mapper\Category as Catego
 
 final class CategoryMapper
 {
+    /**
+     * @var array<string, array<string, bool|string>>
+     */
     private static array $mappings = [
         Category::ANTISPAM       => ['permanent' => false, 'bounce_type' => Type::BLOCKED],
         Category::AUTOREPLY      => ['permanent' => false, 'bounce_type' => Type::AUTOREPLY],

--- a/app/bundles/EmailBundle/Stat/StatHelper.php
+++ b/app/bundles/EmailBundle/Stat/StatHelper.php
@@ -18,6 +18,9 @@ final class StatHelper
      */
     private array $stats = [];
 
+    /**
+     * @var string[]|null[]
+     */
     private array $deleteUs = [];
 
     public function __construct(

--- a/app/bundles/EmailBundle/Stats/Helper/AbstractHelper.php
+++ b/app/bundles/EmailBundle/Stats/Helper/AbstractHelper.php
@@ -79,8 +79,9 @@ abstract class AbstractHelper implements StatHelperInterface
     }
 
     /**
-     * @param string $column
-     * @param string $prefix
+     * @param string            $column
+     * @param string            $prefix
+     * @param array<int, mixed> $ids
      */
     protected function limitQueryToEmailIds(QueryBuilder $q, array $ids, $column, $prefix): void
     {

--- a/app/bundles/EmailBundle/Tests/Controller/EmailFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailFunctionalTest.php
@@ -191,8 +191,8 @@ final class EmailFunctionalTest extends MauticMysqlTestCase
     }
 
     /**
-     * @param mixed[] $expected
-     * @param mixed[] $actual
+     * @param int[]|null[] $expected
+     * @param mixed[]      $actual
      */
     private function assertArrayValuesEquals(array $expected, array $actual): void
     {
@@ -203,8 +203,8 @@ final class EmailFunctionalTest extends MauticMysqlTestCase
     }
 
     /**
-     * @param mixed[] $expectedAvailableOptions
-     * @param mixed[] $expectedValue
+     * @param int[]|null[] $expectedAvailableOptions
+     * @param int[]|null[] $expectedValue
      */
     private function assertChoiceOptions(ChoiceFormField $field, array $expectedAvailableOptions, array $expectedValue): void
     {
@@ -213,7 +213,7 @@ final class EmailFunctionalTest extends MauticMysqlTestCase
     }
 
     /**
-     * @param mixed[] $expectedListIds
+     * @param int[]|null[] $expectedListIds
      */
     private function assertEmailLists(array $expectedListIds, Collection $collection): void
     {

--- a/app/bundles/EmailBundle/Tests/Controller/EmailSendFunctionalTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailSendFunctionalTest.php
@@ -217,7 +217,7 @@ final class EmailSendFunctionalTest extends MauticMysqlTestCase
     }
 
     /**
-     * @param mixed[] $queryParams
+     * @param array<string|int, mixed[]|string> $queryParams
      */
     private function requestUrl(string $uri, array $queryParams): void
     {

--- a/app/bundles/EmailBundle/Tests/EventListener/MatchFilterForLeadTraitTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/MatchFilterForLeadTraitTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
 final class MatchFilterForLeadTraitTest extends TestCase
 {
     /**
-     * @var mixed[]
+     * @var array<string, int|string>
      */
     private array $lead = [
         'id'     => 1,
@@ -21,7 +21,7 @@ final class MatchFilterForLeadTraitTest extends TestCase
     ];
 
     /**
-     * @var mixed[]
+     * @var array<int, array<string, string|null>>
      */
     private array $filter = [
         0 => [

--- a/app/bundles/EmailBundle/Tests/Helper/Transport/BatchTransport.php
+++ b/app/bundles/EmailBundle/Tests/Helper/Transport/BatchTransport.php
@@ -19,9 +19,8 @@ final class BatchTransport extends AbstractTransport implements TokenTransportIn
      * @var array<string, mixed>
      */
     private array $transports = []; // @phpstan-ignore-line
-
     /**
-     * @var mixed[]
+     * @var array<mixed, array<string, array<string, mixed[]>>>
      */
     private array $metadatas  = [];
 
@@ -86,6 +85,9 @@ final class BatchTransport extends AbstractTransport implements TokenTransportIn
         return $this->maxRecipients;
     }
 
+    /**
+     * @return array<mixed, array<string, array<string, mixed[]>>>
+     */
     public function getMetadatas(): array
     {
         return $this->metadatas;

--- a/app/bundles/EmailBundle/Tests/Helper/Transport/BcInterfaceTokenTransport.php
+++ b/app/bundles/EmailBundle/Tests/Helper/Transport/BcInterfaceTokenTransport.php
@@ -29,7 +29,7 @@ final class BcInterfaceTokenTransport implements TransportInterface
     private array $fromNames = [];
 
     /**
-     * @var mixed[]
+     * @var mixed[][]
      */
     private array $metadatas = [];
 
@@ -70,7 +70,7 @@ final class BcInterfaceTokenTransport implements TransportInterface
     }
 
     /**
-     * @return mixed[]
+     * @return mixed[][]
      */
     public function getMetadatas(): array
     {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -157,12 +157,6 @@ parameters:
 			path: app/bundles/CampaignBundle/Controller/Api/CampaignApiController.php
 
 		-
-			message: '#^Method Mautic\\CampaignBundle\\Controller\\CampaignController\:\:getIndexItems\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/bundles/CampaignBundle/Controller/CampaignController.php
-
-		-
 			message: '#^Parameter \#1 \$prefix of function uniqid expects string, int\<0, max\> given\.$#'
 			identifier: argument.type
 			count: 2
@@ -2316,18 +2310,6 @@ parameters:
 		-
 			message: '#^Method Mautic\\CoreBundle\\Test\\Doctrine\\DBALMocker\:\:getMockResultStatement\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: app/bundles/CoreBundle/Test/Doctrine/DBALMocker.php
-
-		-
-			message: '#^Method Mautic\\CoreBundle\\Test\\Doctrine\\DBALMocker\:\:getQueryPart\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: app/bundles/CoreBundle/Test/Doctrine/DBALMocker.php
-
-		-
-			message: '#^Method Mautic\\CoreBundle\\Test\\Doctrine\\DBALMocker\:\:getQueryPart\(\) has parameter \$part with no type specified\.$#'
-			identifier: missingType.parameter
 			count: 1
 			path: app/bundles/CoreBundle/Test/Doctrine/DBALMocker.php
 


### PR DESCRIPTION
Adds precise iterable docblock types (generated via Rector's type-declaration set) across CoreBundle, EmailBundle and CampaignBundle.

Docblock-only change; no runtime behavior affected. Part 1/3 of a split to keep review manageable.