### PR TITLE
[phpstan] Report unused controller action parameters

### DIFF
--- a/app/bundles/CampaignBundle/Controller/SourceController.php
+++ b/app/bundles/CampaignBundle/Controller/SourceController.php
@@ -251,7 +251,7 @@ class SourceController extends CommonFormController
     /**
      * Deletes the entity.
      */
-    public function deleteAction(Request $request, $objectId): JsonResponse
+    public function deleteAction(Request $request): JsonResponse
     {
         $this->setCampaignElements($request->request);
         $modifiedSources = $this->modifiedSources;

--- a/app/bundles/CampaignBundle/Tests/Controller/SourceControllerUnitTest.php
+++ b/app/bundles/CampaignBundle/Tests/Controller/SourceControllerUnitTest.php
@@ -135,7 +135,7 @@ final class SourceControllerUnitTest extends TestCase
             ], JSON_THROW_ON_ERROR),
         ]);
 
-        $response = $controller->deleteAction($request, 1);
+        $response = $controller->deleteAction($request);
 
         $payload = json_decode((string) $response->getContent(), true);
         $this->assertSame(1, $payload['success']);
@@ -156,7 +156,7 @@ final class SourceControllerUnitTest extends TestCase
             'modifiedSources' => json_encode(['lists' => [12 => true]], JSON_THROW_ON_ERROR),
         ]);
 
-        $response = $controller->deleteAction($request, 1);
+        $response = $controller->deleteAction($request);
 
         $payload = json_decode((string) $response->getContent(), true);
         $this->assertSame(['success' => 0], $payload);

--- a/app/bundles/EmailBundle/Controller/EmailController.php
+++ b/app/bundles/EmailBundle/Controller/EmailController.php
@@ -27,7 +27,6 @@ use Mautic\EmailBundle\Model\EmailModel;
 use Mautic\LeadBundle\Controller\EntityContactsTrait;
 use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Helper\FakeContactHelper;
-use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\LeadBundle\Model\ListModel;
 use Mautic\PageBundle\Exception\InvalidRenderedHtmlException;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -1723,7 +1722,7 @@ final class EmailController extends FormController
      * Generating the modal box content for
      * the send multiple example email option.
      */
-    public function sendExampleAction(Request $request, $objectId, CorePermissions $security, EmailModel $model, LeadModel $leadModel, FakeContactHelper $fakeLeadHelper): Response
+    public function sendExampleAction(Request $request, $objectId, CorePermissions $security, EmailModel $model, FakeContactHelper $fakeLeadHelper): Response
     {
         $entity = $model->getEntity($objectId);
 

--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -145,7 +145,7 @@ final class PublicController extends CommonFormController
         name: 'mautic_email_unsubscribe',
         defaults: ['urlEmail' => null, 'secretHash' => null],
     )]
-    public function unsubscribeAction(Request $request, ContactTracker $contactTracker, EmailModel $model, LeadModel $leadModel, FormModel $formModel, PageModel $pageModel, MailHashHelper $mailHash, ThemeHelper $themeHelper, EmailDefaultsHelper $emailDefaultsHelper, $idHash, ?string $urlEmail = null, ?string $secretHash = null): Response
+    public function unsubscribeAction(Request $request, ContactTracker $contactTracker, EmailModel $model, FormModel $formModel, PageModel $pageModel, MailHashHelper $mailHash, ThemeHelper $themeHelper, EmailDefaultsHelper $emailDefaultsHelper, $idHash, ?string $urlEmail = null, ?string $secretHash = null): Response
     {
         $stat                   = $model->getEmailStatus($idHash);
         $message                = '';
@@ -489,7 +489,6 @@ final class PublicController extends CommonFormController
         EmailConfig $emailConfig,
         EmailModel $model,
         Request $request,
-        LeadModel $leadModel,
         FakeContactHelper $fakeLeadHelper,
         string $objectId,
         ?string $objectType = null,

--- a/app/bundles/EmailBundle/Controller/PublicController.php
+++ b/app/bundles/EmailBundle/Controller/PublicController.php
@@ -562,7 +562,6 @@ final class PublicController extends CommonFormController
         // Prepare contact
         if ($contactId) {
             // We have one from request parameter
-            /** @var LeadModel $leadModel */
             $contact = $this->leadRepository->getLead($contactId);
             $contact = $model->enrichedContactWithCompanies($contact);
         } else {

--- a/app/bundles/EmailBundle/Tests/Controller/EmailControllerTest.php
+++ b/app/bundles/EmailBundle/Tests/Controller/EmailControllerTest.php
@@ -20,7 +20,6 @@ use Mautic\EmailBundle\Model\EmailModel;
 use Mautic\FormBundle\Helper\FormFieldHelper;
 use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Helper\FakeContactHelper;
-use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\LeadBundle\Model\ListModel;
 use Mautic\UserBundle\Entity\User;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -253,7 +252,7 @@ final class EmailControllerTest extends TestCase
 
         $request = new Request();
         $this->requestStack->push($request);
-        $this->controller->sendExampleAction($request, 1, $this->corePermissionsMock, $this->modelMock, $this->createStub(LeadModel::class), $this->createStub(FakeContactHelper::class));
+        $this->controller->sendExampleAction($request, 1, $this->corePermissionsMock, $this->modelMock, $this->createStub(FakeContactHelper::class));
     }
 
     public function testWinnerActionForDispatchManualWinnerEvent(): void

--- a/app/bundles/FormBundle/Controller/PublicController.php
+++ b/app/bundles/FormBundle/Controller/PublicController.php
@@ -12,12 +12,10 @@ use Mautic\CoreBundle\Twig\Helper\DateHelper;
 use Mautic\FormBundle\Entity\FieldRepository;
 use Mautic\FormBundle\Entity\Form;
 use Mautic\FormBundle\Event\SubmissionEvent;
-use Mautic\FormBundle\Model\FieldModel;
 use Mautic\FormBundle\Model\FormModel;
 use Mautic\FormBundle\Model\SubmissionModel;
 use Mautic\LeadBundle\Entity\CompanyRepository;
 use Mautic\LeadBundle\Helper\TokenHelper;
-use Mautic\LeadBundle\Model\CompanyModel;
 use Mautic\PageBundle\Helper\TokenHelper as PageTokenHelper;
 use Mautic\UserBundle\Entity\UserRepository;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -686,7 +684,7 @@ final class PublicController extends CommonFormController
         name: 'mautic_form_company_lookup',
         methods: ['POST'],
     )]
-    public function lookupCompanyAction(Request $request, FieldModel $fieldModel, CompanyModel $companyModel): JsonResponse
+    public function lookupCompanyAction(Request $request): JsonResponse
     {
         $parameters = json_decode($request->getContent(), true);
         $search     = InputHelper::clean($parameters['search'] ?? '');

--- a/app/bundles/LeadBundle/Controller/AjaxController.php
+++ b/app/bundles/LeadBundle/Controller/AjaxController.php
@@ -109,7 +109,7 @@ final class AjaxController extends CommonAjaxController
         return $this->sendJsonResponse($results);
     }
 
-    public function getLeadIdsByFieldValueAction(Request $request, LeadModel $leadModel): JsonResponse
+    public function getLeadIdsByFieldValueAction(Request $request): JsonResponse
     {
         $field     = InputHelper::clean($request->query->get('field'));
         $value     = InputHelper::clean($request->query->all()['value'] ?? '');
@@ -403,7 +403,7 @@ final class AjaxController extends CommonAjaxController
         return $this->sendJsonResponse($dataArray);
     }
 
-    public function removeBounceStatusAction(Request $request, DoNotContactModel $doNotContact, EmailModel $emailModel): JsonResponse
+    public function removeBounceStatusAction(Request $request, DoNotContactModel $doNotContact): JsonResponse
     {
         $dataArray   = ['success' => 0];
         $dncId       = $request->request->get('id');

--- a/app/bundles/LeadBundle/Controller/FieldController.php
+++ b/app/bundles/LeadBundle/Controller/FieldController.php
@@ -385,7 +385,7 @@ final class FieldController extends FormController
     /**
      * Clone an entity.
      */
-    public function cloneAction(Request $request, FieldAliasHelper $fieldAliasHelper, FieldModel $fieldModel, $objectId): RedirectResponse|Response
+    public function cloneAction(FieldAliasHelper $fieldAliasHelper, FieldModel $fieldModel, $objectId): RedirectResponse|Response
     {
         $entity = $fieldModel->getEntity($objectId);
 

--- a/app/bundles/LeadBundle/Controller/ImportController.php
+++ b/app/bundles/LeadBundle/Controller/ImportController.php
@@ -190,10 +190,9 @@ final class ImportController extends FormController
     }
 
     /**
-     * @param int  $objectId
      * @param bool $ignorePost
      */
-    public function newAction(Request $request, $objectId = 0, $ignorePost = false): Response
+    public function newAction(Request $request, $ignorePost = false): Response
     {
         try {
             $initEvent = $this->dispatchImportOnInit();
@@ -262,7 +261,7 @@ final class ImportController extends FormController
                     $this->removeImportFile($fullPath);
                     $this->logger->log(LogLevel::INFO, "Import for file {$fullPath} failed with: {$e->getMessage()}.");
 
-                    return $this->newAction($request, 0, true);
+                    return $this->newAction($request, true);
                 }
 
                 break;
@@ -317,7 +316,7 @@ final class ImportController extends FormController
                 $reason = isset($form) ? 'the form is empty' : 'the form was canceled';
                 $this->logger->log(LogLevel::WARNING, "Import for file {$fullPath} was aborted because {$reason}.");
 
-                return $this->newAction($request, 0, true);
+                return $this->newAction($request, true);
             }
 
             $valid = $this->isFormValid($form);
@@ -370,7 +369,7 @@ final class ImportController extends FormController
                                     $this->requestStack->getSession()->set('mautic.'.$object.'.import.progress', [0, $linecount]);
                                     $this->requestStack->getSession()->set('mautic.'.$object.'.import.original.file', $fileData->getClientOriginalName());
 
-                                    return $this->newAction($request, 0, true);
+                                    return $this->newAction($request, true);
                                 }
                             } catch (FileException $e) {
                                 if (str_contains($e->getMessage(), 'upload_max_filesize')) {
@@ -411,7 +410,7 @@ final class ImportController extends FormController
                         $this->removeImportFile($fullPath);
                         $this->logger->log(LogLevel::WARNING, "Import for file {$fullPath} was aborted as there were no matched files found.");
 
-                        return $this->newAction($request, 0, true);
+                        return $this->newAction($request, true);
                     }
 
                     /** @var Import $import */
@@ -451,7 +450,7 @@ final class ImportController extends FormController
                         return $this->indexAction($request);
                     }
 
-                    return $this->newAction($request, 0, true);
+                    return $this->newAction($request, true);
                 default:
                     // Done or something wrong
 

--- a/app/bundles/LeadBundle/Controller/LeadController.php
+++ b/app/bundles/LeadBundle/Controller/LeadController.php
@@ -1432,7 +1432,7 @@ final class LeadController extends FormController
     /**
      * @param int $objectId
      */
-    public function emailAction(Request $request, UserHelper $userHelper, MailHelper $mailHelper, LeadModel $leadModel, EmailModel $emailModel, $objectId = 0): JsonResponse|Response
+    public function emailAction(Request $request, UserHelper $userHelper, MailHelper $mailHelper, EmailModel $emailModel, $objectId = 0): JsonResponse|Response
     {
         $valid = $cancelled = false;
 
@@ -1619,10 +1619,8 @@ final class LeadController extends FormController
 
     /**
      * Bulk edit lead campaigns.
-     *
-     * @param int $objectId
      */
-    public function batchCampaignsAction(Request $request, MembershipManager $membershipManager, $objectId = 0): JsonResponse|Response
+    public function batchCampaignsAction(Request $request, MembershipManager $membershipManager): JsonResponse|Response
     {
         if ('POST' === $request->getMethod()) {
             $data  = $request->request->all()['lead_batch'] ?? [];
@@ -1810,10 +1808,8 @@ final class LeadController extends FormController
 
     /**
      * Bulk edit lead stages.
-     *
-     * @param int $objectId
      */
-    public function batchStagesAction(Request $request, $objectId = 0): JsonResponse|Response
+    public function batchStagesAction(Request $request): JsonResponse|Response
     {
         if ('POST' === $request->getMethod()) {
             $data  = $request->request->all()['lead_batch_stage'] ?? [];
@@ -1907,10 +1903,8 @@ final class LeadController extends FormController
 
     /**
      * Bulk edit lead owner.
-     *
-     * @param int $objectId
      */
-    public function batchOwnersAction(Request $request, $objectId = 0): JsonResponse|Response
+    public function batchOwnersAction(Request $request): JsonResponse|Response
     {
         if (!$this->security->isGranted('user:users:view')) {
             $this->throwAccessDenied();

--- a/app/bundles/LeadBundle/Controller/NoteController.php
+++ b/app/bundles/LeadBundle/Controller/NoteController.php
@@ -337,7 +337,7 @@ final class NoteController extends FormController
     /**
      * Deletes the entity.
      */
-    public function deleteAction(Request $request, $leadId, $objectId): Response|JsonResponse
+    public function deleteAction($leadId, $objectId): Response|JsonResponse
     {
         $lead = $this->checkLeadAccess($leadId, 'view');
         if ($lead instanceof Response) {

--- a/app/bundles/LeadBundle/Controller/NoteController.php
+++ b/app/bundles/LeadBundle/Controller/NoteController.php
@@ -337,7 +337,7 @@ final class NoteController extends FormController
     /**
      * Deletes the entity.
      */
-    public function deleteAction($leadId, $objectId): Response|JsonResponse
+    public function deleteAction(Request $request, $leadId, $objectId): Response|JsonResponse
     {
         $lead = $this->checkLeadAccess($leadId, 'view');
         if ($lead instanceof Response) {

--- a/app/bundles/PageBundle/Controller/PageController.php
+++ b/app/bundles/PageBundle/Controller/PageController.php
@@ -11,7 +11,6 @@ use Mautic\CoreBundle\Form\Type\DateRangeType;
 use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\CoreBundle\Helper\ThemeHelper;
 use Mautic\CoreBundle\Model\AuditLogModel;
-use Mautic\CoreBundle\Translation\Translator;
 use Mautic\FormBundle\Model\SubmissionModel;
 use Mautic\PageBundle\Entity\Page;
 use Mautic\PageBundle\Event\PageEditSubmitEvent;
@@ -382,7 +381,7 @@ final class PageController extends FormController
      *
      * @param Page|null $entity
      */
-    public function newAction(Request $request, PageConfig $pageConfig, Translator $translator, ThemeHelper $themeHelper, PageModel $model, $entity = null): Response
+    public function newAction(Request $request, PageConfig $pageConfig, ThemeHelper $themeHelper, PageModel $model, $entity = null): Response
     {
         if (!$entity instanceof Page) {
             $entity = $model->getEntity();
@@ -692,7 +691,7 @@ final class PageController extends FormController
      *
      * @param int $objectId
      */
-    public function cloneAction(Request $request, PageConfig $pageConfig, Translator $translator, ThemeHelper $themeHelper, PageModel $model, $objectId): Response
+    public function cloneAction(Request $request, PageConfig $pageConfig, ThemeHelper $themeHelper, PageModel $model, $objectId): Response
     {
         $entity = $model->getEntity($objectId);
 
@@ -719,7 +718,7 @@ final class PageController extends FormController
             $session->set($contentName, $entity->getCustomHtml());
         }
 
-        return $this->newAction($request, $pageConfig, $translator, $themeHelper, $model, $entity);
+        return $this->newAction($request, $pageConfig, $themeHelper, $model, $entity);
     }
 
     /**
@@ -892,7 +891,7 @@ final class PageController extends FormController
     /**
      * @param int $objectId
      */
-    public function abtestAction(Request $request, PageConfig $pageConfig, Translator $translator, ThemeHelper $themeHelper, PageModel $model, $objectId): Response
+    public function abtestAction(Request $request, PageConfig $pageConfig, ThemeHelper $themeHelper, PageModel $model, $objectId): Response
     {
         $entity = $model->getEntity($objectId);
 
@@ -921,7 +920,7 @@ final class PageController extends FormController
         $clone->setIsPublished(false);
         $clone->setVariantParent($entity);
 
-        return $this->newAction($request, $pageConfig, $translator, $themeHelper, $model, $clone);
+        return $this->newAction($request, $pageConfig, $themeHelper, $model, $clone);
     }
 
     /**

--- a/app/bundles/UserBundle/Controller/SecurityController.php
+++ b/app/bundles/UserBundle/Controller/SecurityController.php
@@ -108,7 +108,7 @@ final class SecurityController extends CommonController implements EventSubscrib
         '/s/sso_login/{integration}',
         name: 'mautic_sso_login',
     )]
-    public function ssoLoginAction($integration): RedirectResponse
+    public function ssoLoginAction(): RedirectResponse
     {
         return new RedirectResponse($this->generateUrl('login'));
     }
@@ -120,7 +120,7 @@ final class SecurityController extends CommonController implements EventSubscrib
         '/s/sso_login_check/{integration}',
         name: 'mautic_sso_login_check',
     )]
-    public function ssoLoginCheckAction($integration): RedirectResponse
+    public function ssoLoginCheckAction(): RedirectResponse
     {
         // The plugin should be handling this in it's listener
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -260,6 +260,7 @@ rules:
     - Utils\PHPStan\Rule\PreferInterfaceInConstructorRule
     - Utils\PHPStan\Rule\NoPropertyToPropertyAssignRule
     - Utils\PHPStan\Rule\ControllerMethodMustReturnResponseRule
+    - Utils\PHPStan\Rule\NoUnusedControllerActionParameterRule
 
     - Utils\PHPStan\Rule\NoServicesInBundleConfigRule
     - Utils\PHPStan\Rule\NoServiceInMethodParameterRule

--- a/utils/phpstan/src/Rule/NoUnusedControllerActionParameterRule.php
+++ b/utils/phpstan/src/Rule/NoUnusedControllerActionParameterRule.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Rule;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\NodeFinder;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * A controller action must not declare a parameter it never uses.
+ *
+ * Symfony resolves each action argument for every request - a route placeholder, the Request, an injected service.
+ * A parameter the body never reads costs that resolution for nothing and misleads the reader about what the action
+ * needs. Dropping it is safe: actions are dispatched by the argument resolver, not called by name.
+ *
+ * Only the public "*Action()" methods and "__invoke()" are actions. The shared base controllers - those with
+ * "Abstract" or "Common" in their name - are skipped, as a child can override the action with a body that does use
+ * the parameter.
+ *
+ * @implements Rule<ClassMethod>
+ */
+final class NoUnusedControllerActionParameterRule implements Rule
+{
+    /**
+     * @var string
+     */
+    private const CONTROLLER_SUFFIX = 'Controller';
+
+    /**
+     * @var string
+     */
+    private const ACTION_SUFFIX = 'action';
+
+    /**
+     * @var string
+     */
+    private const INVOKE_METHOD = '__invoke';
+
+    /**
+     * @var string[]
+     */
+    private const SKIPPED_CLASS_NAME_PARTS = ['Abstract', 'Common'];
+
+    /**
+     * These read or write the local scope by variable name, so a parameter can be used without ever appearing as a
+     * variable node. When any of them is present the parameters are undecidable and the whole action is left alone.
+     *
+     * @var string[]
+     */
+    private const SCOPE_READING_FUNCTIONS = ['compact', 'extract', 'func_get_args', 'get_defined_vars'];
+
+    private NodeFinder $nodeFinder;
+
+    public function __construct()
+    {
+        $this->nodeFinder = new NodeFinder();
+    }
+
+    public function getNodeType(): string
+    {
+        return ClassMethod::class;
+    }
+
+    /**
+     * @param ClassMethod $node
+     *
+     * @return list<\PHPStan\Rules\IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node->isPublic()) {
+            return [];
+        }
+
+        if (null === $node->stmts) {
+            return [];
+        }
+
+        if ([] === $node->params) {
+            return [];
+        }
+
+        if (!$this->isAction($node)) {
+            return [];
+        }
+
+        if (!$this->isInController($scope)) {
+            return [];
+        }
+
+        if ($this->readsLocalScopeByName($node->stmts)) {
+            return [];
+        }
+
+        $usedVariableNames = $this->collectUsedVariableNames($node->stmts);
+
+        $ruleErrors = [];
+
+        foreach ($node->params as $param) {
+            // a by-reference parameter is written for its caller, not read here
+            if ($param->byRef) {
+                continue;
+            }
+
+            if (!$param->var instanceof Variable || !is_string($param->var->name)) {
+                continue;
+            }
+
+            $parameterName = $param->var->name;
+            if (isset($usedVariableNames[$parameterName])) {
+                continue;
+            }
+
+            $ruleErrors[] = RuleErrorBuilder::message(sprintf(
+                'Controller action "%s()" declares parameter "$%s" that is never used. Remove it.',
+                $node->name->toString(),
+                $parameterName
+            ))
+                ->identifier('mautic.noUnusedControllerActionParameter')
+                ->line($param->getStartLine())
+                ->build();
+        }
+
+        return $ruleErrors;
+    }
+
+    private function isAction(ClassMethod $classMethod): bool
+    {
+        $methodName = $classMethod->name->toLowerString();
+
+        return str_ends_with($methodName, self::ACTION_SUFFIX) || self::INVOKE_METHOD === $methodName;
+    }
+
+    private function isInController(Scope $scope): bool
+    {
+        // inside a trait the scope class is the controller using it, so the trait method would be checked repeatedly
+        if ($scope->isInTrait()) {
+            return false;
+        }
+
+        $classReflection = $scope->getClassReflection();
+        if (!$classReflection instanceof \PHPStan\Reflection\ClassReflection) {
+            return false;
+        }
+
+        $className = $classReflection->getName();
+        if (!str_ends_with($className, self::CONTROLLER_SUFFIX)) {
+            return false;
+        }
+
+        return !$this->isSharedBaseController($className);
+    }
+
+    private function isSharedBaseController(string $className): bool
+    {
+        $lastSeparatorPosition = strrpos($className, '\\');
+        $shortClassName        = false === $lastSeparatorPosition ? $className : substr($className, $lastSeparatorPosition + 1);
+
+        foreach (self::SKIPPED_CLASS_NAME_PARTS as $skippedClassNamePart) {
+            if (str_contains($shortClassName, $skippedClassNamePart)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param Node\Stmt[] $stmts
+     */
+    private function readsLocalScopeByName(array $stmts): bool
+    {
+        foreach ($this->nodeFinder->findInstanceOf($stmts, FuncCall::class) as $funcCall) {
+            if (!$funcCall->name instanceof Name) {
+                continue;
+            }
+
+            if (in_array($funcCall->name->toLowerString(), self::SCOPE_READING_FUNCTIONS, true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param Node\Stmt[] $stmts
+     *
+     * @return array<string, true>
+     */
+    private function collectUsedVariableNames(array $stmts): array
+    {
+        $usedVariableNames = [];
+
+        foreach ($this->nodeFinder->findInstanceOf($stmts, Variable::class) as $variable) {
+            if (is_string($variable->name)) {
+                $usedVariableNames[$variable->name] = true;
+            }
+        }
+
+        return $usedVariableNames;
+    }
+}

--- a/utils/phpstan/src/Rule/NoUnusedControllerActionParameterRule.php
+++ b/utils/phpstan/src/Rule/NoUnusedControllerActionParameterRule.php
@@ -6,11 +6,15 @@ namespace Utils\PHPStan\Rule;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\NodeFinder;
 use PHPStan\Analyser\Scope;
+use PHPStan\Node\InClassNode;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 
@@ -19,13 +23,17 @@ use PHPStan\Rules\RuleErrorBuilder;
  *
  * Symfony resolves each action argument for every request - a route placeholder, the Request, an injected service.
  * A parameter the body never reads costs that resolution for nothing and misleads the reader about what the action
- * needs. Dropping it is safe: actions are dispatched by the argument resolver, not called by name.
+ * needs. Dropping it is safe: actions are dispatched by the argument resolver, which binds by name.
  *
  * Only the public "*Action()" methods and "__invoke()" are actions. The shared base controllers - those with
  * "Abstract" or "Common" in their name - are skipped, as a child can override the action with a body that does use
  * the parameter.
  *
- * @implements Rule<ClassMethod>
+ * A controller that dispatches its own actions by a dynamic call - "$this->{$name.'Action'}($request, $id, ...)" -
+ * is skipped whole: that call hands a fixed, positional argument list to every action it reaches, so a parameter
+ * unused in one action body is still required to keep the positions aligned.
+ *
+ * @implements Rule<InClassNode>
  */
 final class NoUnusedControllerActionParameterRule implements Rule
 {
@@ -43,6 +51,11 @@ final class NoUnusedControllerActionParameterRule implements Rule
      * @var string
      */
     private const INVOKE_METHOD = '__invoke';
+
+    /**
+     * @var string
+     */
+    private const THIS = 'this';
 
     /**
      * @var string[]
@@ -66,45 +79,76 @@ final class NoUnusedControllerActionParameterRule implements Rule
 
     public function getNodeType(): string
     {
-        return ClassMethod::class;
+        return InClassNode::class;
     }
 
     /**
-     * @param ClassMethod $node
+     * @param InClassNode $node
      *
      * @return list<\PHPStan\Rules\IdentifierRuleError>
      */
     public function processNode(Node $node, Scope $scope): array
     {
-        if (!$node->isPublic()) {
+        $className = $node->getClassReflection()->getName();
+        if (!str_ends_with($className, self::CONTROLLER_SUFFIX)) {
             return [];
         }
 
-        if (null === $node->stmts) {
+        if ($this->isSharedBaseController($className)) {
             return [];
         }
 
-        if ([] === $node->params) {
+        // a trait, interface or enum is not a controller with its own dispatched actions
+        $classNode = $node->getOriginalNode();
+        if (!$classNode instanceof Class_) {
             return [];
         }
 
-        if (!$this->isAction($node)) {
+        if ($this->dispatchesActionsPositionally($classNode)) {
             return [];
         }
-
-        if (!$this->isInController($scope)) {
-            return [];
-        }
-
-        if ($this->readsLocalScopeByName($node->stmts)) {
-            return [];
-        }
-
-        $usedVariableNames = $this->collectUsedVariableNames($node->stmts);
 
         $ruleErrors = [];
 
-        foreach ($node->params as $param) {
+        foreach ($classNode->getMethods() as $classMethod) {
+            foreach ($this->processMethod($classMethod) as $ruleError) {
+                $ruleErrors[] = $ruleError;
+            }
+        }
+
+        return $ruleErrors;
+    }
+
+    /**
+     * @return list<\PHPStan\Rules\IdentifierRuleError>
+     */
+    private function processMethod(ClassMethod $classMethod): array
+    {
+        if (!$classMethod->isPublic()) {
+            return [];
+        }
+
+        if (null === $classMethod->stmts) {
+            return [];
+        }
+
+        if ([] === $classMethod->params) {
+            return [];
+        }
+
+        if (!$this->isAction($classMethod)) {
+            return [];
+        }
+
+        if ($this->readsLocalScopeByName($classMethod->stmts)) {
+            return [];
+        }
+
+        $usedVariableNames = $this->collectUsedVariableNames($classMethod->stmts);
+
+        $ruleErrors = [];
+
+        foreach ($classMethod->params as $param) {
             // a by-reference parameter is written for its caller, not read here
             if ($param->byRef) {
                 continue;
@@ -121,7 +165,7 @@ final class NoUnusedControllerActionParameterRule implements Rule
 
             $ruleErrors[] = RuleErrorBuilder::message(sprintf(
                 'Controller action "%s()" declares parameter "$%s" that is never used. Remove it.',
-                $node->name->toString(),
+                $classMethod->name->toString(),
                 $parameterName
             ))
                 ->identifier('mautic.noUnusedControllerActionParameter')
@@ -139,26 +183,6 @@ final class NoUnusedControllerActionParameterRule implements Rule
         return str_ends_with($methodName, self::ACTION_SUFFIX) || self::INVOKE_METHOD === $methodName;
     }
 
-    private function isInController(Scope $scope): bool
-    {
-        // inside a trait the scope class is the controller using it, so the trait method would be checked repeatedly
-        if ($scope->isInTrait()) {
-            return false;
-        }
-
-        $classReflection = $scope->getClassReflection();
-        if (!$classReflection instanceof \PHPStan\Reflection\ClassReflection) {
-            return false;
-        }
-
-        $className = $classReflection->getName();
-        if (!str_ends_with($className, self::CONTROLLER_SUFFIX)) {
-            return false;
-        }
-
-        return !$this->isSharedBaseController($className);
-    }
-
     private function isSharedBaseController(string $className): bool
     {
         $lastSeparatorPosition = strrpos($className, '\\');
@@ -166,6 +190,25 @@ final class NoUnusedControllerActionParameterRule implements Rule
 
         foreach (self::SKIPPED_CLASS_NAME_PARTS as $skippedClassNamePart) {
             if (str_contains($shortClassName, $skippedClassNamePart)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * A "$this->{$expr}(...)" call names its method dynamically, so it reaches sibling actions with a fixed argument
+     * list that PHPStan cannot see here.
+     */
+    private function dispatchesActionsPositionally(Class_ $class): bool
+    {
+        foreach ($this->nodeFinder->findInstanceOf($class, MethodCall::class) as $methodCall) {
+            if ($methodCall->name instanceof Identifier) {
+                continue;
+            }
+
+            if ($methodCall->var instanceof Variable && self::THIS === $methodCall->var->name) {
                 return true;
             }
         }

--- a/utils/phpstan/tests/Rule/Fixture/AbstractUnusedParameterController.php
+++ b/utils/phpstan/tests/Rule/Fixture/AbstractUnusedParameterController.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+abstract class AbstractUnusedParameterController
+{
+    // a child can override this with a body that does use the parameter, so the base is left alone
+    public function indexAction(string $unused): string
+    {
+        return 'index';
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/DynamicDispatchController.php
+++ b/utils/phpstan/tests/Rule/Fixture/DynamicDispatchController.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+final class DynamicDispatchController
+{
+    public function executeAction(string $request, string $objectAction, string $objectId): string
+    {
+        return $this->{"{$objectAction}Action"}($request, $objectId);
+    }
+
+    // $request is unused here, but the dynamic dispatch above hands it over positionally, so it must stay
+    public function deleteAction(string $request, string $objectId): string
+    {
+        return $objectId;
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/UnusedControllerActionParameterController.php
+++ b/utils/phpstan/tests/Rule/Fixture/UnusedControllerActionParameterController.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+final class UnusedControllerActionParameterController
+{
+    public function unsubscribeAction(
+        string $request,
+        string $leadModel,
+        ?string $secretHash = null,
+    ): string {
+        return $request.$secretHash;
+    }
+
+    public function __invoke(string $id, string $unusedName): string
+    {
+        return $id;
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/UsedControllerActionParameterController.php
+++ b/utils/phpstan/tests/Rule/Fixture/UsedControllerActionParameterController.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+final class UsedControllerActionParameterController
+{
+    public function indexAction(string $request, string $idHash): string
+    {
+        return $request.$idHash;
+    }
+
+    // a scope-reading call makes the parameters undecidable, so the action is skipped
+    public function listAction(string $model): string
+    {
+        return implode(',', compact('model'));
+    }
+
+    // a by-reference parameter is written for the caller, not read here
+    public function exportAction(array &$rows): void
+    {
+        $rows[] = 'row';
+    }
+
+    // not an action, and not a controller concern
+    public function getModelName(string $unused): string
+    {
+        return 'name';
+    }
+}

--- a/utils/phpstan/tests/Rule/NoUnusedControllerActionParameterRuleTest.php
+++ b/utils/phpstan/tests/Rule/NoUnusedControllerActionParameterRuleTest.php
@@ -46,4 +46,9 @@ final class NoUnusedControllerActionParameterRuleTest extends RuleTestCase
     {
         $this->analyse([__DIR__.'/Fixture/SomeAutowireService.php'], []);
     }
+
+    public function testSkipControllerDispatchingActionsPositionally(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/DynamicDispatchController.php'], []);
+    }
 }

--- a/utils/phpstan/tests/Rule/NoUnusedControllerActionParameterRuleTest.php
+++ b/utils/phpstan/tests/Rule/NoUnusedControllerActionParameterRuleTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use Utils\PHPStan\Rule\NoUnusedControllerActionParameterRule;
+
+/**
+ * @extends RuleTestCase<NoUnusedControllerActionParameterRule>
+ */
+final class NoUnusedControllerActionParameterRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new NoUnusedControllerActionParameterRule();
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/UnusedControllerActionParameterController.php'], [
+            [
+                'Controller action "unsubscribeAction()" declares parameter "$leadModel" that is never used. Remove it.',
+                11,
+            ],
+            [
+                'Controller action "__invoke()" declares parameter "$unusedName" that is never used. Remove it.',
+                17,
+            ],
+        ]);
+    }
+
+    public function testSkipUsedByRefAndScopeReadingAndNonAction(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/UsedControllerActionParameterController.php'], []);
+    }
+
+    public function testSkipSharedBaseController(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/AbstractUnusedParameterController.php'], []);
+    }
+
+    public function testSkipNonControllerClass(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/SomeAutowireService.php'], []);
+    }
+}


### PR DESCRIPTION
## What

Adds a PHPStan rule that reports parameters declared on a controller action but never used in its body, and drops the 18 such parameters already present.

Example that motivated it - `EmailBundle/Controller/PublicController::unsubscribeAction()`, where `LeadModel $leadModel` was injected on every request and never touched.

## Rule

`Utils\PHPStan\Rule\NoUnusedControllerActionParameterRule`

- Targets only `*Action()` methods and `__invoke()` in `*Controller` classes.
- Skips shared base controllers (`Abstract*`, `*Common*`) - a child may override the action with a body that does use the parameter.
- Skips a method whose body calls `compact()`, `extract()`, `func_get_args()` or `get_defined_vars()`, where the parameters are read by name and cannot be decided statically.
- Skips by-reference parameters, which are written for the caller rather than read locally.

## Removed parameters

18 unused action parameters across 11 controllers. Two actions were also called internally with positional arguments, so those call sites were adjusted:

- `LeadBundle/ImportController::newAction()` - dropped `$objectId`, updated 5 internal `newAction()` calls.
- `PageBundle/PageController::newAction()` - dropped `$translator`, updated the `clone`/`abtest` forwards, then dropped the now-unused `$translator` from `cloneAction()`/`abtestAction()` too.

The rule is registered in `phpstan.neon`; PHPStan is green with no baseline entries.
