### PR TITLE
ValidEmailLinksValidator: normalize-then-validate

### DIFF
--- a/app/bundles/EmailBundle/Validator/ValidEmailLinksValidator.php
+++ b/app/bundles/EmailBundle/Validator/ValidEmailLinksValidator.php
@@ -100,9 +100,77 @@ final class ValidEmailLinksValidator extends ConstraintValidator
         $scheme = strtolower((string) parse_url($url, PHP_URL_SCHEME));
 
         if (in_array($scheme, ['http', 'https', 'ftp', 'ftps'], true)) {
-            return UrlHelper::isValidUrl($url);
+            if (UrlHelper::isValidUrl($url)) {
+                return true;
+            }
+
+            // [ee-patch-2026-09-09 v2] builder round-trips can hand the
+            // validator scheme-carrying hrefs with raw spaces / unencoded
+            // > / parens (see upstream issue below); probe the same
+            // percent-encoded form before rejecting.
+            $probe = $this->encodeUrlProbeChars($url);
+
+            return UrlHelper::isValidUrl($probe);
         }
 
-        return in_array($scheme, ['mailto', 'tel', 'sms'], true);
+        if (in_array($scheme, ['mailto', 'tel', 'sms'], true)) {
+            return true;
+        }
+
+        // [ee-patch-2026-09-09 v2] normalize-then-validate instead of reject:
+        // path-relative and query-only anchors are template links (valid
+        // without a host), and host-prefixed scheme-less forms are validated
+        // after https:// scheme-fill plus percent-encoding, so Mautic's own
+        // click-tag pattern (?tags=Tag Name -> Stage) passes when the exact
+        // encoded form already passes. Still fails unparseable hrefs.
+        if (str_starts_with($url, '/') || str_starts_with($url, '?')) {
+            return true;
+        }
+
+        $candidate = $this->schemelessCandidateUrl($url);
+        if (null === $candidate) {
+            return false;
+        }
+
+        return UrlHelper::isValidUrl('https://'.$this->encodeUrlProbeChars($candidate));
+    }
+
+    /**
+     * Percent-encodes characters a URL validator (filter_var) rejects —
+     * raw spaces and angle brackets — while keeping the scheme and existing
+     * percent-sequences untouched, so the probe form is click-equivalent.
+     */
+    private function encodeUrlProbeChars(string $raw): string
+    {
+        return (string) preg_replace_callback(
+            '/%[0-9A-Fa-f]{2}|[^A-Za-z0-9_.~!$&()*+,;=:@\/?%#\-]/',
+            function (array $m): string {
+                return '%' === $m[0][0] ? $m[0] : rawurlencode($m[0]);
+            },
+            $raw
+        );
+    }
+
+    /**
+     * Returns $url when it is a host-prefixed scheme-less form that carries a
+     * path, query or fragment (safe to probe with an https:// prefix), else
+     * null. Restricting the shape keeps mailto:-like and pseudo-scheme text
+     * out of the probe.
+     */
+    private function schemelessCandidateUrl(string $url): ?string
+    {
+        if ('' === $url
+            || str_starts_with($url, '/')
+            || str_starts_with($url, '?')
+            || str_starts_with($url, '#')
+        ) {
+            return null;
+        }
+
+        if (1 !== preg_match('/^[A-Za-z0-9][A-Za-z0-9.\-]*(\.[A-Za-z][A-Za-z0-9\-]*)+[\/?#]/D', $url)) {
+            return null;
+        }
+
+        return $url;
     }
 }


### PR DESCRIPTION
# ValidEmailLinksValidator: normalize-then-validate

> Diff `patch-0002-valid-email-links-normalize.patch` (against
> 7.2 `app/bundles/EmailBundle/Validator/ValidEmailLinksValidator.php`):
> - `#`, path-relative and query-only hrefs stay valid (template links);
> - http/https/ftp/ftps URLs that fail `UrlHelper::isValidUrl` are retried
>   once against a percent-encoded probe (spaces/angle brackets encoded,
>   existing %-sequences preserved, scheme untouched);
> - scheme-less host-prefixed forms are probed as `https://` + encoding;
> - everything else (`javascript:`, garbage, bare filenames) still rejected.
> Validated with a staged 15-case harness against the live class, pre- and
> post-patch (raw/encoded/relative/scheme-present positive cases;
> javascript/garbage negative cases).

