### PR TITLE
Fix contact timeline "Email sent" entry showing bogus read-status text

### DIFF
--- a/app/bundles/EmailBundle/Resources/views/SubscribedEvents/Timeline/index.html.twig
+++ b/app/bundles/EmailBundle/Resources/views/SubscribedEvents/Timeline/index.html.twig
@@ -14,14 +14,16 @@
             {% else %}
                 {{ 'mautic.email.timeline.event.failed'|trans }}
             {% endif %}
-        {% elseif item.dateRead is empty %}
-            {{ 'mautic.email.timeline.event.not.read'|trans|purify }}
-        {% else %}
-            {{ ('mautic.email.timeline.event.' ~ event['extra']['type'])|trans({
-                    '%date%': dateToFull(event.timestamp),
-                    '%interval%': dateFormatRange(item.dateSent.diff(event.timestamp)),
-                    '%sent%': dateToFull(item.dateSent),
-            })|purify }}
+        {% elseif event['extra']['type'] == 'read' %}
+            {% if item.dateRead is empty %}
+                {{ 'mautic.email.timeline.event.not.read'|trans|purify }}
+            {% else %}
+                {{ ('mautic.email.timeline.event.' ~ event['extra']['type'])|trans({
+                        '%date%': dateToFull(item.dateRead),
+                        '%interval%': dateFormatRange(item.dateSent.diff(item.dateRead)),
+                        '%sent%': dateToFull(item.dateSent),
+                })|purify }}
+            {% endif %}
         {% endif %}
 
         {% if item.viewedInBrowser is not empty and item.viewedInBrowser %}

--- a/app/bundles/EmailBundle/Tests/Unit/Twig/TimelineEventTemplateTest.php
+++ b/app/bundles/EmailBundle/Tests/Unit/Twig/TimelineEventTemplateTest.php
@@ -31,9 +31,7 @@ final class TimelineEventTemplateTest extends TestCase
         $this->twig  = new Environment(new FilesystemLoader($templateDir));
 
         // Minimal stand-ins for the real Twig extensions Mautic wires into the container.
-        $this->twig->addFunction(new TwigFunction('dateToFull', static function ($datetime): string {
-            return $datetime instanceof \DateTimeInterface ? $datetime->format('F j, Y g:i a') : (string) $datetime;
-        }));
+        $this->twig->addFunction(new TwigFunction('dateToFull', static fn ($datetime): string => $datetime instanceof \DateTimeInterface ? $datetime->format('F j, Y g:i a') : (string) $datetime));
 
         $this->twig->addFunction(new TwigFunction('dateFormatRange', static function (\DateInterval $interval): string {
             $units    = ['y' => 'year', 'm' => 'month', 'd' => 'day', 'h' => 'hour', 'i' => 'minute', 's' => 'second'];
@@ -56,9 +54,7 @@ final class TimelineEventTemplateTest extends TestCase
         // Fake translator: returns the translation key followed by the interpolated
         // parameter values, so assertions can check both which key was chosen and
         // the interpolated values (real messages.ini strings aren't loaded here).
-        $this->twig->addFilter(new TwigFilter('trans', static function (string $key, array $params = []): string {
-            return $key.([] === $params ? '' : ' '.implode(' ', $params));
-        }));
+        $this->twig->addFilter(new TwigFilter('trans', static fn (string $key, array $params = []): string => $key.([] === $params ? '' : ' '.implode(' ', $params))));
     }
 
     public function testSentEntryDoesNotShowAnyReadStatusText(): void

--- a/app/bundles/EmailBundle/Tests/Unit/Twig/TimelineEventTemplateTest.php
+++ b/app/bundles/EmailBundle/Tests/Unit/Twig/TimelineEventTemplateTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\EmailBundle\Tests\Unit\Twig;
+
+use PHPUnit\Framework\TestCase;
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
+
+/**
+ * Regression test for https://github.com/mautic/mautic/issues/17320.
+ *
+ * The "Email sent" and "Email read" timeline entries are rendered by the same
+ * template (@MauticEmail/SubscribedEvents/Timeline/index.html.twig) against the
+ * same email_stats row. The template must only show the "was first read"/"not
+ * read yet" text for the 'read' entry, and the interval it displays must always
+ * be the diff between dateSent and dateRead, not the entry's own timestamp.
+ */
+final class TimelineEventTemplateTest extends TestCase
+{
+    private const TEMPLATE = 'index.html.twig';
+
+    private Environment $twig;
+
+    protected function setUp(): void
+    {
+        $templateDir = dirname(__DIR__, 3).'/Resources/views/SubscribedEvents/Timeline';
+        $this->twig  = new Environment(new FilesystemLoader($templateDir));
+
+        // Minimal stand-ins for the real Twig extensions Mautic wires into the container.
+        $this->twig->addFunction(new TwigFunction('dateToFull', static function ($datetime): string {
+            return $datetime instanceof \DateTimeInterface ? $datetime->format('F j, Y g:i a') : (string) $datetime;
+        }));
+
+        $this->twig->addFunction(new TwigFunction('dateFormatRange', static function (\DateInterval $interval): string {
+            $units    = ['y' => 'year', 'm' => 'month', 'd' => 'day', 'h' => 'hour', 'i' => 'minute', 's' => 'second'];
+            $formated = [];
+            foreach ($units as $property => $label) {
+                if ($interval->$property) {
+                    $formated[] = $interval->$property.' '.$label.(1 === $interval->$property ? '' : 's');
+                }
+            }
+
+            return [] === $formated ? 'Less than 1 second' : implode(' ', $formated);
+        }));
+
+        $this->twig->addFunction(new TwigFunction('dateToText', static fn ($datetime): string => (string) $datetime));
+
+        $this->twig->addFunction(new TwigFunction('path', static fn (string $name, array $params = []): string => $name));
+
+        $this->twig->addFilter(new TwigFilter('purify', static fn (?string $html): string => (string) $html));
+
+        // Fake translator: returns the translation key followed by the interpolated
+        // parameter values, so assertions can check both which key was chosen and
+        // the interpolated values (real messages.ini strings aren't loaded here).
+        $this->twig->addFilter(new TwigFilter('trans', static function (string $key, array $params = []): string {
+            return $key.([] === $params ? '' : ' '.implode(' ', $params));
+        }));
+    }
+
+    public function testSentEntryDoesNotShowAnyReadStatusText(): void
+    {
+        $dateSent = new \DateTime('2026-09-08 10:00:00');
+        $dateRead = (clone $dateSent)->modify('+22 hours +6 minutes +5 seconds');
+
+        // Mirrors LeadSubscriber::addEmailEvents(): for the 'sent' state, timestamp is dateSent itself.
+        $html = $this->render('sent', $dateSent, $dateRead, $dateSent);
+
+        $this->assertStringNotContainsString('mautic.email.timeline.event.read', $html);
+        $this->assertStringNotContainsString('mautic.email.timeline.event.not.read', $html);
+        $this->assertStringNotContainsString('Less than 1 second', $html);
+    }
+
+    public function testSentEntryShowsNothingEvenWhenEmailWasNotYetRead(): void
+    {
+        $dateSent = new \DateTime('2026-09-08 10:00:00');
+
+        $html = $this->render('sent', $dateSent, null, $dateSent);
+
+        $this->assertStringNotContainsString('mautic.email.timeline.event.not.read', $html);
+    }
+
+    public function testReadEntryShowsTheRealIntervalBetweenSentAndRead(): void
+    {
+        $dateSent = new \DateTime('2026-09-08 10:00:00');
+        $dateRead = (clone $dateSent)->modify('+22 hours +6 minutes +5 seconds');
+
+        // Mirrors LeadSubscriber::addEmailEvents(): for the 'read' state, timestamp is dateRead.
+        $html = $this->render('read', $dateSent, $dateRead, $dateRead);
+
+        $this->assertStringContainsString('mautic.email.timeline.event.read', $html);
+        $this->assertStringContainsString('22 hours 6 minutes 5 seconds', $html);
+        $this->assertStringNotContainsString('Less than 1 second', $html);
+    }
+
+    public function testReadEntryIntervalIgnoresAMismatchedEventTimestamp(): void
+    {
+        $dateSent = new \DateTime('2026-09-08 10:00:00');
+        $dateRead = (clone $dateSent)->modify('+22 hours +6 minutes +5 seconds');
+
+        // Even if the event's own timestamp diverged from item.dateRead, the interval
+        // must be computed from item.dateSent/item.dateRead, never from event.timestamp.
+        $html = $this->render('read', $dateSent, $dateRead, $dateSent);
+
+        $this->assertStringContainsString('22 hours 6 minutes 5 seconds', $html);
+    }
+
+    public function testReadEntryShowsNotReadYetWhenDateReadIsMissing(): void
+    {
+        $dateSent = new \DateTime('2026-09-08 10:00:00');
+
+        $html = $this->render('read', $dateSent, null, $dateSent);
+
+        $this->assertStringContainsString('mautic.email.timeline.event.not.read', $html);
+    }
+
+    public function testFailedEntryIsUnaffectedByTheTypeCheck(): void
+    {
+        $dateSent = new \DateTime('2026-09-08 10:00:00');
+
+        $html = $this->render('failed', $dateSent, null, $dateSent, isFailed: true);
+
+        $this->assertStringContainsString('mautic.email.timeline.event.failed', $html);
+        $this->assertStringNotContainsString('mautic.email.timeline.event.not.read', $html);
+    }
+
+    private function render(string $type, \DateTime $dateSent, ?\DateTime $dateRead, \DateTime $timestamp, bool $isFailed = false): string
+    {
+        $template = $this->twig->load(self::TEMPLATE);
+
+        return $template->render([
+            'event' => [
+                'extra' => [
+                    'type' => $type,
+                    'stat' => [
+                        'dateSent' => $dateSent,
+                        'dateRead' => $dateRead,
+                        'isFailed' => $isFailed,
+                    ],
+                ],
+                'timestamp' => $timestamp,
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️
| Related user documentation PR URL      | n/a
| Related developer documentation PR URL | n/a
| Issue(s) addressed                     | Fixes #17320

## Description

The contact timeline shows two separate entries per email (`LeadSubscriber::onTimelineGenerate()`: `sent` and `read`), but both are rendered by the same template (`SubscribedEvents/Timeline/index.html.twig`) against the same `email_stats` row (`item`).

The template's branch selection only checked `item.dateRead is empty`, not which entry (`event['extra']['type']`) was actually being rendered. So once an email was read, **both** the "Email sent" and "Email read" entries rendered the "was first read X after being sent" text.

That was compounded by a second bug: the interval shown was `item.dateSent.diff(event.timestamp)`. For the `sent` entry, `event.timestamp` is set to `item.dateSent` itself (see `LeadSubscriber::addEmailEvents()`), so on that entry the diff was always **zero** — i.e. the "Email sent" entry claimed the email was read "less than 1 second" after being sent, regardless of the real read delay (which was correctly shown on the separate "Email read" entry).

### Fix

- Gate the read-status block on `event['extra']['type'] == 'read'`, so the "Email sent" entry no longer shows any read-status text (matching what "Email sent" should show: only sent-related info).
- Compute the interval explicitly as `item.dateSent.diff(item.dateRead)` instead of `item.dateSent.diff(event.timestamp)`, so it's correct regardless of which entry's timestamp is passed in.

No PHP changes were needed — `LeadSubscriber` already tags every event with `extra.type` (`sent`/`read`/`failed`); only the shared template was fixed.

Submitted against `5.2` (the lowest currently maintained branch) since the same buggy branching is present unchanged in 5.2, 6.0, 7.0, 7.1 and 7.2.

---
### 📋 Steps to test this PR:

1. Send an email to a contact via a segment/broadcast (or campaign).
2. Open the tracking pixel URL / webview as that contact so the email is marked read (or manually set `email_stats.is_read = 1` and `date_read` for that row in a test instance).
3. View the contact's timeline (Contact detail page → History) and expand both the "Email sent" and "Email read" entries.
4. Before this fix: "Email sent" incorrectly shows "was first read ... less than 1 second after being sent". After this fix: "Email sent" shows no read-status text at all; only "Email read" shows the (correct) read interval.