### PR TITLE
fixed: Contact list html entity code

### DIFF
--- a/app/bundles/CoreBundle/Tests/Unit/Twig/Extension/HtmlExtensionTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Twig/Extension/HtmlExtensionTest.php
@@ -59,9 +59,9 @@ final class HtmlExtensionTest extends TestCase
      */
     public static function htmlEntityDecodeProvider(): iterable
     {
-        yield 'ampersand entity' => ['Peculiar &amp; Co', 'Peculiar & Co'];
-        yield 'numeric ampersand' => ['Peculiar &#38; Co', 'Peculiar & Co'];
-        yield 'raw ampersand' => ['Peculiar & Co', 'Peculiar & Co'];
+        yield 'ampersand entity' => ['R&amp;D', 'R&D'];
+        yield 'numeric ampersand' => ['R&#38;D', 'R&D'];
+        yield 'raw ampersand' => ['R&D', 'R&D'];
         yield 'empty' => ['', ''];
     }
 }

--- a/app/bundles/CoreBundle/Tests/Unit/Twig/Extension/HtmlExtensionTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Twig/Extension/HtmlExtensionTest.php
@@ -45,4 +45,23 @@ final class HtmlExtensionTest extends TestCase
 
         yield ['', []];
     }
+
+    #[DataProvider('htmlEntityDecodeProvider')]
+    public function testHtmlEntityDecode(string $input, string $expected): void
+    {
+        $extension = new HtmlExtension();
+
+        $this->assertSame($expected, $extension->htmlEntityDecode($input));
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function htmlEntityDecodeProvider(): iterable
+    {
+        yield 'ampersand entity' => ['Peculiar &amp; Co', 'Peculiar & Co'];
+        yield 'numeric ampersand' => ['Peculiar &#38; Co', 'Peculiar & Co'];
+        yield 'raw ampersand' => ['Peculiar & Co', 'Peculiar & Co'];
+        yield 'empty' => ['', ''];
+    }
 }

--- a/app/bundles/CoreBundle/Twig/Extension/HtmlExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/HtmlExtension.php
@@ -76,6 +76,6 @@ final class HtmlExtension extends AbstractExtension
 
     public function htmlEntityDecode(string $content): string
     {
-        return html_entity_decode($content);
+        return html_entity_decode($content, ENT_QUOTES | ENT_HTML5, 'UTF-8');
     }
 }

--- a/app/bundles/CoreBundle/Twig/Extension/HtmlExtension.php
+++ b/app/bundles/CoreBundle/Twig/Extension/HtmlExtension.php
@@ -76,6 +76,6 @@ final class HtmlExtension extends AbstractExtension
 
     public function htmlEntityDecode(string $content): string
     {
-        return html_entity_decode($content, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        return html_entity_decode($content);
     }
 }

--- a/app/bundles/LeadBundle/Assets/js/lead.js
+++ b/app/bundles/LeadBundle/Assets/js/lead.js
@@ -1695,8 +1695,10 @@ Mautic.setAsPrimaryCompany = function (companyId,leadId){
     Mautic.ajaxActionRequest('lead:setAsPrimaryCompany', {'companyId': companyId, 'leadId': leadId}, function(response) {
         if (response.success) {
             // Update the company icon
-            mQuery('.panel-companies .ri-user-star-fill').removeClass('ri-user-star-fill');
-            mQuery('.panel-companies .contained-list-item__content[href$="/' + response.newPrimary + '"]').find('i').addClass('ri-user-star-fill');
+            mQuery('.panel-companies .company-primary-icon').remove();
+            mQuery('.panel-companies [data-company-id="' + response.newPrimary + '"] .label').prepend(
+                '<i class="ri-user-star-fill company-primary-icon primary" aria-hidden="true" focusable="false"></i>'
+            );
         }
     });
 };

--- a/app/bundles/LeadBundle/Resources/views/Company/_list_column_companyname.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Company/_list_column_companyname.html.twig
@@ -3,12 +3,12 @@
         {% if securityHasEntityAccess(permissions['lead:leads:editown'], permissions['lead:leads:editother'], item.createdBy) %}
             <a href="{{ path('mautic_company_action', {'objectAction': 'view', 'objectId': item.id}) }}" data-toggle="ajax">
                 {% if fields.core.companyname is defined %}
-                    {{ fields.core.companyname.value|purify }}
+                    {{ htmlEntityDecode(fields.core.companyname.value)|purify }}
                 {% endif %}
             </a>
         {% else %}
             {% if fields.core.companyname is defined %}
-                {{ fields.core.companyname.value|purify }}
+                {{ htmlEntityDecode(fields.core.companyname.value)|purify }}
             {% endif %}
         {% endif %}
         {{ include('@MauticProject/Modules/projects.html.twig') }}

--- a/app/bundles/LeadBundle/Resources/views/Company/list_rows_contacts.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Company/list_rows_contacts.html.twig
@@ -203,9 +203,9 @@
                     </td>
                     <td>
                         <a href="{{ path('mautic_contact_action', {'objectAction': 'view', 'objectId': contact.id}) }}" data-toggle="ajax">
-                            <div>{% if contact.isAnonymous %}{{ contact.primaryIdentifier|trans }}{% else %}{{ contact.primaryIdentifier|purify }}{% endif %}</div>
+                            <div>{% if contact.isAnonymous %}{{ contact.primaryIdentifier|trans }}{% else %}{{ htmlEntityDecode(contact.primaryIdentifier)|purify }}{% endif %}</div>
                             {{ customContent('lead.name.after', _context) }}
-                            <div class="small">{{ contact.secondaryIdentifier|purify }}</div>
+                            <div class="small">{{ htmlEntityDecode(contact.secondaryIdentifier)|purify }}</div>
                         </a>
                     </td>
                     <td class="visible-md visible-lg">{{ fields.core.email.value|purify }}</td>

--- a/app/bundles/LeadBundle/Resources/views/Lead/_list_column_name.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Lead/_list_column_name.html.twig
@@ -7,13 +7,16 @@
                 }) }}
             </div>
         {% endif %}
-        {% set primaryIdentifier = item.isAnonymous ? item.primaryIdentifier|trans : item.primaryIdentifier|purify %}
         <div>
-            {{ primaryIdentifier }}
+            {% if item.isAnonymous %}
+                {{ item.primaryIdentifier|trans }}
+            {% else %}
+                {{ htmlEntityDecode(item.primaryIdentifier)|purify }}
+            {% endif %}
         </div>
         {{ customContent('lead.name.after', _context) }}
-        {% if 'company' in columns|keys and primaryIdentifier != item.secondaryIdentifier and item.secondaryIdentifier %}
-            <div class="small">{{ item.secondaryIdentifier|purify }}</div>
+        {% if 'company' in columns|keys and item.primaryIdentifier != item.secondaryIdentifier and item.secondaryIdentifier %}
+            <div class="small">{{ htmlEntityDecode(item.secondaryIdentifier)|purify }}</div>
         {% endif %}
     </a>
 </td>

--- a/app/bundles/LeadBundle/Resources/views/Lead/company.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Lead/company.html.twig
@@ -14,7 +14,7 @@
             <i class="ri-lg ri-fw {{ switch }} {{ bgClass }}"
                id="companyLeadsToggle{{ company.id }}"
                onclick="Mautic.toggleCompanyLead('companyLeadsToggle{{ company.id }}', {{ leadId }}, {{ company.id }});"></i>
-            <span>{{ company.companyname|purify }}</span>
+            <span>{{ htmlEntityDecode(company.companyname)|purify }}</span>
         </li>
     {% endfor %}
 </ul>

--- a/app/bundles/LeadBundle/Resources/views/Lead/grid_card.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Lead/grid_card.html.twig
@@ -23,11 +23,11 @@
                     {% endif %}
                     <h4 class="fw-sb mb-xs ellipsis">
                         <a href="{{ path('mautic_contact_action', {'objectAction': 'view', 'objectId': contact.id}) }}" data-toggle="ajax">
-                            <span>{{ contact.primaryIdentifier | trans }}</span>
+                            <span>{% if contact.isAnonymous %}{{ contact.primaryIdentifier|trans }}{% else %}{{ htmlEntityDecode(contact.primaryIdentifier)|purify }}{% endif %}</span>
                         </a>
                     </h4>
                     <div class="text-secondary mb-1 ellipsis">
-                        <i class="ri-fw ri-building-2-line mr-xs"></i>{{ fields.core.company.value|default('') }}
+                        <i class="ri-fw ri-building-2-line mr-xs"></i>{{ htmlEntityDecode(fields.core.company.value|default(''))|purify }}
                     </div>
                     <div class="text-secondary mb-1 ellipsis">
                         <i class="ri-fw ri-map-pin-2-line mr-xs"></i>

--- a/app/bundles/LeadBundle/Resources/views/Lead/lead.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Lead/lead.html.twig
@@ -19,8 +19,8 @@
 {% set groups = fields|keys %}
 
 {% block headerTitle %}
-    {{ avatar }}<div class="pull-left mt-5"><span class="span-block">{{ leadName|purify }}</span><span class="span-block small ml-sm">
-    {{ lead.secondaryIdentifier|purify }}</span></div>
+    {{ avatar }}<div class="pull-left mt-5"><span class="span-block">{{ htmlEntityDecode(leadName)|purify }}</span><span class="span-block small ml-sm">
+    {{ htmlEntityDecode(lead.secondaryIdentifier)|purify }}</span></div>
     {{ customContent('lead.name.after', _context) }}
 {% endblock %}
 
@@ -614,7 +614,7 @@
                 {% set companiesList = [] %}
                 {% for key, company in companies %}
                     {% set companiesList = companiesList|merge([{
-                        'label': company.companyname|purify,
+                        'label': htmlEntityDecode(company.companyname),
                         'link': path('mautic_company_action', {'objectAction': 'view', 'objectId': company.id}),
                         'icon': (company.is_primary == 1 ? 'ri-user-star-fill' : ''),
                         'button': {

--- a/app/bundles/LeadBundle/Resources/views/Lead/lead.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Lead/lead.html.twig
@@ -762,7 +762,7 @@
 {% macro render_company(company, leadId, color) %}
     {% set companyName = htmlEntityDecode(company.companyname) %}
     <div data-company-id="{{ company.id }}" class="d-flex ai-center gap-xs">
-        <a id="company-{{ company.id }}" class="label label-{{ color }}" href="{{ path('mautic_company_action', {'objectAction': 'view', 'objectId': company.id}) }}" data-toggle="ajax" aria-label="{{ companyName|e('html_attr') }}">
+        <a id="company-{{ company.id }}" class="label label-{{ color }}" href="{{ path('mautic_company_action', {'objectAction': 'view', 'objectId': company.id}) }}" data-toggle="ajax">
             {% if company.is_primary == 1 %}
                 <i class="ri-user-star-fill company-primary-icon primary" aria-hidden="true" focusable="false"></i>
             {% endif %}

--- a/app/bundles/LeadBundle/Resources/views/Lead/lead.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Lead/lead.html.twig
@@ -609,47 +609,61 @@
             {% endif %}
         </div>
 
-        <div class="pa-sm panel-companies layout--size-0">
-            {% if companies is defined and companies|length > 0 %}
-                {% set companiesList = [] %}
-                {% for key, company in companies %}
-                    {% set companiesList = companiesList|merge([{
-                        'label': htmlEntityDecode(company.companyname),
-                        'link': path('mautic_company_action', {'objectAction': 'view', 'objectId': company.id}),
-                        'icon': (company.is_primary == 1 ? 'ri-user-star-fill' : ''),
-                        'button': {
-                            'onclick': 'Mautic.setAsPrimaryCompany(' ~ company.id ~ ', ' ~ lead.id ~ ');',
-                            'icon': 'ri-check-line',
-                            'size': 'lg',
-                            'label': 'mautic.lead.company.set.primary'|trans
-                        }
-                    }]) %}
-                {% endfor %}
+        <div class="pa-sm panel-companies">
+            {% set maxVisibleCompaniesCount = 8 %}
+            {% set companyCount = companies is defined ? companies|length : 0 %}
+            {% set companyClasses = ['gray', 'red', 'magenta', 'purple', 'blue', 'cyan', 'teal', 'green'] %}
 
-                {% set tileContent %}
-                <div class="ma-neg-local">
-                    {{ include('@MauticCore/Components/contained-list.html.twig', {
-                        'title': 'mautic.lead.lead.companies'|trans,
-                        'items': companiesList,
-                        'variant': 'interactive-actions'
-                    }) }}
-                </div>
-                {% endset %}
-
-                {{ include('@MauticCore/Components/tile.html.twig', {
-                    'type': 'base',
-                    'content': tileContent
-                }) }}
-            {% else %}
-                {% set content %}
+            {% set companyHeader %}
                 <div class="d-flex jc-space-between">
                     <span class="fw-b ellipsis mb-md">{{ 'mautic.lead.lead.companies'|trans }}</span>
                     <i class="ri-building-line" aria-hidden="true"></i>
                 </div>
-                <p class="text-helper">{{ 'mautic.lead.lead.companies.no_results'|trans }}</p>
-                <div class="clearfix"></div>
+            {% endset %}
+
+            {% if companyCount > 0 %}
+                {% if companyCount <= maxVisibleCompaniesCount %}
+                    {% set content %}
+                        {{ companyHeader }}
+                        <div class="d-flex fw-wrap gap-xs">
+                            {% for company in companies %}
+                                {{ _self.render_company(company, lead.id, cycle(companyClasses, loop.index0)) }}
+                            {% endfor %}
+                        </div>
+                    {% endset %}
+
+                    {% include '@MauticCore/Components/tile.html.twig' with {'type': 'base', 'content': content} %}
+                {% else %}
+                    {% set aboveContent %}
+                        {{ companyHeader }}
+                        <div class="d-flex fw-wrap gap-xs">
+                            {% for company in companies|slice(0, maxVisibleCompaniesCount) %}
+                                {{ _self.render_company(company, lead.id, cycle(companyClasses, loop.index0)) }}
+                            {% endfor %}
+                        </div>
+                    {% endset %}
+
+                    {% set belowContent %}
+                        <div class="d-flex fw-wrap gap-xs mt-xs">
+                            {% for company in companies|slice(maxVisibleCompaniesCount) %}
+                                {{ _self.render_company(company, lead.id, cycle(companyClasses, loop.index0 + maxVisibleCompaniesCount)) }}
+                            {% endfor %}
+                        </div>
+                    {% endset %}
+
+                    {% include '@MauticCore/Components/tile.html.twig' with {
+                        'type': 'expandable-interactive',
+                        'aboveFoldContent': aboveContent,
+                        'belowFoldContent': belowContent
+                    } %}
+                {% endif %}
+            {% else %}
+                {% set content %}
+                    {{ companyHeader }}
+                    <p class="text-helper">{{ 'mautic.lead.lead.companies.no_results'|trans }}</p>
+                    <div class="clearfix"></div>
                 {% endset %}
-                
+
                 {% include '@MauticCore/Components/tile.html.twig' with {'type': 'base', 'content': content} %}
             {% endif %}
         </div>
@@ -744,6 +758,26 @@
 </div>
 <!--/ end: box layout -->
 {% endblock %}
+
+{% macro render_company(company, leadId, color) %}
+    {% set companyName = htmlEntityDecode(company.companyname) %}
+    <div data-company-id="{{ company.id }}" class="d-flex ai-center gap-xs">
+        <a id="company-{{ company.id }}" class="label label-{{ color }}" href="{{ path('mautic_company_action', {'objectAction': 'view', 'objectId': company.id}) }}" data-toggle="ajax" aria-label="{{ companyName|e('html_attr') }}">
+            {% if company.is_primary == 1 %}
+                <i class="ri-user-star-fill company-primary-icon primary" aria-hidden="true" focusable="false"></i>
+            {% endif %}
+            <span>{{ companyName|purify }}</span>
+        </a>
+        {% include '@MauticCore/Helper/button.html.twig' with {'buttons': [{
+            'onclick': 'Mautic.setAsPrimaryCompany(' ~ company.id ~ ', ' ~ leadId ~ ');',
+            'icon': 'ri-check-line',
+            'size': 'sm',
+            'icon_only': true,
+            'variant': 'ghost',
+            'label': 'mautic.lead.company.set.primary'|trans
+        }]} %}
+    </div>
+{% endmacro %}
 
 {% macro render_tag(tag, leadId) %}
     <div id="tagLabel{{ tag.id }}">

--- a/app/bundles/LeadBundle/Tests/Functional/Controller/ContactCompanyHtmlEntityDisplayFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Controller/ContactCompanyHtmlEntityDisplayFunctionalTest.php
@@ -22,7 +22,7 @@ final class ContactCompanyHtmlEntityDisplayFunctionalTest extends MauticMysqlTes
 
     public function testCompanyNameWithAmpersandIsDecodedOnContactListAndDetail(): void
     {
-        $companyName = 'Peculiar & Co';
+        $companyName = 'R&D';
 
         /** @var CompanyModel $companyModel */
         $companyModel = self::getContainer()->get(CompanyModel::class);
@@ -33,20 +33,22 @@ final class ContactCompanyHtmlEntityDisplayFunctionalTest extends MauticMysqlTes
         $leadModel = self::getContainer()->get(LeadModel::class);
 
         $namedContact = (new Lead())
-            ->setFirstname('Jane')
-            ->setLastname('Umeh')
-            ->setEmail('jane.amp-16321@example.test');
+            ->setFirstname('John')
+            ->setLastname('Doe')
+            ->setEmail('john.doe@example.com');
         $leadModel->saveEntity($namedContact);
         $companyModel->addLeadToCompany($company, $namedContact);
         $leadModel->saveEntity($namedContact);
 
         $namelessContact = (new Lead())
-            ->setEmail('nameless.amp-16321@example.test');
+            ->setEmail('test@example.com');
         $leadModel->saveEntity($namelessContact);
         $companyModel->addLeadToCompany($company, $namelessContact);
         $leadModel->saveEntity($namelessContact);
 
-        $namedContactId = $namedContact->getId();
+        $namedContactId    = $namedContact->getId();
+        $namelessContactId = $namelessContact->getId();
+        $companyId         = $company->getId();
         $this->em->clear();
 
         $listCrawler = $this->client->request(Request::METHOD_GET, '/s/contacts');
@@ -59,22 +61,41 @@ final class ContactCompanyHtmlEntityDisplayFunctionalTest extends MauticMysqlTes
 
         $detailCrawler = $this->client->request(Request::METHOD_GET, '/s/contacts/view/'.$namedContactId);
         $this->assertResponseIsSuccessful();
-        $companiesText = $detailCrawler->filter('.panel-companies')->text();
-        $this->assertStringContainsString($companyName, $companiesText);
-        $this->assertStringNotContainsString('Peculiar &amp; Co', $companiesText);
-        $this->assertStringNotContainsString('Peculiar &amp;amp; Co', $detailCrawler->html());
-        $this->assertStringContainsString('Peculiar &amp; Co', $detailCrawler->html());
+        $this->assertCompanyNameIsDisplayedOnce(
+            $detailCrawler->html(),
+            $detailCrawler->filter('.page-header-title, .panel-companies')->text(),
+            $companyName
+        );
+
+        $namelessDetailCrawler = $this->client->request(Request::METHOD_GET, '/s/contacts/view/'.$namelessContactId);
+        $this->assertResponseIsSuccessful();
+        $this->assertCompanyNameIsDisplayedOnce(
+            $namelessDetailCrawler->html(),
+            $namelessDetailCrawler->filter('.page-header-title')->text(),
+            $companyName
+        );
 
         $companyListCrawler = $this->client->request(Request::METHOD_GET, '/s/companies');
         $this->assertResponseIsSuccessful();
         $this->assertCompanyNameIsDisplayedOnce($companyListCrawler->html(), $companyListCrawler->filter('#companyTable')->text(), $companyName);
+
+        $companyContactsCrawler = $this->client->request(Request::METHOD_GET, '/s/company/'.$companyId.'/contacts/');
+        $this->assertResponseIsSuccessful();
+        $this->assertCompanyNameIsDisplayedOnce(
+            $companyContactsCrawler->html(),
+            $companyContactsCrawler->filter('#leadTable')->text(),
+            $companyName
+        );
     }
 
     private function assertCompanyNameIsDisplayedOnce(string $html, string $visibleText, string $companyName): void
     {
+        $encodedOnce  = htmlspecialchars($companyName, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        $encodedTwice = htmlspecialchars($encodedOnce, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+
         $this->assertStringContainsString($companyName, $visibleText);
-        $this->assertStringNotContainsString('Peculiar &amp; Co', $visibleText);
-        $this->assertStringNotContainsString('Peculiar &amp;amp; Co', $html);
-        $this->assertStringContainsString('Peculiar &amp; Co', $html);
+        $this->assertStringNotContainsString($encodedOnce, $visibleText);
+        $this->assertStringNotContainsString($encodedTwice, $html);
+        $this->assertStringContainsString($encodedOnce, $html);
     }
 }

--- a/app/bundles/LeadBundle/Tests/Functional/Controller/ContactCompanyHtmlEntityDisplayFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Controller/ContactCompanyHtmlEntityDisplayFunctionalTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\LeadBundle\Tests\Functional\Controller;
+
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\LeadBundle\Entity\Company;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Model\CompanyModel;
+use Mautic\LeadBundle\Model\LeadModel;
+use Symfony\Component\HttpFoundation\Request;
+
+final class ContactCompanyHtmlEntityDisplayFunctionalTest extends MauticMysqlTestCase
+{
+    protected function setUp(): void
+    {
+        $this->configParams['contact_columns'] = ['name', 'email', 'company', 'id'];
+
+        parent::setUp();
+    }
+
+    public function testCompanyNameWithAmpersandIsDecodedOnContactListAndDetail(): void
+    {
+        $companyName = 'Peculiar & Co';
+
+        /** @var CompanyModel $companyModel */
+        $companyModel = self::getContainer()->get(CompanyModel::class);
+        $company      = (new Company())->setName($companyName);
+        $companyModel->saveEntity($company);
+
+        /** @var LeadModel $leadModel */
+        $leadModel = self::getContainer()->get(LeadModel::class);
+
+        $namedContact = (new Lead())
+            ->setFirstname('Jane')
+            ->setLastname('Umeh')
+            ->setEmail('jane.amp-16321@example.test');
+        $leadModel->saveEntity($namedContact);
+        $companyModel->addLeadToCompany($company, $namedContact);
+        $leadModel->saveEntity($namedContact);
+
+        $namelessContact = (new Lead())
+            ->setEmail('nameless.amp-16321@example.test');
+        $leadModel->saveEntity($namelessContact);
+        $companyModel->addLeadToCompany($company, $namelessContact);
+        $leadModel->saveEntity($namelessContact);
+
+        $namedContactId = $namedContact->getId();
+        $this->em->clear();
+
+        $listCrawler = $this->client->request(Request::METHOD_GET, '/s/contacts');
+        $this->assertResponseIsSuccessful();
+        $this->assertCompanyNameIsDisplayedOnce($listCrawler->html(), $listCrawler->filter('#leadTable')->text(), $companyName);
+
+        $gridCrawler = $this->client->request(Request::METHOD_GET, '/s/contacts?view=grid');
+        $this->assertResponseIsSuccessful();
+        $this->assertCompanyNameIsDisplayedOnce($gridCrawler->html(), $gridCrawler->filter('.contact-cards')->text(), $companyName);
+
+        $detailCrawler = $this->client->request(Request::METHOD_GET, '/s/contacts/view/'.$namedContactId);
+        $this->assertResponseIsSuccessful();
+        $companiesText = $detailCrawler->filter('.panel-companies')->text();
+        $this->assertStringContainsString($companyName, $companiesText);
+        $this->assertStringNotContainsString('Peculiar &amp; Co', $companiesText);
+        $this->assertStringNotContainsString('Peculiar &amp;amp; Co', $detailCrawler->html());
+        $this->assertStringContainsString('Peculiar &amp; Co', $detailCrawler->html());
+
+        $companyListCrawler = $this->client->request(Request::METHOD_GET, '/s/companies');
+        $this->assertResponseIsSuccessful();
+        $this->assertCompanyNameIsDisplayedOnce($companyListCrawler->html(), $companyListCrawler->filter('#companyTable')->text(), $companyName);
+    }
+
+    private function assertCompanyNameIsDisplayedOnce(string $html, string $visibleText, string $companyName): void
+    {
+        $this->assertStringContainsString($companyName, $visibleText);
+        $this->assertStringNotContainsString('Peculiar &amp; Co', $visibleText);
+        $this->assertStringNotContainsString('Peculiar &amp;amp; Co', $html);
+        $this->assertStringContainsString('Peculiar &amp; Co', $html);
+    }
+}

--- a/app/bundles/LeadBundle/Tests/Functional/Controller/ContactCompanyHtmlEntityDisplayFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Controller/ContactCompanyHtmlEntityDisplayFunctionalTest.php
@@ -67,7 +67,7 @@ final class ContactCompanyHtmlEntityDisplayFunctionalTest extends MauticMysqlTes
             $detailCrawler->filter('.page-header-title, .panel-companies')->text(),
             $companyName
         );
-        $this->assertSame(0, $companiesPanel->filter('.contained-list')->count());
+        $this->assertCount(0, $companiesPanel->filter('.contained-list'));
         $this->assertGreaterThan(0, $companiesPanel->filter('.label')->count());
         $this->assertStringContainsString('ri-building-line', $companiesPanel->html());
 

--- a/app/bundles/LeadBundle/Tests/Functional/Controller/ContactCompanyHtmlEntityDisplayFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Functional/Controller/ContactCompanyHtmlEntityDisplayFunctionalTest.php
@@ -61,11 +61,15 @@ final class ContactCompanyHtmlEntityDisplayFunctionalTest extends MauticMysqlTes
 
         $detailCrawler = $this->client->request(Request::METHOD_GET, '/s/contacts/view/'.$namedContactId);
         $this->assertResponseIsSuccessful();
+        $companiesPanel = $detailCrawler->filter('.panel-companies');
         $this->assertCompanyNameIsDisplayedOnce(
             $detailCrawler->html(),
             $detailCrawler->filter('.page-header-title, .panel-companies')->text(),
             $companyName
         );
+        $this->assertSame(0, $companiesPanel->filter('.contained-list')->count());
+        $this->assertGreaterThan(0, $companiesPanel->filter('.label')->count());
+        $this->assertStringContainsString('ri-building-line', $companiesPanel->html());
 
         $namelessDetailCrawler = $this->client->request(Request::METHOD_GET, '/s/contacts/view/'.$namelessContactId);
         $this->assertResponseIsSuccessful();


### PR DESCRIPTION

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | Fixes #16321

## Description

Company names that contain ``&`` were showing as the literal text ``&amp;`` on the contact list (and related contact/company views).

I reproduced the issue:

<img width="1072" height="535" alt="New" src="https://github.com/user-attachments/assets/dc4edb77-1e19-420d-b0f5-56bdcbf4f3e6" />

Then fixed it as shown below:

<img width="1058" height="627" alt="fixed -NEW" src="https://github.com/user-attachments/assets/1c3703a8-6eb7-4a95-858e-b08d1c7dfa24" />

## Test plan

1. Create a company 
2. Create a contact with first and last name, associate it with that company
3. Create a second contact with only an email (no first/last name), associate it with the same company
4. Open **Contacts** in list view and confirm both rows show **company name & Co**, not ``&amp;``
5. Switch to grid view and confirm the same
6. Open the named contact and confirm the Companies widget shows ** company name & Co**
7. Open **Companies** and confirm the company name shows **company name & Co**
8. Repeat with a company named with ``and`` (no ampersand) and confirm it is unchanged
