### PR TITLE
Fix update contact campaign failure flow

### DIFF
--- a/app/bundles/LeadBundle/EventListener/CampaignSubscriber.php
+++ b/app/bundles/LeadBundle/EventListener/CampaignSubscriber.php
@@ -360,23 +360,18 @@ final class CampaignSubscriber implements EventSubscriberInterface
         $lead   = $log->getLead();
         $fields = $lead->getFields(true);
 
-        try {
-            $tokenizedValues = [];
-            foreach ($values as $field => $value) {
-                if (is_string($value)) {
-                    $tokenizedValue = TokenHelper::findLeadTokens($value, $lead->getProfileFields(), true);
-                    $fieldEntity    = $this->leadFieldModel->getEntityByAlias($field);
-                    if ($fieldEntity && ($charLimit = $fieldEntity->getCharLengthLimit()) && mb_strlen($tokenizedValue) > $charLimit) {
-                        $tokenizedValue = mb_substr($tokenizedValue, 0, $charLimit);
-                    }
-                    $tokenizedValues[$field] = $tokenizedValue;
-                } else {
-                    $tokenizedValues[$field] = $value;
+        $tokenizedValues = [];
+        foreach ($values as $field => $value) {
+            if (is_string($value)) {
+                $tokenizedValue = TokenHelper::findLeadTokens($value, $lead->getProfileFields(), true);
+                $fieldEntity    = $this->leadFieldModel->getEntityByAlias($field);
+                if ($fieldEntity && ($charLimit = $fieldEntity->getCharLengthLimit()) && mb_strlen($tokenizedValue) > $charLimit) {
+                    $tokenizedValue = mb_substr($tokenizedValue, 0, $charLimit);
                 }
+                $tokenizedValues[$field] = $tokenizedValue;
+            } else {
+                $tokenizedValues[$field] = $value;
             }
-            $this->leadModel->setFieldValues($lead, CustomFieldHelper::fieldsValuesTransformer($fields, $tokenizedValues), false);
-        } catch (ImportFailedException $e) {
-            $event->fail($log, $e->getMessage());
         }
 
         foreach ($values as $alias => &$value) {
@@ -386,7 +381,14 @@ final class CampaignSubscriber implements EventSubscriberInterface
             }
         }
 
-        $this->leadModel->setFieldValues($lead, CustomFieldHelper::fieldsValuesTransformer($fields, $tokenizedValues), false);
+        try {
+            $this->leadModel->setFieldValues($lead, CustomFieldHelper::fieldsValuesTransformer($fields, $tokenizedValues), false);
+        } catch (ImportFailedException $e) {
+            $event->fail($log, $e->getMessage());
+
+            return;
+        }
+
         $this->leadModel->saveEntity($lead);
         $event->pass($log);
     }

--- a/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberTest.php
@@ -19,6 +19,7 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Entity\LeadFieldRepository;
 use Mautic\LeadBundle\Entity\LeadListRepository;
 use Mautic\LeadBundle\Entity\LeadRepository;
+use Mautic\LeadBundle\Exception\ImportFailedException;
 use Mautic\LeadBundle\EventListener\CampaignSubscriber;
 use Mautic\LeadBundle\Model\CompanyModel;
 use Mautic\LeadBundle\Model\DoNotContact;
@@ -508,9 +509,9 @@ final class CampaignSubscriberTest extends \PHPUnit\Framework\TestCase
 
         $logs = new ArrayCollection([$leadEventLog]);
 
-        $this->mockLeadModel->expects($this->exactly(2))
+        $this->mockLeadModel->expects($this->once())
             ->method('setFieldValues')
-            ->with($lead, $properties, false, true, false);
+            ->with($lead, $properties, false);
 
         $this->mockLeadModel->expects($this->once())
             ->method('saveEntity')
@@ -521,5 +522,59 @@ final class CampaignSubscriberTest extends \PHPUnit\Framework\TestCase
 
         $this->assertCount(1, $pendingEvent->getSuccessful());
         $this->assertCount(0, $pendingEvent->getFailures());
+    }
+
+    public function testOnCampaignTriggerActionUpdateLeadContinuesAfterImportFailure(): void
+    {
+        $eventAccessor = $this->createStub(ActionAccessor::class);
+        $properties    = [
+            'points' => 10,
+        ];
+        $event         = (new Event())->setProperties($properties);
+        $event->setType('lead.updatelead');
+
+        $firstLead  = (new Lead())->setEmail('first@mautic.org');
+        $secondLead = (new Lead())->setEmail('second@mautic.org');
+
+        $firstLog = $this->createLeadEventLogMock(1, $firstLead);
+        $secondLog = $this->createLeadEventLogMock(2, $secondLead);
+
+        $call = 0;
+        $this->mockLeadModel->expects($this->exactly(2))
+            ->method('setFieldValues')
+            ->willReturnCallback(function () use (&$call): void {
+                ++$call;
+
+                if (1 === $call) {
+                    throw new ImportFailedException('Invalid contact data');
+                }
+            });
+
+        $this->mockLeadModel->expects($this->once())
+            ->method('saveEntity')
+            ->with($secondLead);
+
+        $pendingEvent = new PendingEvent($eventAccessor, $event, new ArrayCollection([$firstLog, $secondLog]));
+        $this->subscriber->onCampaignTriggerActionUpdateLead($pendingEvent);
+
+        $this->assertCount(1, $pendingEvent->getFailures());
+        $this->assertSame($firstLog, $pendingEvent->getFailures()->get(1));
+        $this->assertCount(1, $pendingEvent->getSuccessful());
+        $this->assertSame($secondLog, $pendingEvent->getSuccessful()->get(2));
+    }
+
+    private function createLeadEventLogMock(int $id, Lead $lead): LeadEventLog&MockObject
+    {
+        $log = $this->createMock(LeadEventLog::class);
+        $log->method('getId')->willReturn($id);
+        $log->method('getLead')->willReturn($lead);
+        $log->method('getFailedLog')->willReturn(null);
+        $log->method('getMetadata')->willReturn([]);
+        $log->method('setMetadata')->willReturnSelf();
+        $log->method('setRescheduleInterval')->willReturnSelf();
+        $log->method('setIsScheduled')->willReturnSelf();
+        $log->method('setDateTriggered')->willReturnSelf();
+
+        return $log;
     }
 }


### PR DESCRIPTION
## Target release: 7.2.1

Rebased onto `7.2` at `bd76a5d56e85d5d30da00b041edf61ca7c78e31a`. Current head: `62146a1be18ea645245fc55aba67f53db686077b`. `git range-diff` confirms that every patch commit is unchanged by the rebase.

Validation repeated on the rebased source with PHP 8.3.32: Update contact campaign regression: 2 tests, 14 assertions. PHP syntax and whitespace checks passed.

## Summary

Fixes two issues in the Update contact campaign action batch handler:

- `LeadModel::setFieldValues()` is no longer called twice on the success path.
- `ImportFailedException` now marks only the current pending log as failed and returns from that log, allowing the rest of the batch to continue.

Fixes #17264.

## Local checks

```bash
git diff --check
php -d memory_limit=2G bin/console --version --env=test
php -l app/bundles/LeadBundle/EventListener/CampaignSubscriber.php
php -l app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberTest.php
php -d memory_limit=2G bin/phpunit --bootstrap /tmp/mautic-worktree-bootstrap.php app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberTest.php --filter 'UpdateLead'
```

Result:

```text
Mautic 7.2.0 - app/test
OK (2 tests, 14 assertions)
```
