### PR TITLE
[cs] Add precise iterable docblock types (PageBundle source)

### DIFF
--- a/app/bundles/PageBundle/Entity/HitRepository.php
+++ b/app/bundles/PageBundle/Entity/HitRepository.php
@@ -59,7 +59,8 @@ class HitRepository extends CommonRepository
     /**
      * Get a lead's page hits.
      *
-     * @param int|null $leadId
+     * @param int|null             $leadId
+     * @param array<string, mixed> $options
      *
      * @return array
      */
@@ -326,6 +327,8 @@ class HitRepository extends CommonRepository
 
     /**
      * Get array of dwell time labels with ranges.
+     *
+     * @return array<int, array<string, string|int>>
      */
     public function getDwellTimeLabels(): array
     {
@@ -356,6 +359,8 @@ class HitRepository extends CommonRepository
 
     /**
      * Get the dwell times for bunch of pages.
+     *
+     * @param array<string, mixed> $options
      */
     public function getDwellTimesForPages(array $pageIds, array $options): array
     {
@@ -407,7 +412,8 @@ class HitRepository extends CommonRepository
     /**
      * Get the dwell times for bunch of URLs.
      *
-     * @param string $url
+     * @param string               $url
+     * @param array<string, mixed> $options
      */
     public function getDwellTimesForUrl($url, array $options): array
     {
@@ -442,6 +448,8 @@ class HitRepository extends CommonRepository
      * Count stats from hit times.
      *
      * @param array $times
+     *
+     * @return array<string, mixed>
      */
     public function countStats($times): array
     {

--- a/app/bundles/PageBundle/Entity/VideoHitRepository.php
+++ b/app/bundles/PageBundle/Entity/VideoHitRepository.php
@@ -16,7 +16,8 @@ final class VideoHitRepository extends CommonRepository
     /**
      * Get video hit info for lead timeline.
      *
-     * @param int|null $leadId
+     * @param int|null             $leadId
+     * @param array<string, mixed> $options
      *
      * @return array
      */
@@ -55,7 +56,8 @@ final class VideoHitRepository extends CommonRepository
     /**
      * Get a lead's page hits.
      *
-     * @param int $leadId
+     * @param int                  $leadId
+     * @param array<string, mixed> $options
      *
      * @return array
      *
@@ -80,6 +82,8 @@ final class VideoHitRepository extends CommonRepository
      * Count stats from hit times.
      *
      * @param array $times
+     *
+     * @return array<string, mixed>
      */
     public function countStats($times): array
     {

--- a/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
+++ b/app/bundles/PageBundle/EventListener/BuilderSubscriber.php
@@ -266,7 +266,7 @@ final class BuilderSubscriber implements EventSubscriberInterface
     }
 
     /**
-     * @param mixed[] $templateParams
+     * @param array<string, mixed>|array<string, array<int, mixed[]>> $templateParams
      */
     private function renderTemplate(string $templateName, array $templateParams, string $wrapperTemplate = '', string ...$wrapperTemplateValues): string
     {
@@ -298,6 +298,9 @@ final class BuilderSubscriber implements EventSubscriberInterface
         );
     }
 
+    /**
+     * @param array<string, mixed> $params
+     */
     private function renderSegmentList(array $params): string
     {
         return $this->renderTemplate(
@@ -308,6 +311,9 @@ final class BuilderSubscriber implements EventSubscriberInterface
         );
     }
 
+    /**
+     * @param array<string, mixed> $params
+     */
     private function renderCategoryList(array $params): string
     {
         return $this->renderTemplate(
@@ -318,6 +324,9 @@ final class BuilderSubscriber implements EventSubscriberInterface
         );
     }
 
+    /**
+     * @param array<string, mixed> $params
+     */
     private function renderPreferredChannel(array $params): string
     {
         return $this->renderTemplate(
@@ -327,6 +336,9 @@ final class BuilderSubscriber implements EventSubscriberInterface
         );
     }
 
+    /**
+     * @param array<string, mixed> $params
+     */
     private function renderChannelFrequency(array $params): string
     {
         return $this->renderTemplate(
@@ -337,6 +349,9 @@ final class BuilderSubscriber implements EventSubscriberInterface
         );
     }
 
+    /**
+     * @param array<string, mixed> $params
+     */
     private function renderSavePrefs(array $params): string
     {
         return $this->renderTemplate(
@@ -433,7 +448,7 @@ final class BuilderSubscriber implements EventSubscriberInterface
     }
 
     /**
-     * @param mixed[] $params
+     * @param array<string, mixed> $params
      */
     private function wrapPreferenceCenterInFormTag(string $content, array $params): string
     {

--- a/app/bundles/PageBundle/Helper/PointActionHelper.php
+++ b/app/bundles/PageBundle/Helper/PointActionHelper.php
@@ -14,6 +14,9 @@ readonly class PointActionHelper
     ) {
     }
 
+    /**
+     * @param array<string, mixed> $action
+     */
     public static function validatePageHit($eventDetails, array $action): bool
     {
         $pageHit = $eventDetails->getPage();
@@ -35,6 +38,9 @@ readonly class PointActionHelper
         return empty($limitToPages) || in_array($pageHitId, $limitToPages);
     }
 
+    /**
+     * @param array<string, mixed> $action
+     */
     public function validateUrlHit($eventDetails, array $action): bool
     {
         $changePoints = [];

--- a/app/bundles/PageBundle/Model/PageModel.php
+++ b/app/bundles/PageBundle/Model/PageModel.php
@@ -796,8 +796,9 @@ class PageModel extends FormModel implements GlobalSearchInterface
     /**
      * Get line chart data of hits.
      *
-     * @param ?string $unit       {@link php.net/manual/en/function.date.php#refsect1-function.date-parameters}
-     * @param string  $dateFormat
+     * @param ?string              $unit          {@link php.net/manual/en/function.date.php#refsect1-function.date-parameters}
+     * @param string               $dateFormat
+     * @param array<string, mixed> $filter
      */
     public function getHitsLineChartData($unit, \DateTime $dateFrom, \DateTime $dateTo, $dateFormat = null, array $filter = [], bool $canViewOthers = true): array
     {

--- a/app/bundles/PageBundle/Model/TrackableModel.php
+++ b/app/bundles/PageBundle/Model/TrackableModel.php
@@ -86,8 +86,9 @@ class TrackableModel extends AbstractCommonModel
     }
 
     /**
-     * @param bool|false $shortenUrl If true, use the configured shortener service to shorten the URLs
-     * @param array      $utmTags
+     * @param bool|false           $shortenUrl   If true, use the configured shortener service to shorten the URLs
+     * @param array                $utmTags
+     * @param array<string, mixed> $clickthrough
      *
      * @return string
      */
@@ -631,6 +632,8 @@ class TrackableModel extends AbstractCommonModel
 
     /**
      * Build query string while accounting for tokens that include an equal sign.
+     *
+     * @param array<string, mixed> $queryParts
      */
     protected function httpBuildQuery(array $queryParts): ?string
     {


### PR DESCRIPTION
Adds precise iterable docblock types (generated via Rector's type-declaration set).

Docblock-only change; no runtime behavior affected. Split out of #17235 for smaller review.
