### PR TITLE
[cs] Add precise iterable docblock types (Form bundle)

### DIFF
--- a/app/bundles/FormBundle/Collector/AlreadyMappedFieldCollector.php
+++ b/app/bundles/FormBundle/Collector/AlreadyMappedFieldCollector.php
@@ -18,6 +18,9 @@ final readonly class AlreadyMappedFieldCollector implements AlreadyMappedFieldCo
     ) {
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getFields(string $formId, string $object): array
     {
         $cacheItem = $this->cacheProvider->getItem($this->buildCacheKey($formId, $object));

--- a/app/bundles/FormBundle/Controller/Api/FormApiController.php
+++ b/app/bundles/FormBundle/Controller/Api/FormApiController.php
@@ -305,6 +305,8 @@ final class FormApiController extends CommonApiController
     /**
      * Creates the form instance.
      *
+     * @param array<string, mixed> $action
+     *
      * @return FormInterface<mixed>
      */
     protected function createActionEntityForm(Action $entity, array $action): FormInterface

--- a/app/bundles/FormBundle/Controller/FieldController.php
+++ b/app/bundles/FormBundle/Controller/FieldController.php
@@ -421,8 +421,8 @@ final class FieldController extends CommonFormController
     }
 
     /**
-     * @param int     $formId
-     * @param mixed[] $formField
+     * @param int                  $formId
+     * @param array<string, mixed> $formField
      *
      * @return mixed
      */

--- a/app/bundles/FormBundle/Controller/ResultController.php
+++ b/app/bundles/FormBundle/Controller/ResultController.php
@@ -467,6 +467,8 @@ final class ResultController extends CommonFormController
     }
 
     /**
+     * @param array<string, mixed> $parameters
+     *
      * @return mixed
      */
     protected function getFormIdFromRequest(array $parameters = [])

--- a/app/bundles/FormBundle/Entity/Field.php
+++ b/app/bundles/FormBundle/Entity/Field.php
@@ -858,7 +858,7 @@ class Field implements UuidInterface
     /**
      * Was field displayed.
      *
-     * @param mixed[] $data
+     * @param array<string, mixed> $data
      */
     public function showForConditionalField(array $data): bool
     {

--- a/app/bundles/FormBundle/Entity/FormRepository.php
+++ b/app/bundles/FormBundle/Entity/FormRepository.php
@@ -177,6 +177,8 @@ class FormRepository extends CommonRepository
     /**
      * Fetch the form results.
      *
+     * @param array<string, mixed> $options
+     *
      * @throws \Doctrine\ORM\NoResultException
      * @throws \Doctrine\ORM\NonUniqueResultException
      */

--- a/app/bundles/FormBundle/Entity/SubmissionRepository.php
+++ b/app/bundles/FormBundle/Entity/SubmissionRepository.php
@@ -276,6 +276,8 @@ class SubmissionRepository extends CommonRepository
     /**
      * Fetch the base submission data from the database.
      *
+     * @param array<string, mixed> $options
+     *
      * @return array
      *
      * @throws \Doctrine\ORM\NoResultException

--- a/app/bundles/FormBundle/Event/FormBuilderEvent.php
+++ b/app/bundles/FormBundle/Event/FormBuilderEvent.php
@@ -16,6 +16,9 @@ final class FormBuilderEvent extends Event
 
     private array $actions = [];
 
+    /**
+     * @var array<string, mixed>
+     */
     private array $fields = [];
 
     private array $validators = [];
@@ -28,18 +31,18 @@ final class FormBuilderEvent extends Event
     /**
      * Adds a submit action to the list of available actions.
      *
-     * @param string $key    a unique identifier; it is recommended that it be namespaced i.e. lead.action
-     * @param array  $action can contain the following keys:
-     *                       $action = [
-     *                       'group'              => (required) Label of the group to add this action to
-     *                       'label'              => (required) what to display in the list
-     *                       'eventName'          => (required) Event dispatched to execute action; it will receive a SubmissionEvent object
-     *                       'formType'           => (required) name of the form type SERVICE for the action
-     *                       'description'        => (optional) short description of event
-     *                       'template'           => (optional) template to use for the action's HTML in the form builder; eg AcmeMyBundle:FormAction:theaction.html.twig
-     *                       'formTypeOptions'    => (optional) array of options to pass to formType
-     *                       'formTheme'          => (optional)  theme for custom form views
-     *                       ]
+     * @param string               $key    a unique identifier; it is recommended that it be namespaced i.e. lead.action
+     * @param array<string, mixed> $action can contain the following keys:
+     *                                     $action = [
+     *                                     'group'              => (required) Label of the group to add this action to
+     *                                     'label'              => (required) what to display in the list
+     *                                     'eventName'          => (required) Event dispatched to execute action; it will receive a SubmissionEvent object
+     *                                     'formType'           => (required) name of the form type SERVICE for the action
+     *                                     'description'        => (optional) short description of event
+     *                                     'template'           => (optional) template to use for the action's HTML in the form builder; eg AcmeMyBundle:FormAction:theaction.html.twig
+     *                                     'formTypeOptions'    => (optional) array of options to pass to formType
+     *                                     'formTheme'          => (optional)  theme for custom form views
+     *                                     ]
      *
      * @throws BadConfigurationException
      */
@@ -91,26 +94,26 @@ final class FormBuilderEvent extends Event
     /**
      * Adds a form field to the list of available fields in the form builder.
      *
-     * @param string $key   unique identifier; it is recommended that it be namespaced i.e. leadbundle.myfield
-     * @param array  $field can contain the following key/values
-     *                      $field = [
-     *                      'label'            => (required) what to display in the list
-     *                      'formType'         => (required) name of the form type SERVICE for the field's property column
-     *                      'template'         => (required) template to use for the field's HTML eg AcmeMyBundle:FormField:thefield.html.twig
-     *                      'formTypeOptions'  => (optional) array of options to pass to formType
-     *                      'formTheme'        => (optional) theme for custom form view
-     *                      'valueFilter'      => (optional) the filter to use to clean the input as supported by InputHelper or a callback;
-     *                      should accept arguments FormField $field and $filteredValue
-     *                      'builderOptions'   => (optional) array of options
-     *                      [
-     *                      'addHelpMessage'     => (bool) show help message inputs
-     *                      'addShowLabel'       => (bool) show label input
-     *                      'addDefaultValue'    => (bool) show default value input
-     *                      'addLabelAttributes' => (bool) show label attribute input
-     *                      'addInputAttributes' => (bool) show input attribute input
-     *                      'addIsRequired'      => (bool) show is required toggle
-     *                      ]
-     *                      ]
+     * @param string               $key   unique identifier; it is recommended that it be namespaced i.e. leadbundle.myfield
+     * @param array<string, mixed> $field can contain the following key/values
+     *                                    $field = [
+     *                                    'label'            => (required) what to display in the list
+     *                                    'formType'         => (required) name of the form type SERVICE for the field's property column
+     *                                    'template'         => (required) template to use for the field's HTML eg AcmeMyBundle:FormField:thefield.html.twig
+     *                                    'formTypeOptions'  => (optional) array of options to pass to formType
+     *                                    'formTheme'        => (optional) theme for custom form view
+     *                                    'valueFilter'      => (optional) the filter to use to clean the input as supported by InputHelper or a callback;
+     *                                    should accept arguments FormField $field and $filteredValue
+     *                                    'builderOptions'   => (optional) array of options
+     *                                    [
+     *                                    'addHelpMessage'     => (bool) show help message inputs
+     *                                    'addShowLabel'       => (bool) show label input
+     *                                    'addDefaultValue'    => (bool) show default value input
+     *                                    'addLabelAttributes' => (bool) show label attribute input
+     *                                    'addInputAttributes' => (bool) show input attribute input
+     *                                    'addIsRequired'      => (bool) show is required toggle
+     *                                    ]
+     *                                    ]
      *
      * @throws \InvalidArgumentException
      * @throws BadConfigurationException

--- a/app/bundles/FormBundle/Form/Type/SortableListTrait.php
+++ b/app/bundles/FormBundle/Form/Type/SortableListTrait.php
@@ -12,6 +12,9 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 trait SortableListTrait
 {
+    /**
+     * @param array<string, mixed> $options
+     */
     public function addSortableList(FormBuilderInterface $builder, array $options, $listName = 'list', $listData = null, $formName = 'formfield'): void
     {
         $listOptions = [

--- a/app/bundles/FormBundle/Helper/FormFieldHelper.php
+++ b/app/bundles/FormBundle/Helper/FormFieldHelper.php
@@ -20,6 +20,9 @@ class FormFieldHelper extends AbstractFormFieldHelper
 {
     private readonly ValidatorInterface $validator;
 
+    /**
+     * @var array<string, array<string|array<string, array<string, string>>>>
+     */
     private array $types = [
         'captcha' => [
             'constraints' => [
@@ -88,6 +91,9 @@ class FormFieldHelper extends AbstractFormFieldHelper
         $this->translationKeyPrefix = 'mautic.form.field.type.';
     }
 
+    /**
+     * @return array<string, array<string|array<string, array<string, string>>>>
+     */
     public function getTypes(): array
     {
         return $this->types;
@@ -100,6 +106,8 @@ class FormFieldHelper extends AbstractFormFieldHelper
 
     /**
      * @param Field $f
+     *
+     * @return string[]
      */
     public function validateFieldValue($type, $value, $f = null): array
     {

--- a/app/bundles/FormBundle/Helper/PointActionHelper.php
+++ b/app/bundles/FormBundle/Helper/PointActionHelper.php
@@ -4,6 +4,9 @@ namespace Mautic\FormBundle\Helper;
 
 final class PointActionHelper
 {
+    /**
+     * @param array<string, mixed> $action
+     */
     public static function validateFormSubmit($eventDetails, array $action): bool
     {
         $form         = $eventDetails->getForm();

--- a/app/bundles/FormBundle/Helper/PropertiesAccessor.php
+++ b/app/bundles/FormBundle/Helper/PropertiesAccessor.php
@@ -14,7 +14,7 @@ readonly class PropertiesAccessor
     }
 
     /**
-     * @param mixed[] $field
+     * @param array<string, mixed> $field
      *
      * @return mixed[]
      */

--- a/app/bundles/FormBundle/Model/FormModel.php
+++ b/app/bundles/FormBundle/Model/FormModel.php
@@ -482,6 +482,11 @@ class FormModel extends CommonFormModel implements GlobalSearchInterface
         return $html;
     }
 
+    /**
+     * @param Field[] $fields
+     *
+     * @return array<int, int|string|array<string, array<string|int, int>>|bool>
+     */
     public function getPages(array $fields): array
     {
         $pages = ['open' => [], 'close' => []];
@@ -863,8 +868,9 @@ class FormModel extends CommonFormModel implements GlobalSearchInterface
     /**
      * Get a list of assets in a date range.
      *
-     * @param int   $limit
-     * @param array $filters
+     * @param int                  $limit
+     * @param array                $filters
+     * @param array<string, mixed> $options
      */
     public function getFormList($limit = 10, ?\DateTime $dateFrom = null, ?\DateTime $dateTo = null, $filters = [], array $options = []): array
     {

--- a/app/bundles/FormBundle/Model/SubmissionModel.php
+++ b/app/bundles/FormBundle/Model/SubmissionModel.php
@@ -121,7 +121,8 @@ final class SubmissionModel extends CommonFormModel
     }
 
     /**
-     * @param bool $returnEvent
+     * @param bool                 $returnEvent
+     * @param array<string, mixed> $server
      *
      * @throws ORMException
      */
@@ -1179,9 +1180,9 @@ final class SubmissionModel extends CommonFormModel
     }
 
     /**
-     * @return bool|string True if valid; otherwise string with invalid reason
+     * @return true|string|string[] True if valid; otherwise string with invalid reason
      */
-    private function validateFieldValue(Field $field, $value)
+    private function validateFieldValue(Field $field, $value): true|string|array
     {
         $standardValidation = $this->fieldHelper->validateFieldValue($field->getType(), $value, $field);
         if ([] !== $standardValidation) {

--- a/app/bundles/FormBundle/Tests/Controller/PublicControllerFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Controller/PublicControllerFunctionalTest.php
@@ -96,7 +96,7 @@ final class PublicControllerFunctionalTest extends MauticMysqlTestCase
     }
 
     /**
-     * @param mixed[] $payload
+     * @param array<string, string>|array<string, int>|null[] $payload
      */
     private function makeRequest(array $payload): void
     {

--- a/app/bundles/FormBundle/Tests/Model/FieldModelFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Model/FieldModelFunctionalTest.php
@@ -75,7 +75,7 @@ final class FieldModelFunctionalTest extends MauticMysqlTestCase
     }
 
     /**
-     * @param mixed[] $payload
+     * @param array<array<string, mixed>, mixed> $payload
      */
     private function createForm(array $payload): Form
     {

--- a/app/bundles/FormBundle/Tests/Model/FormSubmissionTrait.php
+++ b/app/bundles/FormBundle/Tests/Model/FormSubmissionTrait.php
@@ -107,7 +107,7 @@ trait FormSubmissionTrait
     /**
      * @param mixed[] $payload
      *
-     * @return mixed[]
+     * @return array<int, mixed>
      */
     private function createForm(array $payload): array
     {

--- a/app/bundles/FormBundle/Tests/Model/SubmissionModelFunctionalTest.php
+++ b/app/bundles/FormBundle/Tests/Model/SubmissionModelFunctionalTest.php
@@ -151,7 +151,7 @@ final class SubmissionModelFunctionalTest extends MauticMysqlTestCase
     }
 
     /**
-     * @param mixed[] $payload
+     * @param array<array<string, mixed>, mixed> $payload
      *
      * @return array{int,string}
      */

--- a/app/bundles/FormBundle/Twig/Extension/FormFieldExtension.php
+++ b/app/bundles/FormBundle/Twig/Extension/FormFieldExtension.php
@@ -11,6 +11,9 @@ use Twig\TwigFunction;
 
 final class FormFieldExtension extends AbstractExtension
 {
+    /**
+     * @return TwigFilter[]
+     */
     public function getFilters(): array
     {
         return [
@@ -18,6 +21,9 @@ final class FormFieldExtension extends AbstractExtension
         ];
     }
 
+    /**
+     * @return TwigFunction[]
+     */
     public function getFunctions(): array
     {
         return [

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4087,12 +4087,6 @@ parameters:
 			path: app/bundles/FormBundle/Model/SubmissionModel.php
 
 		-
-			message: '#^Method Mautic\\FormBundle\\Model\\SubmissionModel\:\:validateFieldValue\(\) should return bool\|string but returns array\.$#'
-			identifier: return.type
-			count: 1
-			path: app/bundles/FormBundle/Model/SubmissionModel.php
-
-		-
 			message: '#^Parameter \#1 \$object of method Mautic\\LeadBundle\\Model\\FieldModel\:\:getFieldListWithProperties\(\) expects string, false given\.$#'
 			identifier: argument.type
 			count: 1


### PR DESCRIPTION
Adds precise `iterable<...>` / array-shape docblock types across the Form bundle. Includes the matching phpstan-baseline removal for `SubmissionModel::validateFieldValue()`.

Split out of #17235.

https://claude.ai/code/session_011ZFb9VaYGzNHRS1pUrPbYW