### PR TITLE
Fix AssetMapper output path for non-public Mautic web roots

### DIFF
--- a/app/bundles/CoreBundle/DependencyInjection/Compiler/AssetMapperWebRootPass.php
+++ b/app/bundles/CoreBundle/DependencyInjection/Compiler/AssetMapperWebRootPass.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CoreBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class AssetMapperWebRootPass implements CompilerPassInterface
+{
+    private const PUBLIC_ASSETS_PATH_RESOLVER_ID         = 'asset_mapper.public_assets_path_resolver';
+    private const LOCAL_PUBLIC_ASSETS_FILESYSTEM_ID      = 'asset_mapper.local_public_assets_filesystem';
+    private const COMPILED_ASSET_MAPPER_CONFIG_READER_ID = 'asset_mapper.compiled_asset_mapper_config_reader';
+    private const DEFAULT_PUBLIC_PREFIX                  = '/assets/build/';
+
+    public function process(ContainerBuilder $container): void
+    {
+        $webRoot = $this->resolveWebRoot($container);
+        if (!$webRoot) {
+            return;
+        }
+
+        if ($container->hasDefinition(self::LOCAL_PUBLIC_ASSETS_FILESYSTEM_ID)) {
+            $container
+                ->findDefinition(self::LOCAL_PUBLIC_ASSETS_FILESYSTEM_ID)
+                ->replaceArgument(0, $webRoot);
+        }
+
+        if (!$container->hasDefinition(self::COMPILED_ASSET_MAPPER_CONFIG_READER_ID)) {
+            return;
+        }
+
+        $publicPrefix = $this->resolvePublicPrefix($container);
+
+        $container
+            ->findDefinition(self::COMPILED_ASSET_MAPPER_CONFIG_READER_ID)
+            ->replaceArgument(0, $webRoot.'/'.ltrim($publicPrefix, '/'));
+    }
+
+    private function resolveWebRoot(ContainerBuilder $container): ?string
+    {
+        if ($container->hasParameter('mautic.local_root')) {
+            $localRoot = $container->getParameter('mautic.local_root');
+            if (is_string($localRoot) && '' !== trim($localRoot) && !str_contains($localRoot, '%env(')) {
+                return rtrim($localRoot, '/');
+            }
+        }
+
+        if (!$container->hasParameter('kernel.project_dir')) {
+            return null;
+        }
+
+        $projectDir = $container->getParameter('kernel.project_dir');
+        if (!is_string($projectDir) || '' === trim($projectDir)) {
+            return null;
+        }
+
+        $projectDir    = rtrim($projectDir, '/');
+        $composerFile  = $projectDir.'/composer.json';
+        $configuredDir = $this->resolveConfiguredPublicDir($composerFile, $container);
+
+        if (null === $configuredDir || '' === $configuredDir || '.' === $configuredDir) {
+            return $projectDir;
+        }
+
+        return $projectDir.'/'.trim($configuredDir, '/');
+    }
+
+    private function resolveConfiguredPublicDir(string $composerFile, ContainerBuilder $container): ?string
+    {
+        if (!is_file($composerFile)) {
+            return null;
+        }
+
+        $container->addResource(new FileResource($composerFile));
+
+        $contents = file_get_contents($composerFile);
+        if (false === $contents) {
+            return null;
+        }
+
+        $composerConfig = json_decode($contents, true);
+        if (!is_array($composerConfig)) {
+            return null;
+        }
+
+        $webRoot = $composerConfig['extra']['mautic-scaffold']['locations']['web-root'] ?? null;
+        if (is_string($webRoot) && '' !== trim($webRoot)) {
+            return $webRoot;
+        }
+
+        $publicDir = $composerConfig['extra']['public-dir'] ?? null;
+        if (is_string($publicDir) && '' !== trim($publicDir)) {
+            return $publicDir;
+        }
+
+        return null;
+    }
+
+    private function resolvePublicPrefix(ContainerBuilder $container): string
+    {
+        if (!$container->hasDefinition(self::PUBLIC_ASSETS_PATH_RESOLVER_ID)) {
+            return self::DEFAULT_PUBLIC_PREFIX;
+        }
+
+        $publicPrefix = $container
+            ->findDefinition(self::PUBLIC_ASSETS_PATH_RESOLVER_ID)
+            ->getArgument(0);
+
+        if (!is_string($publicPrefix) || '' === trim($publicPrefix)) {
+            return self::DEFAULT_PUBLIC_PREFIX;
+        }
+
+        return $publicPrefix;
+    }
+}

--- a/app/bundles/CoreBundle/MauticCoreBundle.php
+++ b/app/bundles/CoreBundle/MauticCoreBundle.php
@@ -22,6 +22,7 @@ final class MauticCoreBundle extends Bundle
         $container->addCompilerPass(new Compiler\ServicePass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1000);
         $container->addCompilerPass(new Compiler\ORMPurgerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -10);
         $container->addCompilerPass(new Compiler\SystemThemeTemplatePathPass(), PassConfig::TYPE_BEFORE_REMOVING, 0);
+        $container->addCompilerPass(new Compiler\AssetMapperWebRootPass(), PassConfig::TYPE_BEFORE_REMOVING, 0);
 
         if ('test' === $container->getParameter('kernel.environment')) {
             $container->addCompilerPass(new Compiler\TestPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 0);

--- a/app/bundles/CoreBundle/Tests/Unit/DependencyInjection/Compiler/AssetMapperWebRootPassTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/DependencyInjection/Compiler/AssetMapperWebRootPassTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CoreBundle\Tests\Unit\DependencyInjection\Compiler;
+
+use Mautic\CoreBundle\DependencyInjection\Compiler\AssetMapperWebRootPass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class AssetMapperWebRootPassTest extends TestCase
+{
+    private string $projectDir;
+
+    protected function setUp(): void
+    {
+        $this->projectDir = sys_get_temp_dir().'/mautic_asset_mapper_webroot_'.uniqid();
+        mkdir($this->projectDir);
+    }
+
+    protected function tearDown(): void
+    {
+        if (!is_dir($this->projectDir)) {
+            return;
+        }
+
+        $files = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($this->projectDir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($files as $file) {
+            $file->isDir() ? rmdir($file->getPathname()) : unlink($file->getPathname());
+        }
+
+        rmdir($this->projectDir);
+    }
+
+    public function testAssetMapperArgumentsAreRebasedToConfiguredLocalRoot(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.project_dir', $this->projectDir);
+        $container->setParameter('mautic.local_root', $this->projectDir.'/docroot');
+
+        $container
+            ->register('asset_mapper.public_assets_path_resolver')
+            ->setArguments(['/assets/build/']);
+
+        $container
+            ->register('asset_mapper.local_public_assets_filesystem')
+            ->setArguments([$this->projectDir.'/public']);
+
+        $container
+            ->register('asset_mapper.compiled_asset_mapper_config_reader')
+            ->setArguments([$this->projectDir.'/public/assets/build']);
+
+        $pass = new AssetMapperWebRootPass();
+        $pass->process($container);
+
+        $this->assertSame(
+            $this->projectDir.'/docroot',
+            $container->findDefinition('asset_mapper.local_public_assets_filesystem')->getArgument(0)
+        );
+        $this->assertSame(
+            $this->projectDir.'/docroot/assets/build/',
+            $container->findDefinition('asset_mapper.compiled_asset_mapper_config_reader')->getArgument(0)
+        );
+    }
+
+    public function testAssetMapperArgumentsAreRebasedToMauticScaffoldWebRoot(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.project_dir', $this->projectDir);
+
+        file_put_contents($this->projectDir.'/composer.json', json_encode([
+            'extra' => [
+                'mautic-scaffold' => [
+                    'locations' => [
+                        'web-root' => 'docroot/',
+                    ],
+                ],
+            ],
+        ]));
+
+        $container
+            ->register('asset_mapper.public_assets_path_resolver')
+            ->setArguments(['/assets/build/']);
+
+        $container
+            ->register('asset_mapper.local_public_assets_filesystem')
+            ->setArguments([$this->projectDir.'/public']);
+
+        $container
+            ->register('asset_mapper.compiled_asset_mapper_config_reader')
+            ->setArguments([$this->projectDir.'/public/assets/build']);
+
+        $pass = new AssetMapperWebRootPass();
+        $pass->process($container);
+
+        $this->assertSame(
+            $this->projectDir.'/docroot',
+            $container->findDefinition('asset_mapper.local_public_assets_filesystem')->getArgument(0)
+        );
+        $this->assertSame(
+            $this->projectDir.'/docroot/assets/build/',
+            $container->findDefinition('asset_mapper.compiled_asset_mapper_config_reader')->getArgument(0)
+        );
+    }
+
+    public function testAssetMapperArgumentsFallBackToKernelProjectDirForRootServedInstall(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.project_dir', $this->projectDir);
+
+        $container
+            ->register('asset_mapper.public_assets_path_resolver')
+            ->setArguments(['/assets/build']);
+
+        $container
+            ->register('asset_mapper.local_public_assets_filesystem')
+            ->setArguments([$this->projectDir.'/public']);
+
+        $container
+            ->register('asset_mapper.compiled_asset_mapper_config_reader')
+            ->setArguments([$this->projectDir.'/public/assets/build']);
+
+        $pass = new AssetMapperWebRootPass();
+        $pass->process($container);
+
+        $this->assertSame(
+            $this->projectDir,
+            $container->findDefinition('asset_mapper.local_public_assets_filesystem')->getArgument(0)
+        );
+        $this->assertSame(
+            $this->projectDir.'/assets/build',
+            $container->findDefinition('asset_mapper.compiled_asset_mapper_config_reader')->getArgument(0)
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes AssetMapper production asset output for Mautic installs whose served webroot is not Symfony's default `<project>/public` directory.

Mautic supports layouts where the browser webroot is:

- `docroot/` in `mautic/recommended-project`, declared as `extra.mautic-scaffold.locations.web-root`
- the project root in the classic `mautic/mautic` distribution
- `extra.public-dir` where explicitly configured

Symfony FrameworkBundle currently configures AssetMapper's public directory from `extra.public-dir` only, defaulting to `<project>/public`. In recommended-project upgrades to 7.2.0 this makes `mautic:assets:generate` write `/assets/build/*` under `<project>/public/assets/build`, while the web server serves `<project>/docroot`. The UI then requests `/assets/build/*` and receives 404.

This adds a small CoreBundle compiler pass that rebases AssetMapper's public filesystem and compiled config directory to the Mautic webroot detected from Composer configuration.

Closes/relates to #17259.

## Vanilla reproduction

Environment used locally:

- `mautic/recommended-project:7.1.3`
- upgraded all pinned `mautic/*` packages to `7.2.0`
- MySQL 8.4 disposable container on `127.0.0.1:33061`
- PHP CLI 8.5.9
- `ext-imap` absent locally, but this was only an optional installer warning and not used by the asset path test
- no custom plugins
- no workaround symlink
- document root served as `docroot/`

Upgrade/install commands used:

```bash
composer create-project mautic/recommended-project:7.1.3 vanilla-713 --no-interaction --no-scripts
composer install --no-interaction --no-scripts --ignore-platform-req=ext-imap
npm ci --prefer-offline --no-audit
php -d memory_limit=2G bin/console mautic:install http://127.0.0.1:8071 --force --no-interaction \
  --db_driver=pdo_mysql --db_host=127.0.0.1 --db_port=33061 --db_name=mautic713 \
  --db_user=mautic --db_password=mautic \
  --admin_firstname=Admin --admin_lastname=User --admin_username=admin \
  --admin_email=admin@example.test --admin_password='MauticTest123!'
# update composer.json mautic/* pins from 7.1.3 to 7.2.0
composer update 'mautic/*' --with-all-dependencies --no-interaction --ignore-platform-req=ext-imap
php -d memory_limit=2G bin/console doctrine:migrations:migrate --no-interaction --allow-no-migration
php -d memory_limit=2G bin/console mautic:assets:generate --no-interaction
php -S 127.0.0.1:8071 -t docroot
```

Before this patch, the upgraded 7.2.0 container showed:

```text
asset_mapper.local_public_assets_filesystem argument: <project>/public
asset_mapper.compiled_asset_mapper_config_reader argument: <project>/public/assets/build
```

`mautic:assets:generate` wrote:

```text
Manifest written to public/assets/build/manifest.json
```

The generated JS existed at:

```text
public/assets/build/app-aIt8pJk.js
```

But `docroot/assets` was absent, and serving only `docroot/` returned:

```text
GET /assets/build/app-aIt8pJk.js -> HTTP 404
```

After this patch in the same upgraded instance, the container showed:

```text
asset_mapper.local_public_assets_filesystem argument: <project>/docroot
asset_mapper.compiled_asset_mapper_config_reader argument: <project>/docroot/assets/build/
```

`mautic:assets:generate` wrote:

```text
Manifest written to docroot/assets/build/manifest.json
```

And the same document root served core assets without a symlink:

```text
GET /assets/build/app-aIt8pJk.js -> 200 application/javascript
GET /assets/build/css/app-yY4BIdr.css -> 200 text/css
```

## Tests

```bash
php -d memory_limit=2G bin/phpunit --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist app/bundles/CoreBundle/Tests/Unit/DependencyInjection/Compiler/AssetMapperWebRootPassTest.php
```

Result:

```text
OK (3 tests, 6 assertions)
```

Additional checks:

```bash
php -l app/bundles/CoreBundle/DependencyInjection/Compiler/AssetMapperWebRootPass.php
php -l app/bundles/CoreBundle/Tests/Unit/DependencyInjection/Compiler/AssetMapperWebRootPassTest.php
```

Both returned no syntax errors.
