### PR TITLE
[NOT-FOR-MERGE] Do not track HEAD requests

### DIFF
--- a/app/bundles/LeadBundle/Tracker/ContactTracker.php
+++ b/app/bundles/LeadBundle/Tracker/ContactTracker.php
@@ -261,7 +261,7 @@ class ContactTracker
             $lead->addIpAddress($ip);
         }
 
-        if ($persist && !defined('MAUTIC_NON_TRACKABLE_REQUEST')) {
+        if ($persist && !defined('MAUTIC_NON_TRACKABLE_REQUEST') && !$this->requestStack->getCurrentRequest()?->isMethod('HEAD')) {
             // Dispatch events for new lead to write create log, ip address change, etc
             $event = new LeadEvent($lead, true);
             $this->dispatcher->dispatch($event, LeadEvents::LEAD_PRE_SAVE);

--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -378,6 +378,10 @@ class PageModel extends FormModel
             return;
         }
 
+        if ($request->isMethod('HEAD')) {
+            return;
+        }
+
         // Process the query
         if (empty($query) || !is_array($query)) {
             $query = $this->getHitQuery($request, $page);

--- a/app/bundles/PageBundle/Tests/Controller/PageControllerFunctionalTest.php
+++ b/app/bundles/PageBundle/Tests/Controller/PageControllerFunctionalTest.php
@@ -6,12 +6,42 @@ namespace Mautic\PageBundle\Tests\Controller;
 
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\DynamicContentBundle\Entity\DynamicContent;
+use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadList;
+use Mautic\PageBundle\Entity\Hit;
 use Mautic\PageBundle\Entity\Page;
 use Symfony\Component\HttpFoundation\Request;
 
 class PageControllerFunctionalTest extends MauticMysqlTestCase
 {
+    /**
+     * @dataProvider providePageRequestMethods
+     */
+    public function testPageRequestTracking(string $method, int $expectedCount): void
+    {
+        $page   = $this->createPage();
+        $pageId = $page->getId();
+        $url    = '/'.$page->getAlias();
+
+        $this->client->request(Request::METHOD_GET, '/s/logout');
+        $contactCount = $this->em->getRepository(Lead::class)->count([]);
+
+        $this->client->request($method, $url, [], [], ['HTTP_USER_AGENT' => 'Mozilla/5.0']);
+
+        $this->assertSame(200, $this->client->getResponse()->getStatusCode());
+        $this->assertSame($contactCount + $expectedCount, $this->em->getRepository(Lead::class)->count([]));
+        $this->assertSame($expectedCount, $this->em->getRepository(Hit::class)->count(['page' => $pageId]));
+    }
+
+    /**
+     * @return iterable<string, array{string, int}>
+     */
+    public static function providePageRequestMethods(): iterable
+    {
+        yield 'HEAD does not track' => [Request::METHOD_HEAD, 0];
+        yield 'GET still tracks' => [Request::METHOD_GET, 1];
+    }
+
     public function testPagePreview(): void
     {
         $segment = $this->createSegment();

--- a/app/bundles/PageBundle/Tests/Model/PageModelTest.php
+++ b/app/bundles/PageBundle/Tests/Model/PageModelTest.php
@@ -15,6 +15,17 @@ use Symfony\Component\HttpFoundation\Request;
 
 class PageModelTest extends PageTestAbstract
 {
+    public function testHeadRequestDoesNotCreatePageHit(): void
+    {
+        $pageModel = $this->getPageModel();
+        $lead      = (new Lead())->setId(1);
+
+        $this->security->method('isAnonymous')->willReturn(true);
+        $this->ipLookupHelper->expects($this->never())->method('getIpAddress');
+
+        $pageModel->hitPage(null, Request::create('/', 'HEAD'), '200', $lead);
+    }
+
     public function testUtf8CharsInTitleWithTransletirationEnabled(): void
     {
         $providedTitle = '你好，世界';

--- a/app/bundles/PageBundle/Tests/PageTestAbstract.php
+++ b/app/bundles/PageBundle/Tests/PageTestAbstract.php
@@ -44,6 +44,16 @@ class PageTestAbstract extends TestCase
      */
     protected $router;
 
+    /**
+     * @var IpLookupHelper|MockObject
+     */
+    protected $ipLookupHelper;
+
+    /**
+     * @var CorePermissions|MockObject
+     */
+    protected $security;
+
     protected function setUp(): void
     {
         $this->mockTrackingId = hash('sha1', uniqid(mt_rand(), true));
@@ -61,10 +71,12 @@ class PageTestAbstract extends TestCase
 
         $this->router = $this->createMock(Router::class);
 
-        $ipLookupHelper = $this
+        $this->ipLookupHelper = $this
             ->getMockBuilder(IpLookupHelper::class)
             ->disableOriginalConstructor()
             ->getMock();
+
+        $this->security = $this->createMock(CorePermissions::class);
 
         $leadModel = $this
             ->getMockBuilder(LeadModel::class)
@@ -154,7 +166,7 @@ class PageTestAbstract extends TestCase
 
         $pageModel = new PageModel(
             $cookieHelper,
-            $ipLookupHelper,
+            $this->ipLookupHelper,
             $leadModel,
             $leadFieldModel,
             $redirectModel,
@@ -166,7 +178,7 @@ class PageTestAbstract extends TestCase
             $coreParametersHelper,
             $contactRequestHelper,
             $entityManager,
-            $this->createMock(CorePermissions::class),
+            $this->security,
             $dispatcher,
             $this->router,
             $translator,


### PR DESCRIPTION
⚠️ This PR is provided for use as a patch and is not intended for merging into this Mautic release, as that release is no longer maintained.

## Description

HEAD requests are commonly made by monitoring tools, link checkers, and crawlers to inspect a page without retrieving its content. Mautic currently records these requests as page hits, which inflates page statistics.

This change prevents `PageModel::hitPage()` from processing HEAD requests. Normal page requests continue to be tracked.

---
### 📋 Steps to test this PR:

Use a browser-like user agent because Mautic may already filter curl's default user agent as bot traffic.

1. Create or use an existing published Mautic landing page and record its current page-hit count.
2. Send a normal request with `curl -A "Mozilla/5.0" -o /dev/null -sS -w "%{http_code}\n" "<landing-page-url>"`.
3. Verify that the response is successful and the page-hit count increases.
4. Send a HEAD request with `curl -A "Mozilla/5.0" -I "<landing-page-url>"`.
5. Verify that the response is successful but the page-hit count does not increase.
