### PR TITLE
Custom field related code refactoring

### DIFF
--- a/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
+++ b/app/bundles/LeadBundle/Entity/CustomFieldRepositoryTrait.php
@@ -200,6 +200,10 @@ trait CustomFieldRepositoryTrait
         $q->where($this->getTableAlias().'.id = '.(int) $id);
         $values = $q->executeQuery()->fetchAssociative();
 
+        if (!$values) {
+            return []; // As the entity does not exist, return an empty array
+        }
+
         return $this->formatFieldValues($values, $byGroup, $object);
     }
 
@@ -303,12 +307,7 @@ trait CustomFieldRepositoryTrait
         unset($r['owner_id']);
     }
 
-    /**
-     * @param array  $values
-     * @param bool   $byGroup
-     * @param string $object
-     */
-    protected function formatFieldValues($values, $byGroup = true, $object = 'lead'): array
+    protected function formatFieldValues(array $values, bool $byGroup = true, string $object = 'lead'): array
     {
         [$fields, $fixedFields] = $this->getCustomFieldList($object);
 
@@ -319,45 +318,42 @@ trait CustomFieldRepositoryTrait
 
         $fieldValues = [];
 
-        // loop over results to put fields in something that can be assigned to the entities
-        foreach ($values as $k => $r) {
-            if (isset($fields[$k])) {
-                $r = CustomFieldHelper::fixValueType($fields[$k]['type'], $r);
-
-                if (null !== $r) {
-                    switch ($fields[$k]['type']) {
-                        case 'number':
-                            $r = (float) $r;
-                            break;
-                        case 'boolean':
-                            $r = (int) $r;
-                            break;
-                    }
-                }
-
-                $alias = $fields[$k]['alias'];
-
-                if ($byGroup) {
-                    $group                                = $fields[$k]['group'];
-                    $fieldValues[$group][$alias]          = $fields[$k];
-                    $fieldValues[$group][$alias]['value'] = $r;
-                } else {
-                    $fieldValues[$alias]          = $fields[$k];
-                    $fieldValues[$alias]['value'] = $r;
-                }
-
-                unset($fields[$k]);
+        if ($byGroup) {
+            // Ensure each group key is present.
+            foreach ($this->getFieldGroups() as $g) {
+                $fieldValues[$g] = [];
             }
         }
 
-        if ($byGroup) {
-            // make sure each group key is present
-            $groups = $this->getFieldGroups();
-            foreach ($groups as $g) {
-                if (!isset($fieldValues[$g])) {
-                    $fieldValues[$g] = [];
-                }
+        // Loop over the results, transforming field values into values that can be assigned to the entities.
+        foreach ($values as $k => $r) {
+            if (!isset($fields[$k])) {
+                continue;
             }
+
+            ['type' => $type, 'alias' => $alias, 'group' => $group] = $fields[$k];
+
+            $r = CustomFieldHelper::fixValueType($type, $r);
+
+            if (null !== $r && 'boolean' === $type) {
+                /**
+                 * The fixValueType method used above sets boolean fields to
+                 * actual boolean. The previous iteration of this code cast
+                 * boolean fields to int for assignment to an entity, so we
+                 * retain that functionality here.
+                 */
+                $r = (int) $r;
+            }
+
+            if ($byGroup) {
+                $fieldValues[$group][$alias]          = $fields[$k];
+                $fieldValues[$group][$alias]['value'] = $r;
+            } else {
+                $fieldValues[$alias]          = $fields[$k];
+                $fieldValues[$alias]['value'] = $r;
+            }
+
+            unset($fields[$k]);
         }
 
         return $fieldValues;

--- a/app/bundles/LeadBundle/Helper/CustomFieldHelper.php
+++ b/app/bundles/LeadBundle/Helper/CustomFieldHelper.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Mautic\LeadBundle\Helper;
 
 use Mautic\CoreBundle\Helper\DateTimeHelper;
+use Mautic\LeadBundle\Segment\OperatorOptions;
 
 /**
  * Helper class custom field operations.
@@ -41,49 +42,54 @@ final class CustomFieldHelper
     }
 
     /**
+     * @deprecated use the correctly spelled `fieldValueTransformer` instead
+     *
      * @param mixed $value This value can be at least array, string, null and maybe others
      *
      * @return mixed|string|null
      */
-    public static function fieldValueTransfomer(array $field, $value, ?DateTimeHelper $dateTimeHelper = null)
+    public static function fieldValueTransfomer(array $field, $value, ?DateTimeHelper $dateTimeHelper = null): mixed
     {
-        if (null === $value) {
-            // do not transform null values
+        return self::fieldValueTransformer($field, $value, null, $dateTimeHelper);
+    }
+
+    /**
+     * @param array<string, mixed> $field
+     * @param mixed                $value This value can be at least array, string, null and maybe others
+     *
+     * @return mixed|string|null
+     */
+    public static function fieldValueTransformer(array $field, mixed $value, ?string $operator = null, ?DateTimeHelper $dateTimeHelper = null): mixed
+    {
+        $type = $field['type'];
+
+        if (null === $value || is_array($value) || !in_array($type, ['datetime', 'date', 'time'])) {
+            // Do not transform null, array, and non-date type values
+            return $value;
+        }
+
+        // Not sure if this happens anywhere but just in case do not transform empty strings
+        if ('' === $value) {
             return null;
         }
 
-        $type = $field['type'];
-        switch ($type) {
-            case 'datetime':
-            case 'date':
-            case 'time':
-                // Not sure if this happens anywhere but just in case do not transform empty strings
-                if ('' === $value) {
-                    return null;
-                }
-
-                if (!($value instanceof \DateTimeInterface) && !is_string($value)) {
-                    throw new \InvalidArgumentException('Wrong type given. String or DateTimeInterface expected.');
-                }
-
-                $dtHelper = $dateTimeHelper ?: new DateTimeHelper($value, null, 'local');
-                $dtHelper->setDateTime($value);
-
-                switch ($type) {
-                    case 'datetime':
-                        $value = $dtHelper->toUtcString('Y-m-d H:i:s');
-                        break;
-                    case 'date':
-                        $value = $dtHelper->toUtcString('Y-m-d');
-                        break;
-                    case 'time':
-                        $value = $dtHelper->toUtcString('H:i:s');
-                        break;
-                }
-                break;
+        if (OperatorOptions::IN_NEXT === $operator) {
+            $type = OperatorOptions::IN_NEXT;
+        } elseif (OperatorOptions::IN_LAST === $operator) {
+            $type = OperatorOptions::IN_LAST;
         }
 
-        return $value;
+        $dtHelper = $dateTimeHelper ?: new DateTimeHelper($value, null, 'local');
+        $dtHelper->setDateTime($value);
+
+        return match ($type) {
+            'datetime'               => $dtHelper->toUtcString('Y-m-d H:i:s'),
+            'date'                   => $dtHelper->toUtcString('Y-m-d'),
+            'time'                   => $dtHelper->toUtcString('H:i:s'),
+            OperatorOptions::IN_NEXT => $dtHelper->toUtcString('Y-m-d').' 23:59:59',
+            OperatorOptions::IN_LAST => $dtHelper->toUtcString('Y-m-d').' 00:00:00',
+            default                  => $value,
+        };
     }
 
     /**

--- a/app/bundles/LeadBundle/Helper/CustomFieldHelper.php
+++ b/app/bundles/LeadBundle/Helper/CustomFieldHelper.php
@@ -73,6 +73,10 @@ final class CustomFieldHelper
             return null;
         }
 
+        if (!$value instanceof \DateTimeInterface && !is_string($value)) {
+            throw new \InvalidArgumentException('Wrong type given. String or DateTimeInterface expected.');
+        }
+
         if (OperatorOptions::IN_NEXT === $operator) {
             $type = OperatorOptions::IN_NEXT;
         } elseif (OperatorOptions::IN_LAST === $operator) {

--- a/app/bundles/LeadBundle/Tests/Entity/LeadRepositoryFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadRepositoryFunctionalTest.php
@@ -241,6 +241,16 @@ final class LeadRepositoryFunctionalTest extends MauticMysqlTestCase
         $this->assertTrue($repo->exists((string) $lead->getId()));
     }
 
+    public function testGetFieldValuesReturnEmptyArrayIfLeadDoesNotExist(): void
+    {
+        $leadRepository = $this->em->getRepository(Lead::class);
+        $this->assertInstanceOf(LeadRepository::class, $leadRepository);
+
+
+        $this->assertSame([], $leadRepository->getFieldValues(999));
+    }
+
+
     private function createLead(string $email = ''): Lead
     {
         $lead = new Lead();

--- a/app/bundles/LeadBundle/Tests/Entity/LeadRepositoryFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Entity/LeadRepositoryFunctionalTest.php
@@ -246,10 +246,8 @@ final class LeadRepositoryFunctionalTest extends MauticMysqlTestCase
         $leadRepository = $this->em->getRepository(Lead::class);
         $this->assertInstanceOf(LeadRepository::class, $leadRepository);
 
-
         $this->assertSame([], $leadRepository->getFieldValues(999));
     }
-
 
     private function createLead(string $email = ''): Lead
     {

--- a/app/bundles/LeadBundle/Tests/Helper/CustomFieldHelperTest.php
+++ b/app/bundles/LeadBundle/Tests/Helper/CustomFieldHelperTest.php
@@ -6,6 +6,7 @@ namespace Mautic\LeadBundle\Tests\Helper;
 
 use Mautic\CoreBundle\Helper\DateTimeHelper;
 use Mautic\LeadBundle\Helper\CustomFieldHelper;
+use Mautic\LeadBundle\Segment\OperatorOptions;
 use PHPUnit\Framework\TestCase;
 
 final class CustomFieldHelperTest extends TestCase
@@ -221,6 +222,16 @@ final class CustomFieldHelperTest extends TestCase
             // Date strings without a time component are parsed using PHP's default timezone (UTC here),
             // so the date remains unchanged.
             $this->assertEquals('2025-01-24', $result, 'Date was not converted from Etc/GMT-2 to UTC correctly');
+
+            $field  = ['type' => 'date'];
+            $value  = '2025-01-24';
+            $result = CustomFieldHelper::fieldValueTransformer($field, $value, OperatorOptions::IN_NEXT);
+            $this->assertEquals('2025-01-24 23:59:59', $result, '"In the next operator should always set the time part to 23:59:59"');
+
+            $field  = ['type' => 'date'];
+            $value  = '2025-01-24';
+            $result = CustomFieldHelper::fieldValueTransformer($field, $value, OperatorOptions::IN_LAST);
+            $this->assertEquals('2025-01-24 00:00:00', $result, '"In the last operator should always set the time part to 00:00:00"');
         } finally {
             $property->setValue(null, $originalDefaultLocalTimezone);
             date_default_timezone_set($originalTimezone);


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 7.x)
* a.b for any bug fixes (e.g. 5.2, 6.0)
* c.x for any bug fixes, features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 7.x) -->

<!-- 📄 DOCUMENTATION REVIEW REQUIRED:

After you open this PR, Promptless automatically creates a documentation PR and leaves a comment here with the link. Once your code PR merges, review the documentation PR, request changes if needed, and approve it promptly.

See "Reviewing documentation PRs from Promptless" in the community handbook for more details: https://contribute.mautic.org/en/latest/contributing/developer.html#reviewing-documentation-prs-from-promptless -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌ <!-- Use emojis to indicate positive (green) or negative (red) for each item in the table. -->
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️ <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      |  <!-- required for new features -->
| Related developer documentation PR URL |  <!-- required for developer-facing changes -->
| Issue(s) addressed                     | <!-- prefix each issue number with "Fixes #", no need to create an issue if none exists, explain below instead -->

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

## Description
This PR refactors custom field handling in LeadBundle to improve code clarity, type safety, and correctness.

### Changes

**`CustomFieldRepositoryTrait`**
- `getFieldValues()` now returns an empty array when the entity does not exist instead of passing `false` to `formatFieldValues()`.
- `formatFieldValues()` receives proper type declarations (`array`, `bool`, `string`), removing a redundant docblock.
- The loop body is restructured using an early `continue` and array destructuring, eliminating nested `if`/`switch` blocks.
- The redundant `number` cast `(float)` is removed — `fixValueType` already handles it.

**`CustomFieldHelper`**
- Introduces a correctly spelled `fieldValueTransformer()` method, deprecating the typo'd `fieldValueTransfomer()`.
- The new method accepts an optional `$operator` parameter to support `in_next` / `in_last` segment operators, appending `23:59:59` or `00:00:00` to date values respectively.
- Replaces nested `switch` statements with a `match` expression.
- Adds early returns for `null`, array, non-date types, and empty strings to reduce nesting.



<!--
Please write a short README for your feature/bugfix. This will help people understand your PR and what it aims to do. If you are fixing a bug and if there is no linked issue already, please provide steps to reproduce the issue here.
-->
<!-- Remove HTML comment markup below to use the table for screenshots when relevant. -->
<!--
| Before                                 | After
| -------------------------------------- | ---
|                                        | 
-->


---
### 📋 Steps to test this PR:

<!--
This part is really important. If you want your PR to be merged, take the time to write very clear, annotated and step by step test instructions. Do not assume any previous knowledge - testers may not be developers. Do not write steps performed by the CI. These steps are for manual testing.
-->
1. Open this PR on GitHub Codespaces or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Verify contacts and companies with custom fields still load and display correctly.

<!--
If you have any deprecations and backwards compatibility breaks, list them here along with the new alternative.
-->