### PR TITLE
[di] remove getStatRepository() service getters, inject StatRepository directly

### DIFF
--- a/app/bundles/DynamicContentBundle/Model/DynamicContentModel.php
+++ b/app/bundles/DynamicContentBundle/Model/DynamicContentModel.php
@@ -66,11 +66,6 @@ class DynamicContentModel extends FormModel implements AjaxLookupModelInterface,
         return $this->dynamicContentRepository;
     }
 
-    public function getStatRepository(): StatRepository
-    {
-        return $this->statRepository;
-    }
-
     /**
      * @param object $entity
      * @param bool   $unlock

--- a/app/bundles/NotificationBundle/Model/NotificationModel.php
+++ b/app/bundles/NotificationBundle/Model/NotificationModel.php
@@ -60,11 +60,6 @@ final class NotificationModel extends FormModel implements AjaxLookupModelInterf
         return $this->notificationRepository;
     }
 
-    public function getStatRepository(): StatRepository
-    {
-        return $this->statRepository;
-    }
-
     public function getPermissionBase(): string
     {
         return 'notification:notifications';

--- a/app/bundles/SmsBundle/Model/SmsModel.php
+++ b/app/bundles/SmsBundle/Model/SmsModel.php
@@ -81,11 +81,6 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface, GlobalSear
         return $this->smsRepository;
     }
 
-    public function getStatRepository(): StatRepository
-    {
-        return $this->statRepository;
-    }
-
     public function getDoNotContactRepository(): DoNotContactRepository
     {
         return $this->doNotContactRepository;

--- a/app/bundles/SmsBundle/Tests/Functional/SmsModelFunctionalTest.php
+++ b/app/bundles/SmsBundle/Tests/Functional/SmsModelFunctionalTest.php
@@ -166,7 +166,7 @@ final class SmsModelFunctionalTest extends MauticMysqlTestCase
         $this->assertCount(3, $results, 'Total results count should be 3.');
 
         // 7. Validate SMS stats per contact
-        $statRepo = $smsModel->getStatRepository();
+        $statRepo = $this->getContainer()->get(\Mautic\SmsBundle\Entity\StatRepository::class);
         $this->assertInstanceOf(Lead::class, $contact1);
 
         $stat1 = $statRepo->getLeadStats($contact1->getId());

--- a/app/bundles/SmsBundle/Tests/Model/SmsModelTest.php
+++ b/app/bundles/SmsBundle/Tests/Model/SmsModelTest.php
@@ -177,11 +177,8 @@ final class SmsModelTest extends \PHPUnit\Framework\TestCase
                 $this->createStub(StatRepository::class),
                 $this->createStub(DoNotContactRepository::class),
             ])
-            ->onlyMethods(['getRepository', 'getStatRepository'])
+            ->onlyMethods(['getRepository'])
             ->getMock();
-
-        $smsModel->method('getStatRepository')
-            ->willReturn($this->createStub(StatRepository::class));
 
         $smsRepo->expects($this->once())
             ->method('upCount')
@@ -189,9 +186,6 @@ final class SmsModelTest extends \PHPUnit\Framework\TestCase
 
         $smsModel->method('getRepository')
             ->willReturn($this->createStub(SmsRepository::class));
-
-        $smsModel->method('getStatRepository')
-            ->willReturn($this->createStub(StatRepository::class));
 
         if ($isMMS) {
             $this->transport->expects($this->once())

--- a/plugins/MauticFocusBundle/EventListener/LeadSubscriber.php
+++ b/plugins/MauticFocusBundle/EventListener/LeadSubscriber.php
@@ -6,8 +6,8 @@ use Mautic\CoreBundle\Translation\Translator;
 use Mautic\LeadBundle\Event\LeadTimelineEvent;
 use Mautic\LeadBundle\LeadEvents;
 use MauticPlugin\MauticFocusBundle\Entity\Stat;
+use MauticPlugin\MauticFocusBundle\Entity\StatRepository;
 use MauticPlugin\MauticFocusBundle\FocusEventTypes;
-use MauticPlugin\MauticFocusBundle\Model\FocusModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Routing\RouterInterface;
 
@@ -16,7 +16,7 @@ final readonly class LeadSubscriber implements EventSubscriberInterface
     public function __construct(
         private Translator $translator,
         private RouterInterface $router,
-        private FocusModel $focusModel,
+        private StatRepository $statRepository,
     ) {
     }
 
@@ -44,8 +44,8 @@ final readonly class LeadSubscriber implements EventSubscriberInterface
 
         $leadId = $event->getLeadId();
 
-        $statsViewsByLead = $this->focusModel->getStatRepository()->getStatsViewByLead($leadId, $event->getQueryOptions());
-        $statsClickByLead = $this->focusModel->getStatRepository()->getStatsClickByLead($leadId, $event->getQueryOptions());
+        $statsViewsByLead = $this->statRepository->getStatsViewByLead($leadId, $event->getQueryOptions());
+        $statsClickByLead = $this->statRepository->getStatsClickByLead($leadId, $event->getQueryOptions());
 
         if (!$event->isEngagementCount()) {
             $icon     = 'ri-search-line';

--- a/plugins/MauticFocusBundle/Model/FocusModel.php
+++ b/plugins/MauticFocusBundle/Model/FocusModel.php
@@ -105,11 +105,6 @@ class FocusModel extends FormModel implements GlobalSearchInterface
         return $this->focusRepository;
     }
 
-    public function getStatRepository(): StatRepository
-    {
-        return $this->statRepository;
-    }
-
     /**
      * @param int|null $id
      */

--- a/plugins/MauticFocusBundle/Tests/Entity/StatRepositoryFunctionalTest.php
+++ b/plugins/MauticFocusBundle/Tests/Entity/StatRepositoryFunctionalTest.php
@@ -9,6 +9,7 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\PageBundle\Entity\Hit;
 use MauticPlugin\MauticFocusBundle\Entity\Focus;
 use MauticPlugin\MauticFocusBundle\Entity\Stat;
+use MauticPlugin\MauticFocusBundle\Entity\StatRepository;
 use MauticPlugin\MauticFocusBundle\Model\FocusModel;
 
 final class StatRepositoryFunctionalTest extends MauticMysqlTestCase
@@ -25,12 +26,12 @@ final class StatRepositoryFunctionalTest extends MauticMysqlTestCase
 
     public function testGetStatsViewByLead(): void
     {
-        $this->assertCount(5, $this->focusModel->getStatRepository()->getStatsViewByLead());
+        $this->assertCount(5, self::$kernel->getContainer()->get(StatRepository::class)->getStatsViewByLead());
     }
 
     public function testGetStatsClickByLead(): void
     {
-        $this->assertCount(2, $this->focusModel->getStatRepository()->getStatsClickByLead());
+        $this->assertCount(2, self::$kernel->getContainer()->get(StatRepository::class)->getStatsClickByLead());
     }
 
     private function createLead(): Lead

--- a/plugins/MauticFocusBundle/Tests/EventListener/LeadSubscriberFunctionalTest.php
+++ b/plugins/MauticFocusBundle/Tests/EventListener/LeadSubscriberFunctionalTest.php
@@ -9,6 +9,7 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\PageBundle\Entity\Hit;
 use MauticPlugin\MauticFocusBundle\Entity\Focus;
 use MauticPlugin\MauticFocusBundle\Entity\Stat;
+use MauticPlugin\MauticFocusBundle\Entity\StatRepository;
 use MauticPlugin\MauticFocusBundle\Model\FocusModel;
 
 final class LeadSubscriberFunctionalTest extends MauticMysqlTestCase
@@ -29,24 +30,25 @@ final class LeadSubscriberFunctionalTest extends MauticMysqlTestCase
 
     public function testSearchPhraseInNameFocusStat(): void
     {
-        $this->assertCount(3, $this->searchPhrase('bar', $this->lead, $this->focusModel));
-        $this->assertCount(4, $this->searchPhrase('popup', $this->lead, $this->focusModel));
-        $this->assertCount(2, $this->searchPhrase('popup focus B', $this->lead, $this->focusModel));
+        $this->assertCount(3, $this->searchPhrase('bar', $this->lead));
+        $this->assertCount(4, $this->searchPhrase('popup', $this->lead));
+        $this->assertCount(2, $this->searchPhrase('popup focus B', $this->lead));
     }
 
     public function testSearchPhraseInTypeFocusStat(): void
     {
-        $this->assertCount(2, $this->searchPhrase('click', $this->lead, $this->focusModel));
-        $this->assertCount(5, $this->searchPhrase('view', $this->lead, $this->focusModel));
+        $this->assertCount(2, $this->searchPhrase('click', $this->lead));
+        $this->assertCount(5, $this->searchPhrase('view', $this->lead));
     }
 
     /**
      * @return array<string, mixed>
      */
-    private function searchPhrase(string $phrase, Lead $lead, FocusModel $focusModel): array
+    private function searchPhrase(string $phrase, Lead $lead): array
     {
-        $searchViewStats  = $focusModel->getStatRepository()->getStatsViewByLead($lead->getId(), ['search'=>$phrase]);
-        $searchClickStats = $focusModel->getStatRepository()->getStatsClickByLead($lead->getId(), ['search'=>$phrase]);
+        $statRepository   = self::getContainer()->get(StatRepository::class);
+        $searchViewStats  = $statRepository->getStatsViewByLead($lead->getId(), ['search'=>$phrase]);
+        $searchClickStats = $statRepository->getStatsClickByLead($lead->getId(), ['search'=>$phrase]);
 
         return array_merge($searchViewStats, $searchClickStats);
     }

--- a/plugins/MauticFocusBundle/Tests/EventListener/LeadSubscriberTest.php
+++ b/plugins/MauticFocusBundle/Tests/EventListener/LeadSubscriberTest.php
@@ -13,7 +13,6 @@ use MauticPlugin\MauticFocusBundle\Entity\Stat;
 use MauticPlugin\MauticFocusBundle\Entity\StatRepository;
 use MauticPlugin\MauticFocusBundle\EventListener\LeadSubscriber;
 use MauticPlugin\MauticFocusBundle\FocusEventTypes;
-use MauticPlugin\MauticFocusBundle\Model\FocusModel;
 use PHPUnit\Framework\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\MockObject\Rule\AnyInvokedCount;
@@ -29,11 +28,6 @@ final class LeadSubscriberTest extends CommonMocks
     private MockObject $translator;
 
     /**
-     * @var MockObject&FocusModel
-     */
-    private MockObject $focusModel;
-
-    /**
      * @var MockObject&StatRepository
      */
     private MockObject $statRepository;
@@ -47,7 +41,6 @@ final class LeadSubscriberTest extends CommonMocks
     protected function setUp(): void
     {
         $this->translator     = $this->createMock(Translator::class);
-        $this->focusModel     = $this->createMock(FocusModel::class);
         $this->statRepository = $this->createMock(StatRepository::class);
 
         $matcher              =  new AnyInvokedCount();
@@ -88,7 +81,7 @@ final class LeadSubscriberTest extends CommonMocks
         $subscriber = new LeadSubscriber(
             $this->translator,
             $this->createStub(RouterInterface::class),
-            $this->focusModel
+            $this->statRepository
         );
 
         $dispatcher = new EventDispatcher();
@@ -112,7 +105,7 @@ final class LeadSubscriberTest extends CommonMocks
         $subscriber = new LeadSubscriber(
             $this->translator,
             $this->createStub(RouterInterface::class),
-            $this->focusModel
+            $this->statRepository
         );
 
         $dispatcher = new EventDispatcher();
@@ -141,7 +134,7 @@ final class LeadSubscriberTest extends CommonMocks
         $subscriber = new LeadSubscriber(
             $this->translator,
             $this->createStub(RouterInterface::class),
-            $this->focusModel
+            $this->statRepository
         );
 
         $dispatcher = new EventDispatcher();
@@ -165,7 +158,7 @@ final class LeadSubscriberTest extends CommonMocks
         $subscriber = new LeadSubscriber(
             $this->translator,
             $this->createStub(RouterInterface::class),
-            $this->focusModel
+            $this->statRepository
         );
 
         $dispatcher = new EventDispatcher();
@@ -191,7 +184,6 @@ final class LeadSubscriberTest extends CommonMocks
         ];
 
         $this->statRepository->method($method)->willReturn($stats);
-        $this->focusModel->method('getStatRepository')->willReturn($this->statRepository);
     }
 
     private function getLead(): Lead

--- a/plugins/MauticSocialBundle/Model/TweetModel.php
+++ b/plugins/MauticSocialBundle/Model/TweetModel.php
@@ -205,11 +205,6 @@ final class TweetModel extends FormModel implements AjaxLookupModelInterface
         return $this->tweetRepository;
     }
 
-    public function getStatRepository(): TweetStatRepository
-    {
-        return $this->tweetStatRepository;
-    }
-
     public function getPermissionBase(): string
     {
         return 'mauticSocial:tweets';


### PR DESCRIPTION
## Why

Follow-up to #17238 (`NoServiceGetterRule`). A public getter that only returns an injected repository turns the owning model into a service locator - callers pull the repository out of the model instead of asking for it directly. This removes every in-scope `getStatRepository()` getter.

<br>

Use `StatRepository` service directly :+1: 