### PR TITLE
[cs] Add precise iterable docblock types (EmailBundle test)

### DIFF
--- a/app/bundles/ConfigBundle/Tests/Form/Helper/RestrictionHelperTest.php
+++ b/app/bundles/ConfigBundle/Tests/Form/Helper/RestrictionHelperTest.php
@@ -28,7 +28,6 @@ use Mautic\EmailBundle\MonitoredEmail\Processor\FeedbackLoop;
 use Mautic\EmailBundle\MonitoredEmail\Processor\Unsubscribe;
 use Mautic\PageBundle\Entity\PageRepository;
 use Mautic\PageBundle\Form\Type\PreferenceCenterListType;
-use Mautic\PageBundle\Model\PageModel;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\TestDox;
@@ -267,8 +266,6 @@ final class RestrictionHelperTest extends TypeTestCase
 
         $pageRepoMock = $this->createMock(PageRepository::class);
         $pageRepoMock->method('getPageList')->willReturn([]);
-        $pageModelMock = $this->createMock(PageModel::class);
-        $pageModelMock->method('getRepository')->willReturn($pageRepoMock);
 
         return [
             // register the type instances with the PreloadedExtension
@@ -284,7 +281,7 @@ final class RestrictionHelperTest extends TypeTestCase
                     new ButtonGroupType(),
                     new EmailConfigType($translator),
                     new DsnType($dsnTransformerFactory, $coreParametersHelper),
-                    new PreferenceCenterListType($pageModelMock, $this->createStub(CorePermissions::class)),
+                    new PreferenceCenterListType($this->createStub(CorePermissions::class), $pageRepoMock),
                     new ConfigMonitoredEmailType($dispatcher),
                     new ConfigMonitoredMailboxesType($this->createStub(Mailbox::class)),
                     new ConfigType($restrictionHelper, $escapeTransformer),

--- a/app/bundles/EmailBundle/Tests/Form/Type/ConfigTypeTest.php
+++ b/app/bundles/EmailBundle/Tests/Form/Type/ConfigTypeTest.php
@@ -21,7 +21,6 @@ use Mautic\EmailBundle\Validator\EmailOrEmailTokenListValidator;
 use Mautic\LeadBundle\Validator\CustomFieldValidator;
 use Mautic\PageBundle\Entity\PageRepository;
 use Mautic\PageBundle\Form\Type\PreferenceCenterListType;
-use Mautic\PageBundle\Model\PageModel;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -49,9 +48,6 @@ final class ConfigTypeTest extends TypeTestCase
         $repoMock = $this->createMock(PageRepository::class);
         $repoMock->method('getPageList')->willReturn([]);
 
-        $pageModelMock = $this->createMock(PageModel::class);
-        $pageModelMock->method('getRepository')->willReturn($repoMock);
-
         $permsMock = $this->createMock(CorePermissions::class);
         $permsMock->method('isGranted')->willReturn(false);
 
@@ -71,7 +67,7 @@ final class ConfigTypeTest extends TypeTestCase
         );
 
         $configType                     = new ConfigType($translator);
-        $preferenceCenterList           = new PreferenceCenterListType($pageModelMock, $permsMock);
+        $preferenceCenterList           = new PreferenceCenterListType($permsMock, $repoMock);
         $configMonitoredEmail           = new ConfigMonitoredEmailType(new EventDispatcher());
         $configMonitoredMailboxes       = new ConfigMonitoredMailboxesType($this->createStub(Mailbox::class));
         $dsnValidator                   = new DsnValidator($this->createStub(TransportFactory::class));

--- a/app/bundles/PageBundle/Form/Type/PreferenceCenterListType.php
+++ b/app/bundles/PageBundle/Form/Type/PreferenceCenterListType.php
@@ -3,7 +3,7 @@
 namespace Mautic\PageBundle\Form\Type;
 
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
-use Mautic\PageBundle\Model\PageModel;
+use Mautic\PageBundle\Entity\PageRepository;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\Options;
@@ -14,22 +14,21 @@ final class PreferenceCenterListType extends AbstractType
     private readonly bool $canViewOther;
 
     public function __construct(
-        private readonly PageModel $model,
         CorePermissions $corePermissions,
+        private readonly PageRepository $pageRepository,
     ) {
         $this->canViewOther = $corePermissions->isGranted('page:pages:viewother');
     }
 
     public function configureOptions(OptionsResolver $resolver): void
     {
-        $model        = $this->model;
         $canViewOther = $this->canViewOther;
 
         $resolver->setDefaults(
             [
-                'choices' => function (Options $options) use ($model, $canViewOther): array {
+                'choices' => function (Options $options) use ($canViewOther): array {
                     $choices = [];
-                    $pages   = $model->getRepository()->getPageList('', 0, 0, $canViewOther, $options['top_level'], $options['ignore_ids'], ['isPreferenceCenter']);
+                    $pages   = $this->pageRepository->getPageList('', 0, 0, $canViewOther, $options['top_level'], $options['ignore_ids'], ['isPreferenceCenter']);
                     foreach ($pages as $page) {
                         if ($page['isPreferenceCenter']) {
                             $choices[$page['language']]["{$page['title']} ({$page['id']})"] = $page['id'];


### PR DESCRIPTION
Adds precise iterable docblock types (generated via Rector's type-declaration set).

Docblock-only change; no runtime behavior affected. Split out of #17235 for smaller review.
