### PR TITLE
Support relative dates in report filters

### DIFF
--- a/app/bundles/ReportBundle/Builder/MauticReportBuilder.php
+++ b/app/bundles/ReportBundle/Builder/MauticReportBuilder.php
@@ -9,8 +9,11 @@ use Mautic\ChannelBundle\Helper\ChannelListHelper;
 use Mautic\CoreBundle\Helper\InputHelper;
 use Mautic\ReportBundle\Entity\Report;
 use Mautic\ReportBundle\Event\ReportGeneratorEvent;
+use Mautic\ReportBundle\Helper\RelativeDateHelper;
 use Mautic\ReportBundle\ReportEvents;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
 
 final class MauticReportBuilder implements ReportBuilderInterface
 {
@@ -618,6 +621,41 @@ final class MauticReportBuilder implements ReportBuilderInterface
                     continue;
                 }
 
+                $filterDefinition = $filterDefinitions[$filter['column']] ?? [];
+                $type             = $filterDefinition['type'] ?? null;
+                $isRelativeDate   = in_array($type, ['date', 'datetime', DateType::class, DateTimeType::class], true)
+                    && !in_array($exprFunction, ['like', 'notLike', 'startsWith', 'endsWith', 'contains'], true)
+                    && RelativeDateHelper::isRelative($filter['value']);
+                if ($isRelativeDate) {
+                    if (isset($filterDefinition['formula'])) {
+                        $filter['column'] = $filterDefinition['formula'];
+                    }
+                    if (RelativeDateHelper::isAnniversary($filter['value'])) {
+                        if (!in_array($exprFunction, ['empty', 'notEmpty'], true)) {
+                            $filter['column'] = sprintf("DATE_FORMAT(%s, '%%m-%%d')", $filter['column']);
+                            $filter['value']  = RelativeDateHelper::resolveAnniversary($filter['value']);
+                        }
+                    } else {
+                        $range = RelativeDateHelper::resolveRange($filter['value'], in_array($type, ['date', DateType::class], true));
+                        if (in_array($exprFunction, ['eq', 'neq'], true)) {
+                            $startParam = $paramName.'Start';
+                            $endParam   = $paramName.'End';
+                            $queryBuilder->setParameter($startParam, $range['start']);
+                            $queryBuilder->setParameter($endParam, $range['end']);
+                            $rangeExpression = 'eq' === $exprFunction
+                                ? CompositeExpression::and($expr->gte($filter['column'], ':'.$startParam), $expr->lte($filter['column'], ':'.$endParam))
+                                : CompositeExpression::or($expr->isNull($filter['column']), $expr->lt($filter['column'], ':'.$startParam), $expr->gt($filter['column'], ':'.$endParam));
+                            $andGroup[] = $rangeExpression;
+
+                            continue;
+                        }
+
+                        $filter['value'] = RelativeDateHelper::isCalendarPeriod($filter['value']) || in_array($type, ['date', DateType::class], true)
+                            ? (in_array($exprFunction, ['gt', 'lte'], true) ? $range['end'] : $range['start'])
+                            : RelativeDateHelper::resolveInstant($filter['value'], false);
+                    }
+                }
+
                 switch ($exprFunction) {
                     case 'notEmpty':
                         $andGroup[] = $expr->isNotNull($filter['column']);
@@ -648,11 +686,9 @@ final class MauticReportBuilder implements ReportBuilderInterface
                         break;
                     default:
                         $columnValue = ":{$paramName}";
-                        $type        = $filterDefinitions[$filter['column']]['type'];
-                        if (isset($filterDefinitions[$filter['column']]['formula'])) {
-                            $filter['column'] = $filterDefinitions[$filter['column']]['formula'];
+                        if (!$isRelativeDate && isset($filterDefinition['formula'])) {
+                            $filter['column'] = $filterDefinition['formula'];
                         }
-
                         switch ($type) {
                             case 'bool':
                             case 'boolean':

--- a/app/bundles/ReportBundle/Form/DataTransformer/ReportFilterDataTransformer.php
+++ b/app/bundles/ReportBundle/Form/DataTransformer/ReportFilterDataTransformer.php
@@ -3,6 +3,7 @@
 namespace Mautic\ReportBundle\Form\DataTransformer;
 
 use Mautic\CoreBundle\Helper\DateTimeHelper;
+use Mautic\ReportBundle\Helper\RelativeDateHelper;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
@@ -42,6 +43,9 @@ final class ReportFilterDataTransformer implements DataTransformerInterface
                 if (isset($f['condition']) && in_array($f['condition'], ['like', 'notLike', 'startsWith', 'endsWith', 'contains'])) {
                     continue;
                 }
+                if (in_array($type, ['datetime', 'date', DateTimeType::class, DateType::class], true) && RelativeDateHelper::isRelative($f['value'])) {
+                    continue;
+                }
                 $dt         = new DateTimeHelper($f['value'], null, 'utc');
 
                 if (in_array($type, ['date', DateType::class])) {
@@ -79,6 +83,9 @@ final class ReportFilterDataTransformer implements DataTransformerInterface
             if (in_array($type, ['datetime', 'time'])) {
                 // Skip datetime parsing for string-like conditions
                 if (isset($f['condition']) && in_array($f['condition'], ['like', 'notLike', 'startsWith', 'endsWith', 'contains'])) {
+                    continue;
+                }
+                if (RelativeDateHelper::isRelative($f['value'])) {
                     continue;
                 }
                 $dt         = new DateTimeHelper($f['value'], null, 'local');

--- a/app/bundles/ReportBundle/Helper/RelativeDateHelper.php
+++ b/app/bundles/ReportBundle/Helper/RelativeDateHelper.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\ReportBundle\Helper;
+
+use Mautic\CoreBundle\Helper\DateTimeHelper;
+
+final class RelativeDateHelper
+{
+    public static function isRelative(mixed $value): bool
+    {
+        if (!is_string($value)) {
+            return false;
+        }
+
+        $value = trim($value);
+        if (self::isAnniversary($value)) {
+            $value = trim(str_ireplace(['anniversary', 'birthday'], '', $value));
+            if ('' === $value) {
+                return true;
+            }
+        } elseif (1 !== preg_match(
+            '/^(?:today|tomorrow|yesterday|(?:this|last|next)\s+(?:week|month|year)|[+-].+|.+\sago|(?:first|last)\s+day\s+of\s+.+)$/iD',
+            $value
+        )) {
+            return false;
+        }
+
+        try {
+            new \DateTimeImmutable($value);
+
+            return true;
+        } catch (\Exception) {
+            return false;
+        }
+    }
+
+    public static function isAnniversary(string $value): bool
+    {
+        return str_contains(strtolower($value), 'anniversary') || str_contains(strtolower($value), 'birthday');
+    }
+
+    public static function isCalendarPeriod(string $value): bool
+    {
+        return 1 === preg_match('/^(?:today|tomorrow|yesterday|(?:this|last|next)\s+(?:week|month|year))$/iD', trim($value));
+    }
+
+    public static function resolveInstant(string $value, bool $dateOnly): string
+    {
+        $date = new DateTimeHelper($value, null, 'local');
+
+        return $dateOnly ? $date->toLocalString(DateTimeHelper::FORMAT_DB_DATE_ONLY) : $date->toUtcString();
+    }
+
+    public static function resolveAnniversary(string $value): string
+    {
+        $relativeValue = trim(str_ireplace(['anniversary', 'birthday'], '', $value));
+        $date          = new DateTimeHelper($relativeValue, null, 'local');
+
+        return $date->toLocalString('m-d');
+    }
+
+    /**
+     * @return array{start: string, end: string}
+     */
+    public static function resolveRange(string $value, bool $dateOnly): array
+    {
+        $value  = trim($value);
+        $period = 'day';
+        if (1 === preg_match('/^(?:this|last|next)\s+(week|month|year)$/iD', $value, $matches)) {
+            $period = strtolower($matches[1]);
+            if ('month' === $period) {
+                $value = 'first day of '.$value;
+            } elseif ('year' === $period) {
+                $value = 'first day of January '.$value;
+            }
+        }
+
+        $date  = new DateTimeHelper($value, null, 'local');
+        $start = $date->getLocalDateTime()->setTime(0, 0);
+
+        $end    = (clone $start)->modify('+1 '.$period)->modify('-1 second');
+        $format = $dateOnly ? DateTimeHelper::FORMAT_DB_DATE_ONLY : DateTimeHelper::FORMAT_DB;
+
+        if (!$dateOnly) {
+            $utc = new \DateTimeZone('UTC');
+            $start->setTimezone($utc);
+            $end->setTimezone($utc);
+        }
+
+        return ['start' => $start->format($format), 'end' => $end->format($format)];
+    }
+}

--- a/app/bundles/ReportBundle/Tests/Builder/MauticReportBuilderTest.php
+++ b/app/bundles/ReportBundle/Tests/Builder/MauticReportBuilderTest.php
@@ -14,7 +14,9 @@ use Mautic\CoreBundle\Translation\Translator;
 use Mautic\ReportBundle\Builder\MauticReportBuilder;
 use Mautic\ReportBundle\Entity\Report;
 use Mautic\ReportBundle\Event\ReportGeneratorEvent;
+use Mautic\ReportBundle\Helper\RelativeDateHelper;
 use Mautic\ReportBundle\ReportEvents;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -157,6 +159,128 @@ final class MauticReportBuilderTest extends TestCase
         ]);
 
         $this->assertSame('SELECT `a`.`someField` WHERE a.isPublished = :i0caisPublished', $query->getSql());
+    }
+
+    public function testRelativeDateFiltersAreResolvedWhenParametersAreBound(): void
+    {
+        $report = $this->buildReportWithFilters([
+            $this->buildFilter('a.createdAt', 'gte', '-2 days 12:34:56'),
+            $this->buildFilter('a.publishDate', 'lt', '+1week'),
+            $this->buildFilter('a.updatedAt', 'lte', 'today'),
+            $this->buildFilter('a.name', 'contains', 'today'),
+        ]);
+        $query = $this->buildQueryWithFilters($report, [
+            'a.createdAt'   => $this->buildFilterDefinition('Created at', 'datetime', 'createdAt'),
+            'a.publishDate' => $this->buildFilterDefinition('Publish date', 'date', 'publishDate'),
+            'a.updatedAt'   => $this->buildFilterDefinition('Updated at', 'datetime', 'updatedAt'),
+            'a.name'        => $this->buildFilterDefinition('Name', 'string', 'name'),
+        ]);
+
+        $this->assertSame(
+            RelativeDateHelper::resolveInstant('-2 days 12:34:56', false),
+            $query->getParameters()['i0cacreatedAt']
+        );
+        $this->assertSame(
+            RelativeDateHelper::resolveRange('+1week', true)['start'],
+            $query->getParameters()['i1capublishDate']
+        );
+        $this->assertSame(
+            RelativeDateHelper::resolveRange('today', false)['end'],
+            $query->getParameters()['i2caupdatedAt']
+        );
+        $this->assertSame('%today%', $query->getParameters()['i3caname']);
+    }
+
+    public function testRelativeDatetimeEqualityUsesTheWholePeriod(): void
+    {
+        $report                      = $this->buildReportWithFilters([$this->buildFilter('a.createdAt', 'eq', 'this week')]);
+        $filterDefinition            = $this->buildFilterDefinition('Created at', 'datetime', 'createdAt');
+        $filterDefinition['formula'] = 'DATE(a.createdAt)';
+        $query                       = $this->buildQueryWithFilters($report, [
+            'a.createdAt' => $filterDefinition,
+        ]);
+        $range = RelativeDateHelper::resolveRange('this week', false);
+
+        $this->assertSame(
+            'SELECT `a`.`someField` WHERE (DATE(a.createdAt) >= :i0cacreatedAtStart) AND (DATE(a.createdAt) <= :i0cacreatedAtEnd)',
+            $query->getSQL()
+        );
+        $this->assertSame($range['start'], $query->getParameters()['i0cacreatedAtStart']);
+        $this->assertSame($range['end'], $query->getParameters()['i0cacreatedAtEnd']);
+    }
+
+    public function testRelativeDatetimeInequalityExcludesTheWholePeriod(): void
+    {
+        $report = $this->buildReportWithFilters([$this->buildFilter('a.createdAt', 'neq', 'today')]);
+        $query  = $this->buildQueryWithFilters($report, [
+            'a.createdAt' => $this->buildFilterDefinition('Created at', 'datetime', 'createdAt'),
+        ]);
+
+        $this->assertSame(
+            'SELECT `a`.`someField` WHERE (a.createdAt IS NULL) OR (a.createdAt < :i0cacreatedAtStart) OR (a.createdAt > :i0cacreatedAtEnd)',
+            $query->getSQL()
+        );
+    }
+
+    #[DataProvider('provideAnniversaryOperators')]
+    public function testRelativeAnniversaryPreservesOperator(string $condition, string $sqlOperator): void
+    {
+        $report = $this->buildReportWithFilters([$this->buildFilter('a.createdAt', $condition, 'birthday +2days')]);
+        $query  = $this->buildQueryWithFilters($report, [
+            'a.createdAt' => $this->buildFilterDefinition('Created at', 'datetime', 'createdAt'),
+        ]);
+
+        $this->assertStringContainsString("DATE_FORMAT(a.createdAt, '%m-%d') {$sqlOperator} :i0cacreatedAt", $query->getSQL());
+        $this->assertSame(RelativeDateHelper::resolveAnniversary('birthday +2days'), $query->getParameters()['i0cacreatedAt']);
+        $this->assertMatchesRegularExpression('/^\d{2}-\d{2}$/', $query->getParameters()['i0cacreatedAt']);
+    }
+
+    public static function provideAnniversaryOperators(): \Generator
+    {
+        yield 'equal' => ['eq', '='];
+        yield 'not equal' => ['neq', '<>'];
+        yield 'greater than' => ['gt', '>'];
+        yield 'greater than or equal' => ['gte', '>='];
+        yield 'less than' => ['lt', '<'];
+        yield 'less than or equal' => ['lte', '<='];
+    }
+
+    #[DataProvider('provideEmptyAnniversaryOperators')]
+    public function testEmptyAnniversaryOperatorsUseTheUnderlyingColumn(string $condition, string $sql): void
+    {
+        $report = $this->buildReportWithFilters([$this->buildFilter('a.createdAt', $condition, 'birthday')]);
+        $query  = $this->buildQueryWithFilters($report, [
+            'a.createdAt' => $this->buildFilterDefinition('Created at', 'datetime', 'createdAt'),
+        ]);
+
+        $this->assertSame($sql, $query->getSQL());
+        $this->assertSame([], $query->getParameters());
+    }
+
+    public static function provideEmptyAnniversaryOperators(): \Generator
+    {
+        yield 'empty' => ['empty', 'SELECT `a`.`someField` WHERE a.createdAt IS NULL'];
+        yield 'not empty' => ['notEmpty', 'SELECT `a`.`someField` WHERE a.createdAt IS NOT NULL'];
+    }
+
+    public function testRelativeAnniversaryUsesFilterFormula(): void
+    {
+        $report                      = $this->buildReportWithFilters([$this->buildFilter('a.createdAt', 'eq', 'birthday')]);
+        $filterDefinition            = $this->buildFilterDefinition('Created at', 'datetime', 'createdAt');
+        $filterDefinition['formula'] = 'DATE(a.createdAt)';
+        $query                       = $this->buildQueryWithFilters($report, ['a.createdAt' => $filterDefinition]);
+
+        $this->assertStringContainsString("DATE_FORMAT(DATE(a.createdAt), '%m-%d') = :i0cacreatedAt", $query->getSQL());
+    }
+
+    public function testStringComparisonDoesNotResolveRelativeDatetime(): void
+    {
+        $report = $this->buildReportWithFilters([$this->buildFilter('a.createdAt', 'like', 'today')]);
+        $query  = $this->buildQueryWithFilters($report, [
+            'a.createdAt' => $this->buildFilterDefinition('Created at', 'datetime', 'createdAt'),
+        ]);
+
+        $this->assertSame('%today%', $query->getParameters()['i0cacreatedAt']);
     }
 
     public function testGroupByWithCountOmitsNonGroupedSelectColumns(): void

--- a/app/bundles/ReportBundle/Tests/Form/DataTransformer/ReportFilterDataTransformerTest.php
+++ b/app/bundles/ReportBundle/Tests/Form/DataTransformer/ReportFilterDataTransformerTest.php
@@ -98,6 +98,36 @@ final class ReportFilterDataTransformerTest extends TestCase
         $this->assertSame($expectedUtcDateTime, $reverseTransformedFilters[0]['value']);
     }
 
+    #[DataProvider('provideRelativeDates')]
+    public function testRelativeDatesRemainUnchanged(string $column, string $value): void
+    {
+        $transformer = new ReportFilterDataTransformer($this->columns);
+        $filters     = [['column' => $column, 'condition' => 'eq', 'value' => $value]];
+
+        $this->assertSame($value, $transformer->transform($filters)[0]['value']);
+        $this->assertSame($value, $transformer->reverseTransform($filters)[0]['value']);
+    }
+
+    public static function provideRelativeDates(): \Generator
+    {
+        yield 'today datetime' => ['c.date_added', 'today'];
+        yield 'negative datetime interval' => ['c.date_added', '-2days'];
+        yield 'positive datetime interval' => ['c.publish_up', '+1 week'];
+        yield 'date interval' => ['c.some_date', '-2weeks'];
+        yield 'tomorrow' => ['c.date_added', 'tomorrow'];
+        yield 'yesterday' => ['c.date_added', 'yesterday'];
+        yield 'named week' => ['c.date_added', 'last week'];
+        yield 'named month' => ['c.date_added', 'this month'];
+        yield 'named year' => ['c.date_added', 'next year'];
+        yield 'month interval' => ['c.date_added', '-3 months'];
+        yield 'compound signed interval' => ['c.date_added', '-3 months 2 days'];
+        yield 'ago interval' => ['c.date_added', '5 days ago'];
+        yield 'first day expression' => ['c.date_added', 'first day of next month'];
+        yield 'last day expression' => ['c.date_added', 'last day of this year'];
+        yield 'anniversary' => ['c.date_added', 'anniversary'];
+        yield 'relative birthday' => ['c.date_added', 'birthday +2days'];
+    }
+
     #[DataProvider('provideStringConditions')]
     public function testTransformationIsSkippedForStringLikeConditions(string $condition): void
     {

--- a/app/bundles/ReportBundle/Tests/Helper/RelativeDateHelperTest.php
+++ b/app/bundles/ReportBundle/Tests/Helper/RelativeDateHelperTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\ReportBundle\Tests\Helper;
+
+use Mautic\ReportBundle\Helper\RelativeDateHelper;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class RelativeDateHelperTest extends TestCase
+{
+    #[DataProvider('provideRelativeValues')]
+    public function testRelativeValueDetection(string $value): void
+    {
+        $this->assertTrue(RelativeDateHelper::isRelative($value));
+    }
+
+    public static function provideRelativeValues(): \Generator
+    {
+        yield ['tomorrow'];
+        yield ['last month'];
+        yield ['-3 months 2 days'];
+        yield ['5 days ago'];
+        yield ['first day of next month'];
+        yield ['birthday +2days'];
+    }
+
+    public function testAbsoluteAndInvalidValuesAreNotRelative(): void
+    {
+        $this->assertFalse(RelativeDateHelper::isRelative('2026-09-03'));
+        $this->assertFalse(RelativeDateHelper::isRelative('+invalid'));
+    }
+
+    public function testNamedMonthSpansTheMonth(): void
+    {
+        $range = RelativeDateHelper::resolveRange('this month', true);
+
+        $this->assertStringEndsWith('-01', $range['start']);
+        $this->assertNotSame($range['start'], $range['end']);
+    }
+
+    public function testFirstDayExpressionSpansOneDay(): void
+    {
+        $range = RelativeDateHelper::resolveRange('first day of next month', true);
+
+        $this->assertSame($range['start'], $range['end']);
+    }
+}


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌
| New feature/enhancement? (use the a.x branch) | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | N/A

## Description

Relative expressions in report filters could be converted to fixed values when the report was saved. Expressions such as `today`, `-2 days`, and `last month` therefore stopped moving with time.

This change preserves relative expressions and evaluates them whenever the report runs. Date boundaries, timezones, operators, absolute dates, and string comparisons retain their expected behavior.

<img width="1145" height="601" alt="image" src="https://github.com/user-attachments/assets/139ffcb7-4f34-4593-b924-b472a8787749" />

---
### 📋 Steps to test this PR:

1. Create a report with a date or datetime filter set to **Equals** `today`.
2. Save and reopen it. Confirm the value remains `today`.
3. Run the report and confirm it includes the whole current day.
4. Repeat with `-2 days` and `last month`, then confirm an absolute date still behaves normally.
