### PR TITLE
[tests] Silence mock-without-expectations notices on stub-only unit tests

### DIFF
--- a/app/bundles/ApiBundle/Tests/Entity/oAuth2/ClientRepositoryTest.php
+++ b/app/bundles/ApiBundle/Tests/Entity/oAuth2/ClientRepositoryTest.php
@@ -8,10 +8,12 @@ use Doctrine\DBAL\Query\QueryBuilder;
 use Mautic\ApiBundle\Entity\oAuth2\Client;
 use Mautic\ApiBundle\Entity\oAuth2\ClientRepository;
 use Mautic\CoreBundle\Test\Doctrine\RepositoryConfiguratorTrait;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[AllowMockObjectsWithoutExpectations]
 final class ClientRepositoryTest extends TestCase
 {
     use RepositoryConfiguratorTrait;

--- a/app/bundles/ApiBundle/Tests/Unit/Helper/ClientSearchScopeProviderTest.php
+++ b/app/bundles/ApiBundle/Tests/Unit/Helper/ClientSearchScopeProviderTest.php
@@ -7,8 +7,10 @@ namespace Mautic\ApiBundle\Tests\Unit\Helper;
 use Mautic\ApiBundle\Helper\ClientSearchScopeProvider;
 use Mautic\CoreBundle\Model\SearchCommandListInterface;
 use Mautic\CoreBundle\Tests\Unit\Helper\SearchScopeProviderTestCase;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[AllowMockObjectsWithoutExpectations]
 final class ClientSearchScopeProviderTest extends SearchScopeProviderTestCase
 {
     protected function createProvider(): ClientSearchScopeProvider

--- a/app/bundles/AssetBundle/Tests/Unit/Helper/AssetSearchScopeProviderTest.php
+++ b/app/bundles/AssetBundle/Tests/Unit/Helper/AssetSearchScopeProviderTest.php
@@ -7,8 +7,10 @@ namespace Mautic\AssetBundle\Tests\Unit\Helper;
 use Mautic\AssetBundle\Helper\AssetSearchScopeProvider;
 use Mautic\AssetBundle\Model\AssetModel;
 use Mautic\CoreBundle\Tests\Unit\Helper\SearchScopeProviderTestCase;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[AllowMockObjectsWithoutExpectations]
 final class AssetSearchScopeProviderTest extends SearchScopeProviderTestCase
 {
     protected function createProvider(): AssetSearchScopeProvider

--- a/app/bundles/CampaignBundle/Tests/Unit/Helper/CampaignSearchScopeProviderTest.php
+++ b/app/bundles/CampaignBundle/Tests/Unit/Helper/CampaignSearchScopeProviderTest.php
@@ -7,8 +7,10 @@ namespace Mautic\CampaignBundle\Tests\Unit\Helper;
 use Mautic\CampaignBundle\Helper\CampaignSearchScopeProvider;
 use Mautic\CampaignBundle\Model\CampaignModel;
 use Mautic\CoreBundle\Tests\Unit\Helper\SearchScopeProviderTestCase;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[AllowMockObjectsWithoutExpectations]
 final class CampaignSearchScopeProviderTest extends SearchScopeProviderTestCase
 {
     protected function createProvider(): CampaignSearchScopeProvider

--- a/app/bundles/CategoryBundle/Tests/Unit/Helper/CategorySearchScopeProviderTest.php
+++ b/app/bundles/CategoryBundle/Tests/Unit/Helper/CategorySearchScopeProviderTest.php
@@ -7,8 +7,10 @@ namespace Mautic\CategoryBundle\Tests\Unit\Helper;
 use Mautic\CategoryBundle\Helper\CategorySearchScopeProvider;
 use Mautic\CategoryBundle\Model\CategoryModel;
 use Mautic\CoreBundle\Tests\Unit\Helper\SearchScopeProviderTestCase;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[AllowMockObjectsWithoutExpectations]
 final class CategorySearchScopeProviderTest extends SearchScopeProviderTestCase
 {
     protected function createProvider(): CategorySearchScopeProvider

--- a/app/bundles/ChannelBundle/Tests/Unit/Helper/MessageSearchScopeProviderTest.php
+++ b/app/bundles/ChannelBundle/Tests/Unit/Helper/MessageSearchScopeProviderTest.php
@@ -7,8 +7,10 @@ namespace Mautic\ChannelBundle\Tests\Unit\Helper;
 use Mautic\ChannelBundle\Helper\MessageSearchScopeProvider;
 use Mautic\ChannelBundle\Model\MessageModel;
 use Mautic\CoreBundle\Tests\Unit\Helper\SearchScopeProviderTestCase;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[AllowMockObjectsWithoutExpectations]
 final class MessageSearchScopeProviderTest extends SearchScopeProviderTestCase
 {
     protected function createProvider(): MessageSearchScopeProvider

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/AbstractSearchScopeProviderTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/AbstractSearchScopeProviderTest.php
@@ -6,9 +6,11 @@ namespace Mautic\CoreBundle\Tests\Unit\Helper;
 
 use Mautic\CoreBundle\Helper\AbstractSearchScopeProvider;
 use Mautic\CoreBundle\Helper\SearchScopePresets;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[AllowMockObjectsWithoutExpectations]
 final class AbstractSearchScopeProviderTest extends TestCase
 {
     public function testGetScopesDeduplicatesPinnedAndDynamicCommands(): void

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/PathsHelperTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/PathsHelperTest.php
@@ -8,10 +8,12 @@ use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\PathsHelper;
 use Mautic\CoreBundle\Helper\UserHelper;
 use Mautic\UserBundle\Entity\User;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
+#[AllowMockObjectsWithoutExpectations]
 final class PathsHelperTest extends TestCase
 {
     private string $cacheDir = __DIR__.'/resource/paths/cache';

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/ThemeSearchFilterTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/ThemeSearchFilterTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Mautic\CoreBundle\Tests\Unit\Helper;
 
 use Mautic\CoreBundle\Helper\ThemeSearchFilter;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[AllowMockObjectsWithoutExpectations]
 final class ThemeSearchFilterTest extends TestCase
 {
     private ThemeSearchFilter $filter;

--- a/app/bundles/CoreBundle/Tests/Unit/Helper/ThemeSearchScopeProviderTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Helper/ThemeSearchScopeProviderTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Mautic\CoreBundle\Tests\Unit\Helper;
 
 use Mautic\CoreBundle\Helper\ThemeSearchScopeProvider;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[AllowMockObjectsWithoutExpectations]
 final class ThemeSearchScopeProviderTest extends SearchScopeProviderTestCase
 {
     protected function createProvider(): ThemeSearchScopeProvider

--- a/app/bundles/CoreBundle/Tests/Unit/Serializer/ImportEntityDenormalizerTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Serializer/ImportEntityDenormalizerTest.php
@@ -9,11 +9,13 @@ use Mautic\EmailBundle\Entity\Email;
 use Mautic\FormBundle\Entity\Field;
 use Mautic\FormBundle\Entity\Form;
 use Mautic\LeadBundle\Entity\LeadField;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
+#[AllowMockObjectsWithoutExpectations]
 final class ImportEntityDenormalizerTest extends TestCase
 {
     private DenormalizerInterface&MockObject $decorated;

--- a/app/bundles/DynamicContentBundle/Tests/EventListener/DynamicContentExportListEventSubscriberTest.php
+++ b/app/bundles/DynamicContentBundle/Tests/EventListener/DynamicContentExportListEventSubscriberTest.php
@@ -10,9 +10,11 @@ use Mautic\CoreBundle\Helper\PathsHelper;
 use Mautic\DynamicContentBundle\Entity\DynamicContent;
 use Mautic\DynamicContentBundle\EventListener\DynamicContentExportListEventSubscriber;
 use Mautic\EmailBundle\Helper\EmailMediaImageHelper;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
+#[AllowMockObjectsWithoutExpectations]
 final class DynamicContentExportListEventSubscriberTest extends TestCase
 {
     private Filesystem $filesystem;

--- a/app/bundles/DynamicContentBundle/Tests/Unit/Helper/DynamicContentSearchScopeProviderTest.php
+++ b/app/bundles/DynamicContentBundle/Tests/Unit/Helper/DynamicContentSearchScopeProviderTest.php
@@ -7,8 +7,10 @@ namespace Mautic\DynamicContentBundle\Tests\Unit\Helper;
 use Mautic\CoreBundle\Tests\Unit\Helper\SearchScopeProviderTestCase;
 use Mautic\DynamicContentBundle\Helper\DynamicContentSearchScopeProvider;
 use Mautic\DynamicContentBundle\Model\DynamicContentModel;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[AllowMockObjectsWithoutExpectations]
 final class DynamicContentSearchScopeProviderTest extends SearchScopeProviderTestCase
 {
     protected function createProvider(): DynamicContentSearchScopeProvider

--- a/app/bundles/EmailBundle/Tests/EventListener/EmailExportListEventSubscriberTest.php
+++ b/app/bundles/EmailBundle/Tests/EventListener/EmailExportListEventSubscriberTest.php
@@ -10,9 +10,11 @@ use Mautic\CoreBundle\Helper\PathsHelper;
 use Mautic\EmailBundle\Entity\Email;
 use Mautic\EmailBundle\EventListener\EmailExportListEventSubscriber;
 use Mautic\EmailBundle\Helper\EmailMediaImageHelper;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
+#[AllowMockObjectsWithoutExpectations]
 final class EmailExportListEventSubscriberTest extends TestCase
 {
     private Filesystem $filesystem;

--- a/app/bundles/EmailBundle/Tests/Helper/EmailMediaImageHelperTest.php
+++ b/app/bundles/EmailBundle/Tests/Helper/EmailMediaImageHelperTest.php
@@ -7,10 +7,12 @@ namespace Mautic\EmailBundle\Tests\Helper;
 use Mautic\CoreBundle\Helper\CoreParametersHelper;
 use Mautic\CoreBundle\Helper\PathsHelper;
 use Mautic\EmailBundle\Helper\EmailMediaImageHelper;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
+#[AllowMockObjectsWithoutExpectations]
 final class EmailMediaImageHelperTest extends TestCase
 {
     private Filesystem $filesystem;

--- a/app/bundles/EmailBundle/Tests/Unit/Helper/EmailSearchScopeProviderTest.php
+++ b/app/bundles/EmailBundle/Tests/Unit/Helper/EmailSearchScopeProviderTest.php
@@ -7,8 +7,10 @@ namespace Mautic\EmailBundle\Tests\Unit\Helper;
 use Mautic\CoreBundle\Tests\Unit\Helper\SearchScopeProviderTestCase;
 use Mautic\EmailBundle\Helper\EmailSearchScopeProvider;
 use Mautic\EmailBundle\Model\EmailModel;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[AllowMockObjectsWithoutExpectations]
 final class EmailSearchScopeProviderTest extends SearchScopeProviderTestCase
 {
     protected function createProvider(): EmailSearchScopeProvider

--- a/app/bundles/FormBundle/Tests/Unit/Helper/FormSearchScopeProviderTest.php
+++ b/app/bundles/FormBundle/Tests/Unit/Helper/FormSearchScopeProviderTest.php
@@ -7,8 +7,10 @@ namespace Mautic\FormBundle\Tests\Unit\Helper;
 use Mautic\CoreBundle\Tests\Unit\Helper\SearchScopeProviderTestCase;
 use Mautic\FormBundle\Helper\FormSearchScopeProvider;
 use Mautic\FormBundle\Model\FormModel;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[AllowMockObjectsWithoutExpectations]
 final class FormSearchScopeProviderTest extends SearchScopeProviderTestCase
 {
     protected function createProvider(): FormSearchScopeProvider

--- a/app/bundles/LeadBundle/Tests/Unit/Helper/CompanySearchScopeProviderTest.php
+++ b/app/bundles/LeadBundle/Tests/Unit/Helper/CompanySearchScopeProviderTest.php
@@ -8,8 +8,10 @@ use Mautic\CoreBundle\Tests\Unit\Helper\SearchScopeProviderTestCase;
 use Mautic\LeadBundle\Field\FieldList;
 use Mautic\LeadBundle\Helper\CompanySearchScopeProvider;
 use Mautic\LeadBundle\Model\CompanyModel;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[AllowMockObjectsWithoutExpectations]
 final class CompanySearchScopeProviderTest extends SearchScopeProviderTestCase
 {
     protected function createProvider(): CompanySearchScopeProvider

--- a/app/bundles/LeadBundle/Tests/Unit/Helper/FieldSearchScopeProviderTest.php
+++ b/app/bundles/LeadBundle/Tests/Unit/Helper/FieldSearchScopeProviderTest.php
@@ -7,8 +7,10 @@ namespace Mautic\LeadBundle\Tests\Unit\Helper;
 use Mautic\CoreBundle\Tests\Unit\Helper\SearchScopeProviderTestCase;
 use Mautic\LeadBundle\Helper\FieldSearchScopeProvider;
 use Mautic\LeadBundle\Model\FieldModel;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[AllowMockObjectsWithoutExpectations]
 final class FieldSearchScopeProviderTest extends SearchScopeProviderTestCase
 {
     protected function createProvider(): FieldSearchScopeProvider

--- a/app/bundles/LeadBundle/Tests/Unit/Helper/LeadSearchScopeProviderTest.php
+++ b/app/bundles/LeadBundle/Tests/Unit/Helper/LeadSearchScopeProviderTest.php
@@ -8,8 +8,10 @@ use Mautic\CoreBundle\Tests\Unit\Helper\SearchScopeProviderTestCase;
 use Mautic\LeadBundle\Field\FieldList;
 use Mautic\LeadBundle\Helper\LeadSearchScopeProvider;
 use Mautic\LeadBundle\Model\LeadModel;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[AllowMockObjectsWithoutExpectations]
 final class LeadSearchScopeProviderTest extends SearchScopeProviderTestCase
 {
     protected function createProvider(): LeadSearchScopeProvider

--- a/app/bundles/LeadBundle/Tests/Unit/Helper/SegmentSearchScopeProviderTest.php
+++ b/app/bundles/LeadBundle/Tests/Unit/Helper/SegmentSearchScopeProviderTest.php
@@ -7,8 +7,10 @@ namespace Mautic\LeadBundle\Tests\Unit\Helper;
 use Mautic\CoreBundle\Tests\Unit\Helper\SearchScopeProviderTestCase;
 use Mautic\LeadBundle\Helper\SegmentSearchScopeProvider;
 use Mautic\LeadBundle\Model\ListModel;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[AllowMockObjectsWithoutExpectations]
 final class SegmentSearchScopeProviderTest extends SearchScopeProviderTestCase
 {
     protected function createProvider(): SegmentSearchScopeProvider

--- a/app/bundles/MarketplaceBundle/Tests/Functional/Service/ResourceInstallerTest.php
+++ b/app/bundles/MarketplaceBundle/Tests/Functional/Service/ResourceInstallerTest.php
@@ -13,6 +13,7 @@ use Mautic\CoreBundle\Helper\PathsHelper;
 use Mautic\CoreBundle\Test\AbstractMauticTestCase;
 use Mautic\MarketplaceBundle\Api\Connection;
 use Mautic\MarketplaceBundle\Service\ResourceInstaller;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Http\Message\ResponseInterface;
@@ -20,6 +21,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
+#[AllowMockObjectsWithoutExpectations]
 final class ResourceInstallerTest extends AbstractMauticTestCase
 {
     private const string PACKAGE = 'vendor/pkg';

--- a/app/bundles/PageBundle/Tests/EventListener/CampaignSubscriberTest.php
+++ b/app/bundles/PageBundle/Tests/EventListener/CampaignSubscriberTest.php
@@ -14,9 +14,11 @@ use Mautic\LeadBundle\Entity\LeadDeviceRepository;
 use Mautic\PageBundle\Entity\Hit;
 use Mautic\PageBundle\EventListener\CampaignSubscriber;
 use Mautic\PageBundle\Helper\TrackingHelper;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+#[AllowMockObjectsWithoutExpectations]
 final class CampaignSubscriberTest extends TestCase
 {
     private CampaignSubscriber $subscriber;

--- a/app/bundles/PageBundle/Tests/EventListener/PageExportListEventSubscriberTest.php
+++ b/app/bundles/PageBundle/Tests/EventListener/PageExportListEventSubscriberTest.php
@@ -10,9 +10,11 @@ use Mautic\CoreBundle\Helper\PathsHelper;
 use Mautic\EmailBundle\Helper\EmailMediaImageHelper;
 use Mautic\PageBundle\Entity\Page;
 use Mautic\PageBundle\EventListener\PageExportListEventSubscriber;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
+#[AllowMockObjectsWithoutExpectations]
 final class PageExportListEventSubscriberTest extends TestCase
 {
     private Filesystem $filesystem;

--- a/app/bundles/PageBundle/Tests/Unit/Helper/PageSearchScopeProviderTest.php
+++ b/app/bundles/PageBundle/Tests/Unit/Helper/PageSearchScopeProviderTest.php
@@ -7,8 +7,10 @@ namespace Mautic\PageBundle\Tests\Unit\Helper;
 use Mautic\CoreBundle\Tests\Unit\Helper\SearchScopeProviderTestCase;
 use Mautic\PageBundle\Helper\PageSearchScopeProvider;
 use Mautic\PageBundle\Model\PageModel;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[AllowMockObjectsWithoutExpectations]
 final class PageSearchScopeProviderTest extends SearchScopeProviderTestCase
 {
     protected function createProvider(): PageSearchScopeProvider

--- a/app/bundles/PointBundle/Tests/Unit/Helper/PointGroupSearchScopeProviderTest.php
+++ b/app/bundles/PointBundle/Tests/Unit/Helper/PointGroupSearchScopeProviderTest.php
@@ -7,8 +7,10 @@ namespace Mautic\PointBundle\Tests\Unit\Helper;
 use Mautic\CoreBundle\Tests\Unit\Helper\SearchScopeProviderTestCase;
 use Mautic\PointBundle\Helper\PointGroupSearchScopeProvider;
 use Mautic\PointBundle\Model\PointGroupModel;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[AllowMockObjectsWithoutExpectations]
 final class PointGroupSearchScopeProviderTest extends SearchScopeProviderTestCase
 {
     protected function createProvider(): PointGroupSearchScopeProvider

--- a/app/bundles/PointBundle/Tests/Unit/Helper/PointInsightSearchScopeProviderTest.php
+++ b/app/bundles/PointBundle/Tests/Unit/Helper/PointInsightSearchScopeProviderTest.php
@@ -7,8 +7,10 @@ namespace Mautic\PointBundle\Tests\Unit\Helper;
 use Mautic\CoreBundle\Model\SearchCommandListInterface;
 use Mautic\CoreBundle\Tests\Unit\Helper\SearchScopeProviderTestCase;
 use Mautic\PointBundle\Helper\PointInsightSearchScopeProvider;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[AllowMockObjectsWithoutExpectations]
 final class PointInsightSearchScopeProviderTest extends SearchScopeProviderTestCase
 {
     protected function createProvider(): PointInsightSearchScopeProvider

--- a/app/bundles/PointBundle/Tests/Unit/Helper/PointSearchScopeProviderTest.php
+++ b/app/bundles/PointBundle/Tests/Unit/Helper/PointSearchScopeProviderTest.php
@@ -7,8 +7,10 @@ namespace Mautic\PointBundle\Tests\Unit\Helper;
 use Mautic\CoreBundle\Tests\Unit\Helper\SearchScopeProviderTestCase;
 use Mautic\PointBundle\Helper\PointSearchScopeProvider;
 use Mautic\PointBundle\Model\PointModel;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[AllowMockObjectsWithoutExpectations]
 final class PointSearchScopeProviderTest extends SearchScopeProviderTestCase
 {
     protected function createProvider(): PointSearchScopeProvider

--- a/app/bundles/PointBundle/Tests/Unit/Helper/TriggerSearchScopeProviderTest.php
+++ b/app/bundles/PointBundle/Tests/Unit/Helper/TriggerSearchScopeProviderTest.php
@@ -7,8 +7,10 @@ namespace Mautic\PointBundle\Tests\Unit\Helper;
 use Mautic\CoreBundle\Tests\Unit\Helper\SearchScopeProviderTestCase;
 use Mautic\PointBundle\Helper\TriggerSearchScopeProvider;
 use Mautic\PointBundle\Model\TriggerModel;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[AllowMockObjectsWithoutExpectations]
 final class TriggerSearchScopeProviderTest extends SearchScopeProviderTestCase
 {
     protected function createProvider(): TriggerSearchScopeProvider

--- a/app/bundles/ProjectBundle/Tests/Unit/Helper/ProjectSearchScopeProviderTest.php
+++ b/app/bundles/ProjectBundle/Tests/Unit/Helper/ProjectSearchScopeProviderTest.php
@@ -7,8 +7,10 @@ namespace Mautic\ProjectBundle\Tests\Unit\Helper;
 use Mautic\CoreBundle\Entity\CommonRepository;
 use Mautic\CoreBundle\Tests\Unit\Helper\SearchScopeProviderTestCase;
 use Mautic\ProjectBundle\Helper\ProjectSearchScopeProvider;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[AllowMockObjectsWithoutExpectations]
 final class ProjectSearchScopeProviderTest extends SearchScopeProviderTestCase
 {
     protected function createProvider(): ProjectSearchScopeProvider

--- a/app/bundles/ReportBundle/Tests/Unit/Helper/ReportSearchScopeProviderTest.php
+++ b/app/bundles/ReportBundle/Tests/Unit/Helper/ReportSearchScopeProviderTest.php
@@ -7,8 +7,10 @@ namespace Mautic\ReportBundle\Tests\Unit\Helper;
 use Mautic\CoreBundle\Tests\Unit\Helper\SearchScopeProviderTestCase;
 use Mautic\ReportBundle\Helper\ReportSearchScopeProvider;
 use Mautic\ReportBundle\Model\ReportModel;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[AllowMockObjectsWithoutExpectations]
 final class ReportSearchScopeProviderTest extends SearchScopeProviderTestCase
 {
     protected function createProvider(): ReportSearchScopeProvider

--- a/app/bundles/StageBundle/Tests/Unit/Helper/StageSearchScopeProviderTest.php
+++ b/app/bundles/StageBundle/Tests/Unit/Helper/StageSearchScopeProviderTest.php
@@ -7,8 +7,10 @@ namespace Mautic\StageBundle\Tests\Unit\Helper;
 use Mautic\CoreBundle\Tests\Unit\Helper\SearchScopeProviderTestCase;
 use Mautic\StageBundle\Helper\StageSearchScopeProvider;
 use Mautic\StageBundle\Model\StageModel;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[AllowMockObjectsWithoutExpectations]
 final class StageSearchScopeProviderTest extends SearchScopeProviderTestCase
 {
     protected function createProvider(): StageSearchScopeProvider

--- a/app/bundles/UserBundle/Tests/Unit/Helper/RoleSearchScopeProviderTest.php
+++ b/app/bundles/UserBundle/Tests/Unit/Helper/RoleSearchScopeProviderTest.php
@@ -7,8 +7,10 @@ namespace Mautic\UserBundle\Tests\Unit\Helper;
 use Mautic\CoreBundle\Model\SearchCommandListInterface;
 use Mautic\CoreBundle\Tests\Unit\Helper\SearchScopeProviderTestCase;
 use Mautic\UserBundle\Helper\RoleSearchScopeProvider;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[AllowMockObjectsWithoutExpectations]
 final class RoleSearchScopeProviderTest extends SearchScopeProviderTestCase
 {
     protected function createProvider(): RoleSearchScopeProvider

--- a/app/bundles/UserBundle/Tests/Unit/Helper/UserSearchScopeProviderTest.php
+++ b/app/bundles/UserBundle/Tests/Unit/Helper/UserSearchScopeProviderTest.php
@@ -7,8 +7,10 @@ namespace Mautic\UserBundle\Tests\Unit\Helper;
 use Mautic\CoreBundle\Tests\Unit\Helper\SearchScopeProviderTestCase;
 use Mautic\UserBundle\Helper\UserSearchScopeProvider;
 use Mautic\UserBundle\Model\UserModel;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[AllowMockObjectsWithoutExpectations]
 final class UserSearchScopeProviderTest extends SearchScopeProviderTestCase
 {
     protected function createProvider(): UserSearchScopeProvider

--- a/app/bundles/WebhookBundle/Tests/Entity/WebhookRepositoryTest.php
+++ b/app/bundles/WebhookBundle/Tests/Entity/WebhookRepositoryTest.php
@@ -8,9 +8,11 @@ use Doctrine\DBAL\Query\QueryBuilder;
 use Mautic\CoreBundle\Test\Doctrine\RepositoryConfiguratorTrait;
 use Mautic\WebhookBundle\Entity\Webhook;
 use Mautic\WebhookBundle\Entity\WebhookRepository;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[AllowMockObjectsWithoutExpectations]
 final class WebhookRepositoryTest extends TestCase
 {
     use RepositoryConfiguratorTrait;

--- a/app/bundles/WebhookBundle/Tests/Unit/Helper/WebhookSearchScopeProviderTest.php
+++ b/app/bundles/WebhookBundle/Tests/Unit/Helper/WebhookSearchScopeProviderTest.php
@@ -7,8 +7,10 @@ namespace Mautic\WebhookBundle\Tests\Unit\Helper;
 use Mautic\CoreBundle\Tests\Unit\Helper\SearchScopeProviderTestCase;
 use Mautic\WebhookBundle\Helper\WebhookSearchScopeProvider;
 use Mautic\WebhookBundle\Model\WebhookModel;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[AllowMockObjectsWithoutExpectations]
 final class WebhookSearchScopeProviderTest extends SearchScopeProviderTestCase
 {
     protected function createProvider(): WebhookSearchScopeProvider

--- a/plugins/MauticFocusBundle/Tests/Unit/Helper/FocusSearchScopeProviderTest.php
+++ b/plugins/MauticFocusBundle/Tests/Unit/Helper/FocusSearchScopeProviderTest.php
@@ -7,8 +7,10 @@ namespace MauticPlugin\MauticFocusBundle\Tests\Unit\Helper;
 use Mautic\CoreBundle\Tests\Unit\Helper\SearchScopeProviderTestCase;
 use MauticPlugin\MauticFocusBundle\Helper\FocusSearchScopeProvider;
 use MauticPlugin\MauticFocusBundle\Model\FocusModel;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[AllowMockObjectsWithoutExpectations]
 final class FocusSearchScopeProviderTest extends SearchScopeProviderTestCase
 {
     protected function createProvider(): FocusSearchScopeProvider

--- a/plugins/MauticTagManagerBundle/Tests/Unit/Helper/TagSearchScopeProviderTest.php
+++ b/plugins/MauticTagManagerBundle/Tests/Unit/Helper/TagSearchScopeProviderTest.php
@@ -7,8 +7,10 @@ namespace MauticPlugin\MauticTagManagerBundle\Tests\Unit\Helper;
 use Mautic\CoreBundle\Tests\Unit\Helper\SearchScopeProviderTestCase;
 use Mautic\LeadBundle\Entity\TagRepository;
 use MauticPlugin\MauticTagManagerBundle\Helper\TagSearchScopeProvider;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
+#[AllowMockObjectsWithoutExpectations]
 final class TagSearchScopeProviderTest extends SearchScopeProviderTestCase
 {
     protected function createProvider(): TagSearchScopeProvider


### PR DESCRIPTION
PHPUnit 13 emits a notice when a mock object is created but never has expectations configured, suggesting a test stub instead:

> No expectations were configured for the mock object for X. The #[AllowMockObjectsWithoutExpectations] attribute can be used to opt out of this check.

These notices fire on unit tests that intentionally use mocks purely as stubs:

- `*SearchScopeProviderTest` classes - their shared assertions live in `SearchScopeProviderTestCase`, and each concrete test builds its provider from mocked dependencies used only as stubs.
- `ClientRepositoryTest` and `WebhookRepositoryTest` - built on `RepositoryConfiguratorTrait`, which creates unconfigured Doctrine mocks on purpose (see the trait's own note: metadata may or may not be resolved, so no invocation count can be expected).

This adds the class-level `#[AllowMockObjectsWithoutExpectations]` attribute to opt these tests out of the check, silencing the notices without weakening any assertions.
