### PR TITLE
Fix Campaign Event getting skip which are reschedule due to race-condition

### DIFF
--- a/app/bundles/CampaignBundle/Entity/LeadEventLog.php
+++ b/app/bundles/CampaignBundle/Entity/LeadEventLog.php
@@ -105,6 +105,8 @@ class LeadEventLog implements ChannelInterface, OptimisticLockInterface
 
     private ?\DateTime $dateQueued = null;
 
+    private bool $isExecuted = false;
+
     public static function loadMetadata(ORM\ClassMetadata $metadata): void
     {
         $builder = new ClassMetadataBuilder($metadata);
@@ -539,5 +541,15 @@ class LeadEventLog implements ChannelInterface, OptimisticLockInterface
         $this->dateQueued = $dateQueued;
 
         return $this;
+    }
+
+    public function isExecuted(): bool
+    {
+        return $this->isExecuted;
+    }
+
+    public function setIsExecuted(bool $isExecuted): void
+    {
+        $this->isExecuted = $isExecuted;
     }
 }

--- a/app/bundles/CampaignBundle/Executioner/Dispatcher/LegacyEventDispatcher.php
+++ b/app/bundles/CampaignBundle/Executioner/Dispatcher/LegacyEventDispatcher.php
@@ -69,6 +69,9 @@ class LegacyEventDispatcher
                 $result = $this->dispatchCallback($settings, $log);
             }
 
+            // To know this log has been executed
+            $log->setIsExecuted(true);
+
             // If the new batch event was handled, the $log was already processed so only process legacy logs if false
             if (!$wasBatchProcessed) {
                 $this->dispatchExecutionEvent($config, $log, $result);

--- a/app/bundles/CampaignBundle/Executioner/EventExecutioner.php
+++ b/app/bundles/CampaignBundle/Executioner/EventExecutioner.php
@@ -18,6 +18,7 @@ use Mautic\CampaignBundle\Executioner\Result\EvaluatedContacts;
 use Mautic\CampaignBundle\Executioner\Result\Responses;
 use Mautic\CampaignBundle\Executioner\Scheduler\EventScheduler;
 use Mautic\CampaignBundle\Helper\RemovedContactTracker;
+use Mautic\CoreBundle\Service\OptimisticLockServiceInterface;
 use Mautic\LeadBundle\Entity\Lead;
 use Psr\Log\LoggerInterface;
 
@@ -36,6 +37,7 @@ class EventExecutioner
         private readonly LoggerInterface $logger,
         private readonly EventScheduler $scheduler,
         private readonly RemovedContactTracker $removedContactTracker,
+        private readonly OptimisticLockServiceInterface $optimisticLockService,
     ) {
         // Be sure that all events are compared using the exact same \DateTime
         $this->executionDate = new \DateTime();
@@ -124,7 +126,21 @@ class EventExecutioner
 
         switch ($event->getEventType()) {
             case Event::TYPE_ACTION:
-                $evaluatedContacts = $this->actionExecutioner->execute($config, $logs);
+                try {
+                    $evaluatedContacts = $this->actionExecutioner->execute($config, $logs);
+                } catch (\Exception $e) {
+                    $this->logger->error('CAMPAIGN: Error executing action ID '.$event->getId().' - '.$e->getMessage());
+
+                    // reset version for failed jobs and reschedule it in raceCondition
+                    foreach ($logs as $log) {
+                        if (!$log->isExecuted()) {
+                            $this->optimisticLockService->resetVersion($log);
+                        }
+                    }
+
+                    throw $e;
+                }
+
                 $this->persistLogs($logs);
                 $this->executeConditionEventsForContacts($event, $evaluatedContacts->getPassed(), $counter);
                 $this->executeActionEventsForContacts($event, $evaluatedContacts->getPassed(), $counter);

--- a/app/bundles/CampaignBundle/Tests/Executioner/EventExecutionerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/EventExecutionerTest.php
@@ -68,7 +68,7 @@ final class EventExecutionerTest extends \PHPUnit\Framework\TestCase
     /**
      * @var OptimisticLockServiceInterface&MockObject
      */
-    private $optimisticLockService;
+    private MockObject $optimisticLockService;
 
     protected function setUp(): void
     {

--- a/app/bundles/CampaignBundle/Tests/Executioner/EventExecutionerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/EventExecutionerTest.php
@@ -24,10 +24,12 @@ use Mautic\CampaignBundle\Executioner\Result\EvaluatedContacts;
 use Mautic\CampaignBundle\Executioner\Scheduler\EventScheduler;
 use Mautic\CampaignBundle\Form\Type\CampaignEventJumpToEventType;
 use Mautic\CampaignBundle\Helper\RemovedContactTracker;
+use Mautic\CoreBundle\Service\OptimisticLockServiceInterface;
 use Mautic\CoreBundle\Translation\Translator;
 use Mautic\EmailBundle\EmailEvents;
 use Mautic\EmailBundle\Form\Type\EmailSendType;
 use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Form\Type\PointActionType;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 
@@ -62,6 +64,11 @@ final class EventExecutionerTest extends \PHPUnit\Framework\TestCase
      * @var MockObject&EventRepository
      */
     private MockObject $eventRepository;
+
+    /**
+     * @var OptimisticLockServiceInterface&MockObject
+     */
+    private $optimisticLockService;
 
     protected function setUp(): void
     {
@@ -184,6 +191,7 @@ final class EventExecutionerTest extends \PHPUnit\Framework\TestCase
             $this->createStub(LoggerInterface::class),
             $this->eventScheduler,
             $this->createStub(RemovedContactTracker::class),
+            $this->optimisticLockService
         );
     }
 
@@ -252,5 +260,52 @@ final class EventExecutionerTest extends \PHPUnit\Framework\TestCase
 
         $this->assertCount(1, $pendingEvent->getSuccessful());
         $this->assertCount(0, $pendingEvent->getFailures());
+    }
+
+    public function testActionExecutionHandlesExceptionAndResetsVersionForFailedLogs(): void
+    {
+        $event = $this->createMock(Event::class);
+        $event->method('getId')->willReturn(123);
+        $event->method('getEventType')->willReturn(Event::TYPE_ACTION);
+
+        $config = new ActionAccessor(
+            [
+                'label'                => 'mautic.lead.lead.events.changepoints',
+                'description'          => 'mautic.lead.lead.events.changepoints_descr',
+                'formType'             => PointActionType::class,
+            ]
+        );
+
+        $this->eventCollector->method('getEventConfig')
+            ->with($event)
+            ->willReturn($config);
+
+        $executedLog = $this->createMock(LeadEventLog::class);
+        $executedLog->method('isExecuted')->willReturn(true);
+
+        $failedLog = $this->createMock(LeadEventLog::class);
+        $failedLog->method('isExecuted')->willReturn(false);
+
+        $logs = new ArrayCollection([$executedLog, $failedLog]);
+
+        $exception = new \Exception('Test exception');
+
+        $this->actionExecutioner->expects($this->once())
+            ->method('execute')
+            ->with($config, $logs)
+            ->willThrowException($exception);
+
+        $this->logger->expects($this->once())
+            ->method('error')
+            ->with('CAMPAIGN: Error executing action ID 123 - Test exception');
+
+        $this->optimisticLockService->expects($this->once())
+            ->method('resetVersion')
+            ->with($failedLog);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Test exception');
+
+        $this->getEventExecutioner()->executeLogs($event, $logs);
     }
 }

--- a/app/bundles/CampaignBundle/Tests/Executioner/EventExecutionerTest.php
+++ b/app/bundles/CampaignBundle/Tests/Executioner/EventExecutionerTest.php
@@ -80,6 +80,7 @@ final class EventExecutionerTest extends \PHPUnit\Framework\TestCase
         $this->eventScheduler        = $this->createMock(EventScheduler::class);
         $this->leadRepository        = $this->createMock(LeadRepository::class);
         $this->eventRepository       = $this->createMock(EventRepository::class);
+        $this->optimisticLockService = $this->createMock(OptimisticLockServiceInterface::class);
     }
 
     public function testJumpToEventsAreProcessedAfterOtherEvents(): void
@@ -294,10 +295,6 @@ final class EventExecutionerTest extends \PHPUnit\Framework\TestCase
             ->method('execute')
             ->with($config, $logs)
             ->willThrowException($exception);
-
-        $this->logger->expects($this->once())
-            ->method('error')
-            ->with('CAMPAIGN: Error executing action ID 123 - Test exception');
 
         $this->optimisticLockService->expects($this->once())
             ->method('resetVersion')


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

<!-- 📄 DOCUMENTATION REVIEW REQUIRED:

After you open this PR, Promptless automatically creates a documentation PR and leaves a comment here with the link. Once your code PR merges, review the documentation PR, request changes if needed, and approve it promptly.

See "Reviewing documentation PRs from Promptless" in the community handbook for more details: https://contribute.mautic.org/en/latest/contributing/developer.html#reviewing-documentation-prs-from-promptless -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes #... <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

After executing the `bin/console mautic:campaigns:resume-stuck 16` command. The stuck events that were pending due to errors in previous actions were executed, However, the events that had already failed and were rescheduled due to a race condition were skipped on subsequent execution because of versioning. In this PR, we are resetting the version for failed events to ensure events should execute in next iteration.

<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers. Do not write steps performed by the CI. These steps are for manual testing.
-->
1. Open this PR on GitHub Codespaces or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Create a campaign as per following and add 2 to 5 minutes delay for "Adjust Contact Points" event.
     <img width="1600" height="1614" alt="image" src="https://github.com/user-attachments/assets/d2ce6122-ab00-465b-bf7b-f7d151df8165" />
3. After execution first event "Send Email" block `mautic_leads` table for any contacts from campaign to throw the exception while executing "Adjust Contact Point" event. 
4. The failed event get reschedule due to race condition.
5. Verify all events from the campaign should executed successfully.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->