### PR TITLE
fix(sms): make broadcast recipient processing consistent

### DIFF
--- a/app/bundles/SmsBundle/Broadcast/BroadcastExecutioner.php
+++ b/app/bundles/SmsBundle/Broadcast/BroadcastExecutioner.php
@@ -8,6 +8,7 @@ use Mautic\ChannelBundle\Event\ChannelBroadcastEvent;
 use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\SmsBundle\Entity\Sms;
 use Mautic\SmsBundle\Entity\SmsRepository;
+use Mautic\SmsBundle\Exception\PartialBatchException;
 use Mautic\SmsBundle\Model\SmsModel;
 use Psr\Log\LoggerInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -98,12 +99,19 @@ final readonly class BroadcastExecutioner
 
         $loadedContacts = [];
         $sendFailure    = null;
+        $partialFailure = null;
         try {
             $sendResults = $this->smsModel->sendSms($sms, $contactIds, [
                 'channel' => ['sms', $sms->getId()],
                 'listId'  => $listIds,
             ], $loadedContacts);
             $result->process($sendResults, count($contactIds));
+        } catch (PartialBatchException $exception) {
+            // Only completed/pre-filtered outcomes are included. The collection that
+            // raised the transport exception remains unprocessed and retryable.
+            $result->process($exception->getResults());
+            $result->executionFailed();
+            $partialFailure = $exception;
         } catch (\Throwable $exception) {
             $sendFailure = $exception;
         }
@@ -112,7 +120,7 @@ final readonly class BroadcastExecutioner
         try {
             $this->leadRepository->detachEntities($loadedContacts);
         } catch (\Throwable $exception) {
-            if (null === $sendFailure) {
+            if (null === $sendFailure && null === $partialFailure) {
                 // Submission has already completed. Preserve those known outcomes while
                 // reporting that cleanup could not be completed.
                 $result->executionFailed();
@@ -123,6 +131,21 @@ final readonly class BroadcastExecutioner
 
         if (null !== $sendFailure) {
             throw $sendFailure;
+        }
+
+        if (null !== $partialFailure) {
+            $this->reportExecutionFailureClass($sms, $partialFailure->getOriginalExceptionClass());
+
+            try {
+                // Do not advance the cursor past an unknown transport outcome. Completed
+                // contacts have stats and are excluded; the failed collection can retry.
+                $result->setRemainingCount($this->broadcastQuery->getPendingCount($sms, $partition));
+            } catch (\Throwable) {
+                // The transport failure is already represented and logged. Avoid
+                // replacing or double-reporting it with secondary bookkeeping failures.
+            }
+
+            return $result;
         }
 
         $nextContactId = $contactIds[array_key_last($contactIds)] + 1;

--- a/app/bundles/SmsBundle/Broadcast/BroadcastExecutioner.php
+++ b/app/bundles/SmsBundle/Broadcast/BroadcastExecutioner.php
@@ -2,26 +2,26 @@
 
 namespace Mautic\SmsBundle\Broadcast;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CampaignBundle\Executioner\ContactFinder\Limiter\ContactLimiter;
 use Mautic\ChannelBundle\Event\ChannelBroadcastEvent;
 use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\SmsBundle\Entity\Sms;
 use Mautic\SmsBundle\Entity\SmsRepository;
 use Mautic\SmsBundle\Model\SmsModel;
+use Psr\Log\LoggerInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-final class BroadcastExecutioner
+final readonly class BroadcastExecutioner
 {
-    private ?ContactLimiter $contactLimiter = null;
-
-    private ?BroadcastResult $result = null;
-
     public function __construct(
-        private readonly SmsModel $smsModel,
-        private readonly BroadcastQuery $broadcastQuery,
-        private readonly TranslatorInterface $translator,
-        private readonly LeadRepository $leadRepository,
-        private readonly SmsRepository $smsRepository,
+        private SmsModel $smsModel,
+        private BroadcastQuery $broadcastQuery,
+        private TranslatorInterface $translator,
+        private LeadRepository $leadRepository,
+        private SmsRepository $smsRepository,
+        private EntityManagerInterface $entityManager,
+        private LoggerInterface $logger,
     ) {
     }
 
@@ -30,51 +30,136 @@ final class BroadcastExecutioner
         // Get list of published broadcasts or broadcast if there is only a single ID
         $smses = $this->smsRepository->getPublishedBroadcastsIterable($event->getId());
         foreach ($smses as $sms) {
-            $this->contactLimiter = new ContactLimiter($event->getBatch(), null, $event->getMinContactIdFilter(), $event->getMaxContactIdFilter(), [], $event->getThreadId(), $event->getMaxThreads(), $event->getLimit());
-            $this->result         = new BroadcastResult();
+            $partition = new ContactLimiter(
+                $event->getBatch(),
+                null,
+                $event->getMinContactIdFilter(),
+                $event->getMaxContactIdFilter(),
+                [],
+                $event->getThreadId(),
+                $event->getMaxThreads(),
+            );
+            $result         = new BroadcastResult();
+            $remainingLimit = max(0, $event->getLimit());
+
             try {
-                $this->send($sms);
-            } catch (\Exception) {
+                while ($remainingLimit > 0) {
+                    $batchSize  = min($event->getBatch(), $remainingLimit);
+                    $batchResult = $this->sendNextBatch($sms, $batchSize, $partition);
+                    $result->merge($batchResult);
+
+                    $processedCount  = $batchResult->getProcessedCount();
+                    $remainingLimit -= $processedCount;
+
+                    if ($batchResult->getExecutionFailureCount() > 0 || 0 === $processedCount || 0 === $batchResult->getRemainingCount()) {
+                        break;
+                    }
+                }
+            } catch (\Throwable $exception) {
+                $result->executionFailed();
+                $this->reportExecutionFailure($sms, $exception);
             }
+
             $event->setResults(
                 sprintf('%s: %s', $this->translator->trans('mautic.sms.sms'), $sms->getName()),
-                $this->result->getSentCount(),
-                $this->result->getFailedCount()
+                $result->getSuccessfulCount(),
+                $result->getFailedCount()
             );
         }
     }
 
-    /**
-     * @throws \Mautic\CampaignBundle\Executioner\Exception\NoContactsFoundException
-     */
-    private function send(Sms $sms): void
+    public function sendNextBatch(Sms $sms, int $batchSize, ?ContactLimiter $partition = null): BroadcastResult
     {
-        $contacts = $this->broadcastQuery->getPendingContacts($sms, $this->contactLimiter);
-        while ([] !== $contacts) {
-            $reduction = 0;
-            $leads     = [];
-            foreach ($contacts as $contact) {
-                $contactId  = $contact['id'];
-                $results    = $this->smsModel->sendSms($sms, $contactId, [
-                    'channel'=> [
-                        'sms', $sms->getId(),
-                    ],
-                    'listId'=> $contact['listId'],
-                ], $leads);
-                $this->result->process($results);
-                $reduction += count($results);
-            }
-
-            $this->contactLimiter->setBatchMinContactId($contactId + 1);
-
-            if ($this->contactLimiter->hasCampaignLimit()) {
-                $this->contactLimiter->reduceCampaignLimitRemaining($reduction);
-            }
-
-            $this->leadRepository->detachEntities($leads);
-
-            // Next batch
-            $contacts = $this->broadcastQuery->getPendingContacts($sms, $this->contactLimiter);
+        $result = new BroadcastResult();
+        if ($batchSize <= 0 || null === $sms->getId()) {
+            return $result;
         }
+
+        $this->entityManager->refresh($sms);
+        if ('list' !== $sms->getSmsType() || !$sms->isPublished()) {
+            return $result;
+        }
+
+        $partition ??= new ContactLimiter($batchSize);
+        $contacts = $this->broadcastQuery->getPendingContacts($sms, $partition, $batchSize);
+        if ([] === $contacts) {
+            $result->setRemainingCount($this->broadcastQuery->getPendingCount($sms, $partition));
+
+            return $result;
+        }
+
+        $contactIds = [];
+        $listIds    = [];
+        foreach ($contacts as $contact) {
+            $contactId           = (int) $contact['id'];
+            $contactIds[]        = $contactId;
+            $listIds[$contactId] = (int) $contact['listId'];
+        }
+
+        $loadedContacts = [];
+        $sendFailure    = null;
+        try {
+            $sendResults = $this->smsModel->sendSms($sms, $contactIds, [
+                'channel' => ['sms', $sms->getId()],
+                'listId'  => $listIds,
+            ], $loadedContacts);
+            $result->process($sendResults, count($contactIds));
+        } catch (\Throwable $exception) {
+            $sendFailure = $exception;
+        }
+
+        $executionFailureReported = false;
+        try {
+            $this->leadRepository->detachEntities($loadedContacts);
+        } catch (\Throwable $exception) {
+            if (null === $sendFailure) {
+                // Submission has already completed. Preserve those known outcomes while
+                // reporting that cleanup could not be completed.
+                $result->executionFailed();
+                $this->reportExecutionFailure($sms, $exception);
+                $executionFailureReported = true;
+            }
+        }
+
+        if (null !== $sendFailure) {
+            throw $sendFailure;
+        }
+
+        $nextContactId = $contactIds[array_key_last($contactIds)] + 1;
+        if (null !== $partition->getMaxContactId() && $nextContactId > $partition->getMaxContactId()) {
+            $result->setRemainingCount(0);
+
+            return $result;
+        }
+
+        try {
+            $partition->setBatchMinContactId($nextContactId);
+            $result->setRemainingCount($this->broadcastQuery->getPendingCount($sms, $partition));
+        } catch (\Throwable $exception) {
+            // Submission has already completed. Preserve those known outcomes while
+            // reporting that cursor/count bookkeeping could not be completed.
+            if (!$executionFailureReported) {
+                $result->executionFailed();
+                $this->reportExecutionFailure($sms, $exception);
+            }
+        }
+
+        return $result;
+    }
+
+    private function reportExecutionFailure(Sms $sms, \Throwable $exception): void
+    {
+        $this->reportExecutionFailureClass($sms, $exception::class);
+    }
+
+    /**
+     * @param class-string<\Throwable> $exceptionClass
+     */
+    private function reportExecutionFailureClass(Sms $sms, string $exceptionClass): void
+    {
+        $this->logger->error('SMS broadcast execution failed.', [
+            'smsId'          => $sms->getId(),
+            'exceptionClass' => $exceptionClass,
+        ]);
     }
 }

--- a/app/bundles/SmsBundle/Broadcast/BroadcastQuery.php
+++ b/app/bundles/SmsBundle/Broadcast/BroadcastQuery.php
@@ -2,6 +2,7 @@
 
 namespace Mautic\SmsBundle\Broadcast;
 
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\ORM\EntityManagerInterface;
 use Mautic\CampaignBundle\Entity\ContactLimiterTrait;
@@ -22,24 +23,51 @@ final class BroadcastQuery
     ) {
     }
 
-    public function getPendingContacts(Sms $sms, ContactLimiter $contactLimiter): array
+    public function getPendingContacts(Sms $sms, ContactLimiter $contactLimiter, ?int $batchLimit = null): array
     {
+        if (null !== $batchLimit && $batchLimit <= 0) {
+            return [];
+        }
+
         $query = $this->getBasicQuery($sms);
-        $query->select('DISTINCT l.id, ll.id as listId');
+        $query->select('l.id', 'MIN(ll.id) AS listId')
+            ->groupBy('l.id');
         $this->updateQueryFromContactLimiter('lll', $query, $contactLimiter);
+
+        if (null !== $batchLimit) {
+            $query->setMaxResults($batchLimit);
+        }
 
         return $query->executeQuery()->fetchAllAssociative();
     }
 
     /**
-     * @return bool|string
+     * @param int[] $contactIds
      */
-    public function getPendingCount(Sms $sms)
+    public function getPendingContactsForContactIds(Sms $sms, array $contactIds): array
+    {
+        $contactIds = array_values(array_unique(array_map(intval(...), $contactIds)));
+        if ([] === $contactIds) {
+            return [];
+        }
+
+        return $this->getPendingContacts(
+            $sms,
+            new ContactLimiter(count($contactIds), contactIdList: $contactIds),
+        );
+    }
+
+    public function getPendingCount(Sms $sms, ?ContactLimiter $contactLimiter = null): int
     {
         $query = $this->getBasicQuery($sms);
-        $query->select('COUNT(DISTINCT l.id)');
+        $query->select('COUNT(DISTINCT l.id)')
+            ->resetQueryPart('orderBy');
 
-        return $query->executeQuery()->fetchOne();
+        if (null !== $contactLimiter) {
+            $this->updateQueryFromContactLimiter('lll', $query, $contactLimiter, true);
+        }
+
+        return (int) $query->executeQuery()->fetchOne();
     }
 
     public function getBasicQuery(Sms $sms): QueryBuilder
@@ -47,25 +75,30 @@ final class BroadcastQuery
         $this->query = $this->smsRepository->getSegmentsContactsQuery($sms->getId());
         $this->query->andWhere(
             $this->query->expr()->or(
-                $this->query->expr()->or(
+                $this->query->expr()->and(
                     $this->query->expr()->isNotNull('l.mobile'),
                     $this->query->expr()->neq('l.mobile', $this->query->expr()->literal(''))
                 ),
-                $this->query->expr()->or(
+                $this->query->expr()->and(
                     $this->query->expr()->isNotNull('l.phone'),
                     $this->query->expr()->neq('l.phone', $this->query->expr()->literal(''))
                 )
             )
         );
-        $this->excludeStatsRecords($sms->getId());
+        $this->excludeStatsRecords($this->getTranslationIds($sms));
         $this->excludeDnc();
         $this->excludeQueue();
 
         return $this->query;
     }
 
-    private function excludeStatsRecords(int $smsId): void
+    /**
+     * @param array<int, int|string> $smsIds
+     */
+    private function excludeStatsRecords(array $smsIds): void
     {
+        $smsIds = array_values(array_unique(array_map(intval(...), $smsIds)));
+
         // Do not include leads that have already received text message
         $statQb = $this->entityManager->getConnection()->createQueryBuilder();
         $statQb->select('null')
@@ -73,11 +106,30 @@ final class BroadcastQuery
             ->where(
                 $statQb->expr()->and(
                     $statQb->expr()->eq('stat.lead_id', 'l.id'),
-                    $statQb->expr()->eq('stat.sms_id', $smsId)
+                    $statQb->expr()->in('stat.sms_id', ':relatedSmsIds')
                 )
             );
 
-        $this->query->andWhere(sprintf('NOT EXISTS (%s)', $statQb->getSQL()));
+        $this->query
+            ->andWhere(sprintf('NOT EXISTS (%s)', $statQb->getSQL()))
+            ->setParameter('relatedSmsIds', $smsIds, ArrayParameterType::INTEGER);
+    }
+
+    /**
+     * @return int[]
+     */
+    private function getTranslationIds(Sms $sms): array
+    {
+        [$translationParent, $translationChildren] = $sms->getTranslations();
+        $smsIds                                     = [];
+
+        foreach (array_merge([$sms, $translationParent], $translationChildren) as $translation) {
+            if ($translation instanceof Sms && $translation->getId()) {
+                $smsIds[] = $translation->getId();
+            }
+        }
+
+        return array_values(array_unique($smsIds));
     }
 
     private function excludeDnc(): void

--- a/app/bundles/SmsBundle/Broadcast/BroadcastResult.php
+++ b/app/bundles/SmsBundle/Broadcast/BroadcastResult.php
@@ -6,30 +6,55 @@ namespace Mautic\SmsBundle\Broadcast;
 
 final class BroadcastResult
 {
-    private int $sentCount = 0;
+    private const SCHEDULED_STATUS = 'mautic.sms.timeline.status.scheduled';
+
+    private const UNKNOWN_FAILURE_STATUS = 'mautic.sms.timeline.event.failed';
+
+    private int $processedCount = 0;
+
+    private int $submittedCount = 0;
+
+    private int $scheduledCount = 0;
 
     private int $failedCount = 0;
+
+    private int $executionFailureCount = 0;
+
+    private int $remainingCount = 0;
 
     /**
      * @var array<int, string>
      */
     private array $failedContacts = [];
 
-    public function process(array $results): void
+    public function process(array $results, ?int $processedCount = null): void
     {
-        foreach ($results as $lead_id => $result) {
+        $processedCount ??= count($results);
+        $this->processedCount += max($processedCount, count($results));
+        $this->failedCount += max(0, $processedCount - count($results));
+
+        foreach ($results as $leadId => $result) {
             if (isset($result['sent']) && true === $result['sent']) {
                 $this->sent();
+            } elseif (self::SCHEDULED_STATUS === ($result['status'] ?? null)) {
+                $this->scheduled();
             } else {
                 $this->failed();
-                $this->failedContacts[$lead_id] = $result['status'];
+                $this->failedContacts[(int) $leadId] = is_string($result['status'] ?? null)
+                    ? $result['status']
+                    : self::UNKNOWN_FAILURE_STATUS;
             }
         }
     }
 
     public function sent(): void
     {
-        ++$this->sentCount;
+        ++$this->submittedCount;
+    }
+
+    public function scheduled(): void
+    {
+        ++$this->scheduledCount;
     }
 
     public function failed(): void
@@ -37,14 +62,65 @@ final class BroadcastResult
         ++$this->failedCount;
     }
 
+    public function executionFailed(): void
+    {
+        ++$this->executionFailureCount;
+    }
+
+    public function merge(self $result): void
+    {
+        $this->processedCount += $result->processedCount;
+        $this->submittedCount += $result->submittedCount;
+        $this->scheduledCount += $result->scheduledCount;
+        $this->failedCount += $result->failedCount;
+        $this->executionFailureCount += $result->executionFailureCount;
+        $this->remainingCount         = $result->remainingCount;
+        $this->failedContacts         = array_replace($this->failedContacts, $result->failedContacts);
+    }
+
+    public function setRemainingCount(int $remainingCount): void
+    {
+        $this->remainingCount = max(0, $remainingCount);
+    }
+
+    public function getProcessedCount(): int
+    {
+        return $this->processedCount;
+    }
+
+    public function getSubmittedCount(): int
+    {
+        return $this->submittedCount;
+    }
+
+    public function getScheduledCount(): int
+    {
+        return $this->scheduledCount;
+    }
+
+    public function getSuccessfulCount(): int
+    {
+        return $this->submittedCount + $this->scheduledCount;
+    }
+
     public function getSentCount(): int
     {
-        return $this->sentCount;
+        return $this->submittedCount;
     }
 
     public function getFailedCount(): int
     {
-        return $this->failedCount;
+        return $this->failedCount + $this->executionFailureCount;
+    }
+
+    public function getExecutionFailureCount(): int
+    {
+        return $this->executionFailureCount;
+    }
+
+    public function getRemainingCount(): int
+    {
+        return $this->remainingCount;
     }
 
     /**

--- a/app/bundles/SmsBundle/Config/services.php
+++ b/app/bundles/SmsBundle/Config/services.php
@@ -39,8 +39,10 @@ return function (ContainerConfigurator $configurator): void {
     $services->set('mautic.sms.helper.reply', Mautic\SmsBundle\Helper\ReplyHelper::class);
     $services->set('mautic.sms.twilio.configuration', Mautic\SmsBundle\Integration\Twilio\Configuration::class);
     $services->set('mautic.sms.twilio.callback', Mautic\SmsBundle\Integration\Twilio\TwilioCallback::class)->tag('mautic.sms_callback_handler');
-    $services->set('mautic.sms.broadcast.executioner', Mautic\SmsBundle\Broadcast\BroadcastExecutioner::class);
-    $services->set('mautic.sms.broadcast.query', Mautic\SmsBundle\Broadcast\BroadcastQuery::class);
+    $services->set(Mautic\SmsBundle\Broadcast\BroadcastExecutioner::class)
+        ->arg('$logger', service('monolog.logger.mautic'));
+    $services->alias('mautic.sms.broadcast.executioner', Mautic\SmsBundle\Broadcast\BroadcastExecutioner::class);
+    $services->alias('mautic.sms.broadcast.query', Mautic\SmsBundle\Broadcast\BroadcastQuery::class);
     $services->set('mautic.integration.twilio', Mautic\SmsBundle\Integration\TwilioIntegration::class);
 
     $services->alias('mautic.sms.model.sms', Mautic\SmsBundle\Model\SmsModel::class);

--- a/app/bundles/SmsBundle/Entity/SmsRepository.php
+++ b/app/bundles/SmsBundle/Entity/SmsRepository.php
@@ -80,7 +80,7 @@ class SmsRepository extends CommonRepository
             )
             ->setParameter('smsId', $smsId)
             // Order by ID so we can query by greater than X contact ID when batching
-            ->orderBy('lll.lead_id');
+            ->orderBy('l.id', 'ASC');
 
         return $q;
     }

--- a/app/bundles/SmsBundle/Event/FilterEvent.php
+++ b/app/bundles/SmsBundle/Event/FilterEvent.php
@@ -9,10 +9,17 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 final class FilterEvent extends Event
 {
+    public const REMOVAL_REASON_MISSING_NUMBER = 'missing_number';
+
     /**
      * @var array<int>
      */
     private array $removed  = [];
+
+    /**
+     * @var array<int, string>
+     */
+    private array $removalReasons = [];
 
     /**
      * @param array<int, Lead> $contacts
@@ -33,24 +40,34 @@ final class FilterEvent extends Event
     /**
      * @return array<int>
      */
-    public function getRemovedContacts(): array
+    public function getRemovedContacts(?string $reason = null): array
     {
+        if (null !== $reason) {
+            return array_values(array_filter(
+                $this->removed,
+                fn (int $contactId): bool => $reason === ($this->removalReasons[$contactId] ?? null),
+            ));
+        }
+
         return $this->removed;
     }
 
-    public function removeContact(int $id): void
+    public function removeContact(int $id, ?string $reason = null): void
     {
         $this->removed[] = $id;
+        if (null !== $reason) {
+            $this->removalReasons[$id] = $reason;
+        }
         unset($this->contacts[$id]);
     }
 
     /**
      * @param array<int> $contacts
      */
-    public function removeContacts(array $contacts): void
+    public function removeContacts(array $contacts, ?string $reason = null): void
     {
         foreach ($contacts as $contact) {
-            $this->removeContact((int) $contact);
+            $this->removeContact((int) $contact, $reason);
         }
     }
 }

--- a/app/bundles/SmsBundle/EventListener/SendSmsSubscriber.php
+++ b/app/bundles/SmsBundle/EventListener/SendSmsSubscriber.php
@@ -69,8 +69,14 @@ final readonly class SendSmsSubscriber implements EventSubscriberInterface
 
     public function genericFilter(FilterEvent $event): void
     {
-        $contactsWithoutNumbers = array_filter($event->getContacts(), fn (Lead $contact): bool => empty($contact->getLeadPhoneNumber()));
+        $contactsWithoutNumbers = array_filter(
+            $event->getContacts(),
+            fn (Lead $contact): bool => '' === trim((string) $contact->getLeadPhoneNumber()),
+        );
 
-        $event->removeContacts(array_map(fn (Lead $contact): int => $contact->getId(), $contactsWithoutNumbers));
+        $event->removeContacts(
+            array_map(fn (Lead $contact): int => $contact->getId(), $contactsWithoutNumbers),
+            FilterEvent::REMOVAL_REASON_MISSING_NUMBER,
+        );
     }
 }

--- a/app/bundles/SmsBundle/Exception/PartialBatchException.php
+++ b/app/bundles/SmsBundle/Exception/PartialBatchException.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\SmsBundle\Exception;
+
+final class PartialBatchException extends \RuntimeException
+{
+    private const DEFAULT_FAILURE_STATUS = 'mautic.sms.timeline.event.failed';
+
+    private const DELIVERED_STATUS = 'mautic.sms.timeline.status.delivered';
+
+    private const SAFE_STATUSES = [
+        self::DELIVERED_STATUS,
+        'mautic.sms.timeline.status.failed',
+        'mautic.sms.timeline.status.scheduled',
+        'mautic.sms.campaign.failed.missing_number',
+        'mautic.sms.campaign.failed.not_contactable',
+        'mautic.sms.campaign.failed.unpublished',
+        'mautic.sms.config.no_transport',
+    ];
+
+    /**
+     * @var array<int, array{sent: bool, status: string}>
+     */
+    private array $results = [];
+
+    /**
+     * @param array<int, array<string, mixed>> $results
+     */
+    public function __construct(array $results, \Throwable $previous)
+    {
+        parent::__construct('SMS batch transport failed after partial completion.', 0, $previous);
+
+        foreach ($results as $contactId => $result) {
+            $sent   = true === ($result['sent'] ?? false);
+            $status = $result['status'] ?? null;
+
+            if (!is_string($status) || !in_array($status, self::SAFE_STATUSES, true)) {
+                $status = $sent ? self::DELIVERED_STATUS : self::DEFAULT_FAILURE_STATUS;
+            }
+
+            $this->results[(int) $contactId] = [
+                'sent'   => $sent,
+                'status' => $status,
+            ];
+        }
+    }
+
+    /**
+     * @return array<int, array{sent: bool, status: string}>
+     */
+    public function getResults(): array
+    {
+        return $this->results;
+    }
+
+    /**
+     * Returns class metadata only; structured batch results never include provider messages.
+     *
+     * @return class-string<\Throwable>
+     */
+    public function getOriginalExceptionClass(): string
+    {
+        $previous = $this->getPrevious();
+        \assert($previous instanceof \Throwable);
+
+        return $previous::class;
+    }
+}

--- a/app/bundles/SmsBundle/Helper/DTO/SmsRecipientDTO.php
+++ b/app/bundles/SmsBundle/Helper/DTO/SmsRecipientDTO.php
@@ -30,9 +30,11 @@ final class SmsRecipientDTO implements \JsonSerializable
         return $this->lead;
     }
 
-    public function setResult(bool $result): void
+    public function setResult(mixed $result): void
     {
-        $this->result = $result;
+        // Some legacy transports return provider error strings. Only a literal true
+        // represents acceptance, and raw provider responses must not remain on the DTO.
+        $this->result = true === $result;
     }
 
     public function getResult(): bool

--- a/app/bundles/SmsBundle/Model/SmsModel.php
+++ b/app/bundles/SmsBundle/Model/SmsModel.php
@@ -187,19 +187,18 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface, GlobalSear
 
     /**
      * @param Lead|int|array<Lead>|array<int> $sendTo
+     * @param array<string, mixed>            $options
      * @param array<int, Lead>                $contacts
      */
     public function sendSms(Sms $sms, $sendTo, array $options = [], array &$contacts = []): array
     {
         $channel = $options['channel'] ?? null;
-        $listId  = $options['listId'] ?? null;
+        $listIds = $options['listId'] ?? null;
         $sendTo  = is_array($sendTo) ? $sendTo : [$sendTo];
 
-        $sentCount       = [];
-        $stats           = [];
-        $results         = [];
-        $contacts        = []; // Shall we reset the passed contacts param here?
-        $fetchContacts   = [];
+        $results       = [];
+        $contacts      = [];
+        $fetchContacts = [];
         foreach ($sendTo as $contact) {
             if ($contact instanceof Lead) {
                 $contacts[$contact->getId()] = $contact;
@@ -217,6 +216,9 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface, GlobalSear
             }
         }
 
+        // Keep the by-reference output intact so callers can detach every loaded contact.
+        $sendContacts = $contacts;
+
         if (!$sms->isPublished()) {
             foreach ($contacts as $contactId => $contact) {
                 $results[$contactId] = [
@@ -228,7 +230,7 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface, GlobalSear
             return $results;
         }
 
-        $dncEvent = new DncEvent($contacts);
+        $dncEvent = new DncEvent($sendContacts);
         $this->dispatcher->dispatch($dncEvent, SmsEvents::DNC_FILTER_CONTACTS_ON_SEND);
 
         foreach ($dncEvent->getRemovedContacts() as $contactId) {
@@ -238,14 +240,14 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface, GlobalSear
             ];
         }
 
-        $contacts = $dncEvent->getContacts(); // The contacts param is reset here too, no?
+        $sendContacts = $dncEvent->getContacts();
 
         // Check if any contacts remain. If not, return early.
-        if ([] === $contacts) {
+        if ([] === $sendContacts) {
             return $results;
         }
 
-        $queueEvent = new QueueEvent($contacts, array_merge($options, ['sms_id' => $sms->getId()]));
+        $queueEvent = new QueueEvent($sendContacts, array_merge($options, ['sms_id' => $sms->getId()]));
         $this->dispatcher->dispatch($queueEvent, SmsEvents::QUEUE_FILTER_CONTACTS_ON_SEND);
 
         foreach ($queueEvent->getQueuedContacts() as $contactId) {
@@ -255,14 +257,14 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface, GlobalSear
             ];
         }
 
-        $contacts = $queueEvent->getContacts();
+        $sendContacts = $queueEvent->getContacts();
 
         // Check if any contacts remain. If not, return early.
-        if ([] === $contacts) {
+        if ([] === $sendContacts) {
             return $results;
         }
 
-        $filterEvent = new FilterEvent($contacts);
+        $filterEvent = new FilterEvent($sendContacts);
         $this->dispatcher->dispatch($filterEvent, SmsEvents::FILTER_CONTACTS_ON_SEND);
 
         foreach ($filterEvent->getRemovedContacts() as $contactId) {
@@ -272,9 +274,9 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface, GlobalSear
             ];
         }
 
-        $contacts = $filterEvent->getContacts();
+        $sendContacts = $filterEvent->getContacts();
 
-        if ([] === $contacts) {
+        if ([] === $sendContacts) {
             return $results;
         }
 
@@ -284,12 +286,19 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface, GlobalSear
         $stats = [];
 
         /** @var Lead $contact */
-        foreach ($contacts as $contact) {
+        foreach ($sendContacts as $contact) {
             [, $translatedSms] = $this->getTranslatedEntity($sms, $contact);
             \assert($translatedSms instanceof Sms);
 
-            $stat    = $this->createStatEntry($translatedSms, $contact, $channel, false, $listId);
-            $stats[] = $stat;
+            $contactId = $contact->getId();
+            $stat      = $this->createStatEntry(
+                $translatedSms,
+                $contact,
+                $channel,
+                false,
+                $this->getContactListId($listIds, $contactId),
+            );
+            $stats[$contactId] = $stat;
 
             $smsEvent = new SmsSendEvent($translatedSms->getMessage(), $contact);
             $smsEvent->setSmsId($translatedSms->getId());
@@ -319,6 +328,7 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface, GlobalSear
             unset($smsEvent, $tokenEvent);
         }
 
+        $sentCount = [];
         foreach ($recipientCollections as $recipientCollection) {
             $translatedSms = $recipientCollection->getSms();
             $media         = $translatedSms->getMedia();
@@ -331,8 +341,8 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface, GlobalSear
                 } else {
                     $this->transport->sendBatchSms($recipientCollection, $message);
                 }
-            } catch (PrimaryTransportNotEnabledException $e) {
-                $this->logger->warning($e->getMessage());
+            } catch (PrimaryTransportNotEnabledException $exception) {
+                $this->logger->warning($exception->getMessage());
 
                 return $results;
             }
@@ -346,18 +356,19 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface, GlobalSear
             ];
 
             foreach ($recipientCollection as $recipient) {
+                $contactId = $recipient->getKey();
                 $defaultSendResult['content'] = $recipient->getFinalMessage();
                 if (true !== $recipient->getResult()) {
                     $defaultSendResult['sent']   = false;
                     $defaultSendResult['status'] = $recipient->getResult();
-                    unset($stats[$recipient->getKey()]);
+                    unset($stats[$contactId]);
                 } else {
                     $defaultSendResult['sent']          = true;
                     $defaultSendResult['status']        = 'mautic.sms.timeline.status.delivered';
                     $sentCount[$translatedSms->getId()] = ($sentCount[$translatedSms->getId()] ?? 0) + 1;
                 }
 
-                $results[$recipient->getKey()] = $defaultSendResult;
+                $results[$contactId] = $defaultSendResult;
             }
         }
 
@@ -378,6 +389,11 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface, GlobalSear
         }
 
         return $results;
+    }
+
+    private function getContactListId(mixed $listIds, int $contactId): mixed
+    {
+        return is_array($listIds) ? ($listIds[$contactId] ?? null) : $listIds;
     }
 
     /**

--- a/app/bundles/SmsBundle/Model/SmsModel.php
+++ b/app/bundles/SmsBundle/Model/SmsModel.php
@@ -29,6 +29,7 @@ use Mautic\SmsBundle\Event\FilterEvent;
 use Mautic\SmsBundle\Event\QueueEvent;
 use Mautic\SmsBundle\Event\SmsEvent;
 use Mautic\SmsBundle\Event\SmsSendEvent;
+use Mautic\SmsBundle\Exception\PartialBatchException;
 use Mautic\SmsBundle\Exception\PrimaryTransportNotEnabledException;
 use Mautic\SmsBundle\Form\Type\SmsType;
 use Mautic\SmsBundle\Helper\DTO\SmsRecipientDTO;
@@ -267,12 +268,31 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface, GlobalSear
         $filterEvent = new FilterEvent($sendContacts);
         $this->dispatcher->dispatch($filterEvent, SmsEvents::FILTER_CONTACTS_ON_SEND);
 
+        $missingNumberStats      = [];
+        $missingNumberContactIds = array_flip($filterEvent->getRemovedContacts(FilterEvent::REMOVAL_REASON_MISSING_NUMBER));
         foreach ($filterEvent->getRemovedContacts() as $contactId) {
+            $status = 'mautic.sms.campaign.failed.missing_number';
             $results[$contactId] = [
                 'sent'   => false,
-                'status' => 'mautic.sms.campaign.failed.missing_number',
+                'status' => $status,
             ];
+
+            if (!isset($missingNumberContactIds[$contactId])) {
+                continue;
+            }
+
+            $contact = $sendContacts[$contactId];
+            $stat    = $this->createStatEntry(
+                $sms,
+                $contact,
+                $channel,
+                false,
+                $this->getContactListId($listIds, $contactId),
+            );
+            $this->markStatFailed($stat, $status);
+            $missingNumberStats[$contactId] = $stat;
         }
+        $this->persistStats($missingNumberStats, $results);
 
         $sendContacts = $filterEvent->getContacts();
 
@@ -328,7 +348,6 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface, GlobalSear
             unset($smsEvent, $tokenEvent);
         }
 
-        $sentCount = [];
         foreach ($recipientCollections as $recipientCollection) {
             $translatedSms = $recipientCollection->getSms();
             $media         = $translatedSms->getMedia();
@@ -341,10 +360,25 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface, GlobalSear
                 } else {
                     $this->transport->sendBatchSms($recipientCollection, $message);
                 }
-            } catch (PrimaryTransportNotEnabledException $exception) {
-                $this->logger->warning($exception->getMessage());
+            } catch (PrimaryTransportNotEnabledException) {
+                $this->logger->warning('Primary SMS transport is not enabled.');
 
-                return $results;
+                foreach ($recipientCollection as $recipient) {
+                    $contactId = $recipient->getKey();
+                    unset($stats[$contactId]);
+                    $results[$contactId] = [
+                        'sent'   => false,
+                        'status' => 'mautic.sms.config.no_transport',
+                    ];
+                }
+
+                continue;
+            } catch (\Throwable $exception) {
+                if ([] === $results) {
+                    throw $exception;
+                }
+
+                throw new PartialBatchException($results, $exception);
             }
 
             $defaultSendResult = [
@@ -355,36 +389,39 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface, GlobalSear
                 'name'    => $recipientCollection->getSms()->getName(),
             ];
 
+            $collectionStats = [];
+            $sentCount       = 0;
             foreach ($recipientCollection as $recipient) {
                 $contactId = $recipient->getKey();
                 $defaultSendResult['content'] = $recipient->getFinalMessage();
                 if (true !== $recipient->getResult()) {
+                    $status                      = 'mautic.sms.timeline.status.failed';
                     $defaultSendResult['sent']   = false;
-                    $defaultSendResult['status'] = $recipient->getResult();
-                    unset($stats[$contactId]);
+                    $defaultSendResult['status'] = $status;
+                    $this->markStatFailed($stats[$contactId], $status);
                 } else {
-                    $defaultSendResult['sent']          = true;
-                    $defaultSendResult['status']        = 'mautic.sms.timeline.status.delivered';
-                    $sentCount[$translatedSms->getId()] = ($sentCount[$translatedSms->getId()] ?? 0) + 1;
+                    $defaultSendResult['sent']   = true;
+                    $defaultSendResult['status'] = 'mautic.sms.timeline.status.delivered';
+                    ++$sentCount;
                 }
 
-                $results[$contactId] = $defaultSendResult;
+                $results[$contactId]         = $defaultSendResult;
+                $collectionStats[$contactId] = $stats[$contactId];
             }
-        }
 
-        foreach ($sentCount as $id => $count) {
-            $this->smsRepository->upCount($id, 'sent', $count);
-        }
+            // Commit each translated collection before attempting the next one. A later
+            // transport exception must not make already submitted contacts eligible again.
+            $this->persistStats($collectionStats, $results);
+            foreach (array_keys($collectionStats) as $contactId) {
+                unset($stats[$contactId]);
+            }
 
-        if (count($stats)) {
-            $this->statRepository->saveEntities($stats);
-
-            foreach ($stats as $stat) {
-                if (!$stat->isFailed()) {
-                    $results[$stat->getLead()->getId()]['statId'] = $stat->getId();
+            if ($sentCount > 0) {
+                try {
+                    $this->smsRepository->upCount($translatedSms->getId(), 'sent', $sentCount);
+                } catch (\Throwable $exception) {
+                    throw new PartialBatchException($results, $exception);
                 }
-
-                $this->smsRepository->detachEntity($stat);
             }
         }
 
@@ -394,6 +431,33 @@ class SmsModel extends FormModel implements AjaxLookupModelInterface, GlobalSear
     private function getContactListId(mixed $listIds, int $contactId): mixed
     {
         return is_array($listIds) ? ($listIds[$contactId] ?? null) : $listIds;
+    }
+
+    private function markStatFailed(Stat $stat, string $status): void
+    {
+        $stat->setIsFailed(true);
+        $stat->addDetail('failed', $this->translator->trans($status));
+    }
+
+    /**
+     * @param array<int, Stat>                 $stats
+     * @param array<int, array<string, mixed>> $results
+     */
+    private function persistStats(array $stats, array &$results): void
+    {
+        if ([] === $stats) {
+            return;
+        }
+
+        $this->statRepository->saveEntities($stats);
+
+        foreach ($stats as $stat) {
+            if (!$stat->isFailed()) {
+                $results[$stat->getLead()->getId()]['statId'] = $stat->getId();
+            }
+
+            $this->smsRepository->detachEntity($stat);
+        }
     }
 
     /**

--- a/app/bundles/SmsBundle/Sms/TransportChain.php
+++ b/app/bundles/SmsBundle/Sms/TransportChain.php
@@ -124,7 +124,7 @@ class TransportChain
     /**
      * @param string $content
      *
-     * @return mixed
+     * @return bool|string
      *
      * @throws \Exception
      */

--- a/app/bundles/SmsBundle/Sms/TransportInterface.php
+++ b/app/bundles/SmsBundle/Sms/TransportInterface.php
@@ -11,7 +11,7 @@ interface TransportInterface
     /**
      * @param string $content
      *
-     * @return bool
+     * @return bool|string true when accepted, otherwise false or a legacy provider error
      */
     public function sendSms(Lead $lead, $content);
 }

--- a/app/bundles/SmsBundle/Tests/Broadcast/BroadcastExecutionerTest.php
+++ b/app/bundles/SmsBundle/Tests/Broadcast/BroadcastExecutionerTest.php
@@ -15,9 +15,11 @@ use Mautic\LeadBundle\Entity\LeadRepository;
 use Mautic\LeadBundle\Entity\ListLead;
 use Mautic\SmsBundle\Broadcast\BroadcastExecutioner;
 use Mautic\SmsBundle\Broadcast\BroadcastQuery;
+use Mautic\SmsBundle\Collection\RecipientCollection;
 use Mautic\SmsBundle\Entity\Sms;
 use Mautic\SmsBundle\Entity\SmsRepository;
 use Mautic\SmsBundle\Model\SmsModel;
+use Mautic\SmsBundle\Sms\TransportChain;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -164,6 +166,91 @@ final class BroadcastExecutionerTest extends MauticMysqlTestCase
             'failed'                 => 1,
             'failedRecipientsByList' => [],
         ], array_values($event->getResults())[0]);
+    }
+
+    public function testMixedTranslationFailureKeepsCompletedOutcomesAndLeavesFailedCollectionRetryable(): void
+    {
+        [$sms, $contacts] = $this->createBroadcast(2, 'partial-translations');
+        $sms->setLanguage('en');
+
+        $translatedSms = new Sms();
+        $translatedSms->setName('partial-translations-fr');
+        $translatedSms->setMessage('Bonjour');
+        $translatedSms->setLanguage('fr_FR');
+        $translatedSms->setIsPublished(true);
+        $translatedSms->setTranslationParent($sms);
+        $contacts[1]->addUpdatedField('preferred_locale', 'fr_FR');
+        $this->em->persist($translatedSms);
+        $this->em->flush();
+
+        $smsId           = $sms->getId();
+        $translatedSmsId = $translatedSms->getId();
+        $firstContactId  = $contacts[0]->getId();
+        $secondContactId = $contacts[1]->getId();
+        $this->em->clear();
+
+        $sms = $this->em->find(Sms::class, $smsId);
+        $localizedContact = $this->em->find(Lead::class, $secondContactId);
+        $this->assertInstanceOf(Sms::class, $sms);
+        $this->assertInstanceOf(Lead::class, $localizedContact);
+        $localizedContact->addUpdatedField('preferred_locale', 'fr_FR');
+
+        $transport = $this->createMock(TransportChain::class);
+        $transport->expects($this->exactly(2))
+            ->method('sendBatchSms')
+            ->willReturnCallback(static function (RecipientCollection $collection, string $message): RecipientCollection {
+                if ('Bonjour' === $message) {
+                    throw new \RuntimeException('Provider rejected +41790000001: private message body');
+                }
+
+                foreach ($collection as $recipient) {
+                    $recipient->setResult(true);
+                }
+
+                return $collection;
+            });
+        self::getContainer()->set('mautic.sms.transport_chain', $transport);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('error')
+            ->with('SMS broadcast execution failed.', [
+                'smsId'          => $smsId,
+                'exceptionClass' => \RuntimeException::class,
+            ]);
+        $smsModel = self::getContainer()->get(SmsModel::class);
+        ReflectionHelper::setValue($smsModel, 'transport', $transport);
+        $executioner = $this->createExecutioner($smsModel, $logger);
+
+        $result = $executioner->sendNextBatch($sms, 2, new ContactLimiter(2));
+
+        $this->assertSame(1, $result->getProcessedCount());
+        $this->assertSame(1, $result->getSubmittedCount());
+        $this->assertSame(1, $result->getExecutionFailureCount());
+        $this->assertSame(1, $result->getFailedCount());
+        $this->assertSame([], $result->getFailedContacts());
+        $this->assertSame(1, $result->getRemainingCount());
+
+        $firstStats = $smsModel->getStatRepository()->findBy(['lead' => $firstContactId]);
+        $this->assertCount(1, $firstStats);
+        $this->assertFalse($firstStats[0]->isFailed());
+        $this->assertSame($smsId, $firstStats[0]->getSms()->getId());
+        $this->assertSame([], $smsModel->getStatRepository()->findBy(['lead' => $secondContactId]));
+
+        $this->em->clear();
+        $sms           = $this->em->find(Sms::class, $smsId);
+        $translatedSms = $this->em->find(Sms::class, $translatedSmsId);
+        $this->assertInstanceOf(Sms::class, $sms);
+        $this->assertInstanceOf(Sms::class, $translatedSms);
+        $this->assertSame(1, $sms->getSentCount());
+        $this->assertSame(0, $translatedSms->getSentCount());
+
+        $pendingContacts = self::getContainer()->get(BroadcastQuery::class)
+            ->getPendingContacts($sms, new ContactLimiter(10));
+        $this->assertSame([$secondContactId], array_map(
+            static fn (array $contact): int => (int) $contact['id'],
+            $pendingContacts,
+        ));
     }
 
     public function testExecuteRetainsSentBatchOutcomeWhenRemainingCountFails(): void

--- a/app/bundles/SmsBundle/Tests/Broadcast/BroadcastExecutionerTest.php
+++ b/app/bundles/SmsBundle/Tests/Broadcast/BroadcastExecutionerTest.php
@@ -1,0 +1,404 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\SmsBundle\Tests\Broadcast;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Mautic\CampaignBundle\Executioner\ContactFinder\Limiter\ContactLimiter;
+use Mautic\ChannelBundle\Event\ChannelBroadcastEvent;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\CoreBundle\Test\ReflectionHelper;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadList;
+use Mautic\LeadBundle\Entity\LeadRepository;
+use Mautic\LeadBundle\Entity\ListLead;
+use Mautic\SmsBundle\Broadcast\BroadcastExecutioner;
+use Mautic\SmsBundle\Broadcast\BroadcastQuery;
+use Mautic\SmsBundle\Entity\Sms;
+use Mautic\SmsBundle\Entity\SmsRepository;
+use Mautic\SmsBundle\Model\SmsModel;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class BroadcastExecutionerTest extends MauticMysqlTestCase
+{
+    public function testLegacyServiceIdAliasesCanonicalExecutionerWithMauticLogger(): void
+    {
+        $canonicalExecutioner = self::getContainer()->get(BroadcastExecutioner::class);
+
+        $legacyExecutioner = self::getContainer()->get('mautic.sms.broadcast.executioner'); // @phpstan-ignore mautic.noContainerGet
+        $mauticLogger      = self::getContainer()->get('monolog.logger.mautic'); // @phpstan-ignore mautic.noContainerGet
+
+        $this->assertSame($canonicalExecutioner, $legacyExecutioner);
+        $this->assertSame(
+            $mauticLogger,
+            (new \ReflectionProperty(BroadcastExecutioner::class, 'logger'))->getValue($canonicalExecutioner),
+        );
+    }
+
+    public function testSendNextBatchUsesOneModelCallAndReturnsAuthoritativeCounts(): void
+    {
+        [$sms, $contacts, $segment] = $this->createBroadcast(3, 'single-batch');
+        $batches                    = [];
+        $loadedContacts             = [];
+        $executioner                = $this->createExecutioner(
+            $this->createSuccessfulSmsModel($batches, $loadedContacts),
+            $this->createStub(LoggerInterface::class),
+        );
+        $partition = new ContactLimiter(50);
+
+        $result = $executioner->sendNextBatch($sms, 2, $partition);
+
+        $expectedContactIds = [$contacts[0]->getId(), $contacts[1]->getId()];
+        $this->assertSame([
+            [
+                'contactIds' => $expectedContactIds,
+                'options'    => [
+                    'channel' => ['sms', $sms->getId()],
+                    'listId'  => [
+                        $contacts[0]->getId() => $segment->getId(),
+                        $contacts[1]->getId() => $segment->getId(),
+                    ],
+                ],
+            ],
+        ], $batches);
+        $this->assertSame(2, $result->getProcessedCount());
+        $this->assertSame(2, $result->getSubmittedCount());
+        $this->assertSame(0, $result->getScheduledCount());
+        $this->assertSame(0, $result->getFailedCount());
+        $this->assertSame(1, $result->getRemainingCount());
+        $this->assertSame($contacts[1]->getId() + 1, $partition->getMinContactId());
+
+        foreach ($loadedContacts as $loadedContact) {
+            $this->assertFalse($this->em->contains($loadedContact));
+        }
+    }
+
+    public function testExecuteClampsAContactLimitSmallerThanTheBatch(): void
+    {
+        [$sms, $contacts] = $this->createBroadcast(4, 'exact-limit');
+        $batches          = [];
+        $loadedContacts   = [];
+        $executioner      = $this->createExecutioner(
+            $this->createSuccessfulSmsModel($batches, $loadedContacts),
+            $this->createStub(LoggerInterface::class),
+        );
+        $event = new ChannelBroadcastEvent('sms', $sms->getId(), new BufferedOutput());
+        $event->setBatch(3);
+        $event->setLimit(2);
+
+        $executioner->execute($event);
+
+        $this->assertSame([[$contacts[0]->getId(), $contacts[1]->getId()]], array_column($batches, 'contactIds'));
+        $this->assertSame([
+            'success'                => 2,
+            'failed'                 => 0,
+            'failedRecipientsByList' => [],
+        ], array_values($event->getResults())[0]);
+    }
+
+    public function testExecuteAdvancesTheCursorAcrossBatchesAndPreservesThreadPartitions(): void
+    {
+        [$sms, $contacts] = $this->createBroadcast(6, 'cursor-and-partitions');
+        $batches          = [];
+        $loadedContacts   = [];
+        $executioner      = $this->createExecutioner(
+            $this->createSuccessfulSmsModel($batches, $loadedContacts),
+            $this->createStub(LoggerInterface::class),
+        );
+        $event = new ChannelBroadcastEvent('sms', $sms->getId(), new BufferedOutput());
+        $event->setBatch(2);
+        $event->setLimit(6);
+        $event->setThreadId(1);
+        $event->setMaxThreads(2);
+
+        $executioner->execute($event);
+
+        $processedIds = array_merge(...array_column($batches, 'contactIds'));
+        $expectedIds  = array_values(array_map(
+            static fn (Lead $contact): int => $contact->getId(),
+            array_filter($contacts, static fn (Lead $contact): bool => 0 === $contact->getId() % 2),
+        ));
+        $this->assertSame($expectedIds, $processedIds);
+        $this->assertSame($processedIds, array_values(array_unique($processedIds)));
+        $this->assertGreaterThan(1, count($batches));
+    }
+
+    public function testExecuteReportsOneSanitizedFailureAndKeepsPriorBatchCounts(): void
+    {
+        [$sms]    = $this->createBroadcast(2, 'safe-exception');
+        $call     = 0;
+        $smsModel = $this->createMock(SmsModel::class);
+        $smsModel->method('sendSms')
+            ->willReturnCallback(static function (Sms $sentSms, array $contactIds) use (&$call): array {
+                ++$call;
+                if (2 === $call) {
+                    throw new \RuntimeException('+41791234567 private message body');
+                }
+
+                return [
+                    $contactIds[0] => [
+                        'sent'   => true,
+                        'status' => 'mautic.sms.timeline.status.delivered',
+                    ],
+                ];
+            });
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('error')
+            ->with('SMS broadcast execution failed.', [
+                'smsId'          => $sms->getId(),
+                'exceptionClass' => \RuntimeException::class,
+            ]);
+        $executioner = $this->createExecutioner($smsModel, $logger);
+        $event       = new ChannelBroadcastEvent('sms', $sms->getId(), new BufferedOutput());
+        $event->setBatch(1);
+        $event->setLimit(2);
+
+        $executioner->execute($event);
+
+        $this->assertSame([
+            'success'                => 1,
+            'failed'                 => 1,
+            'failedRecipientsByList' => [],
+        ], array_values($event->getResults())[0]);
+    }
+
+    public function testExecuteRetainsSentBatchOutcomeWhenRemainingCountFails(): void
+    {
+        [$sms]         = $this->createBroadcast(2, 'post-send-failure');
+        $broadcastQuery = self::getContainer()->get(BroadcastQuery::class);
+        $failingEntityManager = $this->createStub(EntityManagerInterface::class);
+        $failingEntityManager->method('getConnection')
+            ->willThrowException(new \RuntimeException('+41791234567 private message body'));
+
+        $smsModel = $this->createMock(SmsModel::class);
+        $smsModel->expects($this->once())
+            ->method('sendSms')
+            ->willReturnCallback(function (Sms $sentSms, array $contactIds) use ($broadcastQuery, $failingEntityManager): array {
+                ReflectionHelper::setValue($broadcastQuery, 'entityManager', $failingEntityManager);
+
+                return [
+                    $contactIds[0] => [
+                        'sent'   => true,
+                        'status' => 'mautic.sms.timeline.status.delivered',
+                    ],
+                ];
+            });
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('error')
+            ->with('SMS broadcast execution failed.', [
+                'smsId'          => $sms->getId(),
+                'exceptionClass' => \RuntimeException::class,
+            ]);
+        $executioner = $this->createExecutioner($smsModel, $logger);
+        $event       = new ChannelBroadcastEvent('sms', $sms->getId(), new BufferedOutput());
+        $event->setBatch(1);
+        $event->setLimit(2);
+
+        try {
+            $executioner->execute($event);
+        } finally {
+            ReflectionHelper::setValue($broadcastQuery, 'entityManager', $this->em);
+        }
+
+        $this->assertSame([
+            'success'                => 1,
+            'failed'                 => 1,
+            'failedRecipientsByList' => [],
+        ], array_values($event->getResults())[0]);
+    }
+
+    public function testSendNextBatchRetainsOutcomeAndRemainingCountWhenDetachFails(): void
+    {
+        [$sms]   = $this->createBroadcast(2, 'post-send-detach-failure');
+        $call     = 0;
+        $smsModel = $this->createMock(SmsModel::class);
+        $smsModel->expects($this->once())
+            ->method('sendSms')
+            ->willReturnCallback(static function (Sms $sentSms, array $contactIds) use (&$call): array {
+                ++$call;
+
+                return [
+                    $contactIds[0] => [
+                        'sent'   => true,
+                        'status' => 'mautic.sms.timeline.status.delivered',
+                    ],
+                ];
+            });
+        $leadRepository = $this->createMock(LeadRepository::class);
+        $leadRepository->expects($this->once())
+            ->method('detachEntities')
+            ->willThrowException(new \RuntimeException('+41791234567 private message body'));
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('error')
+            ->with('SMS broadcast execution failed.', [
+                'smsId'          => $sms->getId(),
+                'exceptionClass' => \RuntimeException::class,
+            ]);
+        $executioner = $this->createExecutioner($smsModel, $logger, $leadRepository);
+        $result      = $executioner->sendNextBatch($sms, 1, new ContactLimiter(1));
+
+        $this->assertSame(1, $call);
+        $this->assertSame(1, $result->getProcessedCount());
+        $this->assertSame(1, $result->getSubmittedCount());
+        $this->assertSame(1, $result->getExecutionFailureCount());
+        $this->assertSame(1, $result->getFailedCount());
+        $this->assertSame(1, $result->getRemainingCount());
+    }
+
+    public function testDetachFailureDoesNotSuppressOrDoubleLogSendFailure(): void
+    {
+        [$sms]   = $this->createBroadcast(1, 'send-and-detach-failure');
+        $smsModel = $this->createMock(SmsModel::class);
+        $smsModel->expects($this->once())
+            ->method('sendSms')
+            ->willThrowException(new \DomainException('+41791111111 primary private message'));
+        $leadRepository = $this->createMock(LeadRepository::class);
+        $leadRepository->expects($this->once())
+            ->method('detachEntities')
+            ->willThrowException(new \RuntimeException('+41792222222 secondary private message'));
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('error')
+            ->with('SMS broadcast execution failed.', [
+                'smsId'          => $sms->getId(),
+                'exceptionClass' => \DomainException::class,
+            ]);
+        $executioner = $this->createExecutioner($smsModel, $logger, $leadRepository);
+        $event       = new ChannelBroadcastEvent('sms', $sms->getId(), new BufferedOutput());
+        $event->setBatch(1);
+        $event->setLimit(1);
+
+        $executioner->execute($event);
+
+        $this->assertSame([
+            'success'                => 0,
+            'failed'                 => 1,
+            'failedRecipientsByList' => [],
+        ], array_values($event->getResults())[0]);
+    }
+
+    public function testSendNextBatchRechecksTheSmsTypeAndPublication(): void
+    {
+        [$templateSms] = $this->createBroadcast(1, 'state-recheck-template');
+        $smsModel = $this->createMock(SmsModel::class);
+        $smsModel->expects($this->never())->method('sendSms');
+        $executioner = $this->createExecutioner($smsModel, $this->createStub(LoggerInterface::class));
+
+        $templateSms->setSmsType('template');
+        $this->em->persist($templateSms);
+        $this->em->flush();
+        $templateResult = $executioner->sendNextBatch($templateSms, 1);
+
+        [$unpublishedSms] = $this->createBroadcast(1, 'state-recheck-unpublished');
+        $unpublishedSms->setIsPublished(false);
+        $this->em->persist($unpublishedSms);
+        $this->em->flush();
+        $unpublishedResult = $executioner->sendNextBatch($unpublishedSms, 1);
+
+        $this->assertSame(0, $templateResult->getProcessedCount());
+        $this->assertSame(0, $unpublishedResult->getProcessedCount());
+    }
+
+    private function createExecutioner(
+        SmsModel $smsModel,
+        LoggerInterface $logger,
+        ?LeadRepository $leadRepository = null,
+    ): BroadcastExecutioner {
+        $leadRepository ??= $this->em->getRepository(Lead::class);
+        $smsRepository  = $this->em->getRepository(Sms::class);
+        $this->assertInstanceOf(LeadRepository::class, $leadRepository);
+        $this->assertInstanceOf(SmsRepository::class, $smsRepository);
+
+        $translator = $this->createStub(TranslatorInterface::class);
+        $translator->method('trans')->willReturn('SMS');
+
+        return new BroadcastExecutioner(
+            $smsModel,
+            self::getContainer()->get(BroadcastQuery::class),
+            $translator,
+            $leadRepository,
+            $smsRepository,
+            $this->em,
+            $logger,
+        );
+    }
+
+    /**
+     * @param array<int, array{contactIds: int[], options: array<string, mixed>}> $batches
+     * @param Lead[]                                                              $loadedContacts
+     */
+    private function createSuccessfulSmsModel(array &$batches, array &$loadedContacts): SmsModel
+    {
+        $smsModel = $this->createMock(SmsModel::class);
+        $smsModel->method('sendSms')
+            ->willReturnCallback(function (Sms $sms, array $contactIds, array $options, array &$contacts) use (&$batches, &$loadedContacts): array {
+                $batches[] = [
+                    'contactIds' => $contactIds,
+                    'options'    => $options,
+                ];
+                $results = [];
+
+                foreach ($contactIds as $contactId) {
+                    $contact = $this->em->find(Lead::class, $contactId);
+                    $this->assertInstanceOf(Lead::class, $contact);
+                    $contacts[$contactId] = $contact;
+                    $loadedContacts[]      = $contact;
+                    $results[$contactId]   = [
+                        'sent'   => true,
+                        'status' => 'mautic.sms.timeline.status.delivered',
+                    ];
+                }
+
+                return $results;
+            });
+
+        return $smsModel;
+    }
+
+    /**
+     * @return array{Sms, Lead[], LeadList}
+     */
+    private function createBroadcast(int $contactCount, string $alias): array
+    {
+        $segment = new LeadList();
+        $segment->setName($alias);
+        $segment->setPublicName($alias);
+        $segment->setAlias($alias);
+        $segment->setIsPublished(true);
+        $this->em->persist($segment);
+
+        $contacts = [];
+        for ($i = 0; $i < $contactCount; ++$i) {
+            $contact = new Lead();
+            $contact->setFirstname('Broadcast');
+            $contact->setLastname('Recipient '.$i);
+            $contact->setMobile('+41790000'.str_pad((string) $i, 3, '0', STR_PAD_LEFT));
+            $this->em->persist($contact);
+
+            $membership = new ListLead();
+            $membership->setLead($contact);
+            $membership->setList($segment);
+            $membership->setDateAdded(new \DateTime());
+            $this->em->persist($membership);
+            $contacts[] = $contact;
+        }
+
+        $sms = new Sms();
+        $sms->setName($alias);
+        $sms->setMessage('Broadcast message');
+        $sms->setSmsType('list');
+        $sms->setIsPublished(true);
+        $sms->setPublishUp(new \DateTime('-1 minute'));
+        $sms->addList($segment);
+        $this->em->persist($sms);
+        $this->em->flush();
+
+        return [$sms, $contacts, $segment];
+    }
+}

--- a/app/bundles/SmsBundle/Tests/Broadcast/BroadcastResultTest.php
+++ b/app/bundles/SmsBundle/Tests/Broadcast/BroadcastResultTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\SmsBundle\Tests\Broadcast;
+
+use Mautic\SmsBundle\Broadcast\BroadcastResult;
+use PHPUnit\Framework\TestCase;
+
+final class BroadcastResultTest extends TestCase
+{
+    public function testItSeparatesSubmittedScheduledAndFailedResults(): void
+    {
+        $result = new BroadcastResult();
+
+        $result->process([
+            10 => [
+                'sent'   => true,
+                'status' => 'mautic.sms.timeline.status.delivered',
+            ],
+            20 => [
+                'sent'   => false,
+                'status' => 'mautic.sms.timeline.status.scheduled',
+            ],
+            30 => [
+                'sent'   => false,
+                'status' => 'mautic.sms.campaign.failed.missing_number',
+            ],
+        ]);
+        $result->setRemainingCount(4);
+
+        $this->assertSame(3, $result->getProcessedCount());
+        $this->assertSame(1, $result->getSubmittedCount());
+        $this->assertSame(1, $result->getSentCount());
+        $this->assertSame(1, $result->getScheduledCount());
+        $this->assertSame(2, $result->getSuccessfulCount());
+        $this->assertSame(1, $result->getFailedCount());
+        $this->assertSame(4, $result->getRemainingCount());
+        $this->assertSame([30 => 'mautic.sms.campaign.failed.missing_number'], $result->getFailedContacts());
+    }
+
+    public function testItAccountsForMissingSendResultsAsFailures(): void
+    {
+        $result = new BroadcastResult();
+
+        $result->process([
+            10 => ['sent' => true],
+            20 => ['sent' => false],
+        ], 3);
+
+        $this->assertSame(3, $result->getProcessedCount());
+        $this->assertSame(1, $result->getSubmittedCount());
+        $this->assertSame(2, $result->getFailedCount());
+        $this->assertSame([20 => 'mautic.sms.timeline.event.failed'], $result->getFailedContacts());
+    }
+
+    public function testItAggregatesBatchAndExecutionResults(): void
+    {
+        $firstBatch = new BroadcastResult();
+        $firstBatch->process([
+            10 => ['sent' => true],
+            20 => [
+                'sent'   => false,
+                'status' => 'mautic.sms.timeline.status.scheduled',
+            ],
+        ]);
+        $firstBatch->setRemainingCount(2);
+
+        $secondBatch = new BroadcastResult();
+        $secondBatch->process([
+            30 => [
+                'sent'   => false,
+                'status' => 'failed',
+            ],
+        ]);
+        $secondBatch->executionFailed();
+        $secondBatch->setRemainingCount(1);
+
+        $result = new BroadcastResult();
+        $result->merge($firstBatch);
+        $result->merge($secondBatch);
+
+        $this->assertSame(3, $result->getProcessedCount());
+        $this->assertSame(1, $result->getSubmittedCount());
+        $this->assertSame(1, $result->getScheduledCount());
+        $this->assertSame(2, $result->getFailedCount());
+        $this->assertSame(1, $result->getExecutionFailureCount());
+        $this->assertSame(1, $result->getRemainingCount());
+        $this->assertSame([30 => 'failed'], $result->getFailedContacts());
+    }
+}

--- a/app/bundles/SmsBundle/Tests/Functional/BroadcastQueryFunctionalTest.php
+++ b/app/bundles/SmsBundle/Tests/Functional/BroadcastQueryFunctionalTest.php
@@ -286,6 +286,33 @@ final class BroadcastQueryFunctionalTest extends MauticMysqlTestCase
         $this->assertSame(0, $this->getBroadcastQuery()->getPendingCount($sms));
     }
 
+    public function testUnusableNumberFailureIsNotReselected(): void
+    {
+        $segment = $this->createSegment('sms-unusable-number');
+        $sms     = $this->createBroadcastSms([$segment]);
+        $contact = $this->createContact("\t", null);
+        $this->addContactToSegment($contact, $segment);
+        $this->em->flush();
+
+        $contactId = $contact->getId();
+        $this->assertSame([$contactId], $this->getIds($this->getBroadcastQuery()->getPendingContacts($sms, new ContactLimiter(100))));
+
+        $transport = $this->createMock(TransportChain::class);
+        $transport->expects($this->never())->method('sendBatchSms');
+        self::getContainer()->set('mautic.sms.transport_chain', $transport);
+
+        /** @var SmsModel $smsModel */
+        $smsModel = self::getContainer()->get(SmsModel::class);
+        $results  = $smsModel->sendSms($sms, $contact);
+
+        $this->assertSame('mautic.sms.campaign.failed.missing_number', $results[$contactId]['status']);
+        $stats = $smsModel->getStatRepository()->findBy(['sms' => $sms->getId(), 'lead' => $contactId]);
+        $this->assertCount(1, $stats);
+        $this->assertTrue($stats[0]->isFailed());
+        $this->assertSame([], $this->getBroadcastQuery()->getPendingContacts($sms, new ContactLimiter(100)));
+        $this->assertSame(0, $this->getBroadcastQuery()->getPendingCount($sms));
+    }
+
     private function getBroadcastQuery(): BroadcastQuery
     {
         return self::getContainer()->get(BroadcastQuery::class);

--- a/app/bundles/SmsBundle/Tests/Functional/BroadcastQueryFunctionalTest.php
+++ b/app/bundles/SmsBundle/Tests/Functional/BroadcastQueryFunctionalTest.php
@@ -1,0 +1,379 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\SmsBundle\Tests\Functional;
+
+use Mautic\CampaignBundle\Executioner\ContactFinder\Limiter\ContactLimiter;
+use Mautic\ChannelBundle\Entity\MessageQueue;
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\LeadBundle\Entity\DoNotContact;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadList;
+use Mautic\LeadBundle\Entity\ListLead;
+use Mautic\SmsBundle\Broadcast\BroadcastQuery;
+use Mautic\SmsBundle\Collection\RecipientCollection;
+use Mautic\SmsBundle\Entity\Sms;
+use Mautic\SmsBundle\Entity\Stat;
+use Mautic\SmsBundle\Model\SmsModel;
+use Mautic\SmsBundle\Sms\TransportChain;
+
+final class BroadcastQueryFunctionalTest extends MauticMysqlTestCase
+{
+    use CreateEntitiesTrait;
+
+    public function testPendingContactsAndCountUseTheSameEligibilityPolicy(): void
+    {
+        $firstSegment  = $this->createSegment('sms-broadcast-first');
+        $secondSegment = $this->createSegment('sms-broadcast-second');
+        $sms           = $this->createBroadcastSms([$firstSegment, $secondSegment]);
+
+        $mobileContact       = $this->createContact('+41790000001', null);
+        $phoneContact        = $this->createContact(null, '+41790000002');
+        $phoneFallback       = $this->createContact('', '+41790000003');
+        $multiSegmentContact = $this->createContact('+41790000004', null);
+        $sentQueueContact    = $this->createContact('+41790000005', null);
+        $emptyContact        = $this->createContact('', '');
+        $emptyMobileContact  = $this->createContact('', null);
+        $emptyPhoneContact   = $this->createContact(null, '');
+        $nullContact         = $this->createContact(null, null);
+        $dncContact          = $this->createContact('+41790000010', null);
+        $previouslySent      = $this->createContact('+41790000011', null);
+        $pendingQueueContact = $this->createContact('+41790000012', null);
+        $removedContact      = $this->createContact('+41790000013', null);
+
+        foreach ([
+            $mobileContact,
+            $phoneContact,
+            $phoneFallback,
+            $sentQueueContact,
+            $emptyContact,
+            $emptyMobileContact,
+            $emptyPhoneContact,
+            $nullContact,
+            $dncContact,
+            $previouslySent,
+            $pendingQueueContact,
+        ] as $contact) {
+            $this->addContactToSegment($contact, $firstSegment);
+        }
+        $this->addContactToSegment($multiSegmentContact, $firstSegment);
+        $this->addContactToSegment($multiSegmentContact, $secondSegment);
+        $this->addContactToSegment($removedContact, $firstSegment, true);
+
+        $this->em->flush();
+
+        $this->createDnc($dncContact);
+        $this->createStat($sms, $previouslySent);
+        $this->createQueueEntry($sms, $pendingQueueContact, MessageQueue::STATUS_PENDING);
+        $this->createQueueEntry($sms, $sentQueueContact, MessageQueue::STATUS_SENT);
+        $this->em->flush();
+
+        $pendingContacts = $this->getBroadcastQuery()->getPendingContacts($sms, new ContactLimiter(100));
+        $actualIds       = array_map(intval(...), array_column($pendingContacts, 'id'));
+        $expectedIds     = [
+            $mobileContact->getId(),
+            $phoneContact->getId(),
+            $phoneFallback->getId(),
+            $multiSegmentContact->getId(),
+            $sentQueueContact->getId(),
+        ];
+        sort($expectedIds);
+
+        $this->assertSame($expectedIds, $actualIds);
+        $this->assertSame($actualIds, array_values(array_unique($actualIds)));
+        $this->assertSame(count($expectedIds), $this->getBroadcastQuery()->getPendingCount($sms));
+
+        $multiSegmentRow = array_values(array_filter(
+            $pendingContacts,
+            fn (array $row): bool => $multiSegmentContact->getId() === (int) $row['id'],
+        ));
+        $this->assertCount(1, $multiSegmentRow);
+        $this->assertSame(
+            min($firstSegment->getId(), $secondSegment->getId()),
+            (int) $multiSegmentRow[0]['listId'],
+        );
+    }
+
+    public function testPendingContactsCanRecheckABoundedListOfIds(): void
+    {
+        $segment = $this->createSegment('sms-bounded-ids');
+        $sms     = $this->createBroadcastSms([$segment]);
+
+        $firstEligible  = $this->createContact('+41790000101', null);
+        $secondEligible = $this->createContact(null, '+41790000102');
+        $emptyContact   = $this->createContact('', '');
+        $dncContact     = $this->createContact('+41790000104', null);
+        $outsideSegment = $this->createContact('+41790000105', null);
+
+        foreach ([$firstEligible, $secondEligible, $emptyContact, $dncContact] as $contact) {
+            $this->addContactToSegment($contact, $segment);
+        }
+
+        $this->em->flush();
+        $this->createDnc($dncContact);
+        $this->em->flush();
+
+        $requestedIds = [
+            $outsideSegment->getId(),
+            $secondEligible->getId(),
+            $dncContact->getId(),
+            $firstEligible->getId(),
+            $emptyContact->getId(),
+            $secondEligible->getId(),
+        ];
+        $pendingContacts = $this->getBroadcastQuery()->getPendingContactsForContactIds($sms, $requestedIds);
+        $actualIds       = array_map(intval(...), array_column($pendingContacts, 'id'));
+        $expectedIds     = [$firstEligible->getId(), $secondEligible->getId()];
+        sort($expectedIds);
+
+        $this->assertSame($expectedIds, $actualIds);
+        $this->assertSame([], $this->getBroadcastQuery()->getPendingContactsForContactIds($sms, []));
+
+        $limiter = new ContactLimiter(100, contactIdList: $requestedIds);
+        $this->assertSame(count($pendingContacts), $this->getBroadcastQuery()->getPendingCount($sms, $limiter));
+    }
+
+    public function testPendingContactsAdvanceByContactIdAcrossBatches(): void
+    {
+        $firstSegment  = $this->createSegment('sms-cursor-first');
+        $secondSegment = $this->createSegment('sms-cursor-second');
+        $sms           = $this->createBroadcastSms([$firstSegment, $secondSegment]);
+        $contacts      = [];
+
+        for ($i = 0; $i < 5; ++$i) {
+            $contact   = $this->createContact(sprintf('+417900002%02d', $i), null);
+            $contacts[] = $contact;
+            $this->addContactToSegment($contact, $firstSegment);
+
+            if (0 === $i) {
+                $this->addContactToSegment($contact, $secondSegment);
+            }
+
+            // Leave gaps between eligible contact IDs to exercise ID-based rather than offset pagination.
+            $this->createContact(sprintf('+417900003%02d', $i), null);
+        }
+
+        $this->em->flush();
+
+        $limiter   = new ContactLimiter(2);
+        $actualIds = [];
+        $batchSizes = [];
+
+        while (true) {
+            $batch = $this->getBroadcastQuery()->getPendingContacts($sms, $limiter);
+            if ([] === $batch) {
+                break;
+            }
+
+            $batchSizes[] = count($batch);
+            foreach ($batch as $row) {
+                $actualIds[] = (int) $row['id'];
+            }
+
+            $lastRow = end($batch);
+            $limiter->setBatchMinContactId(((int) $lastRow['id']) + 1);
+        }
+
+        $expectedIds = array_map(static fn (Lead $contact): int => $contact->getId(), $contacts);
+        sort($expectedIds);
+
+        $this->assertSame([2, 2, 1], $batchSizes);
+        $this->assertSame($expectedIds, $actualIds);
+        $this->assertSame($actualIds, array_values(array_unique($actualIds)));
+        $this->assertSame([], $this->getBroadcastQuery()->getPendingContacts($sms, new ContactLimiter(100), 0));
+        $this->assertCount(1, $this->getBroadcastQuery()->getPendingContacts($sms, new ContactLimiter(100), 1));
+    }
+
+    public function testThreadPartitionsAreDisjointAndCoverAllPendingContacts(): void
+    {
+        $firstSegment  = $this->createSegment('sms-thread-first');
+        $secondSegment = $this->createSegment('sms-thread-second');
+        $sms           = $this->createBroadcastSms([$firstSegment, $secondSegment]);
+        $contacts      = [];
+
+        for ($i = 0; $i < 8; ++$i) {
+            $contact   = $this->createContact(sprintf('+417900004%02d', $i), null);
+            $contacts[] = $contact;
+            $this->addContactToSegment($contact, $firstSegment);
+
+            if (0 === $i % 3) {
+                $this->addContactToSegment($contact, $secondSegment);
+            }
+        }
+
+        $this->em->flush();
+
+        $firstThreadLimiter  = new ContactLimiter(100, threadId: 1, maxThreads: 2);
+        $secondThreadLimiter = new ContactLimiter(100, threadId: 2, maxThreads: 2);
+        $firstThreadIds      = $this->getIds($this->getBroadcastQuery()->getPendingContacts($sms, $firstThreadLimiter));
+        $secondThreadIds     = $this->getIds($this->getBroadcastQuery()->getPendingContacts($sms, $secondThreadLimiter));
+        $allIds              = array_map(static fn (Lead $contact): int => $contact->getId(), $contacts);
+        sort($allIds);
+
+        $this->assertSame([], array_values(array_intersect($firstThreadIds, $secondThreadIds)));
+
+        $partitionedIds = array_merge($firstThreadIds, $secondThreadIds);
+        sort($partitionedIds);
+        $this->assertSame($allIds, $partitionedIds);
+        $this->assertSame(count($firstThreadIds), $this->getBroadcastQuery()->getPendingCount($sms, $firstThreadLimiter));
+        $this->assertSame(count($secondThreadIds), $this->getBroadcastQuery()->getPendingCount($sms, $secondThreadLimiter));
+
+        foreach ($firstThreadIds as $contactId) {
+            $this->assertSame(0, $contactId % 2);
+        }
+        foreach ($secondThreadIds as $contactId) {
+            $this->assertSame(1, $contactId % 2);
+        }
+    }
+
+    public function testPendingQueryOrdersByTheSelectedContactId(): void
+    {
+        $sms = $this->createBroadcastSms([]);
+        $this->em->flush();
+
+        $sql = $this->getBroadcastQuery()->getBasicQuery($sms)->getSQL();
+
+        $this->assertStringEndsWith('ORDER BY l.id ASC', $sql);
+    }
+
+    public function testSuccessfulTranslatedSendIsNotReselectedForTheParentBroadcast(): void
+    {
+        $segment     = $this->createSegment('sms-translated-send');
+        $sms         = $this->createBroadcastSms([$segment]);
+        $translated  = $this->createAnSms('French broadcast SMS', 'Bonjour', true, 'fr_FR');
+        $contact     = $this->createContact('+41790000501', null);
+        $translated->setTranslationParent($sms);
+        $this->em->persist($translated);
+        $this->addContactToSegment($contact, $segment);
+        $this->em->flush();
+
+        $smsId        = $sms->getId();
+        $translatedId = $translated->getId();
+        $contactId    = $contact->getId();
+        $this->em->clear();
+
+        $sms     = $this->em->find(Sms::class, $smsId);
+        $contact = $this->em->find(Lead::class, $contactId);
+        $this->assertInstanceOf(Sms::class, $sms);
+        $this->assertInstanceOf(Lead::class, $contact);
+        $contact->addUpdatedField('preferred_locale', 'fr_FR');
+        $this->em->flush();
+        $this->assertSame([$contactId], $this->getIds($this->getBroadcastQuery()->getPendingContacts($sms, new ContactLimiter(100))));
+
+        $transport = $this->createMock(TransportChain::class);
+        $transport->expects($this->once())
+            ->method('sendBatchSms')
+            ->with($this->isInstanceOf(RecipientCollection::class), 'Bonjour')
+            ->willReturnCallback(static function (RecipientCollection $recipients): RecipientCollection {
+                foreach ($recipients as $recipient) {
+                    $recipient->setResult(true);
+                }
+
+                return $recipients;
+            });
+        self::getContainer()->set('mautic.sms.transport_chain', $transport);
+
+        /** @var SmsModel $smsModel */
+        $smsModel = self::getContainer()->get(SmsModel::class);
+        $results  = $smsModel->sendSms($sms, $contact);
+
+        $this->assertTrue($results[$contactId]['sent']);
+        $stats = $smsModel->getStatRepository()->findBy(['lead' => $contactId]);
+        $this->assertCount(1, $stats);
+        $this->assertSame($translatedId, $stats[0]->getSms()?->getId());
+        $this->assertSame([], $this->getBroadcastQuery()->getPendingContacts($sms, new ContactLimiter(100)));
+        $this->assertSame(0, $this->getBroadcastQuery()->getPendingCount($sms));
+    }
+
+    private function getBroadcastQuery(): BroadcastQuery
+    {
+        return self::getContainer()->get(BroadcastQuery::class);
+    }
+
+    /**
+     * @param LeadList[] $segments
+     */
+    private function createBroadcastSms(array $segments): Sms
+    {
+        $sms = $this->createAnSms('Broadcast SMS', 'Hello');
+        $sms->setSmsType('list');
+        foreach ($segments as $segment) {
+            $sms->addList($segment);
+        }
+        $this->em->persist($sms);
+
+        return $sms;
+    }
+
+    private function createSegment(string $alias): LeadList
+    {
+        $segment = new LeadList();
+        $segment->setName($alias);
+        $segment->setPublicName($alias);
+        $segment->setAlias($alias);
+        $segment->setIsPublished(true);
+        $this->em->persist($segment);
+
+        return $segment;
+    }
+
+    private function createContact(?string $mobile, ?string $phone): Lead
+    {
+        $contact = new Lead();
+        $contact->setMobile($mobile);
+        $contact->setPhone($phone);
+        $this->em->persist($contact);
+
+        return $contact;
+    }
+
+    private function addContactToSegment(Lead $contact, LeadList $segment, bool $manuallyRemoved = false): void
+    {
+        $listLead = new ListLead();
+        $listLead->setLead($contact);
+        $listLead->setList($segment);
+        $listLead->setDateAdded(new \DateTime());
+        $listLead->setManuallyRemoved($manuallyRemoved);
+        $this->em->persist($listLead);
+    }
+
+    private function createDnc(Lead $contact): void
+    {
+        $dnc = new DoNotContact();
+        $dnc->setLead($contact);
+        $dnc->setDateAdded(new \DateTime());
+        $dnc->setReason(DoNotContact::MANUAL);
+        $dnc->setChannel('sms');
+        $this->em->persist($dnc);
+    }
+
+    private function createStat(Sms $sms, Lead $contact): void
+    {
+        $stat = new Stat();
+        $stat->setSms($sms);
+        $stat->setLead($contact);
+        $stat->setDateSent(new \DateTime());
+        $this->em->persist($stat);
+    }
+
+    private function createQueueEntry(Sms $sms, Lead $contact, string $status): void
+    {
+        $queueEntry = new MessageQueue();
+        $queueEntry->setLead($contact);
+        $queueEntry->setChannel('sms');
+        $queueEntry->setChannelId($sms->getId());
+        $queueEntry->setStatus($status);
+        $this->em->persist($queueEntry);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $contacts
+     *
+     * @return int[]
+     */
+    private function getIds(array $contacts): array
+    {
+        return array_map(intval(...), array_column($contacts, 'id'));
+    }
+}

--- a/app/bundles/SmsBundle/Tests/Functional/SmsModelFunctionalTest.php
+++ b/app/bundles/SmsBundle/Tests/Functional/SmsModelFunctionalTest.php
@@ -188,6 +188,50 @@ final class SmsModelFunctionalTest extends MauticMysqlTestCase
         $this->assertSame(2, $smsFr->getSentCount(), 'Sent count for French translated SMS should be 2.');
     }
 
+    public function testWhitespaceOnlyNumberIsPersistedAsFailedWithoutIncreasingSentCount(): void
+    {
+        $sms = $this->createAnSms('Whitespace number SMS', 'Private message body');
+        $this->em->persist($sms);
+        $contact = $this->createLead('Whitespace', 'Number', '   ');
+
+        $smsId     = $sms->getId();
+        $contactId = $contact->getId();
+        $this->em->clear();
+
+        $sms     = $this->em->find(Sms::class, $smsId);
+        $contact = $this->em->find(Lead::class, $contactId);
+        $this->assertInstanceOf(Sms::class, $sms);
+        $this->assertInstanceOf(Lead::class, $contact);
+
+        $transportMock = $this->createMock(TransportChain::class);
+        $transportMock->expects($this->never())->method('sendBatchSms');
+        $this->getContainer()->set('mautic.sms.transport_chain', $transportMock);
+
+        /** @var SmsModel $smsModel */
+        $smsModel       = $this->getContainer()->get(SmsModel::class);
+        $loadedContacts = [];
+        $results        = $smsModel->sendSms($sms, $contact, [], $loadedContacts);
+
+        $this->assertSame([$contactId => $contact], $loadedContacts);
+        $this->assertSame(
+            [$contactId => ['sent' => false, 'status' => 'mautic.sms.campaign.failed.missing_number']],
+            $results,
+        );
+
+        $stats = $smsModel->getStatRepository()->findBy(['sms' => $smsId, 'lead' => $contactId]);
+        $this->assertCount(1, $stats);
+        $this->assertTrue($stats[0]->isFailed());
+        $this->assertSame(
+            ['failed' => ['Missing phone number for contact.']],
+            $stats[0]->getDetails(),
+        );
+
+        $this->em->clear();
+        $sms = $this->em->find(Sms::class, $smsId);
+        $this->assertInstanceOf(Sms::class, $sms);
+        $this->assertSame(0, $sms->getSentCount());
+    }
+
     private function createLead(string $firstname, string $lastname, string $mobile): Lead
     {
         $contact = new Lead();

--- a/app/bundles/SmsBundle/Tests/Helper/DTO/SmsRecipientDTOTest.php
+++ b/app/bundles/SmsBundle/Tests/Helper/DTO/SmsRecipientDTOTest.php
@@ -40,6 +40,12 @@ final class SmsRecipientDTOTest extends TestCase
         );
         $this->assertSame(['key' => 'value'], $this->dto2->getSubstitutionData());
 
+        $this->dto1->setResult('Provider rejected a private phone number');
+        $this->assertFalse($this->dto1->getResult());
+        $this->assertStringNotContainsString('Provider rejected', json_encode($this->dto1, JSON_THROW_ON_ERROR));
+        $this->dto1->setResult(true);
+        $this->assertTrue($this->dto1->getResult());
+
         $choices = $this->collection->toChoices();
         $this->assertSame(1, array_keys($choices)[0]);
         $recipient = $this->collection->getFieldByKey(2);

--- a/app/bundles/SmsBundle/Tests/Model/SmsModelTest.php
+++ b/app/bundles/SmsBundle/Tests/Model/SmsModelTest.php
@@ -12,16 +12,21 @@ use Mautic\CoreBundle\Security\Permissions\CorePermissions;
 use Mautic\CoreBundle\Test\ReflectionHelper;
 use Mautic\LeadBundle\Entity\DoNotContactRepository;
 use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadList;
+use Mautic\LeadBundle\Entity\LeadListRepository;
 use Mautic\LeadBundle\Model\LeadModel;
 use Mautic\PageBundle\Model\TrackableModel;
 use Mautic\SmsBundle\Collection\RecipientCollection;
 use Mautic\SmsBundle\Entity\Sms;
 use Mautic\SmsBundle\Entity\SmsRepository;
 use Mautic\SmsBundle\Entity\StatRepository;
+use Mautic\SmsBundle\Event\FilterEvent;
+use Mautic\SmsBundle\Exception\PrimaryTransportNotEnabledException;
 use Mautic\SmsBundle\Form\Type\SmsType;
 use Mautic\SmsBundle\Helper\DTO\SmsRecipientDTO;
 use Mautic\SmsBundle\Model\SmsModel;
 use Mautic\SmsBundle\Sms\TransportChain;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -30,64 +35,74 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class SmsModelTest extends \PHPUnit\Framework\TestCase
 {
-    private \PHPUnit\Framework\MockObject\Stub&EntityManagerInterface $entityManger;
-
     private \PHPUnit\Framework\MockObject\Stub&LeadModel $leadModel;
-
-    private \PHPUnit\Framework\MockObject\Stub&TrackableModel $pageTrackableModel;
 
     private MockObject&TransportChain $transport;
 
     private MockObject&CorePermissions $security;
 
-    private MockObject&EventDispatcherInterface $dispatcher;
-
-    private \PHPUnit\Framework\MockObject\Stub&UrlGeneratorInterface $urlGenerator;
-
     private MockObject&TranslatorInterface $translator;
 
-    private \PHPUnit\Framework\MockObject\Stub&UserHelper $userHelper;
-
-    private \PHPUnit\Framework\MockObject\Stub&LoggerInterface $logger;
-
-    private \PHPUnit\Framework\MockObject\Stub&CoreParametersHelper $coreParametersHelper;
+    private MockObject&LoggerInterface $logger;
 
     private MockObject&SmsRepository $smsRepository;
 
+    private MockObject&StatRepository $statRepository;
+
     private SmsModel $smsModel;
+
+    /**
+     * @var int[]
+     */
+    private array $thirdPartyFilteredContactIds = [];
 
     protected function setUp(): void
     {
-        $this->pageTrackableModel   = $this->createStub(TrackableModel::class);
+        $pageTrackableModel         = $this->createStub(TrackableModel::class);
         $this->leadModel            = $this->createStub(LeadModel::class);
         $this->transport            = $this->createMock(TransportChain::class);
-        $this->entityManger         = $this->createStub(EntityManagerInterface::class);
+        $entityManger               = $this->createStub(EntityManagerInterface::class);
         $this->security             = $this->createMock(CorePermissions::class);
-        $this->dispatcher           = $this->createMock(EventDispatcherInterface::class);
-        $this->urlGenerator         = $this->createStub(UrlGeneratorInterface::class);
+        $dispatcher                 = $this->createMock(EventDispatcherInterface::class);
+        $urlGenerator               = $this->createStub(UrlGeneratorInterface::class);
         $this->translator           = $this->createMock(TranslatorInterface::class);
-        $this->userHelper           = $this->createStub(UserHelper::class);
-        $this->logger               = $this->createStub(LoggerInterface::class);
-        $this->coreParametersHelper = $this->createStub(CoreParametersHelper::class);
+        $userHelper                 = $this->createStub(UserHelper::class);
+        $this->logger               = $this->createMock(LoggerInterface::class);
+        $coreParametersHelper       = $this->createStub(CoreParametersHelper::class);
         $this->smsRepository        = $this->createMock(SmsRepository::class);
-        $this->dispatcher->method('dispatch')
-            ->willReturnArgument(0);
+        $this->statRepository       = $this->createMock(StatRepository::class);
+        $dispatcher->method('dispatch')
+            ->willReturnCallback(function (object $event): object {
+                if ($event instanceof FilterEvent) {
+                    $contactsWithoutNumbers = array_filter(
+                        $event->getContacts(),
+                        static fn (Lead $contact): bool => '' === trim((string) $contact->getLeadPhoneNumber()),
+                    );
+                    $event->removeContacts(array_map(
+                        static fn (Lead $contact): int => $contact->getId(),
+                        $contactsWithoutNumbers,
+                    ), FilterEvent::REMOVAL_REASON_MISSING_NUMBER);
+                    $event->removeContacts($this->thirdPartyFilteredContactIds);
+                }
+
+                return $event;
+            });
         $this->smsModel             = new SmsModel(
-            $this->pageTrackableModel,
+            $pageTrackableModel,
             $this->leadModel,
             $this->transport,
             $this->createStub(CacheStorageHelper::class),
-            $this->entityManger,
+            $entityManger,
             $this->security,
-            $this->dispatcher,
-            $this->urlGenerator,
+            $dispatcher,
+            $urlGenerator,
             $this->translator,
-            $this->userHelper,
+            $userHelper,
             $this->logger,
-            $this->coreParametersHelper,
-            $this->smsRepository, // $smsRepository
-            $this->createStub(StatRepository::class), // $statRepository
-            $this->createStub(DoNotContactRepository::class), // $doNotContactRepository
+            $coreParametersHelper,
+            $this->smsRepository,
+            $this->statRepository,
+            $this->createStub(DoNotContactRepository::class),
         );
     }
 
@@ -137,6 +152,215 @@ final class SmsModelTest extends \PHPUnit\Framework\TestCase
         $this->sendMessage(true);
     }
 
+    public function testSendSmsPersistsAWhitespaceOnlyNumberAsAFailedStat(): void
+    {
+        $sms = new Sms();
+        ReflectionHelper::setValue($sms, 'id', 1);
+        $sms->setMessage('test');
+
+        $lead = new Lead();
+        $lead->setId(13);
+        $lead->setMobile('   ');
+
+        $this->translator->expects($this->once())
+            ->method('trans')
+            ->with('mautic.sms.campaign.failed.missing_number')
+            ->willReturn('Missing phone number for contact.');
+        $this->transport->expects($this->never())->method('sendBatchSms');
+        $this->smsRepository->expects($this->never())->method('upCount');
+        $this->statRepository->expects($this->once())
+            ->method('saveEntities')
+            ->willReturnCallback(function (array $stats) use ($lead, $sms): void {
+                $this->assertSame([13], array_keys($stats));
+                $this->assertSame($lead, $stats[13]->getLead());
+                $this->assertSame($sms, $stats[13]->getSms());
+                $this->assertTrue($stats[13]->isFailed());
+                $this->assertSame(['failed' => ['Missing phone number for contact.']], $stats[13]->getDetails());
+            });
+
+        $loadedContacts = [];
+        $results        = $this->smsModel->sendSms($sms, $lead, [], $loadedContacts);
+
+        $this->assertSame([13 => $lead], $loadedContacts);
+        $this->assertSame(
+            [13 => ['sent' => false, 'status' => 'mautic.sms.campaign.failed.missing_number']],
+            $results,
+        );
+    }
+
+    public function testSendSmsDoesNotPersistContactsRemovedByAThirdPartyFilter(): void
+    {
+        $sms = new Sms();
+        ReflectionHelper::setValue($sms, 'id', 1);
+        $sms->setMessage('test');
+
+        $lead = new Lead();
+        $lead->setId(13);
+        $lead->setMobile('+41790000000');
+        $this->thirdPartyFilteredContactIds = [13];
+
+        $this->translator->expects($this->never())->method('trans');
+        $this->transport->expects($this->never())->method('sendBatchSms');
+        $this->smsRepository->expects($this->never())->method('upCount');
+        $this->statRepository->expects($this->never())->method('saveEntities');
+
+        $loadedContacts = [];
+        $results        = $this->smsModel->sendSms($sms, $lead, [], $loadedContacts);
+
+        $this->assertSame([13 => $lead], $loadedContacts);
+        $this->assertSame(
+            [13 => ['sent' => false, 'status' => 'mautic.sms.campaign.failed.missing_number']],
+            $results,
+        );
+    }
+
+    /**
+     * @param int|array<int, int> $listIds
+     */
+    #[DataProvider('listIdProvider')]
+    public function testSendSmsSupportsListIdsAndPersistsImmediateRejections(int|array $listIds, int $expectedRejectedListId): void
+    {
+        $sms = new Sms();
+        ReflectionHelper::setValue($sms, 'id', 1);
+        $sms->setMessage('test');
+
+        $acceptedLead = new Lead();
+        $acceptedLead->setId(17);
+        $acceptedLead->setMobile('+1234567890');
+        $rejectedLead = new Lead();
+        $rejectedLead->setId(42);
+        $rejectedLead->setMobile('+1234567891');
+
+        $acceptedList = new LeadList();
+        $rejectedList = new LeadList();
+        $expectedRejectedList = 100 === $expectedRejectedListId ? $acceptedList : $rejectedList;
+        $listRepository = $this->createStub(LeadListRepository::class);
+        $listRepository->method('getEntity')
+            ->willReturnCallback(static fn (int $id): LeadList => match ($id) {
+                100 => $acceptedList,
+                200 => $rejectedList,
+                default => throw new \UnexpectedValueException("Unexpected list ID {$id}"),
+            });
+        $this->leadModel->method('getLeadListRepository')->willReturn($listRepository);
+
+        $this->translator->expects($this->once())
+            ->method('trans')
+            ->with('mautic.sms.timeline.status.failed')
+            ->willReturn('Text Message Failed');
+        $this->transport->expects($this->once())
+            ->method('sendBatchSms')
+            ->willReturnCallback(static function (RecipientCollection $recipients): RecipientCollection {
+                foreach ($recipients as $recipient) {
+                    $recipient->setResult(17 === $recipient->getKey());
+                }
+
+                return $recipients;
+            });
+        $this->smsRepository->expects($this->once())
+            ->method('upCount')
+            ->with(1, 'sent', 1);
+        $this->statRepository->expects($this->once())
+            ->method('saveEntities')
+            ->willReturnCallback(function (array $stats) use ($acceptedList, $expectedRejectedList): void {
+                $this->assertSame([17, 42], array_keys($stats));
+                $this->assertSame($acceptedList, $stats[17]->getList());
+                $this->assertFalse($stats[17]->isFailed());
+                $this->assertSame($expectedRejectedList, $stats[42]->getList());
+                $this->assertTrue($stats[42]->isFailed());
+                $this->assertSame(['failed' => ['Text Message Failed']], $stats[42]->getDetails());
+            });
+
+        $loadedContacts = [];
+        $results        = $this->smsModel->sendSms(
+            $sms,
+            [$acceptedLead, $rejectedLead],
+            ['listId' => $listIds],
+            $loadedContacts,
+        );
+
+        $this->assertSame([17 => $acceptedLead, 42 => $rejectedLead], $loadedContacts);
+        $this->assertTrue($results[17]['sent']);
+        $this->assertSame('mautic.sms.timeline.status.delivered', $results[17]['status']);
+        $this->assertFalse($results[42]['sent']);
+        $this->assertSame('mautic.sms.timeline.status.failed', $results[42]['status']);
+    }
+
+    /**
+     * @return iterable<string, array{int|array<int, int>, int}>
+     */
+    public static function listIdProvider(): iterable
+    {
+        yield 'legacy scalar list ID' => [100, 100];
+        yield 'per-contact list ID map' => [[17 => 100, 42 => 200], 200];
+    }
+
+    public function testPrimaryTransportFailureIsReportedWithoutLoggingExceptionDetails(): void
+    {
+        $sms = new Sms();
+        ReflectionHelper::setValue($sms, 'id', 1);
+        $sms->setMessage('private message body');
+
+        $lead = new Lead();
+        $lead->setId(13);
+        $lead->setMobile('+41790000000');
+
+        $this->transport->expects($this->once())
+            ->method('sendBatchSms')
+            ->willThrowException(new PrimaryTransportNotEnabledException('Failed for +41790000000: private message body'));
+        $this->logger->expects($this->once())
+            ->method('warning')
+            ->with('Primary SMS transport is not enabled.');
+        $this->smsRepository->expects($this->never())->method('upCount');
+        $this->statRepository->expects($this->never())->method('saveEntities');
+
+        $results = $this->smsModel->sendSms($sms, $lead);
+
+        $this->assertSame(
+            [13 => ['sent' => false, 'status' => 'mautic.sms.config.no_transport']],
+            $results,
+        );
+    }
+
+    public function testProviderErrorStringIsPersistedAndReportedAsABoundedFailure(): void
+    {
+        $sms = new Sms();
+        ReflectionHelper::setValue($sms, 'id', 1);
+        $sms->setMessage('private message body');
+
+        $lead = new Lead();
+        $lead->setId(13);
+        $lead->setMobile('+41790000000');
+
+        $providerError = 'Provider rejected +41790000000: private message body';
+        $this->transport->expects($this->once())
+            ->method('sendBatchSms')
+            ->willReturnCallback(static function (RecipientCollection $recipients) use ($providerError): RecipientCollection {
+                foreach ($recipients as $recipient) {
+                    $recipient->setResult($providerError);
+                }
+
+                return $recipients;
+            });
+        $this->translator->expects($this->once())
+            ->method('trans')
+            ->with('mautic.sms.timeline.status.failed')
+            ->willReturn('Text Message Failed');
+        $this->smsRepository->expects($this->never())->method('upCount');
+        $this->statRepository->expects($this->once())
+            ->method('saveEntities')
+            ->willReturnCallback(function (array $stats) use ($providerError): void {
+                $this->assertTrue($stats[13]->isFailed());
+                $this->assertSame(['failed' => ['Text Message Failed']], $stats[13]->getDetails());
+                $this->assertStringNotContainsString($providerError, json_encode($stats[13]->getDetails(), JSON_THROW_ON_ERROR));
+            });
+
+        $results = $this->smsModel->sendSms($sms, $lead);
+
+        $this->assertFalse($results[13]['sent']);
+        $this->assertSame('mautic.sms.timeline.status.failed', $results[13]['status']);
+        $this->assertStringNotContainsString($providerError, json_encode($results, JSON_THROW_ON_ERROR));
+    }
+
     private function sendMessage(bool $isMMS = false): void
     {
         $sms = new Sms();
@@ -154,42 +378,9 @@ final class SmsModelTest extends \PHPUnit\Framework\TestCase
         $lead2->setMobile('+123456790');
         $lead2->setId(2);
 
-        $smsRepo = $this->createMock(SmsRepository::class);
-
-        // Partial mock, mocks just getRepository
-        $smsModel = $this->getMockBuilder(SmsModel::class)
-            ->setConstructorArgs([
-                $this->pageTrackableModel,
-                $this->leadModel,
-                $this->transport,
-                $this->createStub(CacheStorageHelper::class),
-                $this->entityManger,
-                $this->security,
-                $this->dispatcher,
-                $this->urlGenerator,
-                $this->translator,
-                $this->userHelper,
-                $this->logger,
-                $this->coreParametersHelper,
-                $smsRepo,
-                $this->createStub(StatRepository::class),
-                $this->createStub(DoNotContactRepository::class),
-            ])
-            ->onlyMethods(['getRepository', 'getStatRepository'])
-            ->getMock();
-
-        $smsModel->method('getStatRepository')
-            ->willReturn($this->createStub(StatRepository::class));
-
-        $smsRepo->expects($this->once())
+        $this->smsRepository->expects($this->once())
             ->method('upCount')
             ->with($sms->getId(), 'sent', 2);
-
-        $smsModel->method('getRepository')
-            ->willReturn($this->createStub(SmsRepository::class));
-
-        $smsModel->method('getStatRepository')
-            ->willReturn($this->createStub(StatRepository::class));
 
         if ($isMMS) {
             $this->transport->expects($this->once())
@@ -201,7 +392,7 @@ final class SmsModelTest extends \PHPUnit\Framework\TestCase
                 ->willReturnCallback(fn (RecipientCollection $recipientCollection): RecipientCollection => $this->setRecipientResult($recipientCollection));
         }
 
-        $results = $smsModel->sendSms($sms, [$lead1, $lead2], ['channel' => ['campaign.event', 1]]);
+        $results = $this->smsModel->sendSms($sms, [$lead1, $lead2], ['channel' => ['campaign.event', 1]]);
         $this->assertCount(2, $results);
     }
 

--- a/app/bundles/SmsBundle/Tests/Sms/TransportChainTest.php
+++ b/app/bundles/SmsBundle/Tests/Sms/TransportChainTest.php
@@ -120,6 +120,42 @@ final class TransportChainTest extends MauticMysqlTestCase
         $this->createDataAndAssertSendMessage($mmsTransport);
     }
 
+    public function testProviderErrorStringIsNotCoercedToSuccessOrRetained(): void
+    {
+        $providerError = 'Provider rejected +41790000000: private message body';
+        $transport     = new class($providerError) implements TransportInterface {
+            public function __construct(private readonly string $providerError)
+            {
+            }
+
+            public function sendSms(Lead $lead, $content): string
+            {
+                return $this->providerError;
+            }
+        };
+        $transportChain = new class('test', self::getContainer()->get(IntegrationHelper::class)) extends TransportChain {
+            public function getEnabledTransports(): array
+            {
+                return array_map(
+                    static fn (array $transport): TransportInterface => $transport['service'],
+                    $this->getTransports(),
+                );
+            }
+        };
+        $transportChain->addTransport('test', $transport, 'test', 'test');
+
+        $lead = new Lead();
+        $lead->setId(1);
+        $lead->setMobile('+41790000000');
+        $recipients = new RecipientCollection(new Sms(), [new SmsRecipientDTO($lead, [], 'private message body')]);
+
+        $result = $transportChain->sendBatchSms($recipients, 'private message body');
+        $recipient = $result->getFieldByKey(1);
+
+        $this->assertFalse($recipient->getResult());
+        $this->assertStringNotContainsString($providerError, json_encode($recipient, JSON_THROW_ON_ERROR));
+    }
+
     private function createDataAndAssertSendMessage(TransportInterface $transport): void
     {
         $transportChain = new class('mautic.test.bulktwilio.mock', self::getContainer()->get(IntegrationHelper::class)) extends TransportChain {


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch) | ❌
| Deprecations?                          | ❌
| BC breaks?                             | ❌
| Automated tests included?              | ✔️
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | N/A — no issue filed; reproduction is described below

## Description

Segment SMS broadcasts had several inconsistencies between their pending count and the contacts actually processed:

- the phone-number predicate admitted empty values;
- contacts belonging to more than one selected segment could be returned more than once, while the count treated them as one contact;
- the batch cursor and CLI limit could disagree with the selected rows;
- frequency-scheduled contacts were reported as failures;
- executor exceptions were swallowed; and
- contacts with terminally unusable numbers could be selected again on every later run because no failed stat was persisted.

This PR gives SMS broadcasts one recipient policy and one bounded batch operation. It:

- deduplicates recipients and applies the same eligibility predicates to counts, CLI batches, and bounded contact-ID rechecks;
- exposes `BroadcastExecutioner::sendNextBatch()` and makes `--limit` an exact maximum while preserving contact-ID and thread partitions;
- reports processed, transport-submitted, frequency-scheduled, failed, and remaining counts;
- sends a selected batch through `SmsModel` in one call;
- persists terminal failed stats without counting them as sent;
- preserves completed outcomes when a translated batch fails partway through; and
- prevents provider error strings, phone numbers, or message content from leaking into batch results and executor logs.

The implementation remains entirely in `SmsBundle`. It adds no UI, schema change, or dependency, and does not modify the email broadcast path.

---
### 📋 Steps to test this PR:

1. Open this PR on GitHub Codespaces or pull it down for local testing.
2. Configure an SMS transport suitable for test messages.
3. Create two published segments and add the same contact, with a valid mobile number, to both segments. Add at least two other valid contacts to either segment.
4. Create and publish a segment SMS assigned to both segments.
5. Run `php bin/console mautic:broadcasts:send --channel=sms --id=<SMS_ID> --limit=1 --batch=50`.
6. Verify exactly one contact was submitted and exactly one SMS stat was created, despite the batch size being larger than the limit.
7. Run the command again with `--limit=100`. Verify each remaining contact is processed once and the contact shared by both segments has only one stat/submission.
8. Add a contact whose only SMS number contains whitespace (set the database value directly if the form normalizes it), then publish a fresh segment SMS for that contact.
9. Run the broadcast command and verify the contact receives one failed SMS stat with the missing-number status and the SMS sent count is not incremented.
10. Run the command again and verify that failed contact is not selected again.

