### PR TITLE
Fixing time for the day-or-the-week reschedules

### DIFF
--- a/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
+++ b/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
@@ -241,7 +241,7 @@ final class Interval implements ScheduleModeInterface
 
             // When the days-of-week loop advanced past the original day, "hour already passed today" no longer
             // applies: we are on a new allowed day and must honour the configured send-hour.
-            if ($hour && (int) $groupDateTime->format('w') !== $dayBeforeAdvancement) {
+            if ($groupDateTime instanceof \DateTime && $hour && (int) $groupDateTime->format('w') !== $dayBeforeAdvancement) {
                 $groupDateTime->setTime((int) $hour->format('H'), (int) $hour->format('i'), 0);
             }
         }

--- a/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
+++ b/app/bundles/CampaignBundle/Executioner/Scheduler/Mode/Interval.php
@@ -91,12 +91,12 @@ final class Interval implements ScheduleModeInterface
             $dateTriggered = clone $compareFromDateTime;
         }
 
-        $hour      = $event->getTriggerHour();
-        $startTime = $event->getTriggerRestrictedStartHour();
-        $endTime   = $event->getTriggerRestrictedStopHour();
-        $dow       = $event->getTriggerRestrictedDaysOfWeek();
+        $hour       = $event->getTriggerHour();
+        $startTime  = $event->getTriggerRestrictedStartHour();
+        $endTime    = $event->getTriggerRestrictedStopHour();
+        $daysOfWeek = $event->getTriggerRestrictedDaysOfWeek();
 
-        return $this->getGroupExecutionDateTime($event->getId(), $log->getLead(), $dateTriggered, $hour, $startTime, $endTime, $dow);
+        return $this->getGroupExecutionDateTime($event->getId(), $log->getLead(), $dateTriggered, $hour, $startTime, $endTime, $daysOfWeek);
     }
 
     /**
@@ -220,7 +220,7 @@ final class Interval implements ScheduleModeInterface
         if ([] !== $daysOfWeek) {
             $this->logger->debug(
                 sprintf(
-                    'CAMPAIGN: Scheduling event ID %s for contact ID %s based on DOW restrictions of %s',
+                    'CAMPAIGN: Scheduling event ID %s for contact ID %s based on days-of-week restrictions of %s',
                     $eventId,
                     $contact->getId(),
                     implode(',', $daysOfWeek)
@@ -231,10 +231,18 @@ final class Interval implements ScheduleModeInterface
                 throw new \LogicException('The Mautic accepts only 0-6 as day of week (0 is Sunday).');
             }
 
+            $dayBeforeAdvancement = (int) $groupDateTime->format('w');
+
             // Schedule for the next day of the week if applicable
             while (!in_array((int) $groupDateTime->format('w'), $daysOfWeek)) {
                 /** @var \DateTime $groupDateTime */
                 $groupDateTime->modify('+1 day');
+            }
+
+            // When the days-of-week loop advanced past the original day, "hour already passed today" no longer
+            // applies: we are on a new allowed day and must honour the configured send-hour.
+            if ($hour && (int) $groupDateTime->format('w') !== $dayBeforeAdvancement) {
+                $groupDateTime->setTime((int) $hour->format('H'), (int) $hour->format('i'), 0);
             }
         }
 

--- a/app/bundles/CampaignBundle/Tests/Functional/Executioner/Scheduler/Mode/IntervalWeekdayHourTimezoneTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Executioner/Scheduler/Mode/IntervalWeekdayHourTimezoneTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CampaignBundle\Tests\Functional\Executioner\Scheduler\Mode;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Mautic\CampaignBundle\Entity\Campaign;
+use Mautic\CampaignBundle\Entity\Event;
+use Mautic\CampaignBundle\Executioner\Scheduler\Mode\Interval;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\LeadBundle\Entity\Lead;
+use PHPUnit\Framework\Assert;
+
+/**
+ * Reproduces a bug where a contact whose preferred timezone is ahead of UTC
+ * (e.g. Asia/Tokyo, UTC+9) receives a weekday-restricted, single-hour campaign
+ * email at the wrong local time.
+ *
+ * Root cause: getExecutionDateTimeFromHour() returns the original scheduled
+ * UTC-derived time when that time has already passed the configured send-hour
+ * in the contact's timezone, instead of advancing to the next day at the
+ * configured hour (as documented and as getExecutionDateTimeBetweenHours does).
+ *
+ * Scenario from ticket:
+ *  - Decision fires Friday 2026-07-10 09:13 UTC = Friday 18:13 JST.
+ *  - Action is scheduled 1 day later → Saturday 2026-07-11 09:13 UTC = Saturday 18:13 JST.
+ *  - Saturday is restricted (weekdays only). The scheduler must advance to Monday.
+ *  - 18:13 JST is past the 09:00 AM send hour.
+ *  - Expected trigger date: Monday 2026-07-13 09:00 JST = Monday 2026-07-13 00:00 UTC.
+ *  - Buggy result:          Monday 2026-07-13 18:13 JST = Monday 2026-07-13 09:13 UTC.
+ */
+final class IntervalWeekdayHourTimezoneTest extends MauticMysqlTestCase
+{
+    protected $useCleanupRollback = false;
+
+    public function testHourRestrictionIsAppliedAfterDayOfWeekReschedulingForContactWithNonUtcTimezone(): void
+    {
+        $campaign = new Campaign();
+        $campaign->setName('Weekday 9AM email campaign');
+
+        // Action event: 1-day interval, send at 09:00, weekdays only (Mon–Fri).
+        // DOW values: Sun=0, Mon=1, Tue=2, Wed=3, Thu=4, Fri=5, Sat=6
+        $event = new Event();
+        $event->setName('Send email weekday 9AM');
+        $event->setEventType(Event::TYPE_ACTION);
+        $event->setTriggerMode(Event::TRIGGER_MODE_INTERVAL);
+        $event->setType('lead.changepoints');
+        $event->setCampaign($campaign);
+        $event->setTriggerInterval(1);
+        $event->setTriggerIntervalUnit('d');
+        $event->setTriggerHour('09:00:00');
+        $event->setTriggerRestrictedDaysOfWeek([1, 2, 3, 4, 5]); // Mon–Fri
+
+        $contact = new Lead();
+        $contact->setTimezone('Asia/Tokyo'); // UTC+9
+
+        $this->em->persist($contact);
+        $this->em->persist($campaign);
+        $this->em->persist($event);
+        $this->em->flush();
+
+        $intervalScheduler = $this->getContainer()->get(Interval::class);
+        \assert($intervalScheduler instanceof Interval);
+
+        $contacts = new ArrayCollection([$contact]);
+
+        // The initial interval (1d) from Friday 2026-07-10 09:13 UTC produces
+        // Saturday 2026-07-11 09:13 UTC = Saturday 18:13 JST.
+        // Saturday is restricted and 18:13 JST is past the 09:00 send-hour.
+        $scheduledSaturdayUtc = new \DateTime('2026-07-11 09:13:18', new \DateTimeZone('UTC'));
+
+        $groups = $intervalScheduler->groupContactsByDate($event, $contacts, $scheduledSaturdayUtc);
+
+        Assert::assertCount(1, $groups, 'Expected exactly one execution-date group.');
+
+        /** @var \DateTime $executionDate */
+        $executionDate = array_values($groups)[0]->getExecutionDate();
+
+        $executionDateJst = clone $executionDate;
+        $executionDateJst->setTimezone(new \DateTimeZone('Asia/Tokyo'));
+
+        Assert::assertSame(
+            'Monday',
+            $executionDateJst->format('l'),
+            'Event must be rescheduled to Monday (the next allowed weekday after Saturday).'
+        );
+        Assert::assertSame(
+            '09:00',
+            $executionDateJst->format('H:i'),
+            'Event must fire at 09:00 AM JST. '
+            .'The bug causes it to fire at 18:13 JST because the DOW loop advances the day '
+            .'without resetting the time to the configured send-hour.'
+        );
+    }
+}

--- a/app/bundles/CampaignBundle/Tests/Functional/Executioner/Scheduler/Mode/IntervalWeekdayHourTimezoneTest.php
+++ b/app/bundles/CampaignBundle/Tests/Functional/Executioner/Scheduler/Mode/IntervalWeekdayHourTimezoneTest.php
@@ -10,7 +10,6 @@ use Mautic\CampaignBundle\Entity\Event;
 use Mautic\CampaignBundle\Executioner\Scheduler\Mode\Interval;
 use Mautic\CoreBundle\Test\MauticMysqlTestCase;
 use Mautic\LeadBundle\Entity\Lead;
-use PHPUnit\Framework\Assert;
 
 /**
  * Reproduces a bug where a contact whose preferred timezone is ahead of UTC
@@ -61,7 +60,7 @@ final class IntervalWeekdayHourTimezoneTest extends MauticMysqlTestCase
         $this->em->flush();
 
         $intervalScheduler = $this->getContainer()->get(Interval::class);
-        \assert($intervalScheduler instanceof Interval);
+        $this->assertInstanceOf(Interval::class, $intervalScheduler);
 
         $contacts = new ArrayCollection([$contact]);
 
@@ -72,7 +71,7 @@ final class IntervalWeekdayHourTimezoneTest extends MauticMysqlTestCase
 
         $groups = $intervalScheduler->groupContactsByDate($event, $contacts, $scheduledSaturdayUtc);
 
-        Assert::assertCount(1, $groups, 'Expected exactly one execution-date group.');
+        $this->assertCount(1, $groups, 'Expected exactly one execution-date group.');
 
         /** @var \DateTime $executionDate */
         $executionDate = array_values($groups)[0]->getExecutionDate();
@@ -80,17 +79,9 @@ final class IntervalWeekdayHourTimezoneTest extends MauticMysqlTestCase
         $executionDateJst = clone $executionDate;
         $executionDateJst->setTimezone(new \DateTimeZone('Asia/Tokyo'));
 
-        Assert::assertSame(
-            'Monday',
-            $executionDateJst->format('l'),
-            'Event must be rescheduled to Monday (the next allowed weekday after Saturday).'
-        );
-        Assert::assertSame(
-            '09:00',
-            $executionDateJst->format('H:i'),
-            'Event must fire at 09:00 AM JST. '
-            .'The bug causes it to fire at 18:13 JST because the DOW loop advances the day '
-            .'without resetting the time to the configured send-hour.'
-        );
+        $this->assertSame('Monday', $executionDateJst->format('l'), 'Event must be rescheduled to Monday (the next allowed weekday after Saturday).');
+        $this->assertSame('09:00', $executionDateJst->format('H:i'), 'Event must fire at 09:00 AM JST. '
+        .'The bug causes it to fire at 18:13 JST because the DOW loop advances the day '
+        .'without resetting the time to the configured send-hour.');
     }
 }


### PR DESCRIPTION
<!-- ## Which branch should I use for my PR?

Assuming that:

a = current major release
b = current minor release
c = future major release

* a.x for any features and enhancements (e.g. 4.x)
* a.b for any bug fixes (e.g. 4.0, 4.1, 4.2)
* c.x for any features, enhancements or bug fixes with backward compatibility breaking changes (e.g. 5.x) -->

| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | [x]
| New feature/enhancement? (use the a.x branch)      | [ ]
| Deprecations?                          | [ ]
| BC breaks? (use the c.x branch)        | [ ]
| Automated tests included?              | [x] <!-- All PRs must maintain or improve code coverage -->
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | 

<!--
Additionally (see https://contribute.mautic.org/contributing-to-mautic/developer/code/pull-requests#work-on-your-pull-request):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against the "4.x" branch.
-->

#### Description:

Contacts whose **Preferred Timezone** is ahead of UTC (e.g. `Asia/Tokyo`, UTC+9) could receive a campaign email at the wrong local time when both a specific send-hour and a days-of-week restriction were configured on the action event.

**Root cause**

When scheduling the next execution date, `getExecutionDateTimeFromHour()` converts the candidate date to the contact's timezone. If the configured send-hour had already passed on that day (e.g. the scheduler lands on Saturday at 18:13 JST and the send-hour is 09:00), it returns the original time unchanged with the comment _"Execute right away if the hour has passed"_.

The days-of-week loop that follows then advances the date to the next allowed weekday — but leaves the time untouched (18:13 JST). The email is therefore sent at 18:13 local time instead of 09:00.

The documented behaviour ([Acquia docs – Scheduling events](https://docs.acquia.com/campaign-studio/campaigns#scheduling-events)) states:

> _"If a particular time is specified and a contact reaches the event later in the day, the action triggers the **next day** at that time."_

The "hour already passed today" reasoning only applies to the **original** day. Once the days-of-week loop advances to a new allowed day, the send-hour must be re-applied.

**Fix**

In `getGroupExecutionDateTime()` (`Interval.php`), after the days-of-week advancement loop, if the day changed and a specific send-hour is configured, the time is reset to that configured hour.

**Concrete example from the support ticket**
- Contact timezone: `Asia/Tokyo` (UTC+9)
- Event: send 1 day after the decision, at 09:00, weekdays only
- Decision fires: Friday 2026-07-10 09:13 UTC = Friday 18:13 JST
- Scheduled date: Saturday 2026-07-11 09:13 UTC = Saturday 18:13 JST (restricted day, hour passed)
- **Before fix**: Monday 2026-07-13 18:13 JST (09:13 UTC) — email sent at 6 PM local time
- **After fix**: Monday 2026-07-13 09:00 JST (00:00 UTC) — email sent at 9 AM local time

#### Steps to test this PR:

1. Create a contact with **Preferred Timezone** set to `Asia/Tokyo`.
2. Create a campaign with a **Clicks email** decision (event A) followed by a **Send email** action (event B).
3. Configure event B: _At a relative time period_ → **1 Day**, send at **09:00**, restricted to **weekdays (Mon–Fri)**.
4. Trigger the decision for the contact on a **Friday** (so the +1 day lands on Saturday in JST, and the UTC time converts to past 09:00 JST).
5. Verify the campaign event log shows the email scheduled for **Monday at 09:00 AM** in the contact's local timezone, not at the original UTC-offset time.

#### Other areas of Mautic that may be affected by the change:
1. Campaign action scheduling when a specific send-hour and days-of-week restriction are both configured and the contact has a timezone ahead of UTC.

#### List deprecations along with the new alternative:
1. N/A

#### List of areas covered by the unit and/or functional tests:
1. New functional test `IntervalWeekdayHourTimezoneTest::testHourRestrictionIsAppliedAfterDayOfWeekReschedulingForContactWithNonUtcTimezone` — directly reproduces the reported scenario (Saturday 09:13 UTC input, `Asia/Tokyo` contact, 09:00 weekday restriction) and asserts the trigger date is Monday at 09:00 JST.
2. Existing `CampaignActionJumpToEventFunctionalTest` (13 tests) — verifies no regression in the existing hour/range/day-of-week scheduling scenarios.
