### PR TITLE
fix(contacts): keep numeric zero when saving custom fields via the API

### DIFF
--- a/app/bundles/LeadBundle/Controller/Api/CustomFieldsApiControllerTrait.php
+++ b/app/bundles/LeadBundle/Controller/Api/CustomFieldsApiControllerTrait.php
@@ -174,6 +174,11 @@ trait CustomFieldsApiControllerTrait
      */
     protected function setCustomFieldValues($entity, $form, $parameters, $isPostOrPatch = false)
     {
+        // The loop below adds an entry for every form field, including ones the request did not
+        // contain, so record the keys first. Comparing against them is what distinguishes a value
+        // that was supplied from one the form filled in.
+        $parameterKeysBeforeForm = array_keys($parameters);
+
         // set the custom field values
         // pull the data from the form in order to apply the form's formatting
         foreach ($form as $f) {
@@ -186,17 +191,25 @@ trait CustomFieldsApiControllerTrait
                 unset($parameters['points']);
             }
 
-            // When merging a contact because of a unique identifier match in POST /api/contacts//new or PATCH /api/contacts//edit all 0 values must be unset because
-            // we have to assume 0 was not meant to overwrite an existing value. Other empty values will be caught by LeadModel::setFieldValues
+            // On POST /api/contacts//new a unique identifier match turns the request into an update, and
+            // PATCH is always one. A 0 that only appeared via the loop above came from the entity or from
+            // the field default, so it must not overwrite an existing value. A 0 that was supplied in the
+            // request is an explicit instruction and is kept. Other empty values will be caught by
+            // LeadModel::setFieldValues.
             $parameters = array_filter(
                 $parameters,
-                function ($value): bool {
+                function ($value, $key) use ($parameterKeysBeforeForm): bool {
+                    if (in_array($key, $parameterKeysBeforeForm, true)) {
+                        return true;
+                    }
+
                     if (is_numeric($value)) {
                         return 0.0 !== (float) $value;
                     }
 
                     return true;
-                }
+                },
+                ARRAY_FILTER_USE_BOTH
             );
         }
 

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -673,14 +673,17 @@ class LeadModel extends FormModel
                         $newValue = implode('|', $newValue);
                     }
 
-                    $isEmpty = (null == $newValue || '' == $newValue);
+                    // $newValue is never null here - the `?? ''` above already maps null to ''.
+                    // A boolean field's "no change" option arrives as false via InputHelper::boolean(),
+                    // so false has to keep counting as empty. Numeric zero must not: that is #15030.
+                    $isEmpty = ('' === $newValue || false === $newValue);
                     if ($curValue !== $newValue && (!$isEmpty || $overwriteWithBlank)) {
                         $field['value'] = $newValue;
                         $lead->addUpdatedField($alias, $newValue, $curValue);
                     }
 
                     // if empty, check for social media data to plug the hole
-                    if (empty($newValue) && !empty($socialCache)) {
+                    if ($isEmpty && !empty($socialCache)) {
                         foreach ($socialCache as $service => $details) {
                             // check to see if a field has been assigned
 

--- a/app/bundles/LeadBundle/Tests/Controller/Api/CustomFieldsApiControllerTraitTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/CustomFieldsApiControllerTraitTest.php
@@ -10,6 +10,7 @@ use Mautic\LeadBundle\Entity\Lead;
 use Mautic\LeadBundle\Model\FieldModel;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\Form\Form;
+use Symfony\Component\Form\FormInterface;
 
 final class CustomFieldsApiControllerTraitTest extends \PHPUnit\Framework\TestCase
 {
@@ -64,10 +65,12 @@ final class CustomFieldsApiControllerTraitTest extends \PHPUnit\Framework\TestCa
     }
 
     /**
+     * A value the client sent explicitly is always forwarded, including 0.
+     *
      * @param array<string, mixed> $expectedParameters
      */
     #[DataProvider('numericValueProvider')]
-    public function testSetCustomFieldValuesFiltersOnlyNumericZero(mixed $value, array $expectedParameters): void
+    public function testSetCustomFieldValuesKeepsValuesSentByTheClient(mixed $value, array $expectedParameters): void
     {
         $model = new class() {
             /**
@@ -108,15 +111,104 @@ final class CustomFieldsApiControllerTraitTest extends \PHPUnit\Framework\TestCa
             }
         };
 
-        $controller->setCustomFieldValuesPublic(new Lead(), $this->createStub(Form::class), ['number_field' => $value]);
+        $controller->setCustomFieldValuesPublic(new Lead(), $this->createFormStub([]), ['number_field' => $value]);
 
         $this->assertSame($expectedParameters, $model->parameters);
+    }
+
+    /**
+     * A value the client did NOT send is injected by the form loop from the entity's current
+     * state. On a unique identifier match a 0 there must not overwrite an existing value.
+     *
+     * @param array<string, mixed> $expectedParameters
+     */
+    #[DataProvider('injectedValueProvider')]
+    public function testSetCustomFieldValuesDropsZeroInjectedByTheForm(mixed $value, array $expectedParameters): void
+    {
+        $model = new class() {
+            /**
+             * @var array<string, mixed>
+             */
+            public array $parameters = [];
+
+            /**
+             * @param array<string, mixed> $parameters
+             */
+            public function setFieldValues(Lead $lead, array $parameters, bool $overwriteWithBlank): void
+            {
+                $this->parameters = $parameters;
+            }
+        };
+
+        $controller = new class($model) {
+            use CustomFieldsApiControllerTrait;
+
+            private string $entityNameOne = 'lead';
+
+            public function __construct(
+                private object $model,
+            ) {
+            }
+
+            public function getModel(?string $name): object
+            {
+                return $this->model;
+            }
+
+            /**
+             * @param array<string, mixed> $parameters
+             */
+            public function setCustomFieldValuesPublic(Lead $lead, Form $form, array $parameters): void
+            {
+                $this->setCustomFieldValues($lead, $form, $parameters, true);
+            }
+        };
+
+        $controller->setCustomFieldValuesPublic(new Lead(), $this->createFormStub(['number_field' => $value]), []);
+
+        $this->assertSame($expectedParameters, $model->parameters);
+    }
+
+    /**
+     * @param array<string, mixed> $children
+     */
+    private function createFormStub(array $children): Form
+    {
+        $formFields = [];
+
+        foreach ($children as $name => $data) {
+            $formField = $this->createStub(FormInterface::class);
+            $formField->method('getName')->willReturn($name);
+            $formField->method('getData')->willReturn($data);
+            $formFields[] = $formField;
+        }
+
+        $form = $this->createStub(Form::class);
+        $form->method('getIterator')->willReturn(new \ArrayIterator($formFields));
+
+        return $form;
     }
 
     /**
      * @return \Generator<string, array{mixed, array<string, mixed>}>
      */
     public static function numericValueProvider(): \Generator
+    {
+        yield 'positive fraction' => [0.5, ['number_field' => 0.5]];
+        yield 'positive fraction string' => ['0.5', ['number_field' => '0.5']];
+        yield 'negative fraction' => [-0.5, ['number_field' => -0.5]];
+        yield 'integer' => [5, ['number_field' => 5]];
+        yield 'integer string' => ['5', ['number_field' => '5']];
+        yield 'integer zero' => [0, ['number_field' => 0]];
+        yield 'float zero' => [0.0, ['number_field' => 0.0]];
+        yield 'zero string' => ['0', ['number_field' => '0']];
+        yield 'decimal zero string' => ['0.00', ['number_field' => '0.00']];
+    }
+
+    /**
+     * @return \Generator<string, array{mixed, array<string, mixed>}>
+     */
+    public static function injectedValueProvider(): \Generator
     {
         yield 'positive fraction' => [0.5, ['number_field' => 0.5]];
         yield 'positive fraction string' => ['0.5', ['number_field' => '0.5']];

--- a/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiZeroValueFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiZeroValueFunctionalTest.php
@@ -62,6 +62,18 @@ final class LeadApiZeroValueFunctionalTest extends MauticMysqlTestCase
     }
 
     /**
+     * A text "0" already survived POST /new before this change: checkForDuplicateContact()
+     * calls setFieldValues() before the controller filter runs, and '0' was never loosely empty.
+     * Kept as a guard that narrowing the filter does not disturb that.
+     */
+    public function testPostNewPersistsZeroStringOnATextField(): void
+    {
+        $contactId = $this->createContact('zero-text-post@example.com', [self::TEXT_FIELD => '0']);
+
+        $this->assertSame('0', $this->getStoredValue($contactId, self::TEXT_FIELD));
+    }
+
+    /**
      * A field whose default is 0 receives it on POST /new. This already held before the change
      * (checked at the database level on both sides), so it is a guard that narrowing the filter
      * does not disturb how defaults are applied, not a fix.

--- a/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiZeroValueFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiZeroValueFunctionalTest.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\LeadBundle\Tests\Controller\Api;
+
+use Mautic\CoreBundle\Test\MauticMysqlTestCase;
+use Mautic\LeadBundle\Entity\Lead;
+use Mautic\LeadBundle\Entity\LeadField;
+use Mautic\LeadBundle\Model\FieldModel;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @see https://github.com/mautic/mautic/issues/15030
+ */
+final class LeadApiZeroValueFunctionalTest extends MauticMysqlTestCase
+{
+    private const NUMBER_FIELD  = 'test_score';
+
+    private const BOOLEAN_FIELD = 'test_optin';
+
+    private const ZERO_DEFAULT_FIELD = 'test_quota';
+
+    private const TEXT_FIELD = 'test_ref';
+
+    /**
+     * Creating custom fields issues DDL, which cannot be rolled back in a transaction.
+     */
+    protected $useCleanupRollback = false;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createCustomField(self::NUMBER_FIELD, 'number', ['roundmode' => 4, 'scale' => 0]);
+        $this->createCustomField(self::BOOLEAN_FIELD, 'boolean', ['no' => 'No', 'yes' => 'Yes']);
+        $this->createCustomField(self::ZERO_DEFAULT_FIELD, 'number', ['roundmode' => 4, 'scale' => 0], '0');
+        $this->createCustomField(self::TEXT_FIELD, 'text', []);
+    }
+
+    public function testPostNewPersistsZeroNumberField(): void
+    {
+        $contactId = $this->createContact('zero-post@example.com', [self::NUMBER_FIELD => 0]);
+
+        $this->assertSame(0, $this->getStoredValue($contactId, self::NUMBER_FIELD));
+    }
+
+    /**
+     * #15030 names Text fields as well as Number. is_numeric('0') is true, so the old
+     * filter stripped a text "0" on POST and PATCH too.
+     */
+    public function testPatchPersistsZeroStringOnATextField(): void
+    {
+        $contactId = $this->createContact('zero-text@example.com', [self::TEXT_FIELD => 'abc']);
+        $this->assertSame('abc', $this->getStoredValue($contactId, self::TEXT_FIELD));
+
+        $this->client->request(Request::METHOD_PATCH, '/api/contacts/'.$contactId.'/edit', [self::TEXT_FIELD => '0']);
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK, $this->client->getResponse()->getContent());
+
+        $this->assertSame('0', $this->getStoredValue($contactId, self::TEXT_FIELD));
+    }
+
+    /**
+     * A field whose default is 0 receives it on POST /new. This already held before the change
+     * (checked at the database level on both sides), so it is a guard that narrowing the filter
+     * does not disturb how defaults are applied, not a fix.
+     */
+    public function testPostNewAppliesAZeroFieldDefault(): void
+    {
+        $contactId = $this->createContact('zero-default-post@example.com', []);
+
+        $this->assertSame(0, $this->getStoredValue($contactId, self::ZERO_DEFAULT_FIELD));
+    }
+
+    public function testPatchPersistsZeroNumberField(): void
+    {
+        $contactId = $this->createContact('zero-patch@example.com', [self::NUMBER_FIELD => 5]);
+        $this->assertSame(5, $this->getStoredValue($contactId, self::NUMBER_FIELD));
+
+        $this->client->request(Request::METHOD_PATCH, '/api/contacts/'.$contactId.'/edit', [self::NUMBER_FIELD => 0]);
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK, $this->client->getResponse()->getContent());
+
+        $this->assertSame(0, $this->getStoredValue($contactId, self::NUMBER_FIELD));
+    }
+
+    /**
+     * Boolean fields are written through a path that does not reach
+     * LeadModel::setFieldValues(), so this already passes. Kept as a regression
+     * guard: the empty-check change must not alter it.
+     */
+    public function testPatchStillPersistsFalseBooleanField(): void
+    {
+        $contactId = $this->createContact('false-patch@example.com', [self::BOOLEAN_FIELD => 1]);
+        $this->assertSame(1, $this->getStoredValue($contactId, self::BOOLEAN_FIELD));
+
+        $this->client->request(Request::METHOD_PATCH, '/api/contacts/'.$contactId.'/edit', [self::BOOLEAN_FIELD => 0]);
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK, $this->client->getResponse()->getContent());
+
+        $this->assertSame(0, $this->getStoredValue($contactId, self::BOOLEAN_FIELD));
+    }
+
+    public function testPutStillPersistsZeroNumberField(): void
+    {
+        $contactId = $this->createContact('zero-put@example.com', [self::NUMBER_FIELD => 5]);
+
+        $this->client->request(Request::METHOD_PUT, '/api/contacts/'.$contactId.'/edit', [
+            'email'           => 'zero-put@example.com',
+            self::NUMBER_FIELD => 0,
+        ]);
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK, $this->client->getResponse()->getContent());
+
+        $this->assertSame(0, $this->getStoredValue($contactId, self::NUMBER_FIELD));
+    }
+
+    /**
+     * Guards the behaviour the removed array_filter was introduced for in bc7db68326:
+     * a field the client does not send must not be reset when POST /new matches an
+     * existing contact by unique identifier.
+     */
+    public function testPostNewDoesNotZeroUnsentNumericFieldOnIdentifierMatch(): void
+    {
+        $email     = 'identifier-match@example.com';
+        $contactId = $this->createContact($email, [self::NUMBER_FIELD => 5]);
+
+        $this->client->request(Request::METHOD_POST, '/api/contacts/new', [
+            'email'     => $email,
+            'firstname' => 'Unchanged',
+        ]);
+        $response = json_decode($this->client->getResponse()->getContent(), true);
+        $this->assertSame($contactId, $response['contact']['id'], 'Expected the identifier match to update the same contact.');
+
+        $this->assertSame(5, $this->getStoredValue($contactId, self::NUMBER_FIELD));
+    }
+
+    /**
+     * The narrowed filter's reason to exist. On PATCH the form submits with clearMissing=false,
+     * so a field the client omitted is injected from its 'data' option, which falls back to the
+     * field's default of 0. That injected zero must not overwrite the stored null.
+     *
+     * Without the filter this fails: the zero becomes non-empty after the LeadModel fix and is
+     * written. It is the one case that distinguishes narrowing the filter from deleting it.
+     */
+    public function testPatchDoesNotWriteZeroDefaultInjectedByTheFormForAnUnsentField(): void
+    {
+        // Created directly, not via POST, so prepareParametersForBinding does not apply the default.
+        $contact = new Lead();
+        $contact->setEmail('zero-default@example.com');
+        $this->em->persist($contact);
+        $this->em->flush();
+        $contactId = $contact->getId();
+
+        $this->assertNull($this->getStoredValue($contactId, self::ZERO_DEFAULT_FIELD), 'Precondition: field starts unset.');
+
+        $this->client->request(Request::METHOD_PATCH, '/api/contacts/'.$contactId.'/edit', ['firstname' => 'Untouched']);
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK, $this->client->getResponse()->getContent());
+
+        $this->assertNull(
+            $this->getStoredValue($contactId, self::ZERO_DEFAULT_FIELD),
+            'A zero the client did not send was injected by the form and must not be persisted.'
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $fields
+     */
+    private function createContact(string $email, array $fields): int
+    {
+        $this->client->request(Request::METHOD_POST, '/api/contacts/new', ['email' => $email] + $fields);
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED, $this->client->getResponse()->getContent());
+
+        return json_decode($this->client->getResponse()->getContent(), true)['contact']['id'];
+    }
+
+    private function getStoredValue(int $contactId, string $alias): mixed
+    {
+        $this->em->clear();
+
+        $this->client->request(Request::METHOD_GET, '/api/contacts/'.$contactId);
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK, $this->client->getResponse()->getContent());
+
+        return json_decode($this->client->getResponse()->getContent(), true)['contact']['fields']['all'][$alias];
+    }
+
+    /**
+     * @param array<string, mixed> $properties
+     */
+    private function createCustomField(string $alias, string $type, array $properties, ?string $defaultValue = null): void
+    {
+        $field = new LeadField();
+        $field->setDefaultValue($defaultValue);
+        $field->setType($type);
+        $field->setObject('lead');
+        $field->setGroup('core');
+        $field->setLabel(ucfirst(str_replace('_', ' ', $alias)));
+        $field->setAlias($alias);
+        $field->setProperties($properties);
+
+        $fieldModel = static::getContainer()->get(FieldModel::class);
+        \assert($fieldModel instanceof FieldModel);
+        $fieldModel->saveEntity($field);
+
+        $this->em->flush();
+    }
+}

--- a/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiZeroValueFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/Controller/Api/LeadApiZeroValueFunctionalTest.php
@@ -208,8 +208,8 @@ final class LeadApiZeroValueFunctionalTest extends MauticMysqlTestCase
         $field->setAlias($alias);
         $field->setProperties($properties);
 
-        $fieldModel = static::getContainer()->get(FieldModel::class);
-        \assert($fieldModel instanceof FieldModel);
+        $fieldModel = self::getContainer()->get(FieldModel::class);
+        $this->assertInstanceOf(FieldModel::class, $fieldModel);
         $fieldModel->saveEntity($field);
 
         $this->em->flush();

--- a/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
+++ b/app/bundles/LeadBundle/Tests/EventListener/CampaignSubscriberFunctionalTest.php
@@ -80,11 +80,13 @@ final class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
 
     protected function setUp(): void
     {
-        if ('testUpdatesContactCampaignActionWithBooleanFields' === $this->name()) {
-            $this->useCleanupRollback = false;
-        } else {
-            $this->useCleanupRollback = true;
-        }
+        // These tests create custom fields, which issues DDL and cannot be rolled back.
+        $createsCustomFields = [
+            'testUpdatesContactCampaignActionWithBooleanFields',
+            'testUpdatesContactCampaignActionWithNumericZero',
+        ];
+
+        $this->useCleanupRollback = !in_array($this->name(), $createsCustomFields, true);
 
         parent::setUp();
 
@@ -408,6 +410,60 @@ final class CampaignSubscriberFunctionalTest extends MauticMysqlTestCase
         $this->assertEquals($expectedCityValue, $cityValue);
 
         $this->assertEquals('abcdaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', $address1Value, 'Shortening too long messages did not work properly');
+    }
+
+    /**
+     * A campaign "Update contact" action must be able to set a number field to 0.
+     * Reported on #15030: "we have set up a campaign that isn't working correctly
+     * because custom fields values are never set to 0".
+     */
+    public function testUpdatesContactCampaignActionWithNumericZero(): void
+    {
+        $this->createField([
+            'alias'      => 'quota',
+            'label'      => 'Quota',
+            'type'       => 'number',
+            'properties' => ['roundmode' => 4, 'scale' => 0],
+        ]);
+
+        $contact   = $this->createContact('test_zero_'.uniqid().'@example.com');
+        $contactId = $contact->getId();
+
+        /** @var LeadModel $leadModel */
+        $leadModel = $this->getContainer()->get(LeadModel::class);
+        $leadModel->setFieldValues($contact, ['quota' => 5]);
+        $leadModel->saveEntity($contact);
+        $this->assertEquals(5, $contact->getFieldValue('quota'), 'Precondition: quota starts at 5.');
+
+        $campaign = new Campaign();
+        $campaign->setName('Test Numeric Zero Campaign');
+        $this->em->persist($campaign);
+
+        $this->addContactToCampaign($campaign, $contact);
+
+        $event = new Event();
+        $event->setCampaign($campaign);
+        $event->setName('Update contact quota');
+        $event->setType('lead.updatelead');
+        $event->setEventType('action');
+        $event->setTriggerMode('immediate');
+        $event->setProperties(['quota' => 0]);
+
+        $campaign->addEvent(1, $event);
+        $this->em->persist($campaign);
+        $this->em->flush();
+
+        $this->em->clear();
+
+        $exitCode = $this->testSymfonyCommand('mautic:campaigns:trigger', ['--campaign-id' => $campaign->getId()]);
+        $this->assertSame(0, $exitCode->getStatusCode());
+
+        $updated = $this->contactRepository->getEntity($contactId);
+        $this->assertInstanceOf(Lead::class, $updated);
+
+        $quota = $updated->getFieldValue('quota');
+        $this->assertNotNull($quota, 'Quota must still be set, not blanked.');
+        $this->assertEquals(0, $quota, 'A campaign action must be able to set a number field to 0.');
     }
 
     public function testUpdatesContactCampaignActionWithBooleanFields(): void

--- a/app/bundles/LeadBundle/Tests/Model/LeadModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/LeadModelTest.php
@@ -496,7 +496,7 @@ final class LeadModelTest extends \PHPUnit\Framework\TestCase
 
         $this->leadModel->setFieldValues($lead, ['score' => 0], false, true);
 
-        $this->assertSame(0.0, $lead->getFieldValue('score'), 'A zero must not be overwritten from the social cache.');
+        $this->assertEqualsWithDelta(0.0, $lead->getFieldValue('score'), PHP_FLOAT_EPSILON, 'A zero must not be overwritten from the social cache.');
     }
 
     public function testImportIsIgnoringContactWithNotFoundStage(): void

--- a/app/bundles/LeadBundle/Tests/Model/LeadModelTest.php
+++ b/app/bundles/LeadBundle/Tests/Model/LeadModelTest.php
@@ -71,6 +71,11 @@ final class LeadModelTest extends \PHPUnit\Framework\TestCase
     private MockObject|RequestStack $requestStack;
 
     /**
+     * @var MockObject&IntegrationHelper
+     */
+    private MockObject $integrationHelperMock;
+
+    /**
      * @var MockObject&FieldModel
      */
     private MockObject $fieldModelMock;
@@ -144,6 +149,7 @@ final class LeadModelTest extends \PHPUnit\Framework\TestCase
         parent::setUp();
 
         $this->requestStack             = new RequestStack([new Request()]);
+        $this->integrationHelperMock            = $this->createMock(IntegrationHelper::class);
         $this->fieldModelMock                   = $this->createMock(FieldModel::class);
         $this->fieldsWithUniqueIdentifier       = $this->createMock(FieldsWithUniqueIdentifier::class);
         $this->companyModelMock                 = $this->createMock(CompanyModel::class);
@@ -162,7 +168,7 @@ final class LeadModelTest extends \PHPUnit\Framework\TestCase
             $this->requestStack,
             $this->createStub(IpLookupHelper::class),
             $this->createStub(PathsHelper::class),
-            $this->createStub(IntegrationHelper::class),
+            $this->integrationHelperMock,
             $this->fieldModelMock,
             $this->fieldsWithUniqueIdentifier,
             $this->createStub(ListModel::class),
@@ -465,6 +471,32 @@ final class LeadModelTest extends \PHPUnit\Framework\TestCase
             ->with('mautic.stage.event.changed');
 
         $this->leadModel->setFieldValues($lead, $data, false, false);
+    }
+
+    /**
+     * The social-cache block fills "empty" fields from social profile data. empty() is true
+     * for 0, so a contact's legitimate zero used to be replaced by whatever social returned.
+     * Reusing $isEmpty keeps one definition of empty in the method.
+     */
+    public function testSetFieldValuesDoesNotReplaceZeroFromSocialCache(): void
+    {
+        $lead = new Lead();
+        $lead->setFields([
+            'core' => [
+                'score' => ['alias' => 'score', 'type' => 'number', 'value' => 0],
+            ],
+        ]);
+
+        $socialCache           = ['twitter' => ['profile' => ['profileHandle' => 999]]];
+        $socialFeatureSettings = ['twitter' => ['leadFields' => ['profileHandle' => 'score']]];
+
+        $this->integrationHelperMock->expects($this->once())
+            ->method('getUserProfiles')
+            ->willReturn([$socialCache, $socialFeatureSettings]);
+
+        $this->leadModel->setFieldValues($lead, ['score' => 0], false, true);
+
+        $this->assertSame(0.0, $lead->getFieldValue('score'), 'A zero must not be overwritten from the social cache.');
     }
 
     public function testImportIsIgnoringContactWithNotFoundStage(): void


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | Fixes #15030

## Description

A contact custom field cannot be set to `0`. Number fields are affected on `POST /new`, `PATCH /edit` and the campaign *Update contact* action; Text fields on `PATCH /edit`, because `is_numeric('0')` is true and the same code discards a text `"0"` (#15030 names both types). `PUT` is unaffected because it sets `overwriteWithBlank`.

This is my first Mautic contribution and I leaned heavily on AI assistance (Claude Code) for the investigation, so please review sceptically. Every claim below is backed by a test run or a commit I can point at, but I would rather you checked than took my word.

There are **two independent causes**, one per layer. With only the model fix applied, `POST /new` starts working while `PATCH` still fails, so both are needed. The reason for that split: on `POST /new` the values reach the entity through the `setFieldValues()` call inside `LeadModel::checkForDuplicateContact()`, which runs before the controller and never sees its filter, so the model fix is sufficient there. `PATCH` reaches the model only through the filter. That is also why a text `"0"` survived `POST /new` all along, while a Number `0` did not.

### 1. `LeadModel::setFieldValues()`

```php
$isEmpty = (null == $newValue || '' == $newValue);
```

`$newValue` can never be `null` here: `$data[$alias] ?? ''` a few lines above maps null to `''`. So the null half was never a null check. Under PHP 8 it matched `0`, `0.0` and `false`, and `cleanFields()` casts a Number field to float, so a zero arrives as `0.0` and is treated as empty.

`fb158dc5c9` (2017) made this strict deliberately, so boolean `false` would persist. `3473b3a579` ("fix test cases", Feb 2024) flipped both operators back while otherwise sweeping `$this->container` to `$this->getContainer()`; it came in via #10775, whose discussion never mentions this line.

**Restoring the 2017 line does not work**, which is worth flagging because it is the obvious fix:

- A campaign *Update contact* action uses `''` as its "No change" option for boolean fields, and `InputHelper::boolean('')` returns `false`. The loose `null == false` is what made "no change" work, so strictifying it breaks `testUpdatesContactCampaignActionWithBooleanFields`.
- Because the null comparison is dead code, PHPStan rejects it. #15900's CI shows exactly this: `identical.alwaysFalse` at `LeadModel.php:686` and `:694`.

So the condition is spelled out instead:

```php
$isEmpty = ('' === $newValue || false === $newValue);
```

`$isEmpty` is reused for the social-cache check below, which used `empty($newValue)` and so replaced a legitimate `0` with social profile data.

### 2. `CustomFieldsApiControllerTrait::setCustomFieldValues()`

This strips every numeric zero on POST and PATCH before the model runs. `bc7db68326` added it in 2018 to stop points being reset when a POST matches an existing contact, but the explicit `points` unset directly above it already covers that case.

**Not deleted, narrowed.** `b79d4e27ef` (July 2026) reworked this filter to preserve fractional values and added a unit test, so it is live code. The `foreach ($form as $f)` loop adds an entry for every form field including ones the request did not contain, so the keys are now recorded beforehand and skipped by the filter. A zero the form filled in is still dropped; a zero that was supplied is kept. Fractional handling is untouched.

Deleting it instead lets a field's zero *default* overwrite a stored `null` on any PATCH that omits it, which `testPatchDoesNotWriteZeroDefaultInjectedByTheFormForAnUnsentField` pins.

## Related work

- **#15900** targets the same issue and is still open. Credit for the diagnosis belongs to it and to @notz in the issue thread. It changes only `LeadModel`, so it cannot reach the PATCH case, and its strict-both form is what trips the PHPStan and campaign-test failures above.
- **@notz's patch** in the issue thread removes the filter. That fixes PATCH but causes the zero-default regression; I applied it as written and the guard test fails.
- **#17304** fixes #17264 in the same method. The two are compatible: applied together on this branch, `LeadBundle/Tests/{EventListener,Controller/Api,Model}` gives 418 tests, 2668 assertions, all passing. They can land in either order.

## Steps to reproduce

1. Create a Number custom field with alias `score`.
2. Create a contact and set `score` to `5`.
3. `PATCH /api/contacts/{id}/edit` with `{"score": 0}`.
4. Before: still `5`. After: `0`.

## Testing

20 tests added: 9 functional, 1 campaign, 1 model unit test, and 9 new data sets on the trait's existing unit test. The ones demonstrating a fix were each confirmed to fail against unmodified `7.2`; the rest are regression guards that pass either way (PUT, the unique-identifier-match case, boolean `false`, zero field defaults, and a text `"0"` on POST).

- `LeadApiZeroValueFunctionalTest` (9): POST/PATCH/PUT with `0`, text `"0"` on both POST and PATCH, boolean `false`, the unique-identifier-match guard, the injected-default guard, and that a zero field default still applies on POST.
- `CampaignSubscriberFunctionalTest::testUpdatesContactCampaignActionWithNumericZero`: fails on unmodified `7.2` with `Failed asserting that 5.0 matches expected 0`.
- `LeadModelTest::testSetFieldValuesDoesNotReplaceZeroFromSocialCache`: fails with `Failed asserting that 999.0 is identical to 0.0`.
- `CustomFieldsApiControllerTraitTest` split into two contracts: values present before the form loop (zeros kept) and values the form filled in (zeros still dropped).

`composer test`: 6972 tests, 42022 assertions, 1 failure, `SamlTest::testSamlLogin`, which fails identically on a clean `7.2` checkout here because it needs a SAML IdP on `localhost:8080`. Full `LeadBundle`: 1702 tests / 8096 assertions, 0 failures, against a clean baseline of 1682 / 7989. `composer phpstan` and `composer cs` clean.

## Notes

- Setting a boolean field to "No" still relies on the fixup loop in `CampaignSubscriber::updateLead()` (added by `1fcd7bced1`, matching #14224). This PR keeps `false` counting as empty, so that loop is still required. Separating `0`-means-No from `''`-means-no-change would be its own change.
- The same loose-comparison pattern remains at `CustomFieldsApiControllerTrait:55` and `CustomFieldEntityTrait:117`. Out of scope here, noted in case it is useful.
