### PR TITLE
Fix plugin updates without Doctrine metadata

### DIFF
--- a/app/bundles/PluginBundle/Helper/ReloadHelper.php
+++ b/app/bundles/PluginBundle/Helper/ReloadHelper.php
@@ -76,7 +76,7 @@ class ReloadHelper
 
                 // compare versions to see if an update is necessary
                 if ((empty($oldVersion) && !empty($plugin->getVersion())) || (!empty($oldVersion) && -1 === version_compare($oldVersion, $plugin->getVersion()))) {
-                    $metadata        = $pluginMetadata[$pluginConfig['namespace']] ?? null;
+                    $metadata        = $pluginMetadata[$pluginConfig['namespace']] ?? [];
                     $installedSchema = isset($installedPluginsSchemas[$pluginConfig['namespace']])
                         ? $installedPluginsSchemas[$allPlugins[$bundle]['namespace']] : null;
 

--- a/app/bundles/PluginBundle/Tests/Helper/ReloadHelperTest.php
+++ b/app/bundles/PluginBundle/Tests/Helper/ReloadHelperTest.php
@@ -124,6 +124,27 @@ class ReloadHelperTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('Updated description', $updatedPlugins['MauticZapierBundle']->getDescription());
     }
 
+    public function testUpdatePluginWithoutDoctrineMetadata(): void
+    {
+        $this->sampleAllPlugins['MauticZapierBundle']['config']['version'] = '1.0.1';
+        $sampleInstalledPlugins                                            = [
+            'MauticZapierBundle' => $this->createSampleZapierPlugin(),
+        ];
+        $plugin = $this->createSampleZapierPlugin();
+        $plugin->setVersion('1.0.1');
+        $event = new PluginUpdateEvent(
+            $plugin,
+            '1.0',
+            [],
+            $this->sampleSchemas['MauticPlugin\MauticZapierBundle']
+        );
+        $this->eventDispatcher->expects($this->once())->method('dispatch')->with($event, PluginEvents::ON_PLUGIN_UPDATE);
+
+        $updatedPlugins = $this->helper->updatePlugins($this->sampleAllPlugins, $sampleInstalledPlugins, [], $this->sampleSchemas);
+
+        $this->assertCount(1, $updatedPlugins);
+    }
+
     public function testInstallPlugins(): void
     {
         $sampleInstalledPlugins = [


### PR DESCRIPTION
## Summary

- pass an empty metadata array when updating a plugin without Doctrine entities
- keep the existing non-null `PluginUpdateEvent` API unchanged
- cover the missing-metadata update path with a regression test

Fixes #16170.

## Why

`ReloadHelper::updatePlugins()` currently falls back to `null` when the plugin namespace has no Doctrine metadata, but Mautic 6's `PluginUpdateEvent` requires an array. Updating an entity-free plugin can therefore fail with a `TypeError`.

The install path is intentionally unchanged because `PluginInstallEvent` explicitly accepts nullable metadata.

## Verification

- checked against current `origin/6.x` at `f4bec488e1e3424e4ea6918f57dcb27df0d88ef7`
- confirmed no existing fix or competing PR for #16170
- PHP 8.3 syntax checks passed for both changed files
- `bin/phpunit app/bundles/PluginBundle/Tests/Helper/ReloadHelperTest.php`: OK, 5 tests and 21 assertions
- PHP CS Fixer dry run: clean
