### PR TITLE
[dead-code] remove LeadModel::getTagRepository() service getter, inject TagRepository directly

### DIFF
--- a/app/bundles/LeadBundle/Controller/AjaxController.php
+++ b/app/bundles/LeadBundle/Controller/AjaxController.php
@@ -18,6 +18,7 @@ use Mautic\LeadBundle\Entity\DoNotContactRepository;
 use Mautic\LeadBundle\Entity\LeadField;
 use Mautic\LeadBundle\Entity\LeadFieldRepository;
 use Mautic\LeadBundle\Entity\LeadRepository;
+use Mautic\LeadBundle\Entity\TagRepository;
 use Mautic\LeadBundle\Event\ListTypeaheadEvent;
 use Mautic\LeadBundle\Form\Type\FieldType;
 use Mautic\LeadBundle\Form\Type\FilterPropertiesType;
@@ -545,7 +546,7 @@ final class AjaxController extends CommonAjaxController
         return $this->sendJsonResponse($data);
     }
 
-    public function updateLeadTagsAction(Request $request, LeadModel $leadModel): JsonResponse
+    public function updateLeadTagsAction(Request $request, LeadModel $leadModel, TagRepository $tagRepository): JsonResponse
     {
         $post        = $request->request->all()['lead_tags'] ?? [];
         $lead        = $leadModel->getEntity((int) $post['id']);
@@ -560,7 +561,7 @@ final class AjaxController extends CommonAjaxController
             $leadTagKeys = $leadTags->getKeys();
 
             // Get an updated list of tags
-            $tags       = $leadModel->getTagRepository()->getSimpleList(null, [], 'tag');
+            $tags       = $tagRepository->getSimpleList(null, [], 'tag');
             $tagOptions = '';
 
             foreach ($tags as $tag) {
@@ -575,7 +576,7 @@ final class AjaxController extends CommonAjaxController
         return $this->sendJsonResponse($data);
     }
 
-    public function addLeadTagsAction(Request $request, LeadModel $leadModel): JsonResponse
+    public function addLeadTagsAction(Request $request, TagRepository $tagRepository): JsonResponse
     {
         $tags = $request->request->get('tags');
         $tags = json_decode($tags, true);
@@ -585,16 +586,16 @@ final class AjaxController extends CommonAjaxController
 
             foreach ($tags as $tag) {
                 if (!is_numeric($tag)) {
-                    $newTags[] = $leadModel->getTagRepository()->getTagByNameOrCreateNewOne($tag);
+                    $newTags[] = $tagRepository->getTagByNameOrCreateNewOne($tag);
                 }
             }
 
             if ([] !== $newTags) {
-                $leadModel->getTagRepository()->saveEntities($newTags);
+                $tagRepository->saveEntities($newTags);
             }
 
             // Get an updated list of tags
-            $allTags    = $leadModel->getTagRepository()->getSimpleList(null, [], 'tag');
+            $allTags    = $tagRepository->getSimpleList(null, [], 'tag');
             $tagOptions = '';
 
             foreach ($allTags as $tag) {

--- a/app/bundles/LeadBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/CampaignSubscriber.php
@@ -18,6 +18,7 @@ use Mautic\LeadBundle\Entity\LeadFieldRepository;
 use Mautic\LeadBundle\Entity\LeadListRepository;
 use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Entity\PointsChangeLog;
+use Mautic\LeadBundle\Entity\TagRepository;
 use Mautic\LeadBundle\Exception\ImportFailedException;
 use Mautic\LeadBundle\Form\Type\AddToCompanyActionType;
 use Mautic\LeadBundle\Form\Type\CampaignConditionLeadPageHitType;
@@ -70,6 +71,7 @@ final class CampaignSubscriber implements EventSubscriberInterface
         private readonly LeadListRepository $leadListRepository,
         private readonly LeadRepository $leadRepository,
         private readonly LeadFieldRepository $leadFieldRepository,
+        private readonly TagRepository $tagRepository,
     ) {
     }
 
@@ -523,8 +525,7 @@ final class CampaignSubscriber implements EventSubscriberInterface
         if ($event->checkContext('lead.device')) {
             $result = $this->validateContactDevice($event, $lead, $this->leadModel->getDeviceRepository());
         } elseif ($event->checkContext('lead.tags')) {
-            $tagRepo = $this->leadModel->getTagRepository();
-            $result  = $tagRepo->checkLeadByTags($lead, $event->getConfig()['tags']);
+            $result = $this->tagRepository->checkLeadByTags($lead, $event->getConfig()['tags']);
         } elseif ($event->checkContext('lead.segments')) {
             $result = $this->leadListRepository->checkLeadSegmentsByIds($lead, $event->getConfig()['segments']);
         } elseif ($event->checkContext('lead.stages')) {

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -211,14 +211,6 @@ class LeadModel extends FormModel
         return $this->leadRepository;
     }
 
-    /**
-     * Get the tags repository.
-     */
-    public function getTagRepository(): TagRepository
-    {
-        return $this->tagRepository;
-    }
-
     public function getPointLogRepository(): PointsChangeLogRepository
     {
         return $this->pointsChangeLogRepository;

--- a/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberTest.php
@@ -20,6 +20,7 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadFieldRepository;
 use Mautic\LeadBundle\Entity\LeadListRepository;
 use Mautic\LeadBundle\Entity\LeadRepository;
+use Mautic\LeadBundle\Entity\TagRepository;
 use Mautic\LeadBundle\EventListener\CampaignSubscriber;
 use Mautic\LeadBundle\Model\CompanyModel;
 use Mautic\LeadBundle\Model\DoNotContact;
@@ -171,7 +172,8 @@ final class CampaignSubscriberTest extends \PHPUnit\Framework\TestCase
             $filterOperatorProvider,
             $this->createStub(LeadListRepository::class),
             $this->createStub(LeadRepository::class),
-            $this->createStub(LeadFieldRepository::class)
+            $this->createStub(LeadFieldRepository::class),
+            $this->createStub(TagRepository::class)
         );
     }
 


### PR DESCRIPTION
## Why

Follow-up to #17238 (`NoServiceGetterRule`). `LeadModel::getTagRepository()` only returned the injected `TagRepository`, letting callers pull the repository out of the model instead of asking for it directly. Removed; the repository is injected where it is used.
