### PR TITLE
[events] Dispatch LeadTimelineEvent and SocialMonitorEvent by class name

### DIFF
--- a/app/bundles/AssetBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/AssetBundle/EventListener/LeadSubscriber.php
@@ -25,7 +25,7 @@ final readonly class LeadSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            LeadEvents::TIMELINE_ON_GENERATE => ['onTimelineGenerate', 0],
+            LeadTimelineEvent::class => ['onTimelineGenerate', 0],
             LeadEvents::CURRENT_LEAD_CHANGED => ['onLeadChange', 0],
             LeadEvents::LEAD_POST_MERGE      => ['onLeadMerge', 0],
         ];

--- a/app/bundles/CampaignBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/CampaignBundle/EventListener/LeadSubscriber.php
@@ -30,7 +30,7 @@ final readonly class LeadSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            LeadEvents::TIMELINE_ON_GENERATE => ['onTimelineGenerate', 0],
+            LeadTimelineEvent::class => ['onTimelineGenerate', 0],
             LeadEvents::LEAD_POST_MERGE      => ['onLeadMerge', 0],
         ];
     }

--- a/app/bundles/ChannelBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/ChannelBundle/EventListener/LeadSubscriber.php
@@ -4,7 +4,6 @@ namespace Mautic\ChannelBundle\EventListener;
 
 use Mautic\ChannelBundle\Entity\MessageQueueRepository;
 use Mautic\LeadBundle\Event\LeadTimelineEvent;
-use Mautic\LeadBundle\LeadEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -21,7 +20,7 @@ final readonly class LeadSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            LeadEvents::TIMELINE_ON_GENERATE => ['onTimelineGenerate', 0],
+            LeadTimelineEvent::class => ['onTimelineGenerate', 0],
         ];
     }
 

--- a/app/bundles/DynamicContentBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/DynamicContentBundle/EventListener/LeadSubscriber.php
@@ -22,7 +22,7 @@ final readonly class LeadSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            LeadEvents::TIMELINE_ON_GENERATE => ['onTimelineGenerate', 0],
+            LeadTimelineEvent::class => ['onTimelineGenerate', 0],
             LeadEvents::LEAD_POST_MERGE      => ['onLeadMerge', 0],
         ];
     }

--- a/app/bundles/EmailBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/LeadSubscriber.php
@@ -24,7 +24,7 @@ final readonly class LeadSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            LeadEvents::TIMELINE_ON_GENERATE => ['onTimelineGenerate', 0],
+            LeadTimelineEvent::class => ['onTimelineGenerate', 0],
             LeadEvents::LEAD_POST_MERGE      => ['onLeadMerge', 0],
         ];
     }

--- a/app/bundles/FormBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/FormBundle/EventListener/LeadSubscriber.php
@@ -26,7 +26,7 @@ final readonly class LeadSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            LeadEvents::TIMELINE_ON_GENERATE => ['onTimelineGenerate', 0],
+            LeadTimelineEvent::class => ['onTimelineGenerate', 0],
             LeadEvents::LEAD_POST_MERGE      => ['onLeadMerge', 0],
         ];
     }

--- a/app/bundles/IntegrationsBundle/EventListener/TimelineSubscriber.php
+++ b/app/bundles/IntegrationsBundle/EventListener/TimelineSubscriber.php
@@ -6,7 +6,6 @@ namespace Mautic\IntegrationsBundle\EventListener;
 
 use Mautic\LeadBundle\Entity\LeadEventLogRepository;
 use Mautic\LeadBundle\Event\LeadTimelineEvent;
-use Mautic\LeadBundle\LeadEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -21,7 +20,7 @@ final readonly class TimelineSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            LeadEvents::TIMELINE_ON_GENERATE => ['onTimelineGenerate', 0],
+            LeadTimelineEvent::class => ['onTimelineGenerate', 0],
         ];
     }
 

--- a/app/bundles/LeadBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/LeadSubscriber.php
@@ -83,7 +83,7 @@ final class LeadSubscriber implements EventSubscriberInterface
             LeadEvents::FIELD_POST_DELETE    => ['onFieldDelete', 0],
             LeadEvents::NOTE_POST_SAVE       => ['onNotePostSave', 0],
             LeadEvents::NOTE_POST_DELETE     => ['onNoteDelete', 0],
-            LeadEvents::TIMELINE_ON_GENERATE => ['onTimelineGenerate', 0],
+            Events\LeadTimelineEvent::class => ['onTimelineGenerate', 0],
             LeadEvents::LEAD_COMPANY_CHANGE  => ['onLeadCompanyChange', 0],
         ];
     }

--- a/app/bundles/LeadBundle/EventListener/TimelineEventLogCampaignSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/TimelineEventLogCampaignSubscriber.php
@@ -11,7 +11,6 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadEventLog;
 use Mautic\LeadBundle\Entity\LeadEventLogRepository;
 use Mautic\LeadBundle\Event\LeadTimelineEvent;
-use Mautic\LeadBundle\LeadEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final class TimelineEventLogCampaignSubscriber implements EventSubscriberInterface
@@ -32,7 +31,7 @@ final class TimelineEventLogCampaignSubscriber implements EventSubscriberInterfa
         return [
             CampaignEvents::CAMPAIGN_ON_LEADCHANGE     => 'onChange',
             CampaignEvents::LEAD_CAMPAIGN_BATCH_CHANGE => 'onBatchChange',
-            LeadEvents::TIMELINE_ON_GENERATE           => 'onTimelineGenerate',
+            LeadTimelineEvent::class           => 'onTimelineGenerate',
         ];
     }
 

--- a/app/bundles/LeadBundle/EventListener/TimelineEventLogSegmentSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/TimelineEventLogSegmentSubscriber.php
@@ -33,7 +33,7 @@ final class TimelineEventLogSegmentSubscriber implements EventSubscriberInterfac
         return [
             LeadEvents::LEAD_LIST_CHANGE       => 'onChange',
             LeadEvents::LEAD_LIST_BATCH_CHANGE => 'onBatchChange',
-            LeadEvents::TIMELINE_ON_GENERATE   => 'onTimelineGenerate',
+            LeadTimelineEvent::class   => 'onTimelineGenerate',
         ];
     }
 

--- a/app/bundles/LeadBundle/EventListener/TimelineEventLogSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/TimelineEventLogSubscriber.php
@@ -7,7 +7,6 @@ namespace Mautic\LeadBundle\EventListener;
 use Mautic\CoreBundle\Translation\Translator;
 use Mautic\LeadBundle\Entity\LeadEventLogRepository;
 use Mautic\LeadBundle\Event\LeadTimelineEvent;
-use Mautic\LeadBundle\LeadEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final class TimelineEventLogSubscriber implements EventSubscriberInterface
@@ -25,7 +24,7 @@ final class TimelineEventLogSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            LeadEvents::TIMELINE_ON_GENERATE => ['onTimelineGenerate', 0],
+            LeadTimelineEvent::class => ['onTimelineGenerate', 0],
         ];
     }
 

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -2190,8 +2190,7 @@ class LeadModel extends FormModel
     public function getEngagements(?Lead $lead = null, ?array $filters = null, ?array $orderBy = null, int $page = 1, int $limit = 25, bool $forTimeline = true): array
     {
         $event = $this->dispatcher->dispatch(
-            new LeadTimelineEvent($lead, $filters, $orderBy, $page, $limit, $forTimeline, $this->coreParametersHelper->get('site_url')),
-            LeadEvents::TIMELINE_ON_GENERATE
+            new LeadTimelineEvent($lead, $filters, $orderBy, $page, $limit, $forTimeline, $this->coreParametersHelper->get('site_url'))
         );
 
         $payload = [
@@ -2213,7 +2212,7 @@ class LeadModel extends FormModel
         $event = new LeadTimelineEvent();
         $event->fetchTypesOnly();
 
-        $this->dispatcher->dispatch($event, LeadEvents::TIMELINE_ON_GENERATE);
+        $this->dispatcher->dispatch($event);
 
         return $event->getEventTypes();
     }
@@ -2228,7 +2227,7 @@ class LeadModel extends FormModel
         $event = new LeadTimelineEvent($lead);
         $event->setCountOnly($dateFrom, $dateTo, $unit, $chartQuery);
 
-        $this->dispatcher->dispatch($event, LeadEvents::TIMELINE_ON_GENERATE);
+        $this->dispatcher->dispatch($event);
 
         return $event->getEventCounter();
     }

--- a/app/bundles/LeadBundle/Tests/EventListener/LeadSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/LeadSubscriberTest.php
@@ -26,7 +26,6 @@ use Mautic\LeadBundle\Event\LeadTimelineEvent;
 use Mautic\LeadBundle\EventListener\LeadSubscriber;
 use Mautic\LeadBundle\Helper\LeadChangeEventDispatcher;
 use Mautic\LeadBundle\Helper\SegmentCountCacheHelper;
-use Mautic\LeadBundle\LeadEvents;
 use Mautic\LeadBundle\Twig\Helper\DncReasonHelper;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -244,7 +243,7 @@ final class LeadSubscriberTest extends CommonMocks
         $dispatcher = new EventDispatcher();
         $dispatcher->addSubscriber($subscriber);
 
-        $dispatcher->dispatch($leadEvent, LeadEvents::TIMELINE_ON_GENERATE);
+        $dispatcher->dispatch($leadEvent);
 
         $this->assertSame([$timelineEvent], $leadEvent->getEvents());
     }

--- a/app/bundles/PageBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/LeadSubscriber.php
@@ -35,7 +35,7 @@ final class LeadSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            LeadEvents::TIMELINE_ON_GENERATE => [
+            LeadTimelineEvent::class => [
                 ['onTimelineGenerate', 0],
                 ['onTimelineGenerateVideo', 0],
             ],

--- a/app/bundles/PointBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/PointBundle/EventListener/LeadSubscriber.php
@@ -29,7 +29,7 @@ final readonly class LeadSubscriber implements EventSubscriberInterface
     {
         return [
             LeadEvents::LEAD_POINTS_CHANGE   => ['onLeadPointsChange', 0],
-            LeadEvents::TIMELINE_ON_GENERATE => ['onTimelineGenerate', 0],
+            LeadTimelineEvent::class => ['onTimelineGenerate', 0],
             LeadEvents::LEAD_POST_MERGE      => ['onLeadMerge', 0],
             LeadEvents::LEAD_POST_SAVE       => ['onLeadSave', -1],
         ];

--- a/app/bundles/SmsBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/SmsBundle/EventListener/LeadSubscriber.php
@@ -3,7 +3,6 @@
 namespace Mautic\SmsBundle\EventListener;
 
 use Mautic\LeadBundle\Event\LeadTimelineEvent;
-use Mautic\LeadBundle\LeadEvents;
 use Mautic\SmsBundle\Entity\StatRepository;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Routing\RouterInterface;
@@ -21,7 +20,7 @@ final readonly class LeadSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            LeadEvents::TIMELINE_ON_GENERATE => ['onTimelineGenerate', 0],
+            LeadTimelineEvent::class => ['onTimelineGenerate', 0],
         ];
     }
 

--- a/app/bundles/SmsBundle/EventListener/ReplySubscriber.php
+++ b/app/bundles/SmsBundle/EventListener/ReplySubscriber.php
@@ -10,7 +10,6 @@ use Mautic\LeadBundle\Entity\LeadEventLog;
 use Mautic\LeadBundle\Entity\LeadEventLogRepository;
 use Mautic\LeadBundle\Event\LeadTimelineEvent;
 use Mautic\LeadBundle\EventListener\TimelineEventLogTrait;
-use Mautic\LeadBundle\LeadEvents;
 use Mautic\SmsBundle\Event\ReplyEvent;
 use Mautic\SmsBundle\SmsEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -29,7 +28,7 @@ final class ReplySubscriber implements EventSubscriberInterface
     {
         return [
             SmsEvents::ON_REPLY              => ['onReply', 0],
-            LeadEvents::TIMELINE_ON_GENERATE => 'onTimelineGenerate',
+            LeadTimelineEvent::class => 'onTimelineGenerate',
         ];
     }
 

--- a/app/bundles/StageBundle/EventListener/LeadSubscriber.php
+++ b/app/bundles/StageBundle/EventListener/LeadSubscriber.php
@@ -24,7 +24,7 @@ final readonly class LeadSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            LeadEvents::TIMELINE_ON_GENERATE => ['onTimelineGenerate', 0],
+            LeadTimelineEvent::class => ['onTimelineGenerate', 0],
             LeadEvents::LEAD_POST_MERGE      => ['onLeadMerge', 0],
         ];
     }

--- a/plugins/MauticFocusBundle/EventListener/LeadSubscriber.php
+++ b/plugins/MauticFocusBundle/EventListener/LeadSubscriber.php
@@ -4,7 +4,6 @@ namespace MauticPlugin\MauticFocusBundle\EventListener;
 
 use Mautic\CoreBundle\Translation\Translator;
 use Mautic\LeadBundle\Event\LeadTimelineEvent;
-use Mautic\LeadBundle\LeadEvents;
 use MauticPlugin\MauticFocusBundle\Entity\Stat;
 use MauticPlugin\MauticFocusBundle\FocusEventTypes;
 use MauticPlugin\MauticFocusBundle\Model\FocusModel;
@@ -23,7 +22,7 @@ final readonly class LeadSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            LeadEvents::TIMELINE_ON_GENERATE      => ['onTimelineGenerate', 0],
+            LeadTimelineEvent::class      => ['onTimelineGenerate', 0],
         ];
     }
 

--- a/plugins/MauticFocusBundle/Tests/EventListener/LeadSubscriberTest.php
+++ b/plugins/MauticFocusBundle/Tests/EventListener/LeadSubscriberTest.php
@@ -8,7 +8,6 @@ use Mautic\CoreBundle\Tests\CommonMocks;
 use Mautic\CoreBundle\Translation\Translator;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Event\LeadTimelineEvent;
-use Mautic\LeadBundle\LeadEvents;
 use MauticPlugin\MauticFocusBundle\Entity\Stat;
 use MauticPlugin\MauticFocusBundle\Entity\StatRepository;
 use MauticPlugin\MauticFocusBundle\EventListener\LeadSubscriber;
@@ -93,7 +92,7 @@ final class LeadSubscriberTest extends CommonMocks
 
         $dispatcher = new EventDispatcher();
         $dispatcher->addSubscriber($subscriber);
-        $dispatcher->dispatch($leadEvent, LeadEvents::TIMELINE_ON_GENERATE);
+        $dispatcher->dispatch($leadEvent);
 
         $this->assertSame([$timelineEvent], $leadEvent->getEvents());
     }
@@ -117,7 +116,7 @@ final class LeadSubscriberTest extends CommonMocks
 
         $dispatcher = new EventDispatcher();
         $dispatcher->addSubscriber($subscriber);
-        $dispatcher->dispatch($leadEvent, LeadEvents::TIMELINE_ON_GENERATE);
+        $dispatcher->dispatch($leadEvent);
 
         $this->assertSame([$timelineEvent], $leadEvent->getEvents());
     }
@@ -146,7 +145,7 @@ final class LeadSubscriberTest extends CommonMocks
 
         $dispatcher = new EventDispatcher();
         $dispatcher->addSubscriber($subscriber);
-        $dispatcher->dispatch($leadEvent, LeadEvents::TIMELINE_ON_GENERATE);
+        $dispatcher->dispatch($leadEvent);
 
         $this->assertSame([$timelineEvent], $leadEvent->getEvents());
     }
@@ -170,7 +169,7 @@ final class LeadSubscriberTest extends CommonMocks
 
         $dispatcher = new EventDispatcher();
         $dispatcher->addSubscriber($subscriber);
-        $dispatcher->dispatch($leadEvent, LeadEvents::TIMELINE_ON_GENERATE);
+        $dispatcher->dispatch($leadEvent);
 
         $this->assertSame([$timelineEvent], $leadEvent->getEvents());
     }

--- a/plugins/MauticSocialBundle/Command/MonitorTwitterBaseCommand.php
+++ b/plugins/MauticSocialBundle/Command/MonitorTwitterBaseCommand.php
@@ -9,7 +9,6 @@ use MauticPlugin\MauticSocialBundle\Entity\Monitoring;
 use MauticPlugin\MauticSocialBundle\Event\SocialMonitorEvent;
 use MauticPlugin\MauticSocialBundle\Helper\TwitterCommandHelper;
 use MauticPlugin\MauticSocialBundle\Integration\TwitterIntegration;
-use MauticPlugin\MauticSocialBundle\SocialEvents;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -161,8 +160,7 @@ abstract class MonitorTwitterBaseCommand extends Command
         $this->processMonitor($monitor);
 
         $this->dispatcher->dispatch(
-            new SocialMonitorEvent($this->getNetworkName(), $monitor, $this->twitterCommandHelper->getManipulatedLeads(), $this->twitterCommandHelper->getNewLeadsCount(), $this->twitterCommandHelper->getUpdatedLeadsCount()),
-            SocialEvents::MONITOR_POST_PROCESS
+            new SocialMonitorEvent($this->getNetworkName(), $monitor, $this->twitterCommandHelper->getManipulatedLeads(), $this->twitterCommandHelper->getNewLeadsCount(), $this->twitterCommandHelper->getUpdatedLeadsCount())
         );
 
         return Command::SUCCESS;


### PR DESCRIPTION
Both events map 1:1 to a single event-name constant, so they can use Symfony 4.3+ class-name dispatch.

## Changes
- `SocialMonitorEvent`: drop the redundant `SocialEvents::MONITOR_POST_PROCESS` second argument on dispatch (single dispatch site, no listeners keyed elsewhere).
- `LeadTimelineEvent`: drop the second dispatch argument at every dispatch site and key all subscribers on `LeadTimelineEvent::class` instead of `LeadEvents::TIMELINE_ON_GENERATE`. Removed now-unused `LeadEvents` imports.
