### PR TITLE
fix(PageBundle/EmailBundle): allow tracked email click redirects through GPC/DNT privacy signals

### DIFF
--- a/app/bundles/CoreBundle/Helper/IpLookupHelper.php
+++ b/app/bundles/CoreBundle/Helper/IpLookupHelper.php
@@ -272,8 +272,12 @@ class IpLookupHelper
      * - Sec-GPC: 1 (Global Privacy Control - legally required by CCPA)
      * - DNT: 1 (Do Not Track - user preference)
      * - Known bots (existing IP/User-Agent filtering)
+     *
+     * When an explicit user action such as clicking a tracked email link is
+     * detected, callers can pass $isExplicitAction = true to allow the request
+     * through while still honoring HEAD, prefetch and bot checks.
      */
-    public function isRequestTrackable(): bool
+    public function isRequestTrackable(bool $isExplicitAction = false): bool
     {
         $request = $this->requestStack->getCurrentRequest();
 
@@ -292,16 +296,18 @@ class IpLookupHelper
             return false;
         }
 
-        // Respect privacy signals - Global Privacy Control (legally required in California/CCPA)
-        $secGpc = trim((string) ($request->headers->get('Sec-GPC') ?? $request->server->get('HTTP_SEC_GPC')));
-        if ('1' === $secGpc) {
-            return false;
-        }
+        if (!$isExplicitAction) {
+            // Respect privacy signals - Global Privacy Control (legally required in California/CCPA)
+            $secGpc = trim((string) ($request->headers->get('Sec-GPC') ?? $request->server->get('HTTP_SEC_GPC')));
+            if ('1' === $secGpc) {
+                return false;
+            }
 
-        // Respect Do Not Track header
-        $dnt = trim((string) ($request->headers->get('DNT') ?? $request->server->get('HTTP_DNT')));
-        if ('1' === $dnt) {
-            return false;
+            // Respect Do Not Track header
+            $dnt = trim((string) ($request->headers->get('DNT') ?? $request->server->get('HTTP_DNT')));
+            if ('1' === $dnt) {
+                return false;
+            }
         }
 
         // Use existing IP/User-Agent based bot filtering

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/IpLookupHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/IpLookupHelperTest.php
@@ -164,6 +164,52 @@ final class IpLookupHelperTest extends \PHPUnit\Framework\TestCase
         $this->assertFalse($result);
     }
 
+    #[TestDox('Check that explicit actions bypass the GPC header')]
+    public function testIsRequestTrackableBypassesGpcForExplicitAction(): void
+    {
+        $request = new Request([], [], [], [], [], ['REMOTE_ADDR' => '73.77.245.52']);
+        $request->headers->set('Sec-GPC', '1');
+
+        $result = $this->getIpHelper($request)->isRequestTrackable(true);
+
+        $this->assertTrue($result);
+    }
+
+    #[TestDox('Check that explicit actions bypass the DNT header')]
+    public function testIsRequestTrackableBypassesDntForExplicitAction(): void
+    {
+        $request = new Request([], [], [], [], [], ['REMOTE_ADDR' => '73.77.245.52']);
+        $request->headers->set('DNT', '1');
+
+        $result = $this->getIpHelper($request)->isRequestTrackable(true);
+
+        $this->assertTrue($result);
+    }
+
+    #[TestDox('Check that explicit actions still respect the HEAD method')]
+    public function testIsRequestTrackableStillBlocksHeadForExplicitAction(): void
+    {
+        $request = new Request([], [], [], [], [], ['REMOTE_ADDR' => '73.77.245.52']);
+        $request->headers->set('Sec-GPC', '1');
+        $request->setMethod('HEAD');
+
+        $result = $this->getIpHelper($request)->isRequestTrackable(true);
+
+        $this->assertFalse($result);
+    }
+
+    #[TestDox('Check that explicit actions still respect prefetch headers')]
+    public function testIsRequestTrackableStillBlocksPrefetchForExplicitAction(): void
+    {
+        $request = new Request([], [], [], [], [], ['REMOTE_ADDR' => '73.77.245.52']);
+        $request->headers->set('DNT', '1');
+        $request->headers->set('Purpose', 'prefetch');
+
+        $result = $this->getIpHelper($request)->isRequestTrackable(true);
+
+        $this->assertFalse($result);
+    }
+
     #[TestDox('Check that normal requests are trackable')]
     public function testIsRequestTrackableReturnsTrueForNormalRequest(): void
     {

--- a/app/bundles/EmailBundle/EventListener/PageSubscriber.php
+++ b/app/bundles/EmailBundle/EventListener/PageSubscriber.php
@@ -56,8 +56,13 @@ final readonly class PageSubscriber implements EventSubscriberInterface
             if (!empty($stat)) {
                 // Check to see if it has been marked as opened
                 if (!$stat->isRead()) {
-                    // Mark it as read
-                    $this->emailModel->hitEmail($stat, $this->requestStack->getCurrentRequest() ?: $event->getRequest());
+                    // Mark it as read. A click is an explicit user action, so allow it through
+                    // privacy signals (GPC/DNT) while still honoring bot/IP checks.
+                    $this->emailModel->hitEmail(
+                        $stat,
+                        $this->requestStack->getCurrentRequest() ?: $event->getRequest(),
+                        isExplicitAction: true
+                    );
                 }
             }
         }

--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -428,6 +428,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
         bool $activeRequest = true,
         ?\DateTimeInterface $hitDateTime = null,
         bool $throwDoctrineExceptions = false,
+        bool $isExplicitAction = false,
     ): void {
         if (!$stat instanceof Stat) {
             $stat = $this->getEmailStatus($stat);
@@ -439,7 +440,7 @@ class EmailModel extends FormModel implements AjaxLookupModelInterface, GlobalSe
             return;
         }
 
-        if (!$this->ipLookupHelper->isRequestTrackable()) {
+        if (!$this->ipLookupHelper->isRequestTrackable($isExplicitAction)) {
             return;
         }
 

--- a/app/bundles/EmailBundle/Tests/EventListener/PageSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/PageSubscriberTest.php
@@ -35,8 +35,7 @@ final class PageSubscriberTest extends TestCase
 
         $this->request = new Request();
 
-        $requestStack = new RequestStack();
-        $requestStack->push($this->request);
+        $requestStack = new RequestStack([$this->request]);
 
         $this->pageSubscriber = new PageSubscriber(
             $this->emailModel,
@@ -48,10 +47,10 @@ final class PageSubscriberTest extends TestCase
     public function testOnPageHitDispatchesEmailClickForEmailRedirect(): void
     {
         $emailId = 123;
-        $email   = $this->createMock(Email::class);
+        $email   = $this->createStub(Email::class);
         $email->method('getId')->willReturn($emailId);
 
-        $redirect = $this->createMock(Redirect::class);
+        $redirect = $this->createStub(Redirect::class);
 
         $lead = $this->createMock(Lead::class);
         $lead->method('getId')->willReturn(789);
@@ -90,7 +89,7 @@ final class PageSubscriberTest extends TestCase
 
     public function testOnPageHitDoesNotDispatchEmailClickWithoutRedirect(): void
     {
-        $email = $this->createMock(Email::class);
+        $email = $this->createStub(Email::class);
 
         $hit = new Hit();
         $hit->setEmail($email);
@@ -105,12 +104,12 @@ final class PageSubscriberTest extends TestCase
     public function testOnPageHitMarksEmailAsReadWhenStatExists(): void
     {
         $emailId = 123;
-        $email   = $this->createMock(Email::class);
+        $email   = $this->createStub(Email::class);
         $email->method('getId')->willReturn($emailId);
 
-        $redirect = $this->createMock(Redirect::class);
+        $redirect = $this->createStub(Redirect::class);
 
-        $stat = $this->createMock(Stat::class);
+        $stat = $this->createStub(Stat::class);
 
         $hit = new Hit();
         $hit->setRedirect($redirect);

--- a/app/bundles/EmailBundle/Tests/EventListener/PageSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/PageSubscriberTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\EmailBundle\Tests\EventListener;
+
+use Mautic\CampaignBundle\Executioner\RealTimeExecutioner;
+use Mautic\EmailBundle\Entity\Email;
+use Mautic\EmailBundle\Entity\Stat;
+use Mautic\EmailBundle\EventListener\PageSubscriber;
+use Mautic\EmailBundle\Model\EmailModel;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\PageBundle\Entity\Hit;
+use Mautic\PageBundle\Entity\Redirect;
+use Mautic\PageBundle\Event\PageHitEvent;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+final class PageSubscriberTest extends TestCase
+{
+    private EmailModel&MockObject $emailModel;
+
+    private RealTimeExecutioner&MockObject $realTimeExecutioner;
+
+    private PageSubscriber $pageSubscriber;
+
+    private Request $request;
+
+    protected function setUp(): void
+    {
+        $this->emailModel          = $this->createMock(EmailModel::class);
+        $this->realTimeExecutioner = $this->createMock(RealTimeExecutioner::class);
+
+        $this->request = new Request();
+
+        $requestStack = new RequestStack();
+        $requestStack->push($this->request);
+
+        $this->pageSubscriber = new PageSubscriber(
+            $this->emailModel,
+            $this->realTimeExecutioner,
+            $requestStack
+        );
+    }
+
+    public function testOnPageHitDispatchesEmailClickForEmailRedirect(): void
+    {
+        $emailId = 123;
+        $email   = $this->createMock(Email::class);
+        $email->method('getId')->willReturn($emailId);
+
+        $redirect = $this->createMock(Redirect::class);
+
+        $lead = $this->createMock(Lead::class);
+        $lead->method('getId')->willReturn(789);
+
+        $hit = new Hit();
+        $hit->setRedirect($redirect);
+        $hit->setEmail($email);
+        $hit->setLead($lead);
+        $hit->setSource('email');
+        $hit->setSourceId($emailId);
+
+        $clickthrough = ['stat' => 'tracking-hash'];
+
+        $this->emailModel->expects($this->once())
+            ->method('getEmailStatus')
+            ->with('tracking-hash')
+            ->willReturn(null);
+
+        $this->emailModel->expects($this->once())
+            ->method('getEmailStati')
+            ->with($emailId, 789)
+            ->willReturn([]);
+
+        $this->realTimeExecutioner->expects($this->once())
+            ->method('execute')
+            ->with(
+                $this->identicalTo('email.click'),
+                $this->identicalTo($hit),
+                $this->identicalTo('email'),
+                $this->identicalTo($emailId)
+            );
+
+        $event = new PageHitEvent($hit, $this->request, 200, $clickthrough, true);
+        $this->pageSubscriber->onPageHit($event);
+    }
+
+    public function testOnPageHitDoesNotDispatchEmailClickWithoutRedirect(): void
+    {
+        $email = $this->createMock(Email::class);
+
+        $hit = new Hit();
+        $hit->setEmail($email);
+
+        $this->realTimeExecutioner->expects($this->never())
+            ->method('execute');
+
+        $event = new PageHitEvent($hit, $this->request, 200, [], true);
+        $this->pageSubscriber->onPageHit($event);
+    }
+
+    public function testOnPageHitMarksEmailAsReadWhenStatExists(): void
+    {
+        $emailId = 123;
+        $email   = $this->createMock(Email::class);
+        $email->method('getId')->willReturn($emailId);
+
+        $redirect = $this->createMock(Redirect::class);
+
+        $stat = $this->createMock(Stat::class);
+
+        $hit = new Hit();
+        $hit->setRedirect($redirect);
+        $hit->setEmail($email);
+
+        $this->emailModel->expects($this->once())
+            ->method('getEmailStatus')
+            ->with('tracking-hash')
+            ->willReturn($stat);
+
+        $this->emailModel->expects($this->once())
+            ->method('hitEmail');
+
+        $this->realTimeExecutioner->expects($this->once())
+            ->method('execute');
+
+        $event = new PageHitEvent($hit, $this->request, 200, ['stat' => 'tracking-hash'], true);
+        $this->pageSubscriber->onPageHit($event);
+    }
+}

--- a/app/bundles/PageBundle/Controller/PublicController.php
+++ b/app/bundles/PageBundle/Controller/PublicController.php
@@ -494,7 +494,7 @@ final class PublicController extends AbstractFormController
                 // Search replace lead fields in the URL
                 try {
                     $lead           = $contactRequestHelper->getContactFromQuery(['ct' => $ct]);
-                    $isHitTrackable = $pageModel->hitPage($redirect, $request, 200, $lead);
+                    $isHitTrackable = $pageModel->hitPage($redirect, $request, 200, $lead, [], null, true);
                 } catch (InvalidDecodedStringException $e) {
                     // Invalid ct value so we must unset it
                     // and process the request without it
@@ -504,7 +504,7 @@ final class PublicController extends AbstractFormController
                     $request->request->remove('ct');
                     $request->query->remove('ct');
                     $lead           = $contactRequestHelper->getContactFromQuery();
-                    $isHitTrackable = $pageModel->hitPage($redirect, $request, 200, $lead);
+                    $isHitTrackable = $pageModel->hitPage($redirect, $request, 200, $lead, [], null, true);
                 }
 
                 if ($lead) {

--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -404,14 +404,14 @@ class PageModel extends FormModel implements GlobalSearchInterface
      *
      * @throws \Exception
      */
-    public function hitPage(Redirect|Page|null $page, Request $request, $code = '200', ?Lead $lead = null, $query = [], ?\DateTime $dateTime = null): bool
+    public function hitPage(Redirect|Page|null $page, Request $request, $code = '200', ?Lead $lead = null, $query = [], ?\DateTime $dateTime = null, bool $isExplicitAction = false): bool
     {
         // Don't skew results with user hits
         if (!$this->security->isAnonymous() || $request->cookies->get('Blocked-Tracking')) {
             return false;
         }
 
-        if (!$this->ipLookupHelper->isRequestTrackable()) {
+        if (!$this->ipLookupHelper->isRequestTrackable($isExplicitAction)) {
             return false;
         }
 

--- a/app/bundles/PageBundle/Tests/Controller/PublicControllerFunctionalTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PublicControllerFunctionalTest.php
@@ -6,6 +6,7 @@ namespace Mautic\PageBundle\Tests\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Tag;
+use Mautic\PageBundle\Entity\Hit;
 use Mautic\PageBundle\Entity\Page;
 use Mautic\UserBundle\Entity\User;
 use PHPUnit\Framework\Assert;
@@ -143,5 +144,24 @@ final class PublicControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertResponseIsSuccessful();
         $content = $this->client->getResponse()->getContent();
         $this->assertStringNotContainsString('<img src onerror=alert(\'Company\')>', (string) $content);
+    }
+
+    public function testPageHitWithGpcHeaderDoesNotTrack(): void
+    {
+        $page = new Page();
+        $page->setIsPublished(true);
+        $page->setTitle('Privacy landing page');
+        $page->setAlias('privacy-landing-page');
+        $page->setCustomHtml('<html><body>Privacy test</body></html>');
+        $this->em->persist($page);
+        $this->em->flush();
+
+        $this->logoutUser();
+
+        $this->client->request(Request::METHOD_GET, '/privacy-landing-page', [], [], ['HTTP_SEC_GPC' => '1']);
+        $this->assertResponseIsSuccessful();
+
+        $hit = $this->em->getRepository(Hit::class)->findOneBy(['page' => $page]);
+        $this->assertNull($hit, 'Ordinary page visits with an active GPC signal must not be tracked.');
     }
 }

--- a/app/bundles/PageBundle/Tests/Controller/PublicControllerFunctionalTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PublicControllerFunctionalTest.php
@@ -162,6 +162,6 @@ final class PublicControllerFunctionalTest extends MauticMysqlTestCase
         $this->assertResponseIsSuccessful();
 
         $hit = $this->em->getRepository(Hit::class)->findOneBy(['page' => $page]);
-        $this->assertNull($hit, 'Ordinary page visits with an active GPC signal must not be tracked.');
+        $this->assertNotInstanceOf(Hit::class, $hit, 'Ordinary page visits with an active GPC signal must not be tracked.');
     }
 }

--- a/app/bundles/PageBundle/Tests/Controller/PublicControllerRedirectTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PublicControllerRedirectTest.php
@@ -130,22 +130,23 @@ final class PublicControllerRedirectTest extends MauticMysqlTestCase
         $this->assertInstanceOf(Hit::class, $hit);
     }
 
-    public function testRedirectWithGpcHeaderTracksEmailClick(): void
+    #[DataProvider('privacySignalProvider')]
+    public function testRedirectWithPrivacySignalHeaderTracksEmailClick(string $header, string $value, string $emailAddress, string $emailName, string $emailSubject, string $trackingHash, string $redirectId): void
     {
-        $url          = 'https://example.com/test?registrants.source=email';
-        $emailAddress = 'testemail@domain.tld';
-        $lead         = new Lead();
+        $url = 'https://example.com/test?registrants.source=email';
+
+        $lead = new Lead();
         $lead->setEmail($emailAddress);
         $this->em->persist($lead);
 
         $email = new Email();
-        $email->setName('Privacy test email');
-        $email->setSubject('Privacy test subject');
+        $email->setName($emailName);
+        $email->setSubject($emailSubject);
         $this->em->persist($email);
         $this->em->flush();
 
         $stat = new Stat();
-        $stat->setTrackingHash('62970e83798e0668813917');
+        $stat->setTrackingHash($trackingHash);
         $stat->setDateSent(new \DateTime());
         $stat->setEmailAddress($emailAddress);
         $stat->setEmail($email);
@@ -155,7 +156,7 @@ final class PublicControllerRedirectTest extends MauticMysqlTestCase
 
         $redirect = new Redirect();
         $redirect->setUrl($url);
-        $redirect->setRedirectId('57cf5a66a9f9414f301082cf1');
+        $redirect->setRedirectId($redirectId);
         $this->em->persist($redirect);
         $this->em->flush();
 
@@ -174,8 +175,7 @@ final class PublicControllerRedirectTest extends MauticMysqlTestCase
         $this->logoutUser();
 
         $this->client->followRedirects(false);
-        $server = ['HTTP_SEC_GPC' => '1'];
-        $this->client->request(Request::METHOD_GET, sprintf('/r/%s?ct=%s', $redirect->getRedirectId(), $ct), [], [], $server);
+        $this->client->request(Request::METHOD_GET, sprintf('/r/%s?ct=%s', $redirect->getRedirectId(), $ct), [], [], [$header => $value]);
 
         $response = $this->client->getResponse();
         $this->assertInstanceOf(RedirectResponse::class, $response);
@@ -190,63 +190,30 @@ final class PublicControllerRedirectTest extends MauticMysqlTestCase
         $this->assertTrue($stat->isRead(), 'An explicit email click should mark the email stat as read.');
     }
 
-    public function testRedirectWithDntHeaderTracksEmailClick(): void
+    /**
+     * @return iterable<string, array{header: string, value: string, emailAddress: string, emailName: string, emailSubject: string, trackingHash: string, redirectId: string}>
+     */
+    public static function privacySignalProvider(): iterable
     {
-        $url          = 'https://example.com/test?registrants.source=email';
-        $emailAddress = 'testemail2@domain.tld';
-        $lead         = new Lead();
-        $lead->setEmail($emailAddress);
-        $this->em->persist($lead);
+        yield 'Sec-GPC header' => [
+            'header'        => 'HTTP_SEC_GPC',
+            'value'         => '1',
+            'emailAddress'  => 'testemail@domain.tld',
+            'emailName'     => 'Privacy test email',
+            'emailSubject'  => 'Privacy test subject',
+            'trackingHash'  => '62970e83798e0668813917',
+            'redirectId'    => '57cf5a66a9f9414f301082cf1',
+        ];
 
-        $email = new Email();
-        $email->setName('DNT test email');
-        $email->setSubject('DNT test subject');
-        $this->em->persist($email);
-        $this->em->flush();
-
-        $stat = new Stat();
-        $stat->setTrackingHash('62970e83798e0668813918');
-        $stat->setDateSent(new \DateTime());
-        $stat->setEmailAddress($emailAddress);
-        $stat->setEmail($email);
-        $stat->setLead($lead);
-        $this->em->persist($stat);
-        $this->em->flush();
-
-        $redirect = new Redirect();
-        $redirect->setUrl($url);
-        $redirect->setRedirectId('57cf5a66a9f9414f301082cf2');
-        $this->em->persist($redirect);
-        $this->em->flush();
-
-        $ct = ClickthroughHelper::encodeArrayForUrl(
-            [
-                'source'  => ['email', $email->getId()],
-                'email'   => $email->getId(),
-                'stat'    => $stat->getTrackingHash(),
-                'lead'    => $lead->getId(),
-                'channel' => [
-                    'email' => $email->getId(),
-                ],
-            ]
-        );
-
-        $this->logoutUser();
-
-        $this->client->followRedirects(false);
-        $server = ['HTTP_DNT' => '1'];
-        $this->client->request(Request::METHOD_GET, sprintf('/r/%s?ct=%s', $redirect->getRedirectId(), $ct), [], [], $server);
-
-        $response = $this->client->getResponse();
-        $this->assertInstanceOf(RedirectResponse::class, $response);
-        self::assertResponseStatusCodeSame(Response::HTTP_FOUND);
-
-        $hit = $this->em->getRepository(Hit::class)->findOneBy(['url' => $url]);
-        $this->assertInstanceOf(Hit::class, $hit);
-        $this->assertSame($email->getId(), $hit->getEmail()->getId());
-
-        $this->em->refresh($stat);
-        $this->assertTrue($stat->isRead(), 'An explicit email click should mark the email stat as read.');
+        yield 'DNT header' => [
+            'header'        => 'HTTP_DNT',
+            'value'         => '1',
+            'emailAddress'  => 'testemail2@domain.tld',
+            'emailName'     => 'DNT test email',
+            'emailSubject'  => 'DNT test subject',
+            'trackingHash'  => '62970e83798e0668813918',
+            'redirectId'    => '57cf5a66a9f9414f301082cf2',
+        ];
     }
 
     private function getEncodedClickThroughValue(string $trackingHash, int $leadId): string

--- a/app/bundles/PageBundle/Tests/Controller/PublicControllerRedirectTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PublicControllerRedirectTest.php
@@ -6,6 +6,7 @@ namespace Mautic\PageBundle\Tests\Controller;
 
 use Mautic\CoreBundle\Helper\ClickthroughHelper;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\Entity\Stat;
 use Mautic\LeadBundle\Entity\Lead;
 use Mautic\PageBundle\Entity\Hit;
@@ -127,6 +128,125 @@ final class PublicControllerRedirectTest extends MauticMysqlTestCase
 
         $hit = $this->em->getRepository(Hit::class)->findOneBy(['url' => $url]);
         $this->assertInstanceOf(Hit::class, $hit);
+    }
+
+    public function testRedirectWithGpcHeaderTracksEmailClick(): void
+    {
+        $url          = 'https://example.com/test?registrants.source=email';
+        $emailAddress = 'testemail@domain.tld';
+        $lead         = new Lead();
+        $lead->setEmail($emailAddress);
+        $this->em->persist($lead);
+
+        $email = new Email();
+        $email->setName('Privacy test email');
+        $email->setSubject('Privacy test subject');
+        $this->em->persist($email);
+        $this->em->flush();
+
+        $stat = new Stat();
+        $stat->setTrackingHash('62970e83798e0668813917');
+        $stat->setDateSent(new \DateTime());
+        $stat->setEmailAddress($emailAddress);
+        $stat->setEmail($email);
+        $stat->setLead($lead);
+        $this->em->persist($stat);
+        $this->em->flush();
+
+        $redirect = new Redirect();
+        $redirect->setUrl($url);
+        $redirect->setRedirectId('57cf5a66a9f9414f301082cf1');
+        $this->em->persist($redirect);
+        $this->em->flush();
+
+        $ct = ClickthroughHelper::encodeArrayForUrl(
+            [
+                'source'  => ['email', $email->getId()],
+                'email'   => $email->getId(),
+                'stat'    => $stat->getTrackingHash(),
+                'lead'    => $lead->getId(),
+                'channel' => [
+                    'email' => $email->getId(),
+                ],
+            ]
+        );
+
+        $this->logoutUser();
+
+        $this->client->followRedirects(false);
+        $server = ['HTTP_SEC_GPC' => '1'];
+        $this->client->request(Request::METHOD_GET, sprintf('/r/%s?ct=%s', $redirect->getRedirectId(), $ct), [], [], $server);
+
+        $response = $this->client->getResponse();
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+        self::assertResponseStatusCodeSame(Response::HTTP_FOUND);
+        $this->assertSame($url, $response->getTargetUrl());
+
+        $hit = $this->em->getRepository(Hit::class)->findOneBy(['url' => $url]);
+        $this->assertInstanceOf(Hit::class, $hit);
+        $this->assertSame($email->getId(), $hit->getEmail()->getId());
+
+        $this->em->refresh($stat);
+        $this->assertTrue($stat->isRead(), 'An explicit email click should mark the email stat as read.');
+    }
+
+    public function testRedirectWithDntHeaderTracksEmailClick(): void
+    {
+        $url          = 'https://example.com/test?registrants.source=email';
+        $emailAddress = 'testemail2@domain.tld';
+        $lead         = new Lead();
+        $lead->setEmail($emailAddress);
+        $this->em->persist($lead);
+
+        $email = new Email();
+        $email->setName('DNT test email');
+        $email->setSubject('DNT test subject');
+        $this->em->persist($email);
+        $this->em->flush();
+
+        $stat = new Stat();
+        $stat->setTrackingHash('62970e83798e0668813918');
+        $stat->setDateSent(new \DateTime());
+        $stat->setEmailAddress($emailAddress);
+        $stat->setEmail($email);
+        $stat->setLead($lead);
+        $this->em->persist($stat);
+        $this->em->flush();
+
+        $redirect = new Redirect();
+        $redirect->setUrl($url);
+        $redirect->setRedirectId('57cf5a66a9f9414f301082cf2');
+        $this->em->persist($redirect);
+        $this->em->flush();
+
+        $ct = ClickthroughHelper::encodeArrayForUrl(
+            [
+                'source'  => ['email', $email->getId()],
+                'email'   => $email->getId(),
+                'stat'    => $stat->getTrackingHash(),
+                'lead'    => $lead->getId(),
+                'channel' => [
+                    'email' => $email->getId(),
+                ],
+            ]
+        );
+
+        $this->logoutUser();
+
+        $this->client->followRedirects(false);
+        $server = ['HTTP_DNT' => '1'];
+        $this->client->request(Request::METHOD_GET, sprintf('/r/%s?ct=%s', $redirect->getRedirectId(), $ct), [], [], $server);
+
+        $response = $this->client->getResponse();
+        $this->assertInstanceOf(RedirectResponse::class, $response);
+        self::assertResponseStatusCodeSame(Response::HTTP_FOUND);
+
+        $hit = $this->em->getRepository(Hit::class)->findOneBy(['url' => $url]);
+        $this->assertInstanceOf(Hit::class, $hit);
+        $this->assertSame($email->getId(), $hit->getEmail()->getId());
+
+        $this->em->refresh($stat);
+        $this->assertTrue($stat->isRead(), 'An explicit email click should mark the email stat as read.');
     }
 
     private function getEncodedClickThroughValue(string $trackingHash, int $leadId): string


### PR DESCRIPTION
Based on the [Mautic contribution guide](https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests), bug fixes should be submitted against the lowest maintained branch where they apply. This PR targets `7.2`.

| Q | A |
| -------------------------------------- | --- |
| Bug fix? (use the a.b branch) | ✔️ |
| New feature/enhancement? (use the a.x branch) | ❌ |
| Deprecations? | ❌ |
| BC breaks? (use the c.x branch) | ❌ |
| Automated tests included? | ✔️ |
| Related user documentation PR URL | N/A |
| Related developer documentation PR URL | N/A |
| Issue(s) addressed | Fixes #17187 |

## Description

Tracked `/r/...` email links still redirect to the destination when a browser sends `Sec-GPC: 1` or `DNT: 1`, but `PageModel::hitPage()` returns early because `IpLookupHelper::isRequestTrackable()` treats the privacy signal as a non-trackable request. No `Hit` is created, `PageEvents::PAGE_ON_HIT` is never dispatched, and therefore `EmailBundle\EventListener\PageSubscriber` never executes the `email.click` campaign decision.

This change preserves the privacy intent of #15844 while allowing the *explicit* user action of clicking an email link to be tracked:

* `IpLookupHelper::isRequestTrackable()` now accepts an optional `$isExplicitAction` flag. When `false` (the default), `Sec-GPC: 1`, `DNT: 1`, HEAD requests, prefetch/prerender requests, and bot/IP filtering continue to block tracking exactly as before.
* `PageBundle\Controller\PublicController::redirectAction()` and `PageModel::hitPage()` pass `$isExplicitAction = true` for the tracked redirect path, so the click can pass the privacy-signal gate while still honoring the bot, IP, HEAD and prefetch checks.
* `EmailBundle\EventListener\PageSubscriber` and `EmailModel::hitEmail()` use the same explicit-action flag when marking an email stat as read as a consequence of a click, keeping the stat consistent with the newly recorded click.
* Existing callers of `isRequestTrackable()` and `hitEmail()` remain backward compatible because the new parameter defaults to `false`.

## Steps to test this PR

1. Send an email with a tracked link to a contact.
2. With a browser that sends `Sec-GPC: 1` (or `DNT: 1`), click the tracked `/r/...` link.
3. Verify the browser is redirected to the destination URL (HTTP 302) as before.
4. In the Mautic database, check that a `page_hits` row was created for the redirect and that `email_id` is set.
5. Confirm that the related campaign "Clicks Email" decision is evaluated.
6. As a control, visit a normal landing page with `Sec-GPC: 1` and confirm no `page_hits` row is created.
