### PR TITLE
[phpstan] Drop CoreEvents guard in SingleArgumentDispatchRule (probe PHPStan failures)

### DIFF
--- a/utils/phpstan/src/Rule/SingleArgumentDispatchRule.php
+++ b/utils/phpstan/src/Rule/SingleArgumentDispatchRule.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Utils\PHPStan\Rule;
 
-use Mautic\CoreBundle\CoreEvents;
 use PhpParser\Node;
 use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\MethodCall;


### PR DESCRIPTION
Removes the `CoreEvents::class` guard in `SingleArgumentDispatchRule` so the rule flags **every** two-argument `->dispatch($event, SomeEvents::CONST)` call, not only `CoreEvents::` ones.

Purpose: draft to let CI/PHPStan surface where two-arg dispatches still exist across the codebase.