### PR TITLE
[di] remove CompanyModel::getCompanyLeadRepository() service getter, inject CompanyLeadRepository directly

### DIFF
--- a/app/bundles/FormBundle/Model/SubmissionModel.php
+++ b/app/bundles/FormBundle/Model/SubmissionModel.php
@@ -1153,7 +1153,7 @@ final class SubmissionModel extends CommonFormModel
 
         $companyFieldMatches = $getCompanyData($leadFieldMatches);
         if ([] !== $companyFieldMatches) {
-            [$company, $leadAdded, $companyEntity] = IdentifyCompanyHelper::identifyLeadsCompany($companyFieldMatches, $lead, $this->companyModel);
+            [$company, $leadAdded, $companyEntity] = IdentifyCompanyHelper::identifyLeadsCompany($companyFieldMatches, $lead, $this->companyModel, $this->companyLeadRepository);
             $companyChangeLog                      = null;
             if ($leadAdded) {
                 $companyChangeLog = $lead->addCompanyChangeLogEntry('form', 'Identify Company', 'Lead added to the company, '.$company['companyname'], $company['id']);

--- a/app/bundles/LeadBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/CampaignSubscriber.php
@@ -492,7 +492,7 @@ final class CampaignSubscriber implements EventSubscriberInterface
             $primaryCompany = $this->companyModel->getEntity($company['id']);
 
             if (isset($config['companyname']) && $primaryCompany->getName() != $config['companyname']) {
-                [$company, $leadAdded, $companyEntity] = IdentifyCompanyHelper::identifyLeadsCompany($config, $lead, $this->companyModel);
+                [$company, $leadAdded, $companyEntity] = IdentifyCompanyHelper::identifyLeadsCompany($config, $lead, $this->companyModel, $this->companyLeadRepository);
                 $companyChangeLog                      = null;
                 if ($leadAdded) {
                     $companyChangeLog = $lead->addCompanyChangeLogEntry('form', 'Identify Company', 'Lead added to the company, '.$company['companyname'], $company['id']);

--- a/app/bundles/LeadBundle/Helper/IdentifyCompanyHelper.php
+++ b/app/bundles/LeadBundle/Helper/IdentifyCompanyHelper.php
@@ -3,6 +3,7 @@
 namespace Mautic\LeadBundle\Helper;
 
 use Mautic\LeadBundle\Entity\Company;
+use Mautic\LeadBundle\Entity\CompanyLeadRepository;
 use Mautic\LeadBundle\Exception\UniqueFieldNotFoundException;
 use Mautic\LeadBundle\Model\CompanyModel;
 
@@ -11,7 +12,7 @@ final class IdentifyCompanyHelper
     /**
      * @param mixed $lead
      */
-    public static function identifyLeadsCompany(array $data, $lead, CompanyModel $companyModel): array
+    public static function identifyLeadsCompany(array $data, $lead, CompanyModel $companyModel, ?CompanyLeadRepository $companyLeadRepository = null): array
     {
         $addContactToCompany = true;
 
@@ -31,9 +32,8 @@ final class IdentifyCompanyHelper
             $companyEntity = end($companies);
             $companyData   = $companyEntity->getProfileFields();
 
-            if ($lead) {
-                $companyLeadRepo = $companyModel->getCompanyLeadRepository();
-                $companyLead     = $companyLeadRepo->getCompaniesByLeadId($lead->getId(), $companyEntity->getId());
+            if ($lead && null !== $companyLeadRepository) {
+                $companyLead     = $companyLeadRepository->getCompaniesByLeadId($lead->getId(), $companyEntity->getId());
                 if ([] !== $companyLead) {
                     $addContactToCompany = false;
                 }

--- a/app/bundles/LeadBundle/Model/CompanyModel.php
+++ b/app/bundles/LeadBundle/Model/CompanyModel.php
@@ -131,11 +131,6 @@ class CompanyModel extends CommonFormModel implements AjaxLookupModelInterface
         return $this->companyRepository;
     }
 
-    public function getCompanyLeadRepository(): CompanyLeadRepository
-    {
-        return $this->companyLeadRepository;
-    }
-
     public function getPermissionBase(): string
     {
         // We are using lead:leads in the CompanyController so this should match to prevent a BC break

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -429,7 +429,7 @@ class LeadModel extends FormModel
         $changeLogEntity = null;
         if (isset($updatedFields['company'])) {
             $companyFieldMatches['company']            = $updatedFields['company'];
-            [$company, $leadAdded, $companyEntity]     = IdentifyCompanyHelper::identifyLeadsCompany($companyFieldMatches, $entity, $this->companyModel);
+            [$company, $leadAdded, $companyEntity]     = IdentifyCompanyHelper::identifyLeadsCompany($companyFieldMatches, $entity, $this->companyModel, $this->companyLeadRepository);
             if ($leadAdded) {
                 $changeLogEntity = $entity->addCompanyChangeLogEntry('form', 'Identify Company', 'Lead added to the company, '.$company['companyname'], $company['id']);
             }

--- a/app/bundles/LeadBundle/Tests/Entity/CompanyLeadRepositoryFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/CompanyLeadRepositoryFunctionalTest.php
@@ -7,6 +7,7 @@ namespace Mautic\LeadBundle\Tests\Entity;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Company;
 use Mautic\LeadBundle\Entity\CompanyLead;
+use Mautic\LeadBundle\Entity\CompanyLeadRepository;
 use Mautic\LeadBundle\Entity\Lead;
 
 final class CompanyLeadRepositoryFunctionalTest extends MauticMysqlTestCase
@@ -31,7 +32,8 @@ final class CompanyLeadRepositoryFunctionalTest extends MauticMysqlTestCase
 
         $this->em->flush();
 
-        $repoCompanyLead = $this->em->getRepository(CompanyLead::class);
+        /** @var CompanyLeadRepository $repoCompanyLead */
+        $repoCompanyLead = self::getContainer()->get(CompanyLeadRepository::class);
 
         $this->assertCount(0, $repoCompanyLead->getPrimaryCompaniesByLeadIds([]), 'No IDs');
         $this->assertCount(0, $repoCompanyLead->getPrimaryCompaniesByLeadIds([0]), 'Empty IDs');

--- a/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberTest.php
@@ -140,6 +140,11 @@ final class CampaignSubscriberTest extends \PHPUnit\Framework\TestCase
      */
     private MockObject $mockCompanyModel;
 
+    /**
+     * @var MockObject&CompanyLeadRepository
+     */
+    private MockObject $mockCompanyLeadRepository;
+
     private CampaignSubscriber $subscriber;
 
     /**
@@ -151,6 +156,7 @@ final class CampaignSubscriberTest extends \PHPUnit\Framework\TestCase
     {
         $this->mockLeadModel          = $this->createMock(LeadModel::class);
         $this->mockCompanyModel       = $this->createMock(CompanyModel::class);
+        $this->mockCompanyLeadRepository = $this->createMock(CompanyLeadRepository::class);
         $this->doNotContact           = $this->createMock(DoNotContact::class);
         $filterOperatorProvider       = new FilterOperatorProvider(
             $this->createStub(EventDispatcherInterface::class),
@@ -177,7 +183,7 @@ final class CampaignSubscriberTest extends \PHPUnit\Framework\TestCase
             $this->createStub(\Mautic\CampaignBundle\Entity\LeadRepository::class),
             $this->createStub(\Mautic\PointBundle\Entity\GroupContactScoreRepository::class),
             $this->createStub(\Mautic\LeadBundle\Entity\LeadDeviceRepository::class),
-            $this->createStub(CompanyLeadRepository::class)
+            $this->mockCompanyLeadRepository
         );
     }
 
@@ -199,12 +205,7 @@ final class CampaignSubscriberTest extends \PHPUnit\Framework\TestCase
 
         $this->mockCompanyModel->expects($this->once())->method('getEntity')->willReturn($companyEntityFrom);
 
-        $mockCompanyLeadRepo = $this->createMock(CompanyLeadRepository::class);
-        $mockCompanyLeadRepo->expects($this->once())->method('getCompaniesByLeadId')->willReturn([]);
-
-        $this->mockCompanyModel->expects($this->atLeastOnce())
-            ->method('getCompanyLeadRepository')
-            ->willReturn($mockCompanyLeadRepo);
+        $this->mockCompanyLeadRepository->expects($this->once())->method('getCompaniesByLeadId')->willReturn([]);
 
         $this->mockCompanyModel->expects($this->once())
             ->method('checkForDuplicateCompanies')

--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -438,7 +438,7 @@ class PageModel extends FormModel implements GlobalSearchInterface
             $lead = $this->contactRequestHelper->getContactFromQuery($query);
 
             // company
-            [$company, $leadAdded, $companyEntity] = IdentifyCompanyHelper::identifyLeadsCompany($query, $lead, $this->companyModel);
+            [$company, $leadAdded, $companyEntity] = IdentifyCompanyHelper::identifyLeadsCompany($query, $lead, $this->companyModel, $this->companyLeadRepository);
             $companyChangeLog                      = null;
             if ($leadAdded) {
                 $companyChangeLog = $lead->addCompanyChangeLogEntry('form', 'Identify Company', 'Lead added to the company, '.$company['companyname'], $company['id']);


### PR DESCRIPTION
## Why

Follow-up to #17238 (`NoServiceGetterRule`). `CompanyModel::getCompanyLeadRepository()` only returned the injected `CompanyLeadRepository`, letting callers reach the repository through the model instead of asking for it directly. Removed; the repository is injected where it is used.
