### PR TITLE
Fix company import another link

### DIFF
--- a/app/bundles/LeadBundle/Resources/views/Import/progress.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Import/progress.html.twig
@@ -190,7 +190,7 @@ Variables
                                     {
                                         label: 'mautic.lead.import.import_again',
                                         variant: 'link',
-                                        href: path('mautic_import_action', {'object': 'contacts', 'objectAction': 'new'}),
+                                        href: path('mautic_import_action', {'object': object, 'objectAction': 'new'}),
                                         size: 'xl',
                                         attributes: {
                                             'data-toggle': 'ajax'


### PR DESCRIPTION
## Summary

Fixes the completed import progress screen so "Import another" keeps the current import object instead of always opening the contact import form.

For company imports, the template already receives the current `object` and uses it for cancel, queue, view and result links. This changes the remaining hard-coded `contacts` link to use the same value.

Fixes #17220.

## Local checks

```bash
git diff --check
php -d memory_limit=2G bin/console --version --env=test
php -d memory_limit=2G bin/console lint:twig app/bundles/LeadBundle/Resources/views/Import/progress.html.twig --env=test
```

Result: whitespace check passed, Mautic `app/test` booted as `7.2.0`, and Twig syntax validation passed.