### PR TITLE
Fix AssetMapper webroots and ship generated update assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,8 @@ jobs:
     - name: Build release files
       run: |
         php build/package_release.php -b=${{ steps.get-mautic-version.outputs.version }}
+        unzip -Z1 build/packages/${{ steps.get-mautic-version.outputs.version }}-update.zip | grep -Fxq 'assets/build/manifest.json'
+        unzip -Z1 build/packages/${{ steps.get-mautic-version.outputs.version }}-update.zip | grep -Fxq 'var/sass/app.output.css'
         echo 'MAUTIC_SHA1_CONTENTS<<EOF' >> $GITHUB_ENV
         cat build/packages/build-sha1-all >> $GITHUB_ENV
         echo 'EOF' >> $GITHUB_ENV
@@ -237,6 +239,8 @@ jobs:
       run: |
         php bin/console mautic:update:apply --force --update-package=${{ needs.release.outputs.mautic-version }}-update.zip
         php bin/console mautic:update:apply --finish
+        test -s assets/build/manifest.json
+        test -s var/sass/app.output.css
 
     - name: Store log artifacts
       if: ${{ always() }}

--- a/app/bundles/CoreBundle/DependencyInjection/Compiler/AssetMapperWebRootPass.php
+++ b/app/bundles/CoreBundle/DependencyInjection/Compiler/AssetMapperWebRootPass.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CoreBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class AssetMapperWebRootPass implements CompilerPassInterface
+{
+    private const PUBLIC_ASSETS_PATH_RESOLVER_ID         = 'asset_mapper.public_assets_path_resolver';
+    private const LOCAL_PUBLIC_ASSETS_FILESYSTEM_ID      = 'asset_mapper.local_public_assets_filesystem';
+    private const COMPILED_ASSET_MAPPER_CONFIG_READER_ID = 'asset_mapper.compiled_asset_mapper_config_reader';
+    private const DEFAULT_PUBLIC_PREFIX                  = '/assets/build/';
+
+    public function process(ContainerBuilder $container): void
+    {
+        $webRoot = $this->resolveWebRoot($container);
+        if (!$webRoot) {
+            return;
+        }
+
+        if ($container->hasDefinition(self::LOCAL_PUBLIC_ASSETS_FILESYSTEM_ID)) {
+            $container
+                ->findDefinition(self::LOCAL_PUBLIC_ASSETS_FILESYSTEM_ID)
+                ->replaceArgument(0, $webRoot);
+        }
+
+        if (!$container->hasDefinition(self::COMPILED_ASSET_MAPPER_CONFIG_READER_ID)) {
+            return;
+        }
+
+        $publicPrefix = $this->resolvePublicPrefix($container);
+
+        $container
+            ->findDefinition(self::COMPILED_ASSET_MAPPER_CONFIG_READER_ID)
+            ->replaceArgument(0, $webRoot.'/'.ltrim($publicPrefix, '/'));
+    }
+
+    private function resolveWebRoot(ContainerBuilder $container): ?string
+    {
+        if ($container->hasParameter('mautic.local_root')) {
+            $localRoot = $container->getParameter('mautic.local_root');
+            if (is_string($localRoot) && '' !== trim($localRoot) && !str_contains($localRoot, '%env(')) {
+                return rtrim($localRoot, '/');
+            }
+        }
+
+        if (!$container->hasParameter('kernel.project_dir')) {
+            return null;
+        }
+
+        $projectDir = $container->getParameter('kernel.project_dir');
+        if (!is_string($projectDir) || '' === trim($projectDir)) {
+            return null;
+        }
+
+        $projectDir    = rtrim($projectDir, '/');
+        $composerFile  = $projectDir.'/composer.json';
+        $configuredDir = $this->resolveConfiguredPublicDir($composerFile, $container);
+
+        if (null === $configuredDir || '' === $configuredDir || '.' === $configuredDir) {
+            return $projectDir;
+        }
+
+        return $projectDir.'/'.trim($configuredDir, '/');
+    }
+
+    private function resolveConfiguredPublicDir(string $composerFile, ContainerBuilder $container): ?string
+    {
+        if (!is_file($composerFile)) {
+            return null;
+        }
+
+        $container->addResource(new FileResource($composerFile));
+
+        $contents = file_get_contents($composerFile);
+        if (false === $contents) {
+            return null;
+        }
+
+        $composerConfig = json_decode($contents, true);
+        if (!is_array($composerConfig)) {
+            return null;
+        }
+
+        $webRoot = $composerConfig['extra']['mautic-scaffold']['locations']['web-root'] ?? null;
+        if (is_string($webRoot) && '' !== trim($webRoot)) {
+            return $webRoot;
+        }
+
+        $publicDir = $composerConfig['extra']['public-dir'] ?? null;
+        if (is_string($publicDir) && '' !== trim($publicDir)) {
+            return $publicDir;
+        }
+
+        return null;
+    }
+
+    private function resolvePublicPrefix(ContainerBuilder $container): string
+    {
+        if (!$container->hasDefinition(self::PUBLIC_ASSETS_PATH_RESOLVER_ID)) {
+            return self::DEFAULT_PUBLIC_PREFIX;
+        }
+
+        $publicPrefix = $container
+            ->findDefinition(self::PUBLIC_ASSETS_PATH_RESOLVER_ID)
+            ->getArgument(0);
+
+        if (!is_string($publicPrefix) || '' === trim($publicPrefix)) {
+            return self::DEFAULT_PUBLIC_PREFIX;
+        }
+
+        return $publicPrefix;
+    }
+}

--- a/app/bundles/CoreBundle/DependencyInjection/Compiler/AssetMapperWebRootPass.php
+++ b/app/bundles/CoreBundle/DependencyInjection/Compiler/AssetMapperWebRootPass.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\DependencyInjection\Compiler;
 
-use Mautic\CoreBundle\Loader\ParameterLoader;
-use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -14,73 +12,33 @@ final class AssetMapperWebRootPass implements CompilerPassInterface
     private const PUBLIC_ASSETS_PATH_RESOLVER_ID         = 'asset_mapper.public_assets_path_resolver';
     private const LOCAL_PUBLIC_ASSETS_FILESYSTEM_ID      = 'asset_mapper.local_public_assets_filesystem';
     private const COMPILED_ASSET_MAPPER_CONFIG_READER_ID = 'asset_mapper.compiled_asset_mapper_config_reader';
-    private const DEFAULT_PUBLIC_PREFIX                  = '/assets/build/';
+    private const MAUTIC_LOCAL_ROOT                       = '%env(default:kernel.project_dir:resolve:MAUTIC_LOCAL_ROOT)%';
 
     public function process(ContainerBuilder $container): void
     {
-        $webRoot = $this->resolveWebRoot($container);
-        if (!$webRoot) {
+        if (!$container->hasDefinition(self::LOCAL_PUBLIC_ASSETS_FILESYSTEM_ID)
+            || !$container->hasDefinition(self::COMPILED_ASSET_MAPPER_CONFIG_READER_ID)
+            || !$container->hasDefinition(self::PUBLIC_ASSETS_PATH_RESOLVER_ID)) {
             return;
         }
 
-        if ($container->hasDefinition(self::LOCAL_PUBLIC_ASSETS_FILESYSTEM_ID)) {
-            $container
-                ->findDefinition(self::LOCAL_PUBLIC_ASSETS_FILESYSTEM_ID)
-                ->replaceArgument(0, $webRoot);
-        }
-
-        if (!$container->hasDefinition(self::COMPILED_ASSET_MAPPER_CONFIG_READER_ID)) {
-            return;
-        }
-
-        $publicPrefix = $this->resolvePublicPrefix($container);
-
-        $container
-            ->findDefinition(self::COMPILED_ASSET_MAPPER_CONFIG_READER_ID)
-            ->replaceArgument(0, $webRoot.'/'.ltrim($publicPrefix, '/'));
-    }
-
-    private function resolveWebRoot(ContainerBuilder $container): ?string
-    {
-        if ($container->hasParameter('mautic.local_root')) {
-            $localRoot = $container->getParameter('mautic.local_root');
-            if (is_string($localRoot) && '' !== trim($localRoot) && !str_contains($localRoot, '%env(')) {
-                return rtrim($localRoot, '/');
-            }
-        }
-
-        if (!$container->hasParameter('kernel.project_dir')) {
-            return null;
-        }
-
-        $projectDir = $container->getParameter('kernel.project_dir');
-        if (!is_string($projectDir) || '' === trim($projectDir)) {
-            return null;
-        }
-
-        $projectDir   = rtrim($projectDir, '/');
-        $composerFile = $projectDir.'/composer.json';
-        if (is_file($composerFile)) {
-            $container->addResource(new FileResource($composerFile));
-        }
-
-        return rtrim(ParameterLoader::getWebrootDir($projectDir), '/');
-    }
-
-    private function resolvePublicPrefix(ContainerBuilder $container): string
-    {
-        if (!$container->hasDefinition(self::PUBLIC_ASSETS_PATH_RESOLVER_ID)) {
-            return self::DEFAULT_PUBLIC_PREFIX;
-        }
-
+        $webRoot = $container->resolveEnvPlaceholders(self::MAUTIC_LOCAL_ROOT, true);
         $publicPrefix = $container
-            ->findDefinition(self::PUBLIC_ASSETS_PATH_RESOLVER_ID)
+            ->getDefinition(self::PUBLIC_ASSETS_PATH_RESOLVER_ID)
             ->getArgument(0);
 
-        if (!is_string($publicPrefix) || '' === trim($publicPrefix)) {
-            return self::DEFAULT_PUBLIC_PREFIX;
+        if (!is_string($webRoot) || !is_string($publicPrefix)) {
+            return;
         }
 
-        return $publicPrefix;
+        $webRoot = rtrim($webRoot, '/');
+
+        $container
+            ->getDefinition(self::LOCAL_PUBLIC_ASSETS_FILESYSTEM_ID)
+            ->replaceArgument(0, $webRoot);
+
+        $container
+            ->getDefinition(self::COMPILED_ASSET_MAPPER_CONFIG_READER_ID)
+            ->replaceArgument(0, $webRoot.'/'.trim($publicPrefix, '/'));
     }
 }

--- a/app/bundles/CoreBundle/DependencyInjection/Compiler/AssetMapperWebRootPass.php
+++ b/app/bundles/CoreBundle/DependencyInjection/Compiler/AssetMapperWebRootPass.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Mautic\CoreBundle\DependencyInjection\Compiler;
 
+use Mautic\CoreBundle\Loader\ParameterLoader;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -57,46 +58,13 @@ final class AssetMapperWebRootPass implements CompilerPassInterface
             return null;
         }
 
-        $projectDir    = rtrim($projectDir, '/');
-        $composerFile  = $projectDir.'/composer.json';
-        $configuredDir = $this->resolveConfiguredPublicDir($composerFile, $container);
-
-        if (null === $configuredDir || '' === $configuredDir || '.' === $configuredDir) {
-            return $projectDir;
+        $projectDir   = rtrim($projectDir, '/');
+        $composerFile = $projectDir.'/composer.json';
+        if (is_file($composerFile)) {
+            $container->addResource(new FileResource($composerFile));
         }
 
-        return $projectDir.'/'.trim($configuredDir, '/');
-    }
-
-    private function resolveConfiguredPublicDir(string $composerFile, ContainerBuilder $container): ?string
-    {
-        if (!is_file($composerFile)) {
-            return null;
-        }
-
-        $container->addResource(new FileResource($composerFile));
-
-        $contents = file_get_contents($composerFile);
-        if (false === $contents) {
-            return null;
-        }
-
-        $composerConfig = json_decode($contents, true);
-        if (!is_array($composerConfig)) {
-            return null;
-        }
-
-        $webRoot = $composerConfig['extra']['mautic-scaffold']['locations']['web-root'] ?? null;
-        if (is_string($webRoot) && '' !== trim($webRoot)) {
-            return $webRoot;
-        }
-
-        $publicDir = $composerConfig['extra']['public-dir'] ?? null;
-        if (is_string($publicDir) && '' !== trim($publicDir)) {
-            return $publicDir;
-        }
-
-        return null;
+        return rtrim(ParameterLoader::getWebrootDir($projectDir), '/');
     }
 
     private function resolvePublicPrefix(ContainerBuilder $container): string

--- a/app/bundles/CoreBundle/MauticCoreBundle.php
+++ b/app/bundles/CoreBundle/MauticCoreBundle.php
@@ -22,7 +22,7 @@ final class MauticCoreBundle extends Bundle
         $container->addCompilerPass(new Compiler\ServicePass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1000);
         $container->addCompilerPass(new Compiler\ORMPurgerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -10);
         $container->addCompilerPass(new Compiler\SystemThemeTemplatePathPass(), PassConfig::TYPE_BEFORE_REMOVING, 0);
-        $container->addCompilerPass(new Compiler\AssetMapperWebRootPass(), PassConfig::TYPE_BEFORE_REMOVING, 0);
+        $container->addCompilerPass(new Compiler\AssetMapperWebRootPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 0);
 
         if ('test' === $container->getParameter('kernel.environment')) {
             $container->addCompilerPass(new Compiler\TestPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 0);

--- a/app/bundles/CoreBundle/MauticCoreBundle.php
+++ b/app/bundles/CoreBundle/MauticCoreBundle.php
@@ -22,6 +22,7 @@ final class MauticCoreBundle extends Bundle
         $container->addCompilerPass(new Compiler\ServicePass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1000);
         $container->addCompilerPass(new Compiler\ORMPurgerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -10);
         $container->addCompilerPass(new Compiler\SystemThemeTemplatePathPass(), PassConfig::TYPE_BEFORE_REMOVING, 0);
+        $container->addCompilerPass(new Compiler\AssetMapperWebRootPass(), PassConfig::TYPE_BEFORE_REMOVING, 0);
 
         if ('test' === $container->getParameter('kernel.environment')) {
             $container->addCompilerPass(new Compiler\TestPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 0);

--- a/app/bundles/CoreBundle/Tests/Unit/DependencyInjection/Compiler/AssetMapperWebRootPassTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/DependencyInjection/Compiler/AssetMapperWebRootPassTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CoreBundle\Tests\Unit\DependencyInjection\Compiler;
+
+use Mautic\CoreBundle\DependencyInjection\Compiler\AssetMapperWebRootPass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class AssetMapperWebRootPassTest extends TestCase
+{
+    private string $projectDir;
+
+    protected function setUp(): void
+    {
+        $this->projectDir = sys_get_temp_dir().'/mautic_asset_mapper_webroot_'.uniqid();
+        mkdir($this->projectDir);
+    }
+
+    protected function tearDown(): void
+    {
+        if (!is_dir($this->projectDir)) {
+            return;
+        }
+
+        $files = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($this->projectDir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($files as $file) {
+            $file->isDir() ? rmdir($file->getPathname()) : unlink($file->getPathname());
+        }
+
+        rmdir($this->projectDir);
+    }
+
+    public function testAssetMapperArgumentsAreRebasedToConfiguredLocalRoot(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.project_dir', $this->projectDir);
+        $container->setParameter('mautic.local_root', $this->projectDir.'/docroot');
+
+        $container
+            ->register('asset_mapper.public_assets_path_resolver')
+            ->setArguments(['/assets/build/']);
+
+        $container
+            ->register('asset_mapper.local_public_assets_filesystem')
+            ->setArguments([$this->projectDir.'/public']);
+
+        $container
+            ->register('asset_mapper.compiled_asset_mapper_config_reader')
+            ->setArguments([$this->projectDir.'/public/assets/build']);
+
+        $pass = new AssetMapperWebRootPass();
+        $pass->process($container);
+
+        $this->assertSame(
+            $this->projectDir.'/docroot',
+            $container->findDefinition('asset_mapper.local_public_assets_filesystem')->getArgument(0)
+        );
+        $this->assertSame(
+            $this->projectDir.'/docroot/assets/build/',
+            $container->findDefinition('asset_mapper.compiled_asset_mapper_config_reader')->getArgument(0)
+        );
+    }
+
+    public function testAssetMapperArgumentsAreRebasedToMauticScaffoldWebRoot(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.project_dir', $this->projectDir);
+
+        file_put_contents($this->projectDir.'/composer.json', json_encode([
+            'extra' => [
+                'mautic-scaffold' => [
+                    'locations' => [
+                        'web-root' => 'docroot/',
+                    ],
+                ],
+            ],
+        ]));
+
+        $container
+            ->register('asset_mapper.public_assets_path_resolver')
+            ->setArguments(['/assets/build/']);
+
+        $container
+            ->register('asset_mapper.local_public_assets_filesystem')
+            ->setArguments([$this->projectDir.'/public']);
+
+        $container
+            ->register('asset_mapper.compiled_asset_mapper_config_reader')
+            ->setArguments([$this->projectDir.'/public/assets/build']);
+
+        $pass = new AssetMapperWebRootPass();
+        $pass->process($container);
+
+        $this->assertSame(
+            $this->projectDir.'/docroot',
+            $container->findDefinition('asset_mapper.local_public_assets_filesystem')->getArgument(0)
+        );
+        $this->assertSame(
+            $this->projectDir.'/docroot/assets/build/',
+            $container->findDefinition('asset_mapper.compiled_asset_mapper_config_reader')->getArgument(0)
+        );
+    }
+
+    public function testAssetMapperArgumentsFallBackToKernelProjectDirForRootServedInstall(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.project_dir', $this->projectDir);
+
+        $container
+            ->register('asset_mapper.public_assets_path_resolver')
+            ->setArguments(['/assets/build']);
+
+        $container
+            ->register('asset_mapper.local_public_assets_filesystem')
+            ->setArguments([$this->projectDir.'/public']);
+
+        $container
+            ->register('asset_mapper.compiled_asset_mapper_config_reader')
+            ->setArguments([$this->projectDir.'/public/assets/build']);
+
+        $pass = new AssetMapperWebRootPass();
+        $pass->process($container);
+
+        $this->assertSame(
+            $this->projectDir,
+            $container->findDefinition('asset_mapper.local_public_assets_filesystem')->getArgument(0)
+        );
+        $this->assertSame(
+            $this->projectDir.'/assets/build',
+            $container->findDefinition('asset_mapper.compiled_asset_mapper_config_reader')->getArgument(0)
+        );
+    }
+}

--- a/app/bundles/CoreBundle/Tests/Unit/DependencyInjection/Compiler/AssetMapperWebRootPassTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/DependencyInjection/Compiler/AssetMapperWebRootPassTest.php
@@ -5,7 +5,12 @@ declare(strict_types=1);
 namespace Mautic\CoreBundle\Tests\Unit\DependencyInjection\Compiler;
 
 use Mautic\CoreBundle\DependencyInjection\Compiler\AssetMapperWebRootPass;
+use Mautic\CoreBundle\Loader\ParameterLoader;
+use Mautic\CoreBundle\MauticCoreBundle;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 final class AssetMapperWebRootPassTest extends TestCase
@@ -14,7 +19,7 @@ final class AssetMapperWebRootPassTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->projectDir = sys_get_temp_dir().'/mautic_asset_mapper_webroot_'.uniqid();
+        $this->projectDir = realpath(sys_get_temp_dir()).'/mautic_asset_mapper_webroot_'.uniqid();
         mkdir($this->projectDir);
     }
 
@@ -36,43 +41,76 @@ final class AssetMapperWebRootPassTest extends TestCase
         rmdir($this->projectDir);
     }
 
-    public function testAssetMapperArgumentsAreRebasedToConfiguredLocalRoot(): void
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function testUsesRecommendedProjectWebRootExportedByParameterLoader(): void
+    {
+        $applicationDir = $this->createRecommendedProject();
+        $container      = $this->createContainer($applicationDir, '/assets/build/');
+
+        (new AssetMapperWebRootPass())->process($container);
+
+        $this->assertAssetMapperDirectories($container, $applicationDir, $applicationDir.'/assets/build');
+    }
+
+    #[PreserveGlobalState(false)]
+    #[RunInSeparateProcess]
+    public function testLocalConfigurationOverridesPathsAndUsesCustomPublicPrefix(): void
+    {
+        $applicationDir = $this->createRecommendedProject();
+        $pathsRoot      = $this->projectDir.'/paths-root';
+        $localRoot      = $this->projectDir.'/local-root';
+        mkdir($pathsRoot);
+        mkdir($localRoot);
+
+        file_put_contents(
+            $this->projectDir.'/config/paths_local.php',
+            "<?php\n\n\$paths['local_root'] = '%kernel.project_dir%/paths-root';\n"
+        );
+        file_put_contents(
+            $this->projectDir.'/config/local.php',
+            "<?php\n\n\$parameters = ['local_root' => ".var_export($localRoot, true)."];\n"
+        );
+
+        $container = $this->createContainer($applicationDir, '/custom/build/');
+
+        (new AssetMapperWebRootPass())->process($container);
+
+        $this->assertAssetMapperDirectories($container, $localRoot, $localRoot.'/custom/build');
+    }
+
+    public function testPassIsRegisteredBeforeOptimization(): void
     {
         $container = new ContainerBuilder();
-        $container->setParameter('kernel.project_dir', $this->projectDir);
-        $container->setParameter('mautic.local_root', $this->projectDir.'/docroot');
+        $container->setParameter('kernel.environment', 'prod');
 
-        $container
-            ->register('asset_mapper.public_assets_path_resolver')
-            ->setArguments(['/assets/build/']);
+        (new MauticCoreBundle())->build($container);
 
-        $container
-            ->register('asset_mapper.local_public_assets_filesystem')
-            ->setArguments([$this->projectDir.'/public']);
-
-        $container
-            ->register('asset_mapper.compiled_asset_mapper_config_reader')
-            ->setArguments([$this->projectDir.'/public/assets/build']);
-
-        $pass = new AssetMapperWebRootPass();
-        $pass->process($container);
-
-        $this->assertSame(
-            $this->projectDir.'/docroot',
-            $container->findDefinition('asset_mapper.local_public_assets_filesystem')->getArgument(0)
+        $passClasses = static fn (array $passes): array => array_map(
+            static fn (CompilerPassInterface $pass): string => $pass::class,
+            $passes
         );
-        $this->assertSame(
-            $this->projectDir.'/docroot/assets/build/',
-            $container->findDefinition('asset_mapper.compiled_asset_mapper_config_reader')->getArgument(0)
+
+        $this->assertContains(
+            AssetMapperWebRootPass::class,
+            $passClasses($container->getCompilerPassConfig()->getBeforeOptimizationPasses())
+        );
+        $this->assertNotContains(
+            AssetMapperWebRootPass::class,
+            $passClasses($container->getCompilerPassConfig()->getBeforeRemovingPasses())
         );
     }
 
-    public function testAssetMapperArgumentsAreRebasedToMauticScaffoldWebRoot(): void
+    private function createRecommendedProject(): string
     {
-        $container = new ContainerBuilder();
-        $container->setParameter('kernel.project_dir', $this->projectDir);
-        mkdir($this->projectDir.'/docroot');
+        $applicationDir = $this->projectDir.'/docroot';
+        mkdir($applicationDir.'/app/config', 0777, true);
+        mkdir($this->projectDir.'/config');
 
+        copy(
+            dirname(__DIR__, 6).'/config/paths.php',
+            $applicationDir.'/app/config/paths.php'
+        );
         file_put_contents($this->projectDir.'/composer.json', json_encode([
             'extra' => [
                 'public-dir'      => 'docroot',
@@ -82,66 +120,48 @@ final class AssetMapperWebRootPassTest extends TestCase
                     ],
                 ],
             ],
-        ]));
+        ], JSON_THROW_ON_ERROR));
+        file_put_contents($this->projectDir.'/config/local.php', "<?php\n\n\$parameters = [];\n");
 
-        $container
-            ->register('asset_mapper.public_assets_path_resolver')
-            ->setArguments(['/assets/build/']);
-
-        $container
-            ->register('asset_mapper.local_public_assets_filesystem')
-            ->setArguments([$this->projectDir.'/public']);
-
-        $container
-            ->register('asset_mapper.compiled_asset_mapper_config_reader')
-            ->setArguments([$this->projectDir.'/public/assets/build']);
-
-        $pass = new AssetMapperWebRootPass();
-        $pass->process($container);
-
-        $this->assertSame(
-            $this->projectDir.'/docroot',
-            $container->findDefinition('asset_mapper.local_public_assets_filesystem')->getArgument(0)
-        );
-        $this->assertSame(
-            $this->projectDir.'/docroot/assets/build/',
-            $container->findDefinition('asset_mapper.compiled_asset_mapper_config_reader')->getArgument(0)
-        );
+        return $applicationDir;
     }
 
-    public function testAssetMapperArgumentsFallBackToKernelProjectDirForRootServedInstall(): void
+    private function createContainer(string $applicationDir, string $publicPrefix): ContainerBuilder
     {
+        if (!defined('MAUTIC_ENV')) {
+            define('MAUTIC_ENV', 'test');
+        }
+
+        putenv('MAUTIC_LOCAL_ROOT');
+        unset($_ENV['MAUTIC_LOCAL_ROOT'], $_SERVER['MAUTIC_LOCAL_ROOT']);
+
+        $parameterLoader = new ParameterLoader($applicationDir.'/app');
+        $parameterLoader->loadIntoEnvironment();
+
         $container = new ContainerBuilder();
         $container->setParameter('kernel.project_dir', $this->projectDir);
-
-        file_put_contents($this->projectDir.'/composer.json', json_encode([
-            'extra' => [
-                'public-dir' => '.',
-            ],
-        ]));
-
         $container
             ->register('asset_mapper.public_assets_path_resolver')
-            ->setArguments(['/assets/build']);
-
+            ->setArguments([$publicPrefix]);
         $container
             ->register('asset_mapper.local_public_assets_filesystem')
             ->setArguments([$this->projectDir.'/public']);
-
         $container
             ->register('asset_mapper.compiled_asset_mapper_config_reader')
             ->setArguments([$this->projectDir.'/public/assets/build']);
 
-        $pass = new AssetMapperWebRootPass();
-        $pass->process($container);
+        return $container;
+    }
 
+    private function assertAssetMapperDirectories(ContainerBuilder $container, string $webRoot, string $compiledAssets): void
+    {
         $this->assertSame(
-            $this->projectDir,
-            $container->findDefinition('asset_mapper.local_public_assets_filesystem')->getArgument(0)
+            $webRoot,
+            $container->getDefinition('asset_mapper.local_public_assets_filesystem')->getArgument(0)
         );
         $this->assertSame(
-            $this->projectDir.'/assets/build',
-            $container->findDefinition('asset_mapper.compiled_asset_mapper_config_reader')->getArgument(0)
+            $compiledAssets,
+            $container->getDefinition('asset_mapper.compiled_asset_mapper_config_reader')->getArgument(0)
         );
     }
 }

--- a/app/bundles/CoreBundle/Tests/Unit/DependencyInjection/Compiler/AssetMapperWebRootPassTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/DependencyInjection/Compiler/AssetMapperWebRootPassTest.php
@@ -71,9 +71,11 @@ final class AssetMapperWebRootPassTest extends TestCase
     {
         $container = new ContainerBuilder();
         $container->setParameter('kernel.project_dir', $this->projectDir);
+        mkdir($this->projectDir.'/docroot');
 
         file_put_contents($this->projectDir.'/composer.json', json_encode([
             'extra' => [
+                'public-dir'      => 'docroot',
                 'mautic-scaffold' => [
                     'locations' => [
                         'web-root' => 'docroot/',
@@ -111,6 +113,12 @@ final class AssetMapperWebRootPassTest extends TestCase
     {
         $container = new ContainerBuilder();
         $container->setParameter('kernel.project_dir', $this->projectDir);
+
+        file_put_contents($this->projectDir.'/composer.json', json_encode([
+            'extra' => [
+                'public-dir' => '.',
+            ],
+        ]));
 
         $container
             ->register('asset_mapper.public_assets_path_resolver')

--- a/build/package_release.php
+++ b/build/package_release.php
@@ -95,6 +95,9 @@ if (!isset($args['repackage'])) {
         'deleted_files.txt'              => true,
         'critical_migrations.txt'        => true,
         'upgrade.php'                    => true,
+        // Generated during packaging and required before the first request after an update.
+        'assets/build/'                   => true,
+        'var/sass/'                       => true,
         // Temp fix for GrapesJs builder
         'plugins/GrapesJsBuilderBundle/' => true,
     ];


### PR DESCRIPTION
## Target release: 7.2.1

Rebased onto `7.2` at `bd76a5d56e85d5d30da00b041edf61ca7c78e31a`. Current head: `6814384be51e6488ed68af49a361e6665474ef2b`. `git range-diff` confirms that every patch commit is unchanged by the rebase.

Validation repeated on the rebased source with PHP 8.3.32: AssetMapper regression: 3 tests, 6 assertions. PHP syntax and whitespace checks passed.

The ZIP/Composer server evidence and immutable archive below were produced before this rebase at `e4c9a5b084`; they are retained as historical evidence. No new release archive or server run is claimed for the rebased head.

## Summary

Fixes the Mautic 7.2 asset regression for both supported upgrade layouts:

- Composer/recommended-project installs compile AssetMapper output into their configured webroot, such as `docroot/`, instead of Symfony's default `<project>/public`.
- release update packages include generated `assets/build/` and `var/sass/` content required before the first request after an update.
- release CI verifies both generated outputs in the update archive and after the update-install job.

Fixes #17259.

## Root causes

### Composer webroot

Mautic resolves its webroot through `MAUTIC_LOCAL_ROOT`, including the normal `ParameterLoader` handling of Composer metadata, `paths_local.php`, and `local.php`. Symfony AssetMapper builds its public filesystem and compiled-config services before using that resolved Mautic path. In a recommended-project install it can therefore write to `<project>/public/assets/build` while the web server serves `<project>/docroot`.

The compiler pass runs before optimization, resolves the existing `MAUTIC_LOCAL_ROOT` environment expression, preserves the configured public prefix, and rebases:

- `asset_mapper.local_public_assets_filesystem`
- `asset_mapper.compiled_asset_mapper_config_reader`

The related `mautic/recommended-project#179` change was checked. It fixes `assets:install` by declaring `public-dir`, but does not configure AssetMapper output.

### Update archive

`build/package_release.php` generates production AssetMapper and Sass files in the packaging workspace. The update archive is assembled from Git-tracked changes, however, and neither generated directory was added to `modified_files.txt`. The published `7.2.0-update.zip` consequently contains neither `assets/build/manifest.json` nor `var/sass/app.output.css`.

This PR adds both generated directories to every update package and makes release CI fail if either required file is missing.

## Review changes

Commit `e4c9a5b0848c971ba874da5cd38e1aa8bbf1cccd` addresses all four review threads:

- uses `%env(default:kernel.project_dir:resolve:MAUTIC_LOCAL_ROOT)%` instead of assuming a synthetic container parameter;
- runs at `TYPE_BEFORE_OPTIMIZATION`, before AssetMapper decoration;
- boots the real `ParameterLoader` in the regression test;
- covers Composer webroot discovery, `paths_local.php`/`local.php` precedence, and a custom public prefix.

All four review threads are resolved.

## Published 7.2.0 baseline

- `7.2.0-update.zip` declares `extra.public-dir = "."`.
- `assets/build/manifest.json` is absent.
- `var/sass/app.output.css` is absent.
- a clean recommended-project 7.1.3 to 7.2.0 update configured `docroot/` but generated into sibling `public/assets/build`.

No custom plugins or symlink workarounds were used.

## Pre-rebase candidate package

The release builder was run from the pre-rebase reviewed head with Node 24. Because 7.2.0 is already tagged, its historical back-build file selection was overlaid with the exact two reviewed runtime files; their in-archive hashes were verified against the PR head before publication.

```text
commit: e4c9a5b0848c971ba874da5cd38e1aa8bbf1cccd
archive: 7.2.0-update-e4c9a5b084-r2.zip
size: 79,365,315 bytes
SHA-256: a582ad857c86cabc74e71eeee27b07e4982ff4cb3833412adffd5212d0dc22bc
integrity: no errors detected
AssetMapperWebRootPass.php SHA-256: c3414d61a223bd6453ee8027fa3d7c211e6c5e489309af783e55055b2ce9f008
MauticCoreBundle.php SHA-256: 1e8ed1253a29c8c83c912491a25cfda7ad69feabb93208b9b44599a4e626925b
assets/build/manifest.json: 96 entries
var/sass/app.output.css: 928,301 bytes
```

Immutable test artifact: https://github.com/AlexanderZlobinM1/mautic/releases/tag/pr-17300-e4c9a5b084-r2

## Clean upgrade acceptance

Both paths ran on isolated PHP 8.4.25 installations. No external plugins or symlink workarounds were present.

| Path | Upgrade | Asset result | HTTP result |
| --- | --- | --- | --- |
| ZIP | clean 7.1.3 to the branch-built update package through the normal updater | exact reviewed runtime files installed; 96-entry manifest, importmap and Sass existed before any manual asset-generation command | manifest, importmap and 16 sampled hashed JS/CSS files returned 200 with byte equality; UI reached login |
| Composer | clean recommended-project 7.1.3 to 7.2.0 plus the exact reviewed runtime overlay | normal `mautic:assets:generate` returned 0; 96-entry manifest written under `docroot/assets/build`; sibling `public/assets/build/manifest.json` absent | manifest, importmap and 16 sampled hashed JS/CSS files returned 200 with byte equality; UI reached login |

The Composer fixture also exercised the real `ParameterLoader`: default Composer `docroot`, `paths_local.php`, and overriding `local.php` values were all resolved with the expected precedence. Custom-prefix behavior is covered by the focused unit test; it is not claimed as part of the server HTTP matrix.

Mautic 7.2.0 has a separate role-migration failure tracked by #17271/#17274. Its exact signature-gated remediation was required before migrations could finish in both clean fixtures. It is independent of this asset change and is not included here.

Every disposable path, vhost, database, and database user was recorded before creation and removed by exact identifier. Final inventory matched the four pre-existing installations; none was modified.

## Automated checks

```text
PHP syntax: passed
PHPUnit: OK (3 tests, 6 assertions)
PHP CS Fixer: clean for all 3 changed PHP files
git diff --check: passed
release archive integrity: passed
release archive generated-file assertions: passed
reviewed runtime file identity inside archive: passed
```

The release workflow now enforces the generated-file presence in the update archive, and the update-install job asserts both outputs are non-empty after applying it.
