### PR TITLE
Allow manual selection of A/B test winners

### DIFF
--- a/app/bundles/CoreBundle/Resources/views/Variant/row.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Variant/row.html.twig
@@ -31,6 +31,7 @@
 {% set isWinner = abTestResults.winners is defined and variant.id in abTestResults.winners and variants.parent.variantStartDate and isPublished %}
 {% set actionUrl = path(actionRoute, {'objectAction': 'view', 'objectId': variant.id}) %}
 {% set isCurrent = (variant.id is same as activeEntity.id) %}
+{% set canMakeWinner = variants.parent.variantStartDate and isPublished %}
 
 <li class="list-group-item bg-{% if isCurrent %}dark{% else %}light{% endif %}-xs">
     <div class="box-layout">
@@ -49,7 +50,7 @@
                     {% endif %}
                 </div>
                 <div class="col-xs-11">
-                    {% if isWinner %}
+                    {% if canMakeWinner %}
                         <div class="mr-xs pull-left" data-toggle="tooltip" title="{{ 'mautic.core.ab_test.make_winner'|trans }}">
                             {% include '@MauticCore/Helper/button.html.twig' with {
                                 buttons: [
@@ -57,7 +58,7 @@
                                         label: 'mautic.core.ab_test.make_winner',
                                         variant: 'warning',
                                         icon_only: true,
-                                        icon: 'ri-trophy-fill',
+                                        icon: isWinner ? 'ri-trophy-fill' : 'ri-trophy-line',
                                         href: path(actionRoute, {'objectAction': 'winner', 'objectId': variant.id}),
                                         attributes: {
                                             'data-toggle': 'confirmation',

--- a/app/bundles/EmailBundle/Resources/views/Variant/row.html.twig
+++ b/app/bundles/EmailBundle/Resources/views/Variant/row.html.twig
@@ -10,6 +10,7 @@
 {% set isPublished = variant.isPublished() %}
 {% set isWinner = abTestResults.winners is defined and variant.id in abTestResults.winners and variants.parent.variantStartDate and isPublished %}
 {% set isCurrent = variant.id == activeEntity.id %}
+{% set canMakeWinner = variants.parent.variantStartDate and isPublished %}
 
 {# Render variant list item #}
 <div class="list-group-item variant-item d-flex ai-center {% if isCurrent %}bg-aut bg-dark-xs{% endif %}" style="padding: 4px 8px;">
@@ -46,6 +47,19 @@
 
     {# Action buttons #}
     <div class="variant-actions d-flex" style="flex-shrink: 0;">
+        {% if canMakeWinner %}
+            <a href="{{ path(actionRoute, {'objectAction': 'winner', 'objectId': variant.id}) }}"
+               class="btn btn-warning btn--icon-only btn-sm btn-nospin"
+               title="{{ 'mautic.core.ab_test.make_winner'|trans }}"
+               data-toggle="confirmation"
+               data-message="{{ ('mautic.core.ab_test.confirm_make_winner'|trans({'%name%': attribute(variant, nameGetter)})|e) }}"
+               data-confirm-text="{{ 'mautic.core.ab_test.make_winner'|trans|escape }}"
+               data-confirm-callback="executeAction"
+               data-cancel-text="{{ 'mautic.core.form.cancel'|trans|escape }}">
+                <i class="{{ isWinner ? 'ri-trophy-fill' : 'ri-trophy-line' }}"></i>
+            </a>
+        {% endif %}
+
         <a href="{{ path('mautic_email_preview', {'objectId': variant.id}) }}"
            class="btn btn-ghost btn--icon-only btn-sm btn-nospin"
            title="{{ 'mautic.core.preview'|trans }}"


### PR DESCRIPTION
## Target release: 7.2.1

Rebased onto `7.2` at `bd76a5d56e85d5d30da00b041edf61ca7c78e31a`. Current head: `2daf5a626cc3434a613252b13b41c684d5abd425`. `git range-diff` confirms that every patch commit is unchanged by the rebase.

Validation repeated on the rebased source with PHP 8.3.32: Both Twig templates compiled and rendered successfully in 8 cases covering leading/non-leading variants, unpublished variants and tests that have not started. Route, translation and button helpers were isolated test doubles.

## Summary

Allows users to manually select any published A/B test variant as the winner once the test has started, instead of rendering the action only for the statistically leading variant.

The existing statistical winner state is still used for the filled trophy icon. Non-leading published variants get the same confirmed winner action with an outline trophy icon, matching the existing controller/model capability.

Fixes #16318.

## Local checks

```bash
git diff --check
php -d memory_limit=2G bin/console --version --env=test
php -d memory_limit=2G bin/console lint:twig app/bundles/CoreBundle/Resources/views/Variant/row.html.twig app/bundles/EmailBundle/Resources/views/Variant/row.html.twig --env=test
php -r '<static template guard check>'
```

Result: whitespace check passed, Mautic `app/test` booted as `7.2.0`, Twig syntax validation passed, and both variant row templates now render the winner action from published/test-started eligibility rather than statistical winner membership.
