### PR TITLE
Returning service aliases removed during service refactroing

### DIFF
--- a/app/bundles/ApiBundle/Config/services.php
+++ b/app/bundles/ApiBundle/Config/services.php
@@ -27,6 +27,8 @@ return function (ContainerConfigurator $configurator): void {
     $services->set('mautic.api.helper.entity_result', Mautic\ApiBundle\Helper\EntityResultHelper::class);
 
     $services->set(Mautic\ApiBundle\EventListener\PreAuthorizationEventListener::class);
+    $services->alias('mautic.api.oauth.event_listener', Mautic\ApiBundle\EventListener\PreAuthorizationEventListener::class)
+        ->deprecate('mautic/mautic', '7.2', 'The "%alias_id%" service alias is deprecated. Use the "'.Mautic\ApiBundle\EventListener\PreAuthorizationEventListener::class.'" service instead.');
 
     $services->set('mautic.validator.oauthcallback', Mautic\ApiBundle\Form\Validator\Constraints\OAuthCallbackValidator::class)->tag('validator.constraint_validator');
     $services->set('mautic.api.security.voter.permission', Mautic\ApiBundle\Security\Voter\ApiPermissionVoter::class)->tag('security.voter');

--- a/app/bundles/CampaignBundle/Config/services.php
+++ b/app/bundles/CampaignBundle/Config/services.php
@@ -66,6 +66,10 @@ return function (ContainerConfigurator $configurator): void {
     $services->alias('mautic.campaign.scheduler', Mautic\CampaignBundle\Executioner\Scheduler\EventScheduler::class);
     $services->alias('mautic.campaign.executioner.action', Mautic\CampaignBundle\Executioner\Event\ActionExecutioner::class);
     $services->alias('mautic.campaign.executioner.realtime', Mautic\CampaignBundle\Executioner\RealTimeExecutioner::class);
+    $services->alias('mautic.campaign.event_collector', Mautic\CampaignBundle\EventCollector\EventCollector::class)
+        ->deprecate('mautic/mautic', '7.2', 'The "%alias_id%" service alias is deprecated. Use the "'.Mautic\CampaignBundle\EventCollector\EventCollector::class.'" service instead.');
+    $services->alias('mautic.campaign.fixture.campaign', Mautic\CampaignBundle\DataFixtures\ORM\CampaignData::class)
+        ->deprecate('mautic/mautic', '7.2', 'The "%alias_id%" service alias is deprecated. Use the "'.Mautic\CampaignBundle\DataFixtures\ORM\CampaignData::class.'" service instead.');
     $services->set(Mautic\CampaignBundle\Executioner\ScheduledExecutioner::class)->tag('kernel.reset', ['method' => 'reset']);
 
     if ('test' === ($_ENV['APP_ENV'] ?? $_SERVER['APP_ENV'] ?? 'prod')) {

--- a/app/bundles/ChannelBundle/Config/services.php
+++ b/app/bundles/ChannelBundle/Config/services.php
@@ -30,4 +30,6 @@ return function (ContainerConfigurator $configurator): void {
 
     $services->set(Mautic\ChannelBundle\Helper\ChannelListHelper::class)
         ->tag('twig.helper', ['alias' => 'channel']);
+    $services->alias('mautic.channel.helper.channel_list', Mautic\ChannelBundle\Helper\ChannelListHelper::class)
+        ->deprecate('mautic/mautic', '7.2', 'The "%alias_id%" service alias is deprecated. Use the "'.Mautic\ChannelBundle\Helper\ChannelListHelper::class.'" service instead.');
 };

--- a/app/bundles/CoreBundle/Config/services.php
+++ b/app/bundles/CoreBundle/Config/services.php
@@ -186,6 +186,8 @@ return function (ContainerConfigurator $configurator): void {
             service('mautic.helper.core_parameters'),
             service('mautic.cipher.openssl'),
         ]);
+    $services->alias('mautic.helper.encryption', Mautic\CoreBundle\Helper\EncryptionHelper::class)
+        ->deprecate('mautic/mautic', '7.2', 'The "%alias_id%" service alias is deprecated. Use the "'.Mautic\CoreBundle\Helper\EncryptionHelper::class.'" service instead.');
 
     $services->set('mautic.form.list.validator.circular', Mautic\CoreBundle\Form\Validator\Constraints\CircularDependencyValidator::class)->tag('validator.constraint_validator');
     $services->alias(Mautic\CoreBundle\Form\Validator\Constraints\CircularDependencyValidator::class, 'mautic.form.list.validator.circular');
@@ -336,4 +338,18 @@ return function (ContainerConfigurator $configurator): void {
     $services->alias('mautic.core.model.auditlog', Mautic\CoreBundle\Model\AuditLogModel::class);
     $services->alias('mautic.core.model.notification', Mautic\CoreBundle\Model\NotificationModel::class);
     $services->alias('mautic.core.model.form', Mautic\CoreBundle\Model\FormModel::class);
+
+    // Deprecated legacy string aliases kept for plugin BC. Use the FQCN services instead.
+    $services->alias('mautic.core.service.flashbag', Mautic\CoreBundle\Service\FlashBag::class)
+        ->deprecate('mautic/mautic', '7.2', 'The "%alias_id%" service alias is deprecated. Use the "'.Mautic\CoreBundle\Service\FlashBag::class.'" service instead.');
+    $services->alias('mautic.database.version.provider', Mautic\CoreBundle\Doctrine\Provider\VersionProvider::class)
+        ->deprecate('mautic/mautic', '7.2', 'The "%alias_id%" service alias is deprecated. Use the "'.Mautic\CoreBundle\Doctrine\Provider\VersionProvider::class.'" service instead.');
+    $services->alias('mautic.doctrine.loader.mautic_fixtures_loader', Mautic\CoreBundle\Doctrine\Loader\MauticFixturesLoader::class)
+        ->deprecate('mautic/mautic', '7.2', 'The "%alias_id%" service alias is deprecated. Use the "'.Mautic\CoreBundle\Doctrine\Loader\MauticFixturesLoader::class.'" service instead.');
+    $services->alias('mautic.generated.columns.provider', Mautic\CoreBundle\Doctrine\Provider\GeneratedColumnsProvider::class)
+        ->deprecate('mautic/mautic', '7.2', 'The "%alias_id%" service alias is deprecated. Use the "'.Mautic\CoreBundle\Doctrine\Provider\GeneratedColumnsProvider::class.'" service instead.');
+    $services->alias('mautic.helper.twig.menu', Mautic\CoreBundle\Twig\Helper\MenuHelper::class)
+        ->deprecate('mautic/mautic', '7.2', 'The "%alias_id%" service alias is deprecated. Use the "'.Mautic\CoreBundle\Twig\Helper\MenuHelper::class.'" service instead.');
+    $services->alias('mautic.route_loader', Mautic\CoreBundle\Loader\RouteLoader::class)
+        ->deprecate('mautic/mautic', '7.2', 'The "%alias_id%" service alias is deprecated. Use the "'.Mautic\CoreBundle\Loader\RouteLoader::class.'" service instead.');
 };

--- a/app/bundles/DynamicContentBundle/Config/services.php
+++ b/app/bundles/DynamicContentBundle/Config/services.php
@@ -26,4 +26,6 @@ return function (ContainerConfigurator $configurator): void {
     $services->alias(Mautic\DynamicContentBundle\Helper\DynamicContentHelper::class, 'mautic.helper.dynamicContent');
     $services->alias('mautic.dynamicContent.model.dynamicContent', Mautic\DynamicContentBundle\Model\DynamicContentModel::class);
     $services->alias('mautic.dynamicContent.repository.stat', Mautic\DynamicContentBundle\Entity\StatRepository::class);
+    $services->alias('mautic.form.type.dwc_entry_filters', Mautic\DynamicContentBundle\Form\Type\DwcEntryFiltersType::class)
+        ->deprecate('mautic/mautic', '7.2', 'The "%alias_id%" service alias is deprecated. Use the "'.Mautic\DynamicContentBundle\Form\Type\DwcEntryFiltersType::class.'" service instead.');
 };

--- a/app/bundles/IntegrationsBundle/Config/services.php
+++ b/app/bundles/IntegrationsBundle/Config/services.php
@@ -88,4 +88,8 @@ return function (ContainerConfigurator $configurator): void {
     $services->alias('mautic.integrations.helper.config_integrations', Mautic\IntegrationsBundle\Helper\ConfigIntegrationsHelper::class);
     $services->alias('mautic.integrations.helper.builder_integrations', Mautic\IntegrationsBundle\Helper\BuilderIntegrationsHelper::class);
     $services->alias('mautic.integrations.sync.notification.handler_container', Mautic\IntegrationsBundle\Sync\Notification\Handler\HandlerContainer::class);
+    $services->alias('mautic.integrations.subscriber.controller', Mautic\IntegrationsBundle\EventListener\ControllerSubscriber::class)
+        ->deprecate('mautic/mautic', '7.2', 'The "%alias_id%" service alias is deprecated. Use the "'.Mautic\IntegrationsBundle\EventListener\ControllerSubscriber::class.'" service instead.');
+    $services->alias('mautic.integrations.sync.service', Mautic\IntegrationsBundle\Sync\SyncService\SyncService::class)
+        ->deprecate('mautic/mautic', '7.2', 'The "%alias_id%" service alias is deprecated. Use the "'.Mautic\IntegrationsBundle\Sync\SyncService\SyncService::class.'" service instead.');
 };

--- a/app/bundles/LeadBundle/Config/services.php
+++ b/app/bundles/LeadBundle/Config/services.php
@@ -236,5 +236,9 @@ return function (ContainerConfigurator $configurator): void {
     $services->alias('mautic.lead.field.settings.background_service', Mautic\LeadBundle\Field\BackgroundService::class);
     $services->alias('mautic.lead.report.dnc_report_service', Mautic\LeadBundle\Report\DncReportService::class);
     $services->alias('mautic.helper.segment.count.cache', Mautic\LeadBundle\Helper\SegmentCountCacheHelper::class);
+    $services->alias('mautic.lead.export_scheduled_notification_subscriber', Mautic\LeadBundle\EventListener\ContactExportSchedulerNotificationSubscriber::class)
+        ->deprecate('mautic/mautic', '7.2', 'The "%alias_id%" service alias is deprecated. Use the "'.Mautic\LeadBundle\EventListener\ContactExportSchedulerNotificationSubscriber::class.'" service instead.');
+    $services->alias('mautic.lead.segment.stat.chart.query.factory', Mautic\LeadBundle\Segment\Stat\SegmentChartQueryFactory::class)
+        ->deprecate('mautic/mautic', '7.2', 'The "%alias_id%" service alias is deprecated. Use the "'.Mautic\LeadBundle\Segment\Stat\SegmentChartQueryFactory::class.'" service instead.');
     $services->get(Mautic\LeadBundle\Validator\Constraints\SegmentDateValidator::class)->tag('validator.constraint_validator');
 };

--- a/app/bundles/ReportBundle/Config/services.php
+++ b/app/bundles/ReportBundle/Config/services.php
@@ -47,4 +47,6 @@ return function (ContainerConfigurator $configurator): void {
 
     $services->set(Mautic\ReportBundle\Helper\ReportHelper::class)
         ->tag('twig.helper', ['alias' => 'report']);
+    $services->alias('mautic.report.helper.report', Mautic\ReportBundle\Helper\ReportHelper::class)
+        ->deprecate('mautic/mautic', '7.2', 'The "%alias_id%" service alias is deprecated. Use the "'.Mautic\ReportBundle\Helper\ReportHelper::class.'" service instead.');
 };

--- a/app/bundles/UserBundle/Config/services.php
+++ b/app/bundles/UserBundle/Config/services.php
@@ -128,6 +128,10 @@ return function (ContainerConfigurator $configurator): void {
     $services->set('mautic.security.saml.id_store', Mautic\UserBundle\Security\SAML\Store\IdStore::class);
 
     $services->set(Mautic\UserBundle\Security\UserTokenSetter::class);
+    $services->alias('mautic.security.logout_handler', Mautic\UserBundle\EventListener\LogoutListener::class)
+        ->deprecate('mautic/mautic', '7.2', 'The "%alias_id%" service alias is deprecated. Use the "'.Mautic\UserBundle\EventListener\LogoutListener::class.'" service instead.');
+    $services->alias('mautic.security.user_token_setter', Mautic\UserBundle\Security\UserTokenSetter::class)
+        ->deprecate('mautic/mautic', '7.2', 'The "%alias_id%" service alias is deprecated. Use the "'.Mautic\UserBundle\Security\UserTokenSetter::class.'" service instead.');
 
     $services->set('mautic.user.model.user_token_service', Mautic\UserBundle\Model\UserToken\UserTokenService::class);
 

--- a/plugins/MauticClearbitBundle/Config/services.php
+++ b/plugins/MauticClearbitBundle/Config/services.php
@@ -21,4 +21,6 @@ return function (ContainerConfigurator $configurator): void {
 
     $services->alias('mautic.integration.clearbit', MauticPlugin\MauticClearbitBundle\Integration\ClearbitIntegration::class);
     $services->alias('mautic.integration.clearbit.config', MauticPlugin\MauticClearbitBundle\Integration\Support\ConfigSupport::class);
+    $services->alias('mautic.plugin.clearbit.lookup_helper', MauticPlugin\MauticClearbitBundle\Helper\LookupHelper::class)
+        ->deprecate('mautic/mautic', '7.2', 'The "%alias_id%" service alias is deprecated. Use the "'.MauticPlugin\MauticClearbitBundle\Helper\LookupHelper::class.'" service instead.');
 };


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

<!-- 📄 DOCUMENTATION REVIEW REQUIRED:

After you open this PR, Promptless automatically creates a documentation PR and leaves a comment here with the link. Once your code PR merges, review the documentation PR, request changes if needed, and approve it promptly.

See "Reviewing documentation PRs from Promptless" in the community handbook for more details: https://contribute.mautic.org/en/latest/contributing/developer.html#reviewing-documentation-prs-from-promptless -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ✔️
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | Existing tests
| Related user documentation PR URL      | mautic/user-documentation#... <!-- required for new features -->
| Related developer documentation PR URL | mautic/developer-documentation-new#... <!-- required for developer-facing changes -->
| Issue(s) addressed                     | Fixes https://forum.mautic.org/t/ecommerce-connector-for-mautic-7-0-0-free-download/37227/4

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description

In https://github.com/mautic/mautic/pull/16843 we didn't notice that the EncryptionHelper alias was removed when moving the service definition from config.php to services.php.

This PR is returning the alias back and also identified a bunch more aliases that were missed.

### 📋 Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers. Do not write steps performed by the CI. These steps are for manual testing.
-->
1. The green CI is a good enough test here. Nothing was broken in Mautic itself, but for plugins.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->