### PR TITLE
[phpstan] forbid readonly on Doctrine entity classes, check @api cannot be readonly to avoid false override

### DIFF
--- a/app/bundles/EmailBundle/Entity/EmailReply.php
+++ b/app/bundles/EmailBundle/Entity/EmailReply.php
@@ -9,11 +9,11 @@ use Mautic\ApiBundle\Serializer\Driver\ApiMetadataDriver;
 use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
 use Ramsey\Uuid\Uuid;
 
-readonly class EmailReply
+class EmailReply
 {
-    private string $id;
+    private readonly string $id;
 
-    private \DateTimeInterface $dateReplied;
+    private readonly \DateTimeInterface $dateReplied;
 
     public static function loadMetadata(ORM\ClassMetadata $metadata): void
     {
@@ -57,8 +57,8 @@ readonly class EmailReply
     }
 
     public function __construct(
-        private Stat $stat,
-        private ?string $messageId,
+        private readonly Stat $stat,
+        private readonly ?string $messageId,
         ?\DateTime $dateReplied = null,
     ) {
         $this->id          = Uuid::uuid4()->toString();

--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -236,7 +236,7 @@ class MailHelper
      * @param MailerInterface $mailer @api cannot be readonly as changed in tests via reflection
      */
     public function __construct(
-        private readonly MailerInterface $mailer,
+        private MailerInterface $mailer,
         private readonly FromEmailHelper $fromEmailHelper,
         private readonly CoreParametersHelper $coreParametersHelper,
         private readonly Mailbox $mailbox,

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -279,6 +279,7 @@ rules:
     - Utils\PHPStan\Rule\NoRedundantAutowiredServiceArgumentRule
     - Utils\PHPStan\Rule\NoServiceSetterCallRule
     - Utils\PHPStan\Rule\NoServiceGetterRule
+    - Utils\PHPStan\Rule\NoReadonlyEntityClassRule
 
 services:
     - Utils\PHPStan\ServiceNameUsageResolver

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -280,6 +280,7 @@ rules:
     - Utils\PHPStan\Rule\NoServiceSetterCallRule
     - Utils\PHPStan\Rule\NoServiceGetterRule
     - Utils\PHPStan\Rule\NoReadonlyEntityClassRule
+    - Utils\PHPStan\Rule\NoReadonlyApiParamRule
 
 services:
     - Utils\PHPStan\ServiceNameUsageResolver

--- a/utils/phpstan/src/Rule/NoReadonlyApiParamRule.php
+++ b/utils/phpstan/src/Rule/NoReadonlyApiParamRule.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Rule;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * A promoted constructor property marked "@api" in its @param docblock is part of the public API and
+ * may be swapped in tests via reflection, so it must not be readonly.
+ *
+ * @implements Rule<ClassMethod>
+ */
+final readonly class NoReadonlyApiParamRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return ClassMethod::class;
+    }
+
+    /**
+     * @param ClassMethod $node
+     *
+     * @return list<\PHPStan\Rules\IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $docComment = $node->getDocComment();
+        if (!$docComment instanceof \PhpParser\Comment\Doc) {
+            return [];
+        }
+
+        $docText = $docComment->getText();
+
+        $ruleErrors = [];
+        foreach ($node->params as $param) {
+            if (!$param->isReadonly()) {
+                continue;
+            }
+
+            if (!$param->var instanceof Node\Expr\Variable || !is_string($param->var->name)) {
+                continue;
+            }
+
+            $paramName = $param->var->name;
+            if (!$this->hasApiParamAnnotation($docText, $paramName)) {
+                continue;
+            }
+
+            $ruleErrors[] = RuleErrorBuilder::message(sprintf(
+                'Parameter "$%s" is marked "@api" and may be swapped via reflection in tests, so it must not be readonly. Remove the readonly modifier.',
+                $paramName
+            ))
+                ->identifier('mautic.noReadonlyApiParam')
+                ->line($param->getStartLine())
+                ->build();
+        }
+
+        return $ruleErrors;
+    }
+
+    private function hasApiParamAnnotation(string $docText, string $paramName): bool
+    {
+        foreach (explode("\n", $docText) as $line) {
+            if (!str_contains($line, '@param')) {
+                continue;
+            }
+
+            if (!str_contains($line, '$'.$paramName)) {
+                continue;
+            }
+
+            if (str_contains($line, '@api')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/utils/phpstan/src/Rule/NoReadonlyEntityClassRule.php
+++ b/utils/phpstan/src/Rule/NoReadonlyEntityClassRule.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Rule;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * A Doctrine entity is hydrated via reflection without the constructor, so a readonly class breaks
+ * loading and proxying. An entity is recognized by a public static loadMetadata() method.
+ *
+ * @implements Rule<Class_>
+ */
+final readonly class NoReadonlyEntityClassRule implements Rule
+{
+    public function getNodeType(): string
+    {
+        return Class_::class;
+    }
+
+    /**
+     * @param Class_ $node
+     *
+     * @return list<\PHPStan\Rules\IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node->isReadonly()) {
+            return [];
+        }
+
+        if (!$node->name instanceof Node\Identifier) {
+            return [];
+        }
+
+        $loadMetadataMethod = $node->getMethod('loadMetadata');
+        if (!$loadMetadataMethod instanceof Node\Stmt\ClassMethod) {
+            return [];
+        }
+
+        if (!$loadMetadataMethod->isPublic()) {
+            return [];
+        }
+
+        $ruleError = RuleErrorBuilder::message(sprintf(
+            'Entity class "%s" must not be readonly. Doctrine hydrates entities via reflection without the constructor, which a readonly class forbids. Remove the readonly modifier from the class.',
+            (string) $node->namespacedName
+        ))
+            ->identifier('mautic.noReadonlyEntity')
+            ->build();
+
+        return [$ruleError];
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/NonReadonlyApiParam.php
+++ b/utils/phpstan/tests/Rule/Fixture/NonReadonlyApiParam.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+final class NonReadonlyApiParam
+{
+    /**
+     * @param \stdClass $service @api cannot be readonly as changed in tests via reflection
+     */
+    public function __construct(
+        private \stdClass $service,
+        private readonly int $count,
+    ) {
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/NonReadonlyEntity.php
+++ b/utils/phpstan/tests/Rule/Fixture/NonReadonlyEntity.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+use Doctrine\ORM\Mapping\ClassMetadata;
+
+class NonReadonlyEntity
+{
+    public static function loadMetadata(ClassMetadata $metadata): void
+    {
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/ReadonlyApiParam.php
+++ b/utils/phpstan/tests/Rule/Fixture/ReadonlyApiParam.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+final class ReadonlyApiParam
+{
+    /**
+     * @param \stdClass $service @api cannot be readonly as changed in tests via reflection
+     */
+    public function __construct(
+        private readonly \stdClass $service,
+        private readonly int $count,
+    ) {
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/ReadonlyEntity.php
+++ b/utils/phpstan/tests/Rule/Fixture/ReadonlyEntity.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+use Doctrine\ORM\Mapping\ClassMetadata;
+
+readonly class ReadonlyEntity
+{
+    public static function loadMetadata(ClassMetadata $metadata): void
+    {
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/ReadonlyValueObject.php
+++ b/utils/phpstan/tests/Rule/Fixture/ReadonlyValueObject.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+final readonly class ReadonlyValueObject
+{
+    public function __construct(
+        private int $count,
+    ) {
+    }
+
+    public function getCount(): int
+    {
+        return $this->count;
+    }
+}

--- a/utils/phpstan/tests/Rule/NoReadonlyApiParamRuleTest.php
+++ b/utils/phpstan/tests/Rule/NoReadonlyApiParamRuleTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use Utils\PHPStan\Rule\NoReadonlyApiParamRule;
+
+/**
+ * @extends RuleTestCase<NoReadonlyApiParamRule>
+ */
+final class NoReadonlyApiParamRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new NoReadonlyApiParamRule();
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/ReadonlyApiParam.php'], [
+            [
+                'Parameter "$service" is marked "@api" and may be swapped via reflection in tests, so it must not be readonly. Remove the readonly modifier.',
+                13,
+            ],
+        ]);
+    }
+
+    public function testSkipNonReadonlyApiParam(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/NonReadonlyApiParam.php'], []);
+    }
+}

--- a/utils/phpstan/tests/Rule/NoReadonlyEntityClassRuleTest.php
+++ b/utils/phpstan/tests/Rule/NoReadonlyEntityClassRuleTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use Utils\PHPStan\Rule\NoReadonlyEntityClassRule;
+
+/**
+ * @extends RuleTestCase<NoReadonlyEntityClassRule>
+ */
+final class NoReadonlyEntityClassRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new NoReadonlyEntityClassRule();
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/ReadonlyEntity.php'], [
+            [
+                'Entity class "Utils\PHPStan\Tests\Rule\Fixture\ReadonlyEntity" must not be readonly. Doctrine hydrates entities via reflection without the constructor, which a readonly class forbids. Remove the readonly modifier from the class.',
+                9,
+            ],
+        ]);
+    }
+
+    public function testSkipNonReadonlyEntity(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/NonReadonlyEntity.php'], []);
+    }
+
+    public function testSkipReadonlyValueObjectWithoutMetadata(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/ReadonlyValueObject.php'], []);
+    }
+}


### PR DESCRIPTION
## Description

PR #17298 wrongly marked the `EmailReply` Doctrine entity as `readonly`. Doctrine hydrates entities via reflection without the constructor, so a readonly class breaks loading and proxying.

This PR:
- reverts the readonly change on `EmailReply`
- adds a PHPStan rule `NoReadonlyEntityClassRule` that forbids readonly on entity classes, detected by a public `loadMetadata()` method

## Type of change
- Bug fix
- Static analysis rule