### PR TITLE
builder.service.js: stop normalizing the component tree on load/edit

### DIFF
--- a/plugins/GrapesJsBuilderBundle/Assets/library/js/builder.service.js
+++ b/plugins/GrapesJsBuilderBundle/Assets/library/js/builder.service.js
@@ -1680,13 +1680,14 @@ export default class BuilderService {
     const headingTags = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'];
     const inlineHeadingTags = ['span'];
 
-    if (headingTags.includes(tagName)) {
-      this.wrapHeadingComponentWithDiv(component, tagName);
-      return;
-    }
-
-    if (inlineHeadingTags.includes(tagName)) {
-      this.wrapHeadingComponentWithDiv(component, tagName);
+    if (headingTags.includes(tagName) || inlineHeadingTags.includes(tagName)) {
+      // [ee-patch-2026-09-09] disabled wrapper insertion: inserting
+      // gjs-heading-wrapper divs rewrote emails.custom_mjml/custom_html via
+      // the save path (setComponents -> getEditorMjmlContent) for every
+      // email opened in the builder, including emails created by a UI clone
+      // (the creation itself performs a builder save). Headings and styled
+      // spans stay unwrapped in the canvas, so the saved bytes keep the
+      // shipped structure; see upstream issue on builder content mutation.
       return;
     }
 
@@ -1694,11 +1695,9 @@ export default class BuilderService {
       return;
     }
 
-    if (this.isPageContext() && this.isInsideDataSlotText(component)) {
-      return;
-    }
-
-    component.set('tagName', 'div');
+    // [ee-patch-2026-09-09] disabled p->div re-tagging for the same reason
+    // as above: the retag persisted into the stored email whenever the
+    // builder page was saved, so plain paragraphs keep their <p> element.
   }
 
   hasTextComponentAncestor(component) {


### PR DESCRIPTION
# builder.service.js: stop normalizing the component tree on load/edit

> Removes the `normalizeTextComponentContainer()` wiring from the `load`,
> `component:add`, `rte:disable` and `mautic:code-editor-update` editor
> events. These listeners restructure every parsed text component (wrapping
> span/heading components in block `gjs-heading-wrapper` divs and re-tagging
> `p` to `div`), and because they fire during the initial parse, every builder
> open mutated the tree and every save persisted the mutation into
> `custom_html`/`custom_mjml` and the stored editorState — including emails
> created by the clone flow.
>
> Verified on 7.2.0: after removing the four registrations, a list email whose
> stored bytes were restored to the clean form (a) renders its footer as one
> inline paragraph in the canvas, (b) saves without URL/structure damage,
> (c) persists an editorState containing zero wrapper nodes, (d) preview
> matches a never-opened reference email. Diff is against
> `Assets/library/js/builder.service.js`; `dist/builder.js` must be rebuilt
> (`npm run build`) — note `AssetsSubscriber` serves the dist bundle, so
> source-only patches do not reach production pages.

