### PR TITLE
fix: handle hydrated role rows in permissions migration

### DIFF
--- a/app/bundles/CoreBundle/Tests/Unit/Doctrine/Version20211209022550Test.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Doctrine/Version20211209022550Test.php
@@ -24,7 +24,7 @@ final class Version20211209022550Test extends TestCase
         ]);
 
         $roleModel = new class($role) {
-            public function __construct(private Role $role)
+            public function __construct(private readonly Role $role)
             {
             }
 
@@ -38,7 +38,7 @@ final class Version20211209022550Test extends TestCase
         $entityManager->expects($this->once())->method('flush');
 
         $container = $this->createMock(ContainerInterface::class);
-        $container->method('get')->willReturnMap([
+        $container->expects($this->atLeast(2))->method('get')->willReturnMap([
             [\Mautic\UserBundle\Model\RoleModel::class, $roleModel],
             ['doctrine.orm.entity_manager', $entityManager],
         ]);

--- a/app/bundles/CoreBundle/Tests/Unit/Doctrine/Version20211209022550Test.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Doctrine/Version20211209022550Test.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CoreBundle\Tests\Unit\Doctrine;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\ORM\EntityManagerInterface;
+use Mautic\Migrations\Version20211209022550;
+use Mautic\UserBundle\Entity\Role;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+final class Version20211209022550Test extends TestCase
+{
+    public function testMigratesRolesReturnedWithScalarHydrationData(): void
+    {
+        $role = new Role();
+        $role->setRawPermissions([
+            'lead:leads' => ['viewown'],
+            'lead:lists' => [],
+        ]);
+
+        $roleModel = new class($role) {
+            public function __construct(private Role $role)
+            {
+            }
+
+            public function getEntities(array $args = []): array
+            {
+                return [[$this->role, 1]];
+            }
+        };
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects($this->once())->method('flush');
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('get')->willReturnMap([
+            [\Mautic\UserBundle\Model\RoleModel::class, $roleModel],
+            ['doctrine.orm.entity_manager', $entityManager],
+        ]);
+
+        $migration = new Version20211209022550($this->createStub(Connection::class), new NullLogger());
+        $migration->setContainer($container);
+
+        $migration->postUp($this->createStub(Schema::class));
+
+        $this->assertSame(['viewown', 'create'], $role->getRawPermissions()['lead:lists']);
+    }
+}

--- a/app/migrations/Version20211209022550.php
+++ b/app/migrations/Version20211209022550.php
@@ -32,8 +32,14 @@ final class Version20211209022550 extends AbstractMauticMigration
             ],
         ]);
 
-        /** @var Role $role */
-        foreach ($roles as $role) {
+        foreach ($roles as $roleResult) {
+            // RoleRepository adds a scalar user count to this query, so Doctrine
+            // hydrates each row as [Role, user_count] instead of Role.
+            $role = is_array($roleResult) ? ($roleResult[0] ?? null) : $roleResult;
+            if (!$role instanceof Role) {
+                continue;
+            }
+
             $rawPermissions = $role->getRawPermissions();
             if (empty($rawPermissions)) {
                 continue;


### PR DESCRIPTION
## Target release: 7.2.1

Rebased onto `7.2` at `bd76a5d56e85d5d30da00b041edf61ca7c78e31a`. Current head: `acfd00ee68577b0ca3f27f53f44e810bfd6ce94e`. `git range-diff` confirms that every patch commit is unchanged by the rebase.

Validation repeated on the rebased source with PHP 8.3.32: Role migration regression: 1 test, 3 assertions. PHP syntax and whitespace checks passed.

Fixes #17271

## Summary

When the role query includes the scalar `user_count` field, Doctrine hydrates each result as `[Role, user_count]`. The migration then calls `getRawPermissions()` on the row array and the Mautic 7.1.3 to 7.2 update fails when more than one role exists.

This normalizes the hydrated row before accessing the role and skips invalid rows defensively.

## Testing

- Added a regression test covering the `[Role, user_count]` hydration shape.
- PHP syntax checks and `git diff --check` pass.
- Manually validated on a clean Composer-installed Mautic test instance with Administrator and Advanced User roles: upgraded to Mautic 7.2.0 and ran `sudo -u www-data php bin/console doctrine:migration:migrate --no-interaction` successfully, including `Version20211209022550`.

The test instance was intentionally left on Mautic 7.2.0 for further validation.
