### PR TITLE
[cs] Add precise iterable docblock types (remaining bundles + plugins)

### DIFF
--- a/app/bundles/ApiBundle/Controller/CommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/CommonApiController.php
@@ -395,8 +395,8 @@ class CommonApiController extends FetchCommonApiController
     }
 
     /**
-     * @param mixed[] $errors
-     * @param mixed[] $entities
+     * @param mixed[][]          $errors
+     * @param array<object|null> $entities
      */
     protected function processBatchForm(Request $request, $key, $entity, $params, $method, array &$errors, array &$entities)
     {

--- a/app/bundles/ApiBundle/Controller/FetchCommonApiController.php
+++ b/app/bundles/ApiBundle/Controller/FetchCommonApiController.php
@@ -632,7 +632,7 @@ class FetchCommonApiController extends AbstractFOSRestController implements Maut
     /**
      * @param array<int, array<string|int>> $errors
      * @param TEntity|null                  $entity
-     * @param array<int, TEntity|null>      $entities
+     * @param array<TEntity|null>           $entities
      */
     protected function setBatchError(int $key, string $msg, int $code, array &$errors, array &$entities = [], ?object $entity = null): void
     {

--- a/app/bundles/ApiBundle/Helper/BatchIdToEntityHelper.php
+++ b/app/bundles/ApiBundle/Helper/BatchIdToEntityHelper.php
@@ -10,6 +10,9 @@ final class BatchIdToEntityHelper
 
     private array $originalKeys = [];
 
+    /**
+     * @var string[]
+     */
     private array $errors = [];
 
     private bool $isAssociative = false;
@@ -36,6 +39,9 @@ final class BatchIdToEntityHelper
         return [] !== $this->errors;
     }
 
+    /**
+     * @return string[]
+     */
     public function getErrors(): array
     {
         return $this->errors;
@@ -83,6 +89,9 @@ final class BatchIdToEntityHelper
         return $orderedEntities;
     }
 
+    /**
+     * @param array<string, mixed> $parameters
+     */
     private function extractIds(array $parameters): void
     {
         $this->ids = [];
@@ -124,6 +133,9 @@ final class BatchIdToEntityHelper
         $this->errors[] = 'mautic.api.call.id_missing';
     }
 
+    /**
+     * @param array<string, mixed> $parameters
+     */
     private function extractIdsFromParams(array $parameters): void
     {
         $this->isAssociative = $this->isAssociativeArray($parameters);
@@ -150,6 +162,9 @@ final class BatchIdToEntityHelper
         }
     }
 
+    /**
+     * @param array<string, mixed> $array
+     */
     private function isAssociativeArray(array $array): bool
     {
         if ([] === $array) {

--- a/app/bundles/ApiBundle/Helper/EntityResultHelper.php
+++ b/app/bundles/ApiBundle/Helper/EntityResultHelper.php
@@ -49,7 +49,7 @@ class EntityResultHelper
     }
 
     /**
-     * @param mixed[] $array
+     * @param non-empty-array<mixed, mixed> $array
      */
     private function getDataForArray(array $array): mixed
     {

--- a/app/bundles/AssetBundle/Entity/DownloadRepository.php
+++ b/app/bundles/AssetBundle/Entity/DownloadRepository.php
@@ -45,7 +45,8 @@ class DownloadRepository extends CommonRepository
     /**
      * Get a lead's page downloads.
      *
-     * @param int|null $leadId
+     * @param int|null             $leadId
+     * @param array<string, mixed> $options
      *
      * @return array
      */

--- a/app/bundles/AssetBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/BuilderSubscriber.php
@@ -82,6 +82,8 @@ final class BuilderSubscriber implements EventSubscriberInterface
     }
 
     /**
+     * @param int[]|string[] $source
+     *
      * @return mixed[]
      */
     private function generateTokensFromContent(EmailSendEvent|PageDisplayEvent $event, ?int $leadId, array $source = [], ?int $emailId = null): array

--- a/app/bundles/AssetBundle/Helper/PointActionHelper.php
+++ b/app/bundles/AssetBundle/Helper/PointActionHelper.php
@@ -6,6 +6,9 @@ use Mautic\AssetBundle\Entity\Asset;
 
 final class PointActionHelper
 {
+    /**
+     * @param array<string, mixed> $action
+     */
     public static function validateAssetDownload(Asset $eventDetails, array $action): bool
     {
         $assetId       = $eventDetails->getId();

--- a/app/bundles/AssetBundle/Model/AssetModel.php
+++ b/app/bundles/AssetBundle/Model/AssetModel.php
@@ -100,6 +100,8 @@ class AssetModel extends FormModel implements GlobalSearchInterface
     }
 
     /**
+     * @param array<string, mixed> $systemEntry
+     *
      * @throws \Doctrine\ORM\ORMException
      * @throws \Exception
      */
@@ -586,7 +588,8 @@ class AssetModel extends FormModel implements GlobalSearchInterface
     /**
      * Get a list of assets in a date range.
      *
-     * @param array $filters
+     * @param array                $filters
+     * @param array<string, mixed> $options
      */
     public function getAssetList(int $limit = 10, ?\DateTime $dateFrom = null, ?\DateTime $dateTo = null, $filters = [], array $options = []): array
     {

--- a/app/bundles/CacheBundle/Cache/Adapter/RedisAdapterTrait.php
+++ b/app/bundles/CacheBundle/Cache/Adapter/RedisAdapterTrait.php
@@ -11,7 +11,7 @@ use Predis\Client;
 trait RedisAdapterTrait
 {
     /**
-     * @param mixed[] $servers
+     * @param array<string, mixed> $servers
      */
     private function createClient(array $servers, bool $primaryOnly): Client
     {

--- a/app/bundles/ChannelBundle/Entity/MessageQueue.php
+++ b/app/bundles/ChannelBundle/Entity/MessageQueue.php
@@ -90,6 +90,9 @@ class MessageQueue
      */
     private $dateSent;
 
+    /**
+     * @var mixed[][]
+     */
     private array $options = [];
 
     /**
@@ -199,6 +202,9 @@ class MessageQueue
         $this->attempts = $attempts;
     }
 
+    /**
+     * @return mixed[][]
+     */
     public function getOptions(): array
     {
         return $this->options;

--- a/app/bundles/ChannelBundle/Entity/MessageQueueRepository.php
+++ b/app/bundles/ChannelBundle/Entity/MessageQueueRepository.php
@@ -99,7 +99,8 @@ class MessageQueueRepository extends CommonRepository
     /**
      * Get a lead's point log.
      *
-     * @param int|null $leadId
+     * @param int|null             $leadId
+     * @param array<string, mixed> $options
      *
      * @return array
      */

--- a/app/bundles/ChannelBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/ChannelBundle/EventListener/CampaignSubscriber.php
@@ -137,7 +137,8 @@ final class CampaignSubscriber implements EventSubscriberInterface
     }
 
     /**
-     * @param string $channel
+     * @param string               $channel
+     * @param array<string, mixed> $messageChannel
      *
      * @return bool|ArrayCollection
      *

--- a/app/bundles/ChannelBundle/Model/FrequencyActionModel.php
+++ b/app/bundles/ChannelBundle/Model/FrequencyActionModel.php
@@ -28,6 +28,9 @@ final readonly class FrequencyActionModel
         }
     }
 
+    /**
+     * @param array<string, mixed> $params
+     */
     private function updateFrequencyRules(Lead $contact, array $params, ?string $preferredChannel): void
     {
         $frequencyRules = $contact->getFrequencyRules()->toArray();

--- a/app/bundles/ChannelBundle/PreferenceBuilder/PreferenceBuilder.php
+++ b/app/bundles/ChannelBundle/PreferenceBuilder/PreferenceBuilder.php
@@ -40,7 +40,8 @@ final class PreferenceBuilder
     }
 
     /**
-     * @param string $channel
+     * @param string               $channel
+     * @param array<string, mixed> $rule
      */
     private function addChannelRule($channel, array $rule, LeadEventLog $log, int $priority): void
     {

--- a/app/bundles/ChannelBundle/Tests/Controller/Api/MessageApiControllerTest.php
+++ b/app/bundles/ChannelBundle/Tests/Controller/Api/MessageApiControllerTest.php
@@ -191,8 +191,8 @@ JSON;
     }
 
     /**
-     * @param mixed[] $expectedPayload
-     * @param mixed[] $actualPayload
+     * @param array<array<string, mixed>, mixed> $expectedPayload
+     * @param array<string, mixed>               $actualPayload
      */
     private function assertMessagePayload(array $expectedPayload, array $actualPayload, string $deliveredPayloadJson): void
     {

--- a/app/bundles/ConfigBundle/Event/ConfigBuilderEvent.php
+++ b/app/bundles/ConfigBundle/Event/ConfigBuilderEvent.php
@@ -34,6 +34,8 @@ class ConfigBuilderEvent extends Event
 
     /**
      * Set new form to the forms array.
+     *
+     * @param array<string, mixed> $form
      */
     public function addForm(array $form): static
     {
@@ -72,6 +74,8 @@ class ConfigBuilderEvent extends Event
 
     /**
      * Returns the formThemes array.
+     *
+     * @return string[]
      */
     public function getFormThemes(): array
     {
@@ -105,6 +109,9 @@ class ConfigBuilderEvent extends Event
         return $this;
     }
 
+    /**
+     * @return string[]
+     */
     public function getFileFields(): array
     {
         return $this->encodedFields;

--- a/app/bundles/ConfigBundle/Model/SysinfoModel.php
+++ b/app/bundles/ConfigBundle/Model/SysinfoModel.php
@@ -131,6 +131,9 @@ final class SysinfoModel
         return $this->tail($log, $lines);
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getDbInfo(): array
     {
         return [

--- a/app/bundles/DashboardBundle/Entity/Widget.php
+++ b/app/bundles/DashboardBundle/Entity/Widget.php
@@ -323,6 +323,9 @@ class Widget extends FormEntity
         return $this->loadTime;
     }
 
+    /**
+     * @return array<string, int|string|mixed[]|null>
+     */
     public function toArray(): array
     {
         return [

--- a/app/bundles/DashboardBundle/Model/DashboardModel.php
+++ b/app/bundles/DashboardBundle/Model/DashboardModel.php
@@ -106,6 +106,8 @@ class DashboardModel extends FormModel
      * Useful for dashboard exports.
      *
      * @param string $name
+     *
+     * @return array<string, string|mixed[]>
      */
     public function toArray($name): array
     {
@@ -307,6 +309,8 @@ class DashboardModel extends FormModel
 
     /**
      * Generate default date range filter and time unit.
+     *
+     * @return array<string, \DateTime>
      */
     public function getDefaultFilter(): array
     {

--- a/app/bundles/DynamicContentBundle/Entity/StatRepository.php
+++ b/app/bundles/DynamicContentBundle/Entity/StatRepository.php
@@ -102,7 +102,8 @@ final class StatRepository extends CommonRepository
     /**
      * Get a lead's dynamic content stat.
      *
-     * @param int|null $leadId
+     * @param int|null             $leadId
+     * @param array<string, mixed> $options
      *
      * @return array
      *

--- a/app/bundles/DynamicContentBundle/Form/Type/DynamicContentType.php
+++ b/app/bundles/DynamicContentBundle/Form/Type/DynamicContentType.php
@@ -49,19 +49,19 @@ final class DynamicContentType extends AbstractType
     private array $fieldChoices;
 
     /**
-     * @var mixed[]
+     * @var array<string, string>
      */
     private readonly array $countryChoices;
 
     /**
-     * @var mixed[]
+     * @var array<string, array<string, string>>
      */
     private readonly array $regionChoices;
 
     private readonly array $timezoneChoices;
 
     /**
-     * @var mixed[]
+     * @var array<string, string>
      */
     private readonly array $localeChoices;
 
@@ -73,7 +73,7 @@ final class DynamicContentType extends AbstractType
     private $deviceBrandsChoices;
 
     /**
-     * @var mixed[]
+     * @var int[]|string[]
      */
     private readonly array $deviceOsChoices;
 

--- a/app/bundles/DynamicContentBundle/Helper/DynamicContentHelper.php
+++ b/app/bundles/DynamicContentBundle/Helper/DynamicContentHelper.php
@@ -228,8 +228,8 @@ class DynamicContentHelper
     }
 
     /**
-     * @param mixed[] $filters
-     * @param mixed[] $contactArray
+     * @param mixed[]              $filters
+     * @param array<string, mixed> $contactArray
      */
     private function filtersMatchContact(array $filters, array $contactArray): bool
     {

--- a/app/bundles/DynamicContentBundle/Model/DynamicContentModel.php
+++ b/app/bundles/DynamicContentBundle/Model/DynamicContentModel.php
@@ -263,9 +263,10 @@ class DynamicContentModel extends FormModel implements AjaxLookupModelInterface,
     /**
      * Get line chart data of hits.
      *
-     * @param ?string $unit          {@link php.net/manual/en/function.date.php#refsect1-function.date-parameters}
-     * @param string  $dateFormat
-     * @param bool    $canViewOthers
+     * @param ?string              $unit          {@link php.net/manual/en/function.date.php#refsect1-function.date-parameters}
+     * @param string               $dateFormat
+     * @param bool                 $canViewOthers
+     * @param array<string, mixed> $filter
      */
     public function getHitsLineChartData($unit, \DateTime $dateFrom, \DateTime $dateTo, $dateFormat = null, array $filter = [], $canViewOthers = true): array
     {

--- a/app/bundles/InstallBundle/Command/InstallCommand.php
+++ b/app/bundles/InstallBundle/Command/InstallCommand.php
@@ -352,8 +352,8 @@ final class InstallCommand extends Command
     /**
      * Controller action for install steps.
      *
-     * @param array $params The install parameters
-     * @param float $index  The step number to process
+     * @param array<string, mixed> $params The install parameters
+     * @param float                $index  The step number to process
      *
      * @throws \Exception
      */

--- a/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
+++ b/app/bundles/InstallBundle/Configurator/Step/CheckStep.php
@@ -68,6 +68,9 @@ final class CheckStep implements StepInterface
         return CheckStepType::class;
     }
 
+    /**
+     * @return string[]
+     */
     public function checkRequirements(): array
     {
         $messages = [];
@@ -149,6 +152,9 @@ final class CheckStep implements StepInterface
         return $messages;
     }
 
+    /**
+     * @return string[]
+     */
     public function checkOptionalSettings(): array
     {
         $messages = [];

--- a/app/bundles/InstallBundle/Configurator/Step/DoctrineStep.php
+++ b/app/bundles/InstallBundle/Configurator/Step/DoctrineStep.php
@@ -92,6 +92,9 @@ final class DoctrineStep implements StepInterface
         return DoctrineStepType::class;
     }
 
+    /**
+     * @return string[]
+     */
     public function checkRequirements(): array
     {
         $messages = [];

--- a/app/bundles/InstallBundle/Helper/SchemaHelper.php
+++ b/app/bundles/InstallBundle/Helper/SchemaHelper.php
@@ -32,6 +32,8 @@ final class SchemaHelper
     private ?AbstractSchemaManager $schemaManager = null;
 
     /**
+     * @param array<string, mixed> $dbParams
+     *
      * @throws \Doctrine\DBAL\Exception
      */
     public function __construct(
@@ -196,6 +198,9 @@ final class SchemaHelper
     }
 
     /**
+     * @param string[]              $tables
+     * @param array<string, string> $mauticTables
+     *
      * @throws \Doctrine\DBAL\Exception
      */
     private function backupExistingSchema(array $tables, array $mauticTables, string $backupPrefix): array
@@ -292,6 +297,10 @@ final class SchemaHelper
         return $sql;
     }
 
+    /**
+     * @param string[]              $tables
+     * @param array<string, string> $mauticTables
+     */
     private function dropExistingSchema(array $tables, array $mauticTables): array
     {
         $sql = [];

--- a/app/bundles/InstallBundle/Install/InstallService.php
+++ b/app/bundles/InstallBundle/Install/InstallService.php
@@ -216,6 +216,8 @@ class InstallService
     }
 
     /**
+     * @param array<string, mixed> $dbParams
+     *
      * @return array Validation errors
      */
     public function validateDatabaseParams(array $dbParams): array
@@ -259,6 +261,8 @@ class InstallService
 
     /**
      * Create the database.
+     *
+     * @param array<string, mixed> $dbParams
      */
     public function createDatabaseStep(StepInterface $step, array $dbParams): array
     {
@@ -384,6 +388,8 @@ class InstallService
 
     /**
      * Create the administrator user.
+     *
+     * @param array<string, mixed> $data
      */
     public function createAdminUserStep(array $data): array
     {

--- a/app/bundles/MarketplaceBundle/DTO/Maintainer.php
+++ b/app/bundles/MarketplaceBundle/DTO/Maintainer.php
@@ -12,6 +12,9 @@ final class Maintainer
     ) {
     }
 
+    /**
+     * @param array<string, mixed> $array
+     */
     public static function fromArray(array $array): self
     {
         return new self(

--- a/app/bundles/MarketplaceBundle/DTO/PackageBase.php
+++ b/app/bundles/MarketplaceBundle/DTO/PackageBase.php
@@ -26,6 +26,9 @@ final class PackageBase
     ) {
     }
 
+    /**
+     * @param array<string, mixed> $array
+     */
     public static function fromArray(array $array): self
     {
         return new self(

--- a/app/bundles/MarketplaceBundle/DTO/PackageDetail.php
+++ b/app/bundles/MarketplaceBundle/DTO/PackageDetail.php
@@ -22,6 +22,9 @@ final class PackageDetail
     ) {
     }
 
+    /**
+     * @param array<string, mixed> $array
+     */
     public static function fromArray(array $array): self
     {
         $reviews = ReviewCollection::fromArray($array['reviews'] ?? []);

--- a/app/bundles/MarketplaceBundle/DTO/Version.php
+++ b/app/bundles/MarketplaceBundle/DTO/Version.php
@@ -21,6 +21,9 @@ final class Version
     ) {
     }
 
+    /**
+     * @param array<string, mixed> $array
+     */
     public static function fromArray(array $array): self
     {
         return new self(

--- a/app/bundles/MessengerBundle/Message/Traits/MessageRequestTrait.php
+++ b/app/bundles/MessengerBundle/Message/Traits/MessageRequestTrait.php
@@ -45,7 +45,7 @@ trait MessageRequestTrait
     }
 
     /**
-     * @param mixed[] $data
+     * @param array<string, mixed> $data
      */
     public function __unserialize(array $data): void
     {

--- a/app/bundles/NotificationBundle/Api/AbstractNotificationApi.php
+++ b/app/bundles/NotificationBundle/Api/AbstractNotificationApi.php
@@ -31,7 +31,8 @@ abstract class AbstractNotificationApi
     /**
      * Convert a non-tracked url to a tracked url.
      *
-     * @param string $url
+     * @param string               $url
+     * @param array<string, mixed> $clickthrough
      *
      * @return string
      */

--- a/app/bundles/NotificationBundle/Api/OneSignalApi.php
+++ b/app/bundles/NotificationBundle/Api/OneSignalApi.php
@@ -104,6 +104,9 @@ class OneSignalApi extends AbstractNotificationApi
         return $this->send('/notifications', $data);
     }
 
+    /**
+     * @param array<string, mixed> $data
+     */
     protected function addMobileData(array &$data, array $mobileConfig): void
     {
         foreach ($mobileConfig as $key => $value) {

--- a/app/bundles/NotificationBundle/Model/NotificationModel.php
+++ b/app/bundles/NotificationBundle/Model/NotificationModel.php
@@ -203,9 +203,10 @@ final class NotificationModel extends FormModel implements AjaxLookupModelInterf
     /**
      * Get line chart data of hits.
      *
-     * @param ?string $unit          {@link php.net/manual/en/function.date.php#refsect1-function.date-parameters}
-     * @param string  $dateFormat
-     * @param bool    $canViewOthers
+     * @param ?string              $unit          {@link php.net/manual/en/function.date.php#refsect1-function.date-parameters}
+     * @param string               $dateFormat
+     * @param bool                 $canViewOthers
+     * @param array<string, mixed> $filter
      */
     public function getHitsLineChartData($unit, \DateTime $dateFrom, \DateTime $dateTo, $dateFormat = null, array $filter = [], $canViewOthers = true): array
     {

--- a/app/bundles/NotificationBundle/Tests/Functional/EventListener/CampaignSubscriberTest.php
+++ b/app/bundles/NotificationBundle/Tests/Functional/EventListener/CampaignSubscriberTest.php
@@ -498,7 +498,7 @@ final class CampaignSubscriberTest extends MauticMysqlTestCase
     }
 
     /**
-     * @param mixed[] $expectedData
+     * @param array<array<string, mixed>, mixed> $expectedData
      */
     private function responseDataAssertion(
         array $expectedData,

--- a/app/bundles/PluginBundle/Entity/Integration.php
+++ b/app/bundles/PluginBundle/Entity/Integration.php
@@ -158,7 +158,7 @@ class Integration extends CommonEntity implements CacheInvalidateInterface
     /**
      * @return array<array-key, mixed>
      */
-    public function getSupportedFeatures()
+    public function getSupportedFeatures(): array
     {
         return $this->supportedFeatures;
     }

--- a/app/bundles/PluginBundle/EventListener/PushToIntegrationTrait.php
+++ b/app/bundles/PluginBundle/EventListener/PushToIntegrationTrait.php
@@ -32,6 +32,8 @@ trait PushToIntegrationTrait
 
     /**
      * Used because the the Point trigger actions have not be converted to Events yet and thus must leverage a callback.
+     *
+     * @param array<string, mixed> $config
      */
     protected function pushIt(array $config, $lead, &$errors): bool
     {

--- a/app/bundles/PluginBundle/Form/Type/FieldsTypeTrait.php
+++ b/app/bundles/PluginBundle/Form/Type/FieldsTypeTrait.php
@@ -254,6 +254,9 @@ trait FieldsTypeTrait
         );
     }
 
+    /**
+     * @param array<string, mixed> $options
+     */
     protected function buildFieldView(FormView $view, array $options): void
     {
         $view->vars['specialInstructions'] = $options['special_instructions'];

--- a/app/bundles/PluginBundle/Helper/ReloadHelper.php
+++ b/app/bundles/PluginBundle/Helper/ReloadHelper.php
@@ -62,6 +62,7 @@ final readonly class ReloadHelper
      * @param array<string, array<class-string, ClassMetadata>> $pluginMetadata
      * @param array<string, Plugin>                             $installedPlugins
      * @param array<string, Schema>                             $installedPluginsSchemas
+     * @param array<string, mixed>                              $allPlugins
      */
     public function updatePlugins(array $allPlugins, array $installedPlugins, array $pluginMetadata, array $installedPluginsSchemas): array
     {
@@ -124,6 +125,9 @@ final readonly class ReloadHelper
         return $installedPlugins;
     }
 
+    /**
+     * @param array<string, mixed> $config
+     */
     private function mapConfigToPluginEntity(Plugin $plugin, array $config): Plugin
     {
         $plugin->setBundle($config['bundle']);

--- a/app/bundles/PluginBundle/Helper/oAuthHelper.php
+++ b/app/bundles/PluginBundle/Helper/oAuthHelper.php
@@ -20,8 +20,14 @@ final class oAuthHelper
 
     private $callback;
 
+    /**
+     * @var array<string, mixed>
+     */
     private readonly array $settings;
 
+    /**
+     * @param array<string, mixed> $settings
+     */
     public function __construct(
         UnifiedIntegrationInterface $integration,
         private readonly ?Request $request = null,
@@ -39,6 +45,9 @@ final class oAuthHelper
         $this->settings          = $settings;
     }
 
+    /**
+     * @return array<int, string>
+     */
     public function getAuthorizationHeader(string $url, $parameters, string $method): array
     {
         // Get standard OAuth headers

--- a/app/bundles/PluginBundle/Integration/AbstractIntegration.php
+++ b/app/bundles/PluginBundle/Integration/AbstractIntegration.php
@@ -99,6 +99,9 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
 
     protected array $deleteIntegrationEntities  = [];
 
+    /**
+     * @var IntegrationEntity[]|null[]
+     */
     protected array $persistIntegrationEntities = [];
 
     protected array $commandParameters = [];
@@ -274,9 +277,9 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
      *  sso_service - SSO using 3rd party service via sso_login and sso_login_check routes
      *  sso_form - SSO using submitted credentials through the login form
      *
-     * @return array
+     * @return string[]
      */
-    public function getSupportedFeatures()
+    public function getSupportedFeatures(): array
     {
         return [];
     }
@@ -291,7 +294,7 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
      *
      * @return array<string, string>
      */
-    public function getSupportedFeatureTooltips()
+    public function getSupportedFeatureTooltips(): array
     {
         return [];
     }
@@ -299,9 +302,9 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
     /**
      * Returns the field the integration needs in order to find the user.
      *
-     * @return mixed
+     * @return string[]
      */
-    public function getIdentifierFields()
+    public function getIdentifierFields(): array
     {
         return [];
     }
@@ -509,7 +512,7 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
     /**
      * Array of keys to mask in the config form.
      *
-     * @return array
+     * @return array<int, string>
      */
     public function getSecretKeys()
     {
@@ -533,7 +536,7 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
     /**
      * Get the keys for the refresh token and expiry.
      *
-     * @return array
+     * @return string[]
      */
     public function getRefreshTokenKeys()
     {
@@ -645,10 +648,10 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
     /**
      * Make a basic call using cURL to get the data.
      *
-     * @param string $url
-     * @param array  $parameters
-     * @param string $method
-     * @param array  $settings   Set $settings['return_raw'] to receive a ResponseInterface
+     * @param string               $url
+     * @param array                $parameters
+     * @param string               $method
+     * @param array<string, mixed> $settings   Set $settings['return_raw'] to receive a ResponseInterface
      *
      * @return mixed|string|ResponseInterface
      */
@@ -869,7 +872,9 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
     /**
      * Method to prepare the request parameters. Builds array of headers and parameters.
      *
-     * @return array
+     * @param array<string, mixed> $settings
+     *
+     * @return array<int, mixed>
      */
     public function prepareRequest(string $url, $parameters, string $method, array $settings, $authType)
     {
@@ -1062,8 +1067,8 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
     /**
      * Retrieves and stores tokens returned from oAuthLogin.
      *
-     * @param mixed[] $settings
-     * @param mixed[] $parameters
+     * @param array<string, mixed> $settings
+     * @param mixed[]              $parameters
      *
      * @throws ApiErrorException if OAuth2 state does not match
      */
@@ -1352,7 +1357,7 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
     /**
      * Get a list of available fields from the connecting API.
      *
-     * @param mixed[] $settings
+     * @param array<string, mixed> $settings
      *
      * @return mixed[]
      */
@@ -1369,6 +1374,8 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
     }
 
     /**
+     * @param array<string, mixed> $mauticLeadFields
+     *
      * @return array
      */
     public function cleanUpFields(Integration $entity, array $mauticLeadFields, array $mauticCompanyFields)
@@ -1762,6 +1769,8 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
     /**
      * Merges a config from integration_list with feature settings.
      *
+     * @param array<string, mixed> $config
+     *
      * @return array|mixed
      */
     public function mergeConfigToFeatureSettings(array $config = [])
@@ -2084,7 +2093,7 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
     /**
      * Get available fields for choices in the config UI.
      *
-     * @param mixed[] $settings
+     * @param array<string, mixed> $settings
      *
      * @return mixed[]
      */
@@ -2099,6 +2108,8 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
 
     /**
      * Get available company fields for choices in the config UI.
+     *
+     * @param array<string, mixed> $settings
      *
      * @return array
      */
@@ -2280,8 +2291,9 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
     }
 
     /**
-     * @param CommonEntity|null $entity
-     * @param bool              $ignoreEntityChanges
+     * @param CommonEntity|null    $entity
+     * @param bool                 $ignoreEntityChanges
+     * @param array<string, mixed> $params
      *
      * @return bool|\DateTime|null
      */
@@ -2327,6 +2339,8 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
      * Function used to format unformated fields coming from FieldsTypeTrait
      * (usually used in campaign actions).
      *
+     * @param array<string, mixed> $fields
+     *
      * @return array
      */
     public function formatMatchedFields(array $fields)
@@ -2371,6 +2385,8 @@ abstract class AbstractIntegration implements UnifiedIntegrationInterface
 
     /**
      * Get pseudo fields from mautic, these are lead properties we want to map to integration fields.
+     *
+     * @param array<string, mixed> $lead
      *
      * @return mixed
      */

--- a/app/bundles/PluginBundle/Integration/AbstractSsoFormIntegration.php
+++ b/app/bundles/PluginBundle/Integration/AbstractSsoFormIntegration.php
@@ -10,9 +10,9 @@ namespace Mautic\PluginBundle\Integration;
 abstract class AbstractSsoFormIntegration extends AbstractSsoServiceIntegration
 {
     /**
-     * @return array
+     * @return string[]
      */
-    public function getSupportedFeatures()
+    public function getSupportedFeatures(): array
     {
         return [
             'sso_form',

--- a/app/bundles/PluginBundle/Integration/AbstractSsoServiceIntegration.php
+++ b/app/bundles/PluginBundle/Integration/AbstractSsoServiceIntegration.php
@@ -99,9 +99,9 @@ abstract class AbstractSsoServiceIntegration extends AbstractIntegration
     }
 
     /**
-     * @return array
+     * @return string[]
      */
-    public function getSupportedFeatures()
+    public function getSupportedFeatures(): array
     {
         return [
             'sso_service',

--- a/app/bundles/PointBundle/Event/PointBuilderEvent.php
+++ b/app/bundles/PointBundle/Event/PointBuilderEvent.php
@@ -18,25 +18,25 @@ class PointBuilderEvent extends Event
     /**
      * Adds an action to the list of available .
      *
-     * @param string $key    - a unique identifier; it is recommended that it be namespaced i.e. lead.action
-     * @param array  $action - can contain the following keys:
-     *                       'label'           => (required) what to display in the list
-     *                       'description'     => (optional) short description of event
-     *                       'template'        => (optional) template to use for the action's HTML in the point builder
-     *                       i.e AcmeMyBundle:PointAction:theaction.html.twig
-     *                       'formType'        => (optional) name of the form type SERVICE for the action; will use a default form with point change only
-     *                       'formTypeOptions' => (optional) array of options to pass to formType
-     *                       'callback'        => (optional) callback function that will be passed when the action is triggered; return true to
-     *                       change the configured points or false to ignore the action
-     *                       The callback function can receive the following arguments by name (via ReflectionMethod::invokeArgs())
-     *                       Mautic\LeadBundle\Entity\Lead $lead
-     *                       $eventDetails - variable sent from firing function to call back function
-     *                       array $action = array(
-     *                       'id' => int
-     *                       'type' => string
-     *                       'name' => string
-     *                       'properties' => array()
-     *                       )
+     * @param string               $key    - a unique identifier; it is recommended that it be namespaced i.e. lead.action
+     * @param array<string, mixed> $action - can contain the following keys:
+     *                                     'label'           => (required) what to display in the list
+     *                                     'description'     => (optional) short description of event
+     *                                     'template'        => (optional) template to use for the action's HTML in the point builder
+     *                                     i.e AcmeMyBundle:PointAction:theaction.html.twig
+     *                                     'formType'        => (optional) name of the form type SERVICE for the action; will use a default form with point change only
+     *                                     'formTypeOptions' => (optional) array of options to pass to formType
+     *                                     'callback'        => (optional) callback function that will be passed when the action is triggered; return true to
+     *                                     change the configured points or false to ignore the action
+     *                                     The callback function can receive the following arguments by name (via ReflectionMethod::invokeArgs())
+     *                                     Mautic\LeadBundle\Entity\Lead $lead
+     *                                     $eventDetails - variable sent from firing function to call back function
+     *                                     array $action = array(
+     *                                     'id' => int
+     *                                     'type' => string
+     *                                     'name' => string
+     *                                     'properties' => array()
+     *                                     )
      *
      * @throws InvalidArgumentException
      */
@@ -96,6 +96,10 @@ class PointBuilderEvent extends Event
     }
 
     /**
+     * @param string[]             $keys
+     * @param string[]             $methods
+     * @param array<string, mixed> $component
+     *
      * @throws InvalidArgumentException
      */
     private function verifyComponent(array $keys, array $methods, array $component): void

--- a/app/bundles/PointBundle/Event/TriggerBuilderEvent.php
+++ b/app/bundles/PointBundle/Event/TriggerBuilderEvent.php
@@ -18,18 +18,18 @@ final class TriggerBuilderEvent extends Event
     /**
      * Adds an action to the list of available .
      *
-     * @param string $key   - a unique identifier; it is recommended that it be namespaced i.e. lead.action
-     * @param array  $event - can contain the following keys:
-     *                      'label'           => (required) what to display in the list
-     *                      'description'     => (optional) short description of event
-     *                      'template'        => (optional) template to use for the action's HTML in the point builder
-     *                      i.e AcmeMyBundle:PointAction:theaction.html.twig
-     *                      'formType'        => (optional) name of the form type SERVICE for the action
-     *                      'formTypeOptions' => (optional) array of options to pass to formType
-     *                      'callback'        => (required) callback function that will be passed when the action is triggered
-     *                      The callback function can receive the following arguments by name (via ReflectionMethod::invokeArgs())
-     *                      Mautic\PointBundle\Entity\TriggerEvent  $event
-     *                      Mautic\LeadBundle\Entity\Lead           $lead
+     * @param string               $key   - a unique identifier; it is recommended that it be namespaced i.e. lead.action
+     * @param array<string, mixed> $event - can contain the following keys:
+     *                                    'label'           => (required) what to display in the list
+     *                                    'description'     => (optional) short description of event
+     *                                    'template'        => (optional) template to use for the action's HTML in the point builder
+     *                                    i.e AcmeMyBundle:PointAction:theaction.html.twig
+     *                                    'formType'        => (optional) name of the form type SERVICE for the action
+     *                                    'formTypeOptions' => (optional) array of options to pass to formType
+     *                                    'callback'        => (required) callback function that will be passed when the action is triggered
+     *                                    The callback function can receive the following arguments by name (via ReflectionMethod::invokeArgs())
+     *                                    Mautic\PointBundle\Entity\TriggerEvent  $event
+     *                                    Mautic\LeadBundle\Entity\Lead           $lead
      *
      * @throws InvalidArgumentException
      */
@@ -68,6 +68,10 @@ final class TriggerBuilderEvent extends Event
     }
 
     /**
+     * @param string[]             $keys
+     * @param string[]             $methods
+     * @param array<string, mixed> $component
+     *
      * @throws InvalidArgumentException
      */
     private function verifyComponent(array $keys, array $methods, array $component): void

--- a/app/bundles/PointBundle/Helper/EventHelper.php
+++ b/app/bundles/PointBundle/Helper/EventHelper.php
@@ -9,7 +9,8 @@ use Mautic\LeadBundle\Entity\Lead;
 final class EventHelper
 {
     /**
-     * @param Lead $lead
+     * @param Lead                 $lead
+     * @param array<string, mixed> $action
      *
      * @return int
      */

--- a/app/bundles/PointBundle/Model/TriggerModel.php
+++ b/app/bundles/PointBundle/Model/TriggerModel.php
@@ -299,8 +299,8 @@ class TriggerModel extends CommonFormModel implements GlobalSearchInterface
     /**
      * Triggers a specific event.
      *
-     * @param array $event triggerEvent converted to array
-     * @param bool  $force
+     * @param array<string, mixed> $event triggerEvent converted to array
+     * @param bool                 $force
      *
      * @return bool Was event triggered
      */
@@ -346,6 +346,10 @@ class TriggerModel extends CommonFormModel implements GlobalSearchInterface
         return (bool) $triggerExecutedEvent->getResult();
     }
 
+    /**
+     * @param array<string, mixed> $event
+     * @param array<string, mixed> $settings
+     */
     private function invokeCallback(array $event, Lead $lead, array $settings): mixed
     {
         $args = [

--- a/app/bundles/ReportBundle/Builder/MauticReportBuilder.php
+++ b/app/bundles/ReportBundle/Builder/MauticReportBuilder.php
@@ -136,7 +136,7 @@ final class MauticReportBuilder implements ReportBuilderInterface
     /**
      * This method configures the ReportBuilder. It has to return a configured Doctrine DBAL QueryBuilder.
      *
-     * @param array $options Options array
+     * @param array<string, mixed> $options Options array
      *
      * @return QueryBuilder
      */
@@ -825,8 +825,8 @@ final class MauticReportBuilder implements ReportBuilderInterface
     }
 
     /**
-     * @param mixed[] $filter
-     * @param mixed[] $filterDefinitions
+     * @param array<string, mixed> $filter
+     * @param mixed[]              $filterDefinitions
      */
     private function doesColumnSupportEmptyValue(array $filter, array $filterDefinitions): bool
     {

--- a/app/bundles/ReportBundle/Crate/ReportDataResult.php
+++ b/app/bundles/ReportBundle/Crate/ReportDataResult.php
@@ -13,6 +13,9 @@ final class ReportDataResult
      */
     private $data;
 
+    /**
+     * @var string[]|mixed[]
+     */
     private array $headers = [];
 
     private array $types = [];
@@ -165,6 +168,9 @@ final class ReportDataResult
         return $this->columnKeys;
     }
 
+    /**
+     * @param array<string, mixed> $data
+     */
     private function buildHeader(array $data): void
     {
         foreach ($this->columnKeys as $k) {
@@ -180,6 +186,9 @@ final class ReportDataResult
         }
     }
 
+    /**
+     * @param array<string, mixed> $data
+     */
     private function buildTypes(array $data): void
     {
         foreach ($this->columnKeys as $k) {

--- a/app/bundles/ReportBundle/Event/ReportBuilderEvent.php
+++ b/app/bundles/ReportBundle/Event/ReportBuilderEvent.php
@@ -52,8 +52,8 @@ class ReportBuilderEvent extends AbstractReportEvent
      * 'display_name' => The translation key to display in the select list
      * 'columns'      => An array containing the table's columns
      *
-     * @param string $context Context for data
-     * @param array  $data    Data array for the table
+     * @param string               $context Context for data
+     * @param array<string, mixed> $data    Data array for the table
      */
     public function addTable($context, array $data, $group = null): static
     {
@@ -180,6 +180,8 @@ class ReportBuilderEvent extends AbstractReportEvent
 
     /**
      * Add campaign columns joined by the campaign lead event log table.
+     *
+     * @return array<string, array<string, string>>
      */
     public function getCampaignByChannelColumns(): array
     {

--- a/app/bundles/ReportBundle/Model/ReportModel.php
+++ b/app/bundles/ReportBundle/Model/ReportModel.php
@@ -446,7 +446,9 @@ class ReportModel extends FormModel implements GlobalSearchInterface
     /**
      * Get report data for view rendering.
      *
-     * @return mixed[]
+     * @param array<string, mixed> $options
+     *
+     * @return array<string, mixed>
      */
     public function getReportData(Report $entity, ?FormFactoryInterface $formFactory = null, array $options = []): array
     {
@@ -763,6 +765,8 @@ class ReportModel extends FormModel implements GlobalSearchInterface
     /**
      * Determine what operators should be used for the filter type.
      *
+     * @param array<string, mixed> $data
+     *
      * @return mixed|string
      */
     private function getOperatorOptions(array $data)
@@ -787,6 +791,9 @@ class ReportModel extends FormModel implements GlobalSearchInterface
         return $options;
     }
 
+    /**
+     * @param array<string, mixed> $debugData
+     */
     private function getTotalCount(QueryBuilder $qb, array &$debugData): int
     {
         $countQb = clone $qb;

--- a/app/bundles/ReportBundle/Scheduler/Enum/SchedulerEnum.php
+++ b/app/bundles/ReportBundle/Scheduler/Enum/SchedulerEnum.php
@@ -34,6 +34,9 @@ final class SchedulerEnum
 
     public const string MONTH_FREQUENCY_LAST  = '-1';
 
+    /**
+     * @return array<string, string>
+     */
     public static function getUnitEnumForSelect(): array
     {
         return [
@@ -44,6 +47,9 @@ final class SchedulerEnum
         ];
     }
 
+    /**
+     * @return array<string, string>
+     */
     public static function getDayEnumForSelect(): array
     {
         return [
@@ -58,6 +64,9 @@ final class SchedulerEnum
         ];
     }
 
+    /**
+     * @return array<string, string>
+     */
     public static function getMonthFrequencyForSelect(): array
     {
         return [
@@ -66,6 +75,9 @@ final class SchedulerEnum
         ];
     }
 
+    /**
+     * @return array<int, string>
+     */
     public static function getWeekDays(): array
     {
         return [

--- a/app/bundles/ReportBundle/Tests/Builder/MauticReportBuilderTest.php
+++ b/app/bundles/ReportBundle/Tests/Builder/MauticReportBuilderTest.php
@@ -597,7 +597,7 @@ final class MauticReportBuilderTest extends TestCase
     }
 
     /**
-     * @param mixed[] $filters
+     * @param array<int, array<string, string>> $filters
      */
     private function buildReportWithFilters(array $filters): Report
     {
@@ -609,7 +609,7 @@ final class MauticReportBuilderTest extends TestCase
     }
 
     /**
-     * @param mixed[] $filterDefinitions
+     * @param array<string, array<string, string>> $filterDefinitions
      */
     private function buildQueryWithFilters(Report $report, array $filterDefinitions): QueryBuilder
     {

--- a/app/bundles/ReportBundle/Tests/Fixtures.php
+++ b/app/bundles/ReportBundle/Tests/Fixtures.php
@@ -7,7 +7,7 @@ namespace Mautic\ReportBundle\Tests;
 final class Fixtures
 {
     /**
-     * @return mixed[]
+     * @return array<string, \DateTime|mixed[]|string|int>
      */
     public static function getValidReportResult(): array
     {
@@ -57,7 +57,7 @@ final class Fixtures
     }
 
     /**
-     * @return mixed[]
+     * @return array<int, array<string, string>>
      */
     public static function getValidReportData(): array
     {
@@ -192,7 +192,7 @@ final class Fixtures
     }
 
     /**
-     * @return mixed[]
+     * @return array<string, array<string, array<array<string, array<string, mixed>>, mixed>>>
      */
     public static function getReportBuilderEventData(): array
     {
@@ -251,7 +251,7 @@ final class Fixtures
     }
 
     /**
-     * @return mixed[]
+     * @return array<string, \DateTime|mixed[]|string|int>
      */
     public static function getValidReportResultWithAggregatedColumns(): array
     {
@@ -301,7 +301,7 @@ final class Fixtures
     }
 
     /**
-     * @return mixed[]
+     * @return array<int, array<string, string>>
      */
     public static function getValidReportDataAggregatedColumns(): array
     {

--- a/app/bundles/SmsBundle/Entity/StatRepository.php
+++ b/app/bundles/SmsBundle/Entity/StatRepository.php
@@ -100,7 +100,8 @@ class StatRepository extends CommonRepository
     /**
      * Get a lead's email stat.
      *
-     * @param int $leadId
+     * @param int                  $leadId
+     * @param array<string, mixed> $options
      *
      * @return array
      *

--- a/app/bundles/SmsBundle/EventListener/CampaignSendSubscriber.php
+++ b/app/bundles/SmsBundle/EventListener/CampaignSendSubscriber.php
@@ -77,7 +77,7 @@ final readonly class CampaignSendSubscriber implements EventSubscriberInterface
     }
 
     /**
-     * @param mixed[] $result
+     * @param array<int, mixed> $result
      */
     private function processResponse(PendingEvent $event, array $result): void
     {

--- a/app/bundles/SmsBundle/Model/SmsModel.php
+++ b/app/bundles/SmsBundle/Model/SmsModel.php
@@ -180,6 +180,7 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface, GlobalSear
     /**
      * @param Lead|int|array<Lead>|array<int> $sendTo
      * @param array<int, Lead>                $contacts
+     * @param array<string, mixed>            $options
      */
     public function sendSms(Sms $sms, $sendTo, array $options = [], array &$contacts = []): array
     {
@@ -450,9 +451,10 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface, GlobalSear
     /**
      * Get line chart data of hits.
      *
-     * @param ?string $unit          {@link php.net/manual/en/function.date.php#refsect1-function.date-parameters}
-     * @param string  $dateFormat
-     * @param bool    $canViewOthers
+     * @param ?string              $unit          {@link php.net/manual/en/function.date.php#refsect1-function.date-parameters}
+     * @param string               $dateFormat
+     * @param bool                 $canViewOthers
+     * @param array<string, mixed> $filter
      */
     public function getHitsLineChartData($unit, \DateTime $dateFrom, \DateTime $dateTo, $dateFormat = null, array $filter = [], $canViewOthers = true): array
     {

--- a/app/bundles/StageBundle/Event/StageBuilderEvent.php
+++ b/app/bundles/StageBundle/Event/StageBuilderEvent.php
@@ -18,25 +18,25 @@ final class StageBuilderEvent extends Event
     /**
      * Adds an action to the list of available .
      *
-     * @param string $key    - a unique identifier; it is recommended that it be namespaced i.e. lead.action
-     * @param array  $action - can contain the following keys:
-     *                       'label'           => (required) what to display in the list
-     *                       'description'     => (optional) short description of event
-     *                       'template'        => (optional) template to use for the action's HTML in the stage builder
-     *                       i.e AcmeMyBundle:StageAction:theaction.html.twig
-     *                       'formType'        => (optional) name of the form type SERVICE for the action; will use a default form with stage change only
-     *                       'formTypeOptions' => (optional) array of options to pass to formType
-     *                       'callback'        => (optional) callback function that will be passed when the action is triggered; return true to
-     *                       change the configured stages or false to ignore the action
-     *                       The callback function can receive the following arguments by name (via ReflectionMethod::invokeArgs())
-     *                       Mautic\LeadBundle\Entity\Lead $lead
-     *                       $eventDetails - variable sent from firing function to call back function
-     *                       array $action = array(
-     *                       'id' => int
-     *                       'type' => string
-     *                       'name' => string
-     *                       'properties' => array()
-     *                       )
+     * @param string               $key    - a unique identifier; it is recommended that it be namespaced i.e. lead.action
+     * @param array<string, mixed> $action - can contain the following keys:
+     *                                     'label'           => (required) what to display in the list
+     *                                     'description'     => (optional) short description of event
+     *                                     'template'        => (optional) template to use for the action's HTML in the stage builder
+     *                                     i.e AcmeMyBundle:StageAction:theaction.html.twig
+     *                                     'formType'        => (optional) name of the form type SERVICE for the action; will use a default form with stage change only
+     *                                     'formTypeOptions' => (optional) array of options to pass to formType
+     *                                     'callback'        => (optional) callback function that will be passed when the action is triggered; return true to
+     *                                     change the configured stages or false to ignore the action
+     *                                     The callback function can receive the following arguments by name (via ReflectionMethod::invokeArgs())
+     *                                     Mautic\LeadBundle\Entity\Lead $lead
+     *                                     $eventDetails - variable sent from firing function to call back function
+     *                                     array $action = array(
+     *                                     'id' => int
+     *                                     'type' => string
+     *                                     'name' => string
+     *                                     'properties' => array()
+     *                                     )
      *
      * @throws InvalidArgumentException
      */
@@ -97,6 +97,10 @@ final class StageBuilderEvent extends Event
     }
 
     /**
+     * @param string[]             $keys
+     * @param string[]             $methods
+     * @param array<string, mixed> $component
+     *
      * @throws InvalidArgumentException
      */
     private function verifyComponent(array $keys, array $methods, array $component): void

--- a/app/bundles/UserBundle/Controller/RoleController.php
+++ b/app/bundles/UserBundle/Controller/RoleController.php
@@ -464,6 +464,9 @@ final class RoleController extends FormController
         ]);
     }
 
+    /**
+     * @return array<string, array<string, non-empty-array<mixed>>>
+     */
     private function getPermissionsConfig(Entity\Role $role): array
     {
         $permissionObjects = $this->security->getPermissionObjects();

--- a/app/bundles/UserBundle/Entity/User.php
+++ b/app/bundles/UserBundle/Entity/User.php
@@ -345,6 +345,9 @@ class User extends FormEntity implements UserInterface, EquatableInterface, Pass
         return $this->currentPassword;
     }
 
+    /**
+     * @return string[]
+     */
     public function getRoles(): array
     {
         $roles = [];

--- a/app/bundles/UserBundle/Entity/UserRepository.php
+++ b/app/bundles/UserBundle/Entity/UserRepository.php
@@ -47,6 +47,8 @@ class UserRepository extends CommonRepository
     /**
      * Checks to ensure that a username and/or email is unique.
      *
+     * @param array<string, mixed> $params
+     *
      * @return array
      */
     public function checkUniqueUsernameEmail(array $params)

--- a/app/bundles/UserBundle/Security/SAML/User/UserCreator.php
+++ b/app/bundles/UserBundle/Security/SAML/User/UserCreator.php
@@ -15,6 +15,9 @@ final class UserCreator implements UserCreatorInterface
 {
     private readonly int $defaultRole;
 
+    /**
+     * @var string[]
+     */
     private array $requiredFields = [
         'username',
         'firstname',

--- a/app/bundles/WebhookBundle/Entity/Webhook.php
+++ b/app/bundles/WebhookBundle/Entity/Webhook.php
@@ -98,6 +98,9 @@ class Webhook extends FormEntity implements SkipModifiedInterface
      */
     private $logs;
 
+    /**
+     * @var Event[]
+     */
     private array $removedEvents = [];
 
     /**
@@ -109,6 +112,8 @@ class Webhook extends FormEntity implements SkipModifiedInterface
     /**
      * Holds a simplified array of events, just an array of event types.
      * It's used for API serializaiton.
+     *
+     * @var string[]|null[]
      */
     #[Groups(['webhook:read', 'webhook:write'])]
     private array $triggers = [];

--- a/app/bundles/WebhookBundle/Event/WebhookBuilderEvent.php
+++ b/app/bundles/WebhookBundle/Event/WebhookBuilderEvent.php
@@ -18,10 +18,10 @@ class WebhookBuilderEvent extends Event
     /**
      * Add an event for the event list.
      *
-     * @param string $key   - a unique identifier; it is recommended that it be namespaced i.e. lead.mytrigger
-     * @param array  $event - can contain the following keys:
-     *                      'label'       => (required) what to display in the list
-     *                      'description' => (optional) short description of event
+     * @param string               $key   - a unique identifier; it is recommended that it be namespaced i.e. lead.mytrigger
+     * @param array<string, mixed> $event - can contain the following keys:
+     *                                    'label'       => (required) what to display in the list
+     *                                    'description' => (optional) short description of event
      */
     public function addEvent($key, array $event): void
     {

--- a/app/bundles/WebhookBundle/Helper/CampaignHelper.php
+++ b/app/bundles/WebhookBundle/Helper/CampaignHelper.php
@@ -28,6 +28,8 @@ final class CampaignHelper
 
     /**
      * Prepares the neccessary data transformations and then makes the HTTP request.
+     *
+     * @param array<string, mixed> $config
      */
     public function fireWebhook(array $config, Lead $contact): void
     {
@@ -49,6 +51,8 @@ final class CampaignHelper
 
     /**
      * Gets the payload fields from the config and if there are tokens it translates them to contact values.
+     *
+     * @param array<string, mixed> $config
      */
     private function getPayload(array $config, Lead $contact): array
     {
@@ -60,6 +64,8 @@ final class CampaignHelper
 
     /**
      * Gets the payload fields from the config and if there are tokens it translates them to contact values.
+     *
+     * @param array<string, mixed> $config
      */
     private function getHeaders(array $config, Lead $contact): array
     {
@@ -70,7 +76,8 @@ final class CampaignHelper
     }
 
     /**
-     * @param int $timeout
+     * @param int                  $timeout
+     * @param array<string, mixed> $headers
      *
      * @throws \InvalidArgumentException
      * @throws \OutOfRangeException
@@ -117,6 +124,8 @@ final class CampaignHelper
 
     /**
      * Translates tokens to values.
+     *
+     * @param int[]|string[] $rawTokens
      */
     private function getTokenValues(array $rawTokens, Lead $contact): array
     {

--- a/app/bundles/WebhookBundle/Tests/Functional/Model/WebhookModelTest.php
+++ b/app/bundles/WebhookBundle/Tests/Functional/Model/WebhookModelTest.php
@@ -92,7 +92,7 @@ final class WebhookModelTest extends MauticMysqlTestCase
     }
 
     /**
-     * @param mixed[] $payload
+     * @param array<string, int> $payload
      */
     private function createWebhookQueue(Webhook $webhook, Event $event, array $payload): void
     {

--- a/plugins/MauticClearbitBundle/Helper/LookupHelper.php
+++ b/plugins/MauticClearbitBundle/Helper/LookupHelper.php
@@ -166,6 +166,9 @@ final class LookupHelper
         return ($person) ? new Clearbit_Person($keys['apikey']) : new Clearbit_Company($keys['apikey']);
     }
 
+    /**
+     * @return array<int, string|non-empty-array<mixed>>
+     */
     private function getCache(Lead|Company $entity, $notify): array
     {
         $user      = $this->userHelper->getUser();

--- a/plugins/MauticClearbitBundle/Services/Clearbit_Base.php
+++ b/plugins/MauticClearbitBundle/Services/Clearbit_Base.php
@@ -40,7 +40,7 @@ class Clearbit_Base
     }
 
     /**
-     * @param mixed[] $hdr
+     * @param array<string, mixed> $hdr
      */
     private function _update_rate_limit(array $hdr): void
     {
@@ -74,6 +74,8 @@ class Clearbit_Base
     }
 
     /**
+     * @param array<string, mixed> $params
+     *
      * @return object
      */
     protected function _execute(array $params = [])

--- a/plugins/MauticCloudStorageBundle/Integration/CloudStorageIntegration.php
+++ b/plugins/MauticCloudStorageBundle/Integration/CloudStorageIntegration.php
@@ -61,7 +61,7 @@ abstract class CloudStorageIntegration extends AbstractIntegration
      */
     abstract public function getPublicUrl($key);
 
-    public function getSupportedFeatures()
+    public function getSupportedFeatures(): array
     {
         return ['cloud_storage'];
     }

--- a/plugins/MauticCrmBundle/Api/ConnectwiseApi.php
+++ b/plugins/MauticCrmBundle/Api/ConnectwiseApi.php
@@ -60,7 +60,8 @@ class ConnectwiseApi extends CrmApi
     }
 
     /**
-     * @param int $page
+     * @param int                  $page
+     * @param array<string, mixed> $params
      *
      * @return mixed|string
      *
@@ -86,7 +87,8 @@ class ConnectwiseApi extends CrmApi
     }
 
     /**
-     * @param int $page
+     * @param int                  $page
+     * @param array<string, mixed> $params
      *
      * @return mixed|string
      *

--- a/plugins/MauticCrmBundle/Api/DynamicsApi.php
+++ b/plugins/MauticCrmBundle/Api/DynamicsApi.php
@@ -16,7 +16,9 @@ final class DynamicsApi extends CrmApi
     }
 
     /**
-     * @param string $moduleobject
+     * @param string                                               $moduleobject
+     * @param array<string, mixed>                                 $parameters
+     * @param array<string, string|array<string|int, string|bool>> $settings
      *
      * @return array|ResponseInterface
      *
@@ -76,8 +78,10 @@ final class DynamicsApi extends CrmApi
 
         $operation  = sprintf('EntityDefinitions(LogicalName=\'%s\')/Attributes', $logicalName);
         $parameters = [
-            '$filter' => 'Microsoft.Dynamics.CRM.NotIn(PropertyName=\'AttributeTypeName\',PropertyValues=["Virtual", "Uniqueidentifier", "Picklist", "Lookup", "Owner", "Customer"]) and IsValidForUpdate eq true and AttributeOf eq null and LogicalName ne \'parentcustomerid\'', // ignore system fields
-            '$select' => 'RequiredLevel,LogicalName,DisplayName,AttributeTypeName', // select only miningful columns
+            // ignore system fields
+            '$filter' => 'Microsoft.Dynamics.CRM.NotIn(PropertyName=\'AttributeTypeName\',PropertyValues=["Virtual", "Uniqueidentifier", "Picklist", "Lookup", "Owner", "Customer"]) and IsValidForUpdate eq true and AttributeOf eq null and LogicalName ne \'parentcustomerid\'',
+            // select only miningful columns
+            '$select' => 'RequiredLevel,LogicalName,DisplayName,AttributeTypeName',
         ];
 
         return $this->request($operation, $parameters, 'GET', $object);

--- a/plugins/MauticCrmBundle/Api/HubspotApi.php
+++ b/plugins/MauticCrmBundle/Api/HubspotApi.php
@@ -12,6 +12,9 @@ use MauticPlugin\MauticCrmBundle\Integration\HubspotIntegration;
  */
 final class HubspotApi extends CrmApi
 {
+    /**
+     * @var array<string, string>
+     */
     private array $requestSettings = [
         'encode_parameters' => 'json',
     ];
@@ -23,6 +26,9 @@ final class HubspotApi extends CrmApi
         parent::__construct($integration);
     }
 
+    /**
+     * @param array<string, mixed> $parameters
+     */
     private function request(string $operation, array $parameters = [], string $method = 'GET', string $object = 'contacts')
     {
         if ('oauth2' === $this->integration->getAuthenticationType()) {
@@ -74,6 +80,8 @@ final class HubspotApi extends CrmApi
 
     /**
      * Creates Hubspot lead.
+     *
+     * @param array<string, mixed> $data
      *
      * @return mixed
      */

--- a/plugins/MauticCrmBundle/Api/SalesforceApi.php
+++ b/plugins/MauticCrmBundle/Api/SalesforceApi.php
@@ -96,6 +96,8 @@ final class SalesforceApi extends CrmApi
     }
 
     /**
+     * @param array<string, mixed> $data
+     *
      * @throws ApiErrorException
      */
     public function getPerson(array $data): array
@@ -138,6 +140,8 @@ final class SalesforceApi extends CrmApi
     }
 
     /**
+     * @param array<string, mixed> $data
+     *
      * @throws ApiErrorException
      */
     public function getCompany(array $data): array
@@ -178,6 +182,8 @@ final class SalesforceApi extends CrmApi
     }
 
     /**
+     * @param array<string, mixed> $data
+     *
      * @return array|mixed|string
      *
      * @throws ApiErrorException
@@ -192,6 +198,8 @@ final class SalesforceApi extends CrmApi
     }
 
     /**
+     * @param non-empty-array<string, mixed> $data
+     *
      * @return mixed|string
      *
      * @throws ApiErrorException
@@ -226,6 +234,8 @@ final class SalesforceApi extends CrmApi
     }
 
     /**
+     * @param array<array<string, mixed>, mixed> $data
+     *
      * @return mixed|string
      *
      * @throws ApiErrorException
@@ -544,6 +554,8 @@ final class SalesforceApi extends CrmApi
     }
 
     /**
+     * @param non-empty-array<mixed, mixed> $error
+     *
      * @throws ApiErrorException
      * @throws RetryRequestException
      */

--- a/plugins/MauticCrmBundle/Api/SugarcrmApi.php
+++ b/plugins/MauticCrmBundle/Api/SugarcrmApi.php
@@ -13,7 +13,8 @@ final class SugarcrmApi extends CrmApi
     private string $object = 'Leads';
 
     /**
-     * @param string $method
+     * @param string               $method
+     * @param array<string, mixed> $data
      *
      * @return mixed|string
      *
@@ -103,6 +104,8 @@ final class SugarcrmApi extends CrmApi
     }
 
     /**
+     * @param array<string, mixed> $fields
+     *
      * @return array
      *
      * @throws ApiErrorException
@@ -548,7 +551,8 @@ final class SugarcrmApi extends CrmApi
     /**
      * Get SugarCRM leads.
      *
-     * @param string $object
+     * @param string               $object
+     * @param array<string, mixed> $query
      *
      * @return mixed
      */

--- a/plugins/MauticCrmBundle/Api/Zoho/Mapper.php
+++ b/plugins/MauticCrmBundle/Api/Zoho/Mapper.php
@@ -89,6 +89,9 @@ final class Mapper
         return $mapped;
     }
 
+    /**
+     * @return array[]
+     */
     public function getArray(): array
     {
         return $this->objectMappedValues;

--- a/plugins/MauticCrmBundle/Api/ZohoApi.php
+++ b/plugins/MauticCrmBundle/Api/ZohoApi.php
@@ -7,7 +7,9 @@ use Mautic\PluginBundle\Exception\ApiErrorException;
 final class ZohoApi extends CrmApi
 {
     /**
-     * @param string $operation
+     * @param string                        $operation
+     * @param array<string, string|mixed[]> $parameters
+     * @param array<string, mixed>          $settings
      *
      * @return array
      *
@@ -81,7 +83,8 @@ final class ZohoApi extends CrmApi
     }
 
     /**
-     * @param string $object
+     * @param string               $object
+     * @param array<string, mixed> $params
      *
      * @return array
      *
@@ -115,6 +118,8 @@ final class ZohoApi extends CrmApi
     }
 
     /**
+     * @param array<string, mixed> $params
+     *
      * @return array
      *
      * @throws ApiErrorException

--- a/plugins/MauticCrmBundle/Integration/ConnectwiseIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/ConnectwiseIntegration.php
@@ -295,7 +295,7 @@ class ConnectwiseIntegration extends CrmAbstractIntegration
     }
 
     /**
-     * @return array of company fields for connectwise
+     * @return array<string, array<string, bool|string>> of company fields for connectwise
      */
     public function getCompanyFields(): array
     {
@@ -342,7 +342,7 @@ class ConnectwiseIntegration extends CrmAbstractIntegration
     }
 
     /**
-     * @return array of contact fields for connectwise
+     * @return array<string, array<array<string, mixed>, mixed>> of contact fields for connectwise
      */
     public function getContactFields(): array
     {
@@ -621,6 +621,7 @@ class ConnectwiseIntegration extends CrmAbstractIntegration
 
     /**
      * @param array<string, mixed> $config
+     * @param array<string, mixed> $cwContactData
      */
     public function getMappedFields(string $object, $lead, bool $personFound, array $config, array $cwContactData = []): array
     {
@@ -958,6 +959,8 @@ class ConnectwiseIntegration extends CrmAbstractIntegration
     }
 
     /**
+     * @param array<string, mixed> $config
+     *
      * @throws ApiErrorException
      */
     public function createActivity(array $config, $cwContactId, $leadId): ?IntegrationEntity

--- a/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/CrmAbstractIntegration.php
@@ -40,9 +40,9 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
     }
 
     /**
-     * @return array
+     * @return string[]
      */
-    public function getSupportedFeatures()
+    public function getSupportedFeatures(): array
     {
         return ['push_lead', 'get_leads'];
     }
@@ -448,6 +448,8 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
     }
 
     /**
+     * @param array<string, mixed> $settings
+     *
      * @return array|mixed
      */
     protected function getFormFieldsByObject($object, array $settings = [])
@@ -486,7 +488,8 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
     }
 
     /**
-     * @param string $priorityObject
+     * @param string               $priorityObject
+     * @param array<string, mixed> $config
      *
      * @return array
      */
@@ -497,6 +500,7 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
 
     /**
      * @param string[]|string|null $objects
+     * @param array<string, mixed> $fieldsToUpdate
      *
      * @return array
      */
@@ -514,7 +518,9 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
     }
 
     /**
-     * @return array
+     * @param array<string, mixed> $params
+     *
+     * @return array<int, string|null>
      */
     protected function getSyncTimeframeDates(array $params)
     {
@@ -526,6 +532,9 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
         return [$fromDate, $toDate];
     }
 
+    /**
+     * @param array<string, mixed> $integrationData
+     */
     public function getBlankFieldsToUpdateInMautic(array $matchedFields, array $leadFieldValues, $objectFields, array $integrationData, $object = 'Lead')
     {
         foreach ($objectFields as $integrationField => $mauticField) {
@@ -537,6 +546,10 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
         return $matchedFields;
     }
 
+    /**
+     * @param array<string, mixed> $objectFields
+     * @param array<string, mixed> $config
+     */
     public function getBlankFieldsToUpdate(array $fields, $sfRecord, array $objectFields, array $config)
     {
         // check if update blank fields is selected
@@ -583,6 +596,8 @@ abstract class CrmAbstractIntegration extends AbstractIntegration
     }
 
     /**
+     * @param array<string, mixed> $matchedFields
+     *
      * @return array
      */
     private function hydrateCompanyName(array $matchedFields)

--- a/plugins/MauticCrmBundle/Integration/DynamicsIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/DynamicsIntegration.php
@@ -417,6 +417,9 @@ final class DynamicsIntegration extends CrmAbstractIntegration
         return $executed;
     }
 
+    /**
+     * @param array<string, mixed> $params
+     */
     public function getCompanies(array $params = []): int
     {
         $executed    = 0;
@@ -669,6 +672,8 @@ final class DynamicsIntegration extends CrmAbstractIntegration
     }
 
     /**
+     * @param array<string, mixed> $params
+     *
      * @return mixed[]
      */
     public function pushLeads(array $params = []): array

--- a/plugins/MauticCrmBundle/Integration/HubspotIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/HubspotIntegration.php
@@ -384,7 +384,8 @@ class HubspotIntegration extends CrmAbstractIntegration
     }
 
     /**
-     * @param bool $id
+     * @param bool                 $id
+     * @param array<string, mixed> $params
      */
     public function getCompanies(array $params = [], $id = false, &$executed = null)
     {

--- a/plugins/MauticCrmBundle/Integration/Salesforce/Helper/StateValidationHelper.php
+++ b/plugins/MauticCrmBundle/Integration/Salesforce/Helper/StateValidationHelper.php
@@ -25,6 +25,8 @@ final class StateValidationHelper
      * Out of the box SF only supports states for the following countries. So in order to prevent SF from rejecting the entire payload, we'll
      * only send state if it is supported out of the box by SF.
      *
+     * @param array<string, mixed> $mappedData
+     *
      * @return array
      */
     public static function validate(array $mappedData)

--- a/plugins/MauticCrmBundle/Integration/Salesforce/ResultsPaginator.php
+++ b/plugins/MauticCrmBundle/Integration/Salesforce/ResultsPaginator.php
@@ -36,6 +36,8 @@ final class ResultsPaginator
     }
 
     /**
+     * @param array<string, mixed> $results
+     *
      * @throws ApiErrorException
      */
     public function setResults(array $results): static

--- a/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SalesforceIntegration.php
@@ -1081,6 +1081,8 @@ class SalesforceIntegration extends CrmAbstractIntegration
     }
 
     /**
+     * @param array<string, mixed> $params
+     *
      * @return mixed[]
      */
     public function pushLeads(array $params = []): array
@@ -1429,6 +1431,8 @@ class SalesforceIntegration extends CrmAbstractIntegration
 
     /**
      * @param array<string, mixed> $fields
+     *
+     * @return string[]
      */
     public function getMixedLeadFields(array $fields, $object): array
     {
@@ -1566,6 +1570,9 @@ class SalesforceIntegration extends CrmAbstractIntegration
         return mb_strtolower($this->cleanPushData($email));
     }
 
+    /**
+     * @param mixed[] $trackedContacts
+     */
     protected function getMauticContactsToUpdate(
         array &$checkEmailsInSF,
         $mauticLeadFieldString,
@@ -1616,6 +1623,8 @@ class SalesforceIntegration extends CrmAbstractIntegration
     }
 
     /**
+     * @param array<string, mixed> $fieldMapping
+     *
      * @return array
      *
      * @throws ApiErrorException
@@ -1693,6 +1702,10 @@ class SalesforceIntegration extends CrmAbstractIntegration
         return $sfEntityRecords;
     }
 
+    /**
+     * @param array<string, mixed> $mauticData
+     * @param array<string, mixed> $objectFields
+     */
     protected function buildCompositeBody(
         array &$mauticData,
         array $objectFields,
@@ -1793,6 +1806,11 @@ class SalesforceIntegration extends CrmAbstractIntegration
         return $updateEntity;
     }
 
+    /**
+     * @param array<string, mixed> $config
+     *
+     * @return array<int, string|mixed[]>
+     */
     protected function getRequiredFieldString(array $config, array $availableFields, $object): array
     {
         $requiredFields = $this->getRequiredFields($availableFields[$object]);
@@ -1894,6 +1912,8 @@ class SalesforceIntegration extends CrmAbstractIntegration
      * @param int $totalUpdated
      * @param int $totalCreated
      * @param int $totalErrored
+     *
+     * @return array<int, int>
      */
     protected function processCompositeResponse($response, &$totalUpdated = 0, &$totalCreated = 0, &$totalErrored = 0): array
     {
@@ -2058,6 +2078,12 @@ class SalesforceIntegration extends CrmAbstractIntegration
         return $this->getApiHelper()->request('query', ['q' => $findQuery], 'GET', false, null, $queryUrl);
     }
 
+    /**
+     * @param array<string, mixed> $checkEmailsInSF
+     * @param array<string, mixed> $processedLeads
+     * @param array<string, mixed> $trackedContacts
+     * @param array<string, mixed> $sfEntityRecords
+     */
     protected function prepareMauticContactsToUpdate(
         &$mauticData,
         array &$checkEmailsInSF,
@@ -2208,6 +2234,10 @@ class SalesforceIntegration extends CrmAbstractIntegration
         }
     }
 
+    /**
+     * @param array<string, mixed> $checkEmailsInSF
+     * @param array<string, mixed> $processedLeads
+     */
     protected function prepareMauticContactsToCreate(
         &$mauticData,
         array &$checkEmailsInSF,
@@ -2270,6 +2300,10 @@ class SalesforceIntegration extends CrmAbstractIntegration
         }
     }
 
+    /**
+     * @param array<string, mixed> $checkEmailsInSF
+     * @param array<string, mixed> $lead
+     */
     protected function setContactToSync(array &$checkEmailsInSF, array $lead): false|string
     {
         $key = $this->getSyncKey($lead['email']);
@@ -2328,6 +2362,9 @@ class SalesforceIntegration extends CrmAbstractIntegration
         return $this->prepareFieldsForSync($fields, $fieldsToUpdate, $objects);
     }
 
+    /**
+     * @param array<string, mixed> $config
+     */
     protected function mapContactDataForPush(Lead $lead, array $config): array
     {
         $fields             = array_keys($config['leadFields'] ?? []);
@@ -2375,6 +2412,9 @@ class SalesforceIntegration extends CrmAbstractIntegration
         return $mappedData;
     }
 
+    /**
+     * @param array<string, mixed> $config
+     */
     protected function mapCompanyDataForPush(Company $company, array $config): array
     {
         $object     = 'company';
@@ -2495,8 +2535,9 @@ class SalesforceIntegration extends CrmAbstractIntegration
     /**
      * Update the record in each system taking the last modified record.
      *
-     * @param string $channel
-     * @param string $sfObject
+     * @param string               $channel
+     * @param string               $sfObject
+     * @param array<string, mixed> $params
      *
      * @throws ApiErrorException
      */
@@ -2589,6 +2630,8 @@ class SalesforceIntegration extends CrmAbstractIntegration
     }
 
     /**
+     * @param array<string, mixed> $params
+     *
      * @return mixed[]
      */
     public function pushCompanies(array $params = []): array
@@ -2778,6 +2821,10 @@ class SalesforceIntegration extends CrmAbstractIntegration
         return [$totalUpdated, $totalCreated, $totalErrors, $totalIgnored];
     }
 
+    /**
+     * @param array<string, array<string, mixed[]>> $objectFields
+     * @param array<string, mixed>                  $sfEntityRecords
+     */
     protected function prepareMauticCompaniesToUpdate(
         &$mauticData,
         array &$checkCompaniesInSF,
@@ -2870,6 +2917,9 @@ class SalesforceIntegration extends CrmAbstractIntegration
         }
     }
 
+    /**
+     * @param array<string, array<string, mixed[]>> $objectFields
+     */
     protected function prepareMauticCompaniesToCreate(
         &$mauticData,
         array &$checkCompaniesInSF,

--- a/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/SugarcrmIntegration.php
@@ -368,7 +368,8 @@ final class SugarcrmIntegration extends CrmAbstractIntegration
     }
 
     /**
-     * @param array|null $query
+     * @param array|null           $query
+     * @param array<string, mixed> $params
      *
      * @return int|null
      */
@@ -1087,8 +1088,9 @@ final class SugarcrmIntegration extends CrmAbstractIntegration
     }
 
     /**
-     * @param array  $keys
-     * @param string $object
+     * @param array                $keys
+     * @param string               $object
+     * @param array<string, mixed> $fields
      */
     public function cleanSugarData(array $fields, $keys, $object): array
     {
@@ -1106,6 +1108,8 @@ final class SugarcrmIntegration extends CrmAbstractIntegration
     }
 
     /**
+     * @param array<string, mixed> $params
+     *
      * @return mixed[]
      */
     public function pushLeads(array $params = []): array
@@ -1225,6 +1229,8 @@ final class SugarcrmIntegration extends CrmAbstractIntegration
 
     /**
      * Update body to sync.
+     *
+     * @param array<string, mixed> $lead
      */
     private function pushDncToSugar(array $lead, array &$body): void
     {
@@ -1262,6 +1268,9 @@ final class SugarcrmIntegration extends CrmAbstractIntegration
         }
     }
 
+    /**
+     * @param array<string, mixed> $data
+     */
     private function fetchDncToMautic(?Lead $lead = null, array $data = []): void
     {
         if (null === $lead) {
@@ -1299,9 +1308,9 @@ final class SugarcrmIntegration extends CrmAbstractIntegration
     /**
      * @param string $object
      *
-     * @return array The first element is made up of records that exist in Mautic, but which no longer have a match in CRM.
-     *               We therefore assume that they've been deleted in CRM and will mark them as deleted in the pushLeads function (~line 1320).
-     *               The second element contains Ids of records that were explicitly marked as deleted in CRM. ATM, nothing is done with this data.
+     * @return array<int, mixed> The first element is made up of records that exist in Mautic, but which no longer have a match in CRM.
+     *                           We therefore assume that they've been deleted in CRM and will mark them as deleted in the pushLeads function (~line 1320).
+     *                           The second element contains Ids of records that were explicitly marked as deleted in CRM. ATM, nothing is done with this data.
      */
     public function getObjectDataToUpdate($checkEmailsInSugar, array &$mauticData, $availableFields, $contactSugarFields, $leadSugarFields, $object = 'Leads'): array
     {
@@ -1404,6 +1413,9 @@ final class SugarcrmIntegration extends CrmAbstractIntegration
         return $result;
     }
 
+    /**
+     * @param array<string, mixed> $lead
+     */
     private function getOwnerEmail(array $lead)
     {
         if (isset($lead['owner_id']) && !empty($lead['owner_id'])) {
@@ -1416,6 +1428,10 @@ final class SugarcrmIntegration extends CrmAbstractIntegration
         return null;
     }
 
+    /**
+     * @param array<string, mixed> $mauticData
+     * @param array<string, mixed> $availableFields
+     */
     private function buildCompositeBody(array &$mauticData, array $availableFields, array $fieldsToUpdateInSugarUpdate, string $object, array $lead, ?array $onwerAssignedUserIdByEmail = null, $objectId = null): void
     {
         $body = [];
@@ -1460,6 +1476,8 @@ final class SugarcrmIntegration extends CrmAbstractIntegration
 
     /**
      * @param array $response
+     *
+     * @return array<int, int>
      */
     private function processCompositeResponse($response): array
     {

--- a/plugins/MauticCrmBundle/Integration/ZohoIntegration.php
+++ b/plugins/MauticCrmBundle/Integration/ZohoIntegration.php
@@ -471,7 +471,8 @@ final class ZohoIntegration extends CrmAbstractIntegration
     }
 
     /**
-     * @param array $result
+     * @param array                $result
+     * @param array<string, mixed> $params
      */
     public function getCompanies(array $params = [], $query = null, &$executed = null, &$result = []): int
     {
@@ -764,6 +765,8 @@ final class ZohoIntegration extends CrmAbstractIntegration
     }
 
     /**
+     * @param array<string, mixed> $params
+     *
      * @return mixed[]
      */
     public function pushLeads(array $params = []): array
@@ -1148,7 +1151,8 @@ final class ZohoIntegration extends CrmAbstractIntegration
     }
 
     /**
-     * @param array<mixed, mixed> $fields
+     * @param array<mixed, mixed>  $fields
+     * @param array<string, mixed> $data
      */
     private function parseZohoRecord(array $data, array $fields): array
     {

--- a/plugins/MauticEmailMarketingBundle/Api/ConstantContactApi.php
+++ b/plugins/MauticEmailMarketingBundle/Api/ConstantContactApi.php
@@ -8,6 +8,9 @@ final class ConstantContactApi extends EmailMarketingApi
 {
     private string $version = 'v2';
 
+    /**
+     * @param array<string, mixed> $query
+     */
     private function request(string $endpoint, array $parameters = [], string $method = 'GET', array $query = [])
     {
         $url = sprintf('https://api.constantcontact.com/%s/%s?api_key=%s', $this->version, $endpoint, $this->keys['client_id']);
@@ -41,7 +44,8 @@ final class ConstantContactApi extends EmailMarketingApi
     }
 
     /**
-     * @param array $fields
+     * @param array                $fields
+     * @param array<string, mixed> $config
      *
      * @return mixed|string
      *

--- a/plugins/MauticEmailMarketingBundle/Api/IcontactApi.php
+++ b/plugins/MauticEmailMarketingBundle/Api/IcontactApi.php
@@ -6,6 +6,9 @@ use Mautic\PluginBundle\Exception\ApiErrorException;
 
 final class IcontactApi extends EmailMarketingApi
 {
+    /**
+     * @param array<int, mixed[]> $parameters
+     */
     private function request(string $endpoint, array $parameters = [], string $method = 'GET')
     {
         $url = sprintf('%s/%s/c/%s/%s', $this->integration->getApiUrl(), $this->keys['accountId'], $this->keys['clientFolderId'], $endpoint);
@@ -43,6 +46,8 @@ final class IcontactApi extends EmailMarketingApi
     }
 
     /**
+     * @param array<string, mixed> $fields
+     *
      * @return mixed|string
      *
      * @throws ApiErrorException

--- a/plugins/MauticEmailMarketingBundle/Api/MailchimpApi.php
+++ b/plugins/MauticEmailMarketingBundle/Api/MailchimpApi.php
@@ -9,6 +9,8 @@ final class MailchimpApi extends EmailMarketingApi
     private string $version = '3.0';
 
     /**
+     * @param array<string, int> $parameters
+     *
      * @return mixed|string
      *
      * @throws ApiErrorException

--- a/plugins/MauticEmailMarketingBundle/Integration/EmailAbstractIntegration.php
+++ b/plugins/MauticEmailMarketingBundle/Integration/EmailAbstractIntegration.php
@@ -11,9 +11,9 @@ abstract class EmailAbstractIntegration extends AbstractIntegration
     protected $pushContactLink = false;
 
     /**
-     * @return array
+     * @return string[]
      */
-    public function getSupportedFeatures()
+    public function getSupportedFeatures(): array
     {
         return ['push_lead'];
     }

--- a/plugins/MauticFocusBundle/Controller/FocusController.php
+++ b/plugins/MauticFocusBundle/Controller/FocusController.php
@@ -213,6 +213,9 @@ final class FocusController extends AbstractStandardFormController
         return $args;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     protected function getEntityFormOptions(): array
     {
         $focus        = $this->getCurrentRequest()->request->all()['focus'] ?? [];

--- a/plugins/MauticFullContactBundle/Controller/PublicController.php
+++ b/plugins/MauticFullContactBundle/Controller/PublicController.php
@@ -256,8 +256,8 @@ final class PublicController extends FormController
     /**
      * This is only called internally.
      *
-     * @param mixed[] $result
-     * @param mixed[] $validatedRequest
+     * @param array<string, mixed> $result
+     * @param array<string, mixed> $validatedRequest
      *
      * @throws \InvalidArgumentException
      */

--- a/plugins/MauticFullContactBundle/Helper/LookupHelper.php
+++ b/plugins/MauticFullContactBundle/Helper/LookupHelper.php
@@ -181,6 +181,9 @@ final class LookupHelper
         return ($person) ? new FullContact_Person($keys['apikey']) : new FullContact_Company($keys['apikey']);
     }
 
+    /**
+     * @return array<int, string|non-empty-array<mixed>>
+     */
     private function getCache(Lead|Company $entity, $notify): array
     {
         $user      = $this->userHelper->getUser();

--- a/plugins/MauticFullContactBundle/Services/FullContact_Base.php
+++ b/plugins/MauticFullContactBundle/Services/FullContact_Base.php
@@ -53,7 +53,7 @@ class FullContact_Base
     }
 
     /**
-     * @param mixed[] $hdr
+     * @param array<string, mixed> $hdr
      */
     private function _update_rate_limit(array $hdr): void
     {
@@ -102,7 +102,8 @@ class FullContact_Base
      * @author  Keith Casey <contrib@caseysoftware.com>
      * @author  David Boskovic <me@david.gs> @dboskovic
      *
-     * @param array $postData
+     * @param array                $postData
+     * @param array<string, mixed> $params
      *
      * @return object
      *

--- a/plugins/MauticSocialBundle/Command/MonitorTwitterBaseCommand.php
+++ b/plugins/MauticSocialBundle/Command/MonitorTwitterBaseCommand.php
@@ -242,6 +242,8 @@ abstract class MonitorTwitterBaseCommand extends Command
     /**
      * Prints the search query metadata from twitter.
      * Only shows stats if explicitly requested or if we're in verbose mode.
+     *
+     * @param array<string, mixed> $metadata
      */
     protected function printQueryMetadata(array $metadata): void
     {
@@ -266,7 +268,8 @@ abstract class MonitorTwitterBaseCommand extends Command
      * Prints a summary of the search query.
      * Only shows stats if explicitly requested or if we're in verbose mode.
      *
-     * @param Monitoring $monitor
+     * @param Monitoring           $monitor
+     * @param array<string, mixed> $results
      */
     protected function printInformation($monitor, array $results): void
     {

--- a/plugins/MauticSocialBundle/Entity/MonitoringRepository.php
+++ b/plugins/MauticSocialBundle/Entity/MonitoringRepository.php
@@ -11,6 +11,8 @@ use Mautic\CoreBundle\Entity\CommonRepository;
 final class MonitoringRepository extends CommonRepository
 {
     /**
+     * @param array<string, mixed> $args
+     *
      * @return Paginator
      */
     public function getPublishedEntities(array $args = [])

--- a/plugins/MauticSocialBundle/Entity/PostCountRepository.php
+++ b/plugins/MauticSocialBundle/Entity/PostCountRepository.php
@@ -13,6 +13,8 @@ final class PostCountRepository extends CommonRepository
     /**
      * Fetch Lead stats for some period of time.
      *
+     * @param array<string, mixed> $options
+     *
      * @return PostCount[]
      *
      * @throws \Doctrine\ORM\NoResultException

--- a/plugins/MauticSocialBundle/Helper/TwitterCommandHelper.php
+++ b/plugins/MauticSocialBundle/Helper/TwitterCommandHelper.php
@@ -338,6 +338,8 @@ final class TwitterCommandHelper
 
     /**
      * Increment the post counter.
+     *
+     * @param array<string, mixed> $tweet
      */
     private function incrementPostCount(Monitoring $monitor, array $tweet): void
     {

--- a/plugins/MauticSocialBundle/Integration/InstagramIntegration.php
+++ b/plugins/MauticSocialBundle/Integration/InstagramIntegration.php
@@ -17,9 +17,9 @@ final class InstagramIntegration extends SocialIntegration
         ];
     }
 
-    public function getIdentifierFields(): string
+    public function getIdentifierFields(): array
     {
-        return 'instagram';
+        return ['instagram'];
     }
 
     public function getAuthenticationUrl(): string

--- a/plugins/MauticSocialBundle/Integration/SocialIntegration.php
+++ b/plugins/MauticSocialBundle/Integration/SocialIntegration.php
@@ -203,6 +203,8 @@ abstract class SocialIntegration extends AbstractIntegration
     /**
      * Get the access token from session or socialCache.
      *
+     * @param array<string, mixed> $socialCache
+     *
      * @return array|mixed|null
      */
     protected function getContactAccessToken(array &$socialCache)

--- a/plugins/MauticSocialBundle/Integration/TwitterIntegration.php
+++ b/plugins/MauticSocialBundle/Integration/TwitterIntegration.php
@@ -18,11 +18,17 @@ final class TwitterIntegration extends SocialIntegration
         return 5000;
     }
 
-    public function getIdentifierFields(): string
+    /**
+     * @return string[]
+     */
+    public function getIdentifierFields(): array
     {
-        return 'twitter';
+        return ['twitter'];
     }
 
+    /**
+     * @return string[]
+     */
     public function getSupportedFeatures(): array
     {
         return [

--- a/plugins/MauticSocialBundle/Model/TweetModel.php
+++ b/plugins/MauticSocialBundle/Model/TweetModel.php
@@ -80,8 +80,9 @@ final class TweetModel extends FormModel implements AjaxLookupModelInterface
     /**
      * Create/update Tweet Stat and update sent count for Tweet.
      *
-     * @param string $source
-     * @param int    $sourceId
+     * @param string               $source
+     * @param int                  $sourceId
+     * @param array<string, mixed> $sendResponse
      */
     public function registerSend(Tweet $tweet, Lead $lead, array $sendResponse, $source = null, $sourceId = null): static
     {


### PR DESCRIPTION
Adds precise iterable docblock types (generated via Rector's type-declaration set) across the remaining app bundles and plugins.

Docblock-only change; no runtime behavior affected. Part 3/3 of a split to keep review manageable.