### PR TITLE
[rector] Prepare loadMetadata() to Doctrine attributes custom rules

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -297,7 +297,6 @@ rules:
     - Utils\PHPStan\Rule\NoReadonlyEntityClassRule
     - Utils\PHPStan\Rule\NoReadonlyApiParamRule
     # enable later, might not be needed
-    # - Utils\PHPStan\Rule\NoLoadMetadataMethodRule
     - Utils\PHPStan\Rule\NoDuplicateNonRepeatableAttributeRule
 
 services:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -92,6 +92,15 @@ parameters:
             message: '#Property .+::\$variantParent type mapping mismatch: property can contain .+VariantEntityInterface\|null but database expects#'
             path: app/bundles/CoreBundle/Entity/VariantEntityTrait.php
             identifier: doctrine.associationType
+        # oAuth2 entities redeclare FOS parent properties whose declared types (interfaces, int) differ from the concrete Doctrine mapping
+        -
+            message: '#Property .+::\$(client|user) type mapping mismatch: property can contain .+but database expects#'
+            path: app/bundles/ApiBundle/Entity/oAuth2/*.php
+            identifier: doctrine.associationType
+        -
+            message: '#Property .+::\$expiresAt type mapping mismatch: database can contain string\|null but property expects int\|null#'
+            path: app/bundles/ApiBundle/Entity/oAuth2/*.php
+            identifier: doctrine.columnType
         # mocks
         - '#is not subtype of native type PHPUnit\\Framework\\MockObject\\MockObject#'
         - '#Call to an undefined method PHPUnit\\Framework\\MockObject\\MockObject#'
@@ -232,6 +241,11 @@ parameters:
             identifier: parameterByRef.type
             path: app/bundles/EmailBundle/Helper/PlainTextHelper.php
 
+        # not relevant
+        -
+            path: utils/rector/src/LoadMetadataToDoctrineAttributeRector.php
+            identifier: return.type
+
     scanDirectories:
         # the kernel boot reflects these classes, so PHPStan can no longer locate them by autoloading
         - vendor/javer/sp-bundle/src
@@ -251,6 +265,7 @@ parameters:
 rules:
     - Symplify\PHPStanRules\Rules\Complexity\NoJustPropertyAssignRule
     - Utils\PHPStan\Rule\AbstractClassNameMustBeAbstractRule
+    - Utils\PHPStan\Rule\NoStringTargetEntityRule
     - Utils\PHPStan\Rule\NoTablePrefixDefinitionInTestsRule
     - Utils\PHPStan\Rule\AutowireMethodNameMustMatchClassRule
     - Utils\PHPStan\Rule\NoGetModelWithStringInControllerRule
@@ -281,6 +296,9 @@ rules:
     - Utils\PHPStan\Rule\NoServiceGetterRule
     - Utils\PHPStan\Rule\NoReadonlyEntityClassRule
     - Utils\PHPStan\Rule\NoReadonlyApiParamRule
+    # enable later, might not be needed
+    # - Utils\PHPStan\Rule\NoLoadMetadataMethodRule
+    - Utils\PHPStan\Rule\NoDuplicateNonRepeatableAttributeRule
 
 services:
     - Utils\PHPStan\ServiceNameUsageResolver

--- a/rector.php
+++ b/rector.php
@@ -24,6 +24,9 @@ return RectorConfig::configure()
     ->withPhpSets(php84: true)
     ->withCache(__DIR__.'/var/cache/rector')
     ->withRules([
+        // to be used next on loadMetadata()
+        // \Utils\Rector\LoadMetadataToDoctrineAttributeRector::class,
+
         Rector\PHPUnit\CodeQuality\Rector\ClassMethod\AssertClassToThisAssertRector::class,
         Rector\TypeDeclarationDocblocks\Rector\Property\MergePhpstanDocTagIntoNativeRector::class,
         Rector\TypeDeclarationDocblocks\Rector\ClassMethod\NarrowArrayCollectionUnionReturnDocblockRector::class,

--- a/rector.php
+++ b/rector.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Utils\Rector\LoadMetadataMauticHelperToAttributeRector;
 use Utils\Rector\LoadMetadataStaticHelperToAttributeRector;
 use Utils\Rector\UnserializeToSerializerDecodeRector;
 
@@ -28,6 +29,7 @@ return RectorConfig::configure()
         // to be used next on loadMetadata()
         // \Utils\Rector\LoadMetadataToDoctrineAttributeRector::class,
         // LoadMetadataStaticHelperToAttributeRector::class,
+        // LoadMetadataMauticHelperToAttributeRector::class
 
         Rector\PHPUnit\CodeQuality\Rector\ClassMethod\AssertClassToThisAssertRector::class,
         Rector\TypeDeclarationDocblocks\Rector\Property\MergePhpstanDocTagIntoNativeRector::class,

--- a/rector.php
+++ b/rector.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Utils\Rector\LoadMetadataStaticHelperToAttributeRector;
 use Utils\Rector\UnserializeToSerializerDecodeRector;
 
 return RectorConfig::configure()
@@ -26,6 +27,7 @@ return RectorConfig::configure()
     ->withRules([
         // to be used next on loadMetadata()
         // \Utils\Rector\LoadMetadataToDoctrineAttributeRector::class,
+        // LoadMetadataStaticHelperToAttributeRector::class,
 
         Rector\PHPUnit\CodeQuality\Rector\ClassMethod\AssertClassToThisAssertRector::class,
         Rector\TypeDeclarationDocblocks\Rector\Property\MergePhpstanDocTagIntoNativeRector::class,

--- a/utils/phpstan/src/Rule/NoDuplicateNonRepeatableAttributeRule.php
+++ b/utils/phpstan/src/Rule/NoDuplicateNonRepeatableAttributeRule.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Rule;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Property;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * An attribute can only be repeated on the same class, method or property when it is
+ * declared with the \Attribute::IS_REPEATABLE flag. Report every non-repeatable one used twice.
+ *
+ * @implements Rule<Node\Stmt>
+ */
+final readonly class NoDuplicateNonRepeatableAttributeRule implements Rule
+{
+    public function __construct(
+        private ReflectionProvider $reflectionProvider,
+    ) {
+    }
+
+    public function getNodeType(): string
+    {
+        return Node\Stmt::class;
+    }
+
+    /**
+     * @return list<\PHPStan\Rules\IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $elementType = $this->resolveElementType($node);
+        if (null === $elementType) {
+            return [];
+        }
+
+        /** @var Class_|ClassMethod|Property $node */
+        $countByAttribute = [];
+        foreach ($node->attrGroups as $attrGroup) {
+            foreach ($attrGroup->attrs as $attr) {
+                $attributeName = $attr->name->toString();
+                $countByAttribute[$attributeName] = ($countByAttribute[$attributeName] ?? 0) + 1;
+            }
+        }
+
+        $ruleErrors = [];
+        foreach ($countByAttribute as $attributeName => $count) {
+            if ($count < 2) {
+                continue;
+            }
+
+            if ($this->isRepeatable($attributeName)) {
+                continue;
+            }
+
+            $ruleErrors[] = RuleErrorBuilder::message(sprintf(
+                'Attribute "#[%s]" is used %d times on the same %s, but is not repeatable. Add the \Attribute::IS_REPEATABLE flag to its #[\Attribute] declaration, or remove the duplicate.',
+                $attributeName,
+                $count,
+                $elementType
+            ))
+                ->identifier('mautic.noDuplicateNonRepeatableAttribute')
+                ->build();
+        }
+
+        return $ruleErrors;
+    }
+
+    private function resolveElementType(Node $node): ?string
+    {
+        if ($node instanceof Class_) {
+            return 'class';
+        }
+
+        if ($node instanceof ClassMethod) {
+            return 'method';
+        }
+
+        if ($node instanceof Property) {
+            return 'property';
+        }
+
+        return null;
+    }
+
+    private function isRepeatable(string $attributeName): bool
+    {
+        if (!$this->reflectionProvider->hasClass($attributeName)) {
+            // cannot confirm it is non-repeatable, so stay silent to avoid a false positive
+            return true;
+        }
+
+        $nativeReflection = $this->reflectionProvider->getClass($attributeName)->getNativeReflection();
+        foreach ($nativeReflection->getAttributes(\Attribute::class) as $reflectionAttribute) {
+            $flags = $reflectionAttribute->getArguments()[0] ?? 0;
+
+            return (bool) ($flags & \Attribute::IS_REPEATABLE);
+        }
+
+        // the class has no #[\Attribute] declaration, treat as non-repeatable
+        return false;
+    }
+}

--- a/utils/phpstan/src/Rule/NoStringTargetEntityRule.php
+++ b/utils/phpstan/src/Rule/NoStringTargetEntityRule.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Rule;
+
+use PhpParser\Node;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * A Doctrine association attribute must reference its target entity as a class constant
+ * (Target::class), not a string. A string skips IDE navigation, refactoring and static analysis,
+ * and hides typos until runtime.
+ *
+ * @implements Rule<Attribute>
+ */
+final class NoStringTargetEntityRule implements Rule
+{
+    /**
+     * @var string[]
+     */
+    private const ASSOCIATION_ATTRIBUTES = [
+        'Doctrine\ORM\Mapping\ManyToOne',
+        'Doctrine\ORM\Mapping\OneToMany',
+        'Doctrine\ORM\Mapping\OneToOne',
+        'Doctrine\ORM\Mapping\ManyToMany',
+    ];
+
+    public function getNodeType(): string
+    {
+        return Attribute::class;
+    }
+
+    /**
+     * @return list<\PHPStan\Rules\IdentifierRuleError>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!in_array($node->name->toString(), self::ASSOCIATION_ATTRIBUTES, true)) {
+            return [];
+        }
+
+        foreach ($node->args as $arg) {
+            if (!$arg->name instanceof Node\Identifier || 'targetEntity' !== $arg->name->toString()) {
+                continue;
+            }
+
+            if (!$arg->value instanceof String_) {
+                return [];
+            }
+
+            return [
+                RuleErrorBuilder::message(sprintf(
+                    'Doctrine association #[%s] uses a string targetEntity "%s"; use %s::class instead.',
+                    $node->name->getLast(),
+                    $arg->value->value,
+                    $arg->value->value,
+                ))
+                    ->identifier('mautic.noStringTargetEntity')
+                    ->build(),
+            ];
+        }
+
+        return [];
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/DuplicateNonRepeatableAttribute.php
+++ b/utils/phpstan/tests/Rule/Fixture/DuplicateNonRepeatableAttribute.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+#[NonRepeatableAttribute]
+#[NonRepeatableAttribute]
+final class DuplicateNonRepeatableAttribute
+{
+    #[NonRepeatableAttribute]
+    #[NonRepeatableAttribute]
+    private string $name;
+
+    #[NonRepeatableAttribute]
+    #[NonRepeatableAttribute]
+    public function run(): void
+    {
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/DuplicateRepeatableAttribute.php
+++ b/utils/phpstan/tests/Rule/Fixture/DuplicateRepeatableAttribute.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+#[RepeatableAttribute]
+#[RepeatableAttribute]
+final class DuplicateRepeatableAttribute
+{
+    #[RepeatableAttribute]
+    #[RepeatableAttribute]
+    private string $name;
+
+    #[NonRepeatableAttribute]
+    public function run(): void
+    {
+    }
+}

--- a/utils/phpstan/tests/Rule/Fixture/NonRepeatableAttribute.php
+++ b/utils/phpstan/tests/Rule/Fixture/NonRepeatableAttribute.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+#[\Attribute(\Attribute::TARGET_ALL)]
+final class NonRepeatableAttribute
+{
+}

--- a/utils/phpstan/tests/Rule/Fixture/RepeatableAttribute.php
+++ b/utils/phpstan/tests/Rule/Fixture/RepeatableAttribute.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+#[\Attribute(\Attribute::TARGET_ALL | \Attribute::IS_REPEATABLE)]
+final class RepeatableAttribute
+{
+}

--- a/utils/phpstan/tests/Rule/Fixture/StringTargetEntityAssociation.php
+++ b/utils/phpstan/tests/Rule/Fixture/StringTargetEntityAssociation.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+
+class StringTargetEntityAssociation
+{
+    #[ORM\ManyToOne(targetEntity: 'Tweet', inversedBy: 'stats')]
+    private $tweet;
+
+    #[ORM\ManyToOne(targetEntity: Tweet::class)]
+    private $tweetOk;
+
+    #[ORM\OneToMany(mappedBy: 'parent', targetEntity: 'Child')]
+    private $children;
+
+    #[ORM\Column(type: 'string')]
+    private $name;
+}

--- a/utils/phpstan/tests/Rule/NoDuplicateNonRepeatableAttributeRuleTest.php
+++ b/utils/phpstan/tests/Rule/NoDuplicateNonRepeatableAttributeRuleTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use Utils\PHPStan\Rule\NoDuplicateNonRepeatableAttributeRule;
+
+/**
+ * @extends RuleTestCase<NoDuplicateNonRepeatableAttributeRule>
+ */
+final class NoDuplicateNonRepeatableAttributeRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new NoDuplicateNonRepeatableAttributeRule($this->createReflectionProvider());
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/DuplicateNonRepeatableAttribute.php'], [
+            [
+                'Attribute "#[Utils\PHPStan\Tests\Rule\Fixture\NonRepeatableAttribute]" is used 2 times on the same class, but is not repeatable. Add the \Attribute::IS_REPEATABLE flag to its #[\Attribute] declaration, or remove the duplicate.',
+                7,
+            ],
+            [
+                'Attribute "#[Utils\PHPStan\Tests\Rule\Fixture\NonRepeatableAttribute]" is used 2 times on the same property, but is not repeatable. Add the \Attribute::IS_REPEATABLE flag to its #[\Attribute] declaration, or remove the duplicate.',
+                11,
+            ],
+            [
+                'Attribute "#[Utils\PHPStan\Tests\Rule\Fixture\NonRepeatableAttribute]" is used 2 times on the same method, but is not repeatable. Add the \Attribute::IS_REPEATABLE flag to its #[\Attribute] declaration, or remove the duplicate.',
+                15,
+            ],
+        ]);
+    }
+
+    public function testSkipRepeatableAttribute(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/DuplicateRepeatableAttribute.php'], []);
+    }
+}

--- a/utils/phpstan/tests/Rule/NoStringTargetEntityRuleTest.php
+++ b/utils/phpstan/tests/Rule/NoStringTargetEntityRuleTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\PHPStan\Tests\Rule;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use Utils\PHPStan\Rule\NoStringTargetEntityRule;
+
+/**
+ * @extends RuleTestCase<NoStringTargetEntityRule>
+ */
+final class NoStringTargetEntityRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new NoStringTargetEntityRule();
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse([__DIR__.'/Fixture/StringTargetEntityAssociation.php'], [
+            [
+                'Doctrine association #[ManyToOne] uses a string targetEntity "Tweet"; use Tweet::class instead.',
+                11,
+            ],
+            [
+                'Doctrine association #[OneToMany] uses a string targetEntity "Child"; use Child::class instead.',
+                17,
+            ],
+        ]);
+    }
+}

--- a/utils/rector/src/LoadMetadataMauticHelperToAttributeRector.php
+++ b/utils/rector/src/LoadMetadataMauticHelperToAttributeRector.php
@@ -1,0 +1,621 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\Rector;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\ArrayItem;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Expression;
+use Rector\Rector\AbstractRector;
+
+/**
+ * Rewrites Mautic's ClassMetadataBuilder convenience helpers in loadMetadata (addId,
+ * addBigIntIdField, addPublishDates, addContact, addFulltextIndex, ...) into the equivalent native
+ * builder calls they wrap. LoadMetadataToDoctrineAttributeRector then turns those native calls into
+ * attributes, so only vanilla Doctrine vocabulary reaches the first rule.
+ *
+ * Run this rule before LoadMetadataToDoctrineAttributeRector.
+ */
+final class LoadMetadataMauticHelperToAttributeRector extends AbstractRector
+{
+    /**
+     * Field and association helpers, each a standalone builder call that becomes one or more native
+     * createField()/createManyToOne() statements.
+     *
+     * @var string[]
+     */
+    private const array FIELD_HELPERS = [
+        'addId', 'addBigIntIdField', 'addIdColumns', 'addDateAdded', 'addPublishDates',
+        'addNullableField', 'addNamedField', 'addLead', 'addContact', 'addCategory', 'addIpAddress',
+    ];
+
+    /**
+     * Every builder call that heads a segment; trailing modifiers (columnName, addJoinColumn, ...)
+     * belong to the segment they follow.
+     *
+     * @var string[]
+     */
+    private const array SEGMENT_STARTERS = [
+        'setTable', 'setCustomRepositoryClass', 'setMappedSuperClass', 'addIndex', 'addFulltextIndex',
+        'addIndexWithOptions', 'addUniqueConstraint',
+        'createField', 'addField', 'createManyToOne', 'createOneToMany', 'createOneToOne', 'createManyToMany',
+        'addId', 'addBigIntIdField', 'addIdColumns', 'addDateAdded', 'addPublishDates',
+        'addNullableField', 'addNamedField', 'addLead', 'addContact', 'addCategory', 'addIpAddress',
+    ];
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        if (!$node instanceof Class_) {
+            return null;
+        }
+
+        $loadMetadata = $node->getMethod('loadMetadata');
+        if (!$loadMetadata instanceof ClassMethod || null === $loadMetadata->stmts) {
+            return null;
+        }
+
+        // In an already attribute-mapped class the leftover field helpers are redundant; leave them
+        // (and the class) alone. Class-level index helpers are still rewritten below.
+        $isHybrid = $this->hasClassLevelOrmAttribute($node);
+
+        $newStmts = [];
+        $changed  = false;
+
+        foreach ($loadMetadata->stmts as $stmt) {
+            if (!$isHybrid && $stmt instanceof Expression && $this->containsFieldHelper($stmt)) {
+                foreach ($this->unchainAndDesugar($stmt) as $produced) {
+                    $newStmts[] = $produced;
+                }
+
+                $changed = true;
+
+                continue;
+            }
+
+            // addFulltextIndex()/addIndexWithOptions() sit inside a fluent class-level chain; rewrite
+            // them to native addIndex() in place so the chain stays a single statement.
+            if ($this->rewriteIndexHelpers($stmt)) {
+                $changed = true;
+            }
+
+            $newStmts[] = $stmt;
+        }
+
+        if (!$changed) {
+            return null;
+        }
+
+        $loadMetadata->stmts = $newStmts;
+
+        return $node;
+    }
+
+    private function containsFieldHelper(Expression $stmt): bool
+    {
+        $current = $stmt->expr;
+        while ($current instanceof MethodCall) {
+            if ($current->name instanceof Identifier && in_array($current->name->toString(), self::FIELD_HELPERS, true)) {
+                return true;
+            }
+
+            $current = $current->var;
+        }
+
+        return false;
+    }
+
+    /**
+     * Split the statement's builder chain into per-starter segments; desugar the Mautic field/assoc
+     * segments and re-emit every other segment as its own native statement.
+     *
+     * @return list<Expression>
+     */
+    private function unchainAndDesugar(Expression $stmt): array
+    {
+        $expr = $stmt->expr;
+
+        $calls = $this->flattenChain($expr);
+        $root  = $this->chainRoot($expr);
+        if (null === $calls || !$root instanceof Variable) {
+            return [$stmt];
+        }
+
+        $segments = $this->splitIntoSegments($calls);
+        if (null === $segments) {
+            return [new Expression($expr)];
+        }
+
+        $produced = [];
+        foreach ($segments as $segment) {
+            $starter = $this->methodName($segment[0]);
+
+            if (1 === count($segment) && in_array($starter, self::FIELD_HELPERS, true)) {
+                foreach ($this->desugarFieldHelper($root, $segment[0]) as $desugared) {
+                    $produced[] = $desugared;
+                }
+
+                continue;
+            }
+
+            // Native segment: rebuild it as its own statement and rewrite index helpers in place.
+            $rebuilt = $this->rebuildSegment($root, $segment);
+            $this->rewriteIndexHelpers($rebuilt);
+            $produced[] = $rebuilt;
+        }
+
+        return $produced;
+    }
+
+    /**
+     * @return list<Expression>
+     */
+    private function desugarFieldHelper(Variable $builder, MethodCall $call): array
+    {
+        return match ($this->methodName($call)) {
+            'addId'            => [$this->buildAddId($builder)],
+            'addBigIntIdField' => [$this->buildBigIntIdField($builder, $call)],
+            'addIdColumns'     => $this->buildAddIdColumns($builder, $call),
+            'addDateAdded'     => [$this->buildDateAdded($builder, $call)],
+            'addPublishDates'  => $this->buildPublishDates($builder),
+            'addNullableField' => [$this->buildNullableField($builder, $call)],
+            'addNamedField'    => [$this->buildNamedField($builder, $call)],
+            'addLead'          => [$this->buildContactHelper($builder, $call, 'lead', 'lead_id', 'Mautic\\LeadBundle\\Entity\\Lead')],
+            'addContact'       => [$this->buildContactHelper($builder, $call, 'contact', 'contact_id', 'Mautic\\LeadBundle\\Entity\\Lead')],
+            'addCategory'      => [$this->buildCategory($builder)],
+            'addIpAddress'     => [$this->buildIpAddress($builder, $call)],
+            default            => [new Expression($call)],
+        };
+    }
+
+    private function buildAddId(Variable $builder): Expression
+    {
+        return $this->chain($builder, [
+            $this->step('createField', [$this->strArg('id'), $this->strArg('integer')]),
+            $this->step('makePrimaryKey', []),
+            $this->step('generatedValue', []),
+            $this->step('option', [$this->strArg('unsigned'), $this->boolArg(true)]),
+            $this->step('build', []),
+        ]);
+    }
+
+    private function buildBigIntIdField(Variable $builder, MethodCall $call): Expression
+    {
+        $fieldName  = $this->stringArg($call, 0) ?? 'id';
+        $columnName = $this->stringArg($call, 1) ?? 'id';
+        $isPrimary  = $this->boolArgValue($call, 2, true);
+        $isNullable = $this->boolArgValue($call, 3, false);
+
+        $steps = [
+            $this->step('createField', [$this->strArg($fieldName), $this->strArg('bigint')]),
+            $this->step('columnName', [$this->strArg($columnName)]),
+        ];
+
+        if ($isPrimary) {
+            $steps[] = $this->step('makePrimaryKey', []);
+            $steps[] = $this->step('generatedValue', []);
+        } elseif ($isNullable) {
+            $steps[] = $this->step('nullable', []);
+        }
+
+        $steps[] = $this->step('option', [$this->strArg('unsigned'), $this->boolArg(true)]);
+        $steps[] = $this->step('build', []);
+
+        return $this->chain($builder, $steps);
+    }
+
+    /**
+     * @return list<Expression>
+     */
+    private function buildAddIdColumns(Variable $builder, MethodCall $call): array
+    {
+        $nameColumn = $this->stringOrFalseArg($call, 0, 'name');
+        $descColumn = $this->stringOrFalseArg($call, 1, 'description');
+
+        $statements = [$this->buildAddId($builder)];
+
+        if (is_string($nameColumn)) {
+            $statements[] = $this->chain($builder, [
+                $this->step('createField', [$this->strArg($nameColumn), $this->strArg('string')]),
+                $this->step('build', []),
+            ]);
+        }
+
+        if (is_string($descColumn)) {
+            $statements[] = $this->chain($builder, [
+                $this->step('createField', [$this->strArg($descColumn), $this->strArg('text')]),
+                $this->step('nullable', []),
+                $this->step('build', []),
+            ]);
+        }
+
+        return $statements;
+    }
+
+    private function buildDateAdded(Variable $builder, MethodCall $call): Expression
+    {
+        $steps = [
+            $this->step('createField', [$this->strArg('dateAdded'), $this->strArg('datetime')]),
+            $this->step('columnName', [$this->strArg('date_added')]),
+        ];
+
+        if ($this->boolArgValue($call, 0, false)) {
+            $steps[] = $this->step('nullable', []);
+        }
+
+        $steps[] = $this->step('build', []);
+
+        return $this->chain($builder, $steps);
+    }
+
+    /**
+     * @return list<Expression>
+     */
+    private function buildPublishDates(Variable $builder): array
+    {
+        return [
+            $this->chain($builder, [
+                $this->step('createField', [$this->strArg('publishUp'), $this->strArg('datetime')]),
+                $this->step('columnName', [$this->strArg('publish_up')]),
+                $this->step('nullable', []),
+                $this->step('build', []),
+            ]),
+            $this->chain($builder, [
+                $this->step('createField', [$this->strArg('publishDown'), $this->strArg('datetime')]),
+                $this->step('columnName', [$this->strArg('publish_down')]),
+                $this->step('nullable', []),
+                $this->step('build', []),
+            ]),
+        ];
+    }
+
+    private function buildNullableField(Variable $builder, MethodCall $call): Expression
+    {
+        $name       = $this->stringArg($call, 0) ?? '';
+        $typeExpr   = $this->argValue($call, 1) ?? new String_('string');
+        $columnName = $this->stringArg($call, 2);
+
+        $steps = [
+            $this->step('createField', [$this->strArg($name), new Arg($typeExpr)]),
+            $this->step('nullable', []),
+        ];
+
+        if (null !== $columnName) {
+            $steps[] = $this->step('columnName', [$this->strArg($columnName)]);
+        }
+
+        $steps[] = $this->step('build', []);
+
+        return $this->chain($builder, $steps);
+    }
+
+    private function buildNamedField(Variable $builder, MethodCall $call): Expression
+    {
+        $name       = $this->stringArg($call, 0) ?? '';
+        $typeExpr   = $this->argValue($call, 1) ?? new String_('string');
+        $columnName = $this->stringArg($call, 2) ?? '';
+
+        $steps = [
+            $this->step('createField', [$this->strArg($name), new Arg($typeExpr)]),
+            $this->step('columnName', [$this->strArg($columnName)]),
+        ];
+
+        if ($this->boolArgValue($call, 3, false)) {
+            $steps[] = $this->step('nullable', []);
+        }
+
+        $steps[] = $this->step('build', []);
+
+        return $this->chain($builder, $steps);
+    }
+
+    private function buildContactHelper(Variable $builder, MethodCall $call, string $fieldName, string $joinColumnName, string $targetFqn): Expression
+    {
+        $nullable   = $this->boolArgValue($call, 0, false);
+        $onDelete   = $this->stringArg($call, 1) ?? 'CASCADE';
+        $isPrimary  = $this->boolArgValue($call, 2, false);
+        $inversedBy = $this->stringArg($call, 3);
+
+        $steps = [
+            $this->step('createManyToOne', [$this->strArg($fieldName), $this->classConstArg($targetFqn)]),
+        ];
+
+        if ($isPrimary) {
+            $steps[] = $this->step('makePrimaryKey', []);
+        }
+
+        if (null !== $inversedBy) {
+            $steps[] = $this->step('inversedBy', [$this->strArg($inversedBy)]);
+        }
+
+        $steps[] = $this->step('addJoinColumn', [
+            $this->strArg($joinColumnName),
+            $this->strArg('id'),
+            $this->boolArg($nullable),
+            $this->boolArg(false),
+            $this->strArg($onDelete),
+        ]);
+        $steps[] = $this->step('build', []);
+
+        return $this->chain($builder, $steps);
+    }
+
+    private function buildCategory(Variable $builder): Expression
+    {
+        return $this->chain($builder, [
+            $this->step('createManyToOne', [$this->strArg('category'), $this->classConstArg('Mautic\\CategoryBundle\\Entity\\Category')]),
+            $this->step('cascadeMerge', []),
+            $this->step('cascadeDetach', []),
+            $this->step('addJoinColumn', [
+                $this->strArg('category_id'),
+                $this->strArg('id'),
+                $this->boolArg(true),
+                $this->boolArg(false),
+                $this->strArg('SET NULL'),
+            ]),
+            $this->step('build', []),
+        ]);
+    }
+
+    private function buildIpAddress(Variable $builder, MethodCall $call): Expression
+    {
+        $nullable = $this->boolArgValue($call, 0, false);
+
+        return $this->chain($builder, [
+            $this->step('createManyToOne', [$this->strArg('ipAddress'), $this->classConstArg('Mautic\\CoreBundle\\Entity\\IpAddress')]),
+            $this->step('cascadePersist', []),
+            $this->step('cascadeMerge', []),
+            $this->step('cascadeDetach', []),
+            $this->step('addJoinColumn', [
+                $this->strArg('ip_id'),
+                $this->strArg('id'),
+                $this->boolArg($nullable),
+                $this->boolArg(false),
+                $this->strArg('SET NULL'),
+            ]),
+            $this->step('build', []),
+        ]);
+    }
+
+    /**
+     * Rewrites addFulltextIndex()/addIndexWithOptions() calls anywhere in the statement to the native
+     * addIndex(columns, name, flags, options) they expand to. Returns whether anything changed.
+     */
+    private function rewriteIndexHelpers(Node\Stmt $stmt): bool
+    {
+        if (!$stmt instanceof Expression) {
+            return false;
+        }
+
+        $changed = false;
+        $current = $stmt->expr;
+
+        while ($current instanceof MethodCall) {
+            if ($current->name instanceof Identifier) {
+                if ('addFulltextIndex' === $current->name->toString()) {
+                    $current->name = new Identifier('addIndex');
+                    $current->args = [
+                        ...$current->args,
+                        new Arg(new Array_([new ArrayItem(new String_('fulltext'))])),
+                    ];
+                    $changed = true;
+                } elseif ('addIndexWithOptions' === $current->name->toString() && 3 === count($current->args)) {
+                    // addIndex(columns, name, null flags, options).
+                    $options       = $current->args[2];
+                    $current->args = [
+                        $current->args[0],
+                        $current->args[1],
+                        new Arg(new ConstFetch(new Name('null'))),
+                        $options,
+                    ];
+                    $current->name = new Identifier('addIndex');
+                    $changed       = true;
+                }
+            }
+
+            $current = $current->var;
+        }
+
+        return $changed;
+    }
+
+    /**
+     * Rebuild a segment as a fresh $builder->a()->b() chain statement.
+     *
+     * @param list<MethodCall> $segment
+     */
+    private function rebuildSegment(Variable $builder, array $segment): Expression
+    {
+        $steps = [];
+        foreach ($segment as $call) {
+            $steps[] = $this->step($this->methodName($call), $call->args);
+        }
+
+        return $this->chain($builder, $steps);
+    }
+
+    /**
+     * @return list<MethodCall>|null
+     */
+    private function flattenChain(Expr $expr): ?array
+    {
+        $calls   = [];
+        $current = $expr;
+
+        while ($current instanceof MethodCall) {
+            $calls[] = $current;
+            $current = $current->var;
+        }
+
+        if (!$current instanceof Variable) {
+            return null;
+        }
+
+        return array_reverse($calls);
+    }
+
+    private function chainRoot(Expr $expr): Expr
+    {
+        $current = $expr;
+        while ($current instanceof MethodCall) {
+            $current = $current->var;
+        }
+
+        return $current;
+    }
+
+    /**
+     * @param list<MethodCall> $calls
+     *
+     * @return list<list<MethodCall>>|null
+     */
+    private function splitIntoSegments(array $calls): ?array
+    {
+        $segments = [];
+        $current  = null;
+
+        foreach ($calls as $call) {
+            if (in_array($this->methodName($call), self::SEGMENT_STARTERS, true)) {
+                if (null !== $current) {
+                    $segments[] = $current;
+                }
+
+                $current = [$call];
+
+                continue;
+            }
+
+            if (null === $current) {
+                return null;
+            }
+
+            $current[] = $call;
+        }
+
+        if (null !== $current) {
+            $segments[] = $current;
+        }
+
+        return $segments;
+    }
+
+    /**
+     * @param list<array{0: string, 1: array<Arg|Node\VariadicPlaceholder>}> $steps
+     */
+    private function chain(Variable $builder, array $steps): Expression
+    {
+        $expr = new Variable($builder->name);
+
+        foreach ($steps as [$name, $args]) {
+            $expr = new MethodCall($expr, new Identifier($name), $args);
+        }
+
+        return new Expression($expr);
+    }
+
+    /**
+     * @param array<Arg|Node\VariadicPlaceholder> $args
+     *
+     * @return array{0: string, 1: array<Arg|Node\VariadicPlaceholder>}
+     */
+    private function step(string $name, array $args): array
+    {
+        return [$name, $args];
+    }
+
+    private function strArg(string $value): Arg
+    {
+        return new Arg(new String_($value));
+    }
+
+    private function boolArg(bool $value): Arg
+    {
+        return new Arg(new ConstFetch(new Name($value ? 'true' : 'false')));
+    }
+
+    private function classConstArg(string $fqn): Arg
+    {
+        return new Arg(new ClassConstFetch(new FullyQualified($fqn), new Identifier('class')));
+    }
+
+    private function methodName(MethodCall $call): string
+    {
+        return $call->name instanceof Identifier ? $call->name->toString() : '';
+    }
+
+    private function argValue(MethodCall $call, int $index): ?Expr
+    {
+        if (!isset($call->args[$index]) || !$call->args[$index] instanceof Arg) {
+            return null;
+        }
+
+        return $call->args[$index]->value;
+    }
+
+    private function stringArg(MethodCall $call, int $index): ?string
+    {
+        $value = $this->argValue($call, $index);
+
+        return $value instanceof String_ ? $value->value : null;
+    }
+
+    private function boolArgValue(MethodCall $call, int $index, bool $default): bool
+    {
+        $value = $this->argValue($call, $index);
+        if (!$value instanceof ConstFetch) {
+            return $default;
+        }
+
+        return 'true' === $value->name->toString();
+    }
+
+    private function stringOrFalseArg(MethodCall $call, int $index, string $default): string|false
+    {
+        $value = $this->argValue($call, $index);
+
+        if ($value instanceof String_) {
+            return $value->value;
+        }
+
+        if ($value instanceof ConstFetch && 'false' === $value->name->toString()) {
+            return false;
+        }
+
+        return $default;
+    }
+
+    private function hasClassLevelOrmAttribute(Class_ $class): bool
+    {
+        foreach ($class->attrGroups as $attrGroup) {
+            foreach ($attrGroup->attrs as $attr) {
+                $name = $attr->name->toString();
+                if (str_starts_with($name, 'ORM\\') || str_starts_with($name, 'Doctrine\\ORM\\Mapping\\')) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/utils/rector/src/LoadMetadataStaticHelperToAttributeRector.php
+++ b/utils/rector/src/LoadMetadataStaticHelperToAttributeRector.php
@@ -1,0 +1,351 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\Rector;
+
+use PhpParser\Modifiers;
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\ArrayItem;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\AttributeGroup;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\PropertyItem;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\Property;
+use PhpParser\Node\Stmt\TraitUse;
+use Rector\Rector\AbstractRector;
+
+/**
+ * Converts the static mapping helpers in loadMetadata (self::addUuidField, self::addProjectsField,
+ * ...) into Doctrine attributes. Native ClassMetadataBuilder calls are left behind in a trimmed
+ * loadMetadata for LoadMetadataToDoctrineAttributeRector. A class is left untouched when no static
+ * helper could be converted.
+ *
+ * When both rules are configured together, order this one first: it treats a class that already
+ * carries ORM attributes as hybrid and then leaves addProjectsField behind, so it must see the
+ * pre-attribute class to emit the projects property.
+ */
+final class LoadMetadataStaticHelperToAttributeRector extends AbstractRector
+{
+    private bool $isHybrid = false;
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        if (!$node instanceof Class_) {
+            return null;
+        }
+
+        $loadMetadata = $node->getMethod('loadMetadata');
+        if (!$loadMetadata instanceof ClassMethod || null === $loadMetadata->stmts) {
+            return null;
+        }
+
+        // A hybrid class already maps its own fields via attributes, so a property-emitting helper
+        // is left behind; only known no-op helpers drop out of loadMetadata.
+        $this->isHybrid = $this->hasOrmMappingAttribute($node->attrGroups);
+
+        $builderAssignStatement = null;
+        $keptStatements         = [];
+        $newProperties          = [];
+        $anyConverted           = false;
+
+        foreach ($loadMetadata->stmts as $stmt) {
+            $converted = $this->convertStatement($stmt);
+
+            if ('assign' === $converted) {
+                $builderAssignStatement = $stmt;
+
+                continue;
+            }
+
+            if ('drop' === $converted) {
+                $anyConverted = true;
+
+                continue;
+            }
+
+            if ($converted instanceof Property) {
+                $newProperties[] = $converted;
+                $anyConverted    = true;
+
+                continue;
+            }
+
+            // Native builder calls and anything not understood stay in loadMetadata.
+            $keptStatements[] = $stmt;
+        }
+
+        // Nothing understood: leave the file untouched.
+        if (!$anyConverted) {
+            return null;
+        }
+
+        if ([] === $keptStatements) {
+            // Everything converted: drop loadMetadata entirely.
+            $node->stmts = array_values(array_filter(
+                $node->stmts,
+                static fn (Node $stmt): bool => $stmt !== $loadMetadata
+            ));
+        } else {
+            // Native builder calls stay in a trimmed loadMetadata for the attribute rule; keep their builder.
+            $loadMetadata->stmts = array_values(array_filter([$builderAssignStatement, ...$keptStatements]));
+        }
+
+        // Properties whose declaration lives in a trait get emitted into the class body so their
+        // per-entity mapping can be attached; place them after trait uses.
+        if ([] !== $newProperties) {
+            $insertAt = 0;
+            foreach ($node->stmts as $index => $stmt) {
+                if ($stmt instanceof TraitUse) {
+                    $insertAt = $index + 1;
+                }
+            }
+
+            array_splice($node->stmts, $insertAt, 0, $newProperties);
+        }
+
+        return $node;
+    }
+
+    /**
+     * Convert a single loadMetadata statement: 'assign' for the builder assignment, 'drop' for a
+     * no-op helper to remove, a Property for addProjectsField, or null to keep the statement.
+     */
+    private function convertStatement(Node\Stmt $stmt): string|Property|null
+    {
+        if (!$stmt instanceof Expression) {
+            return null;
+        }
+
+        $expr = $stmt->expr;
+
+        // $builder = new ClassMetadataBuilder($metadata);
+        if ($expr instanceof Expr\Assign) {
+            if ($expr->var instanceof Variable && $this->isName($expr->var, 'builder') && $expr->expr instanceof New_) {
+                return 'assign';
+            }
+
+            return null;
+        }
+
+        if (!$expr instanceof StaticCall) {
+            return null;
+        }
+
+        if ($this->isHybrid) {
+            return $this->isNoOpHelper($expr) ? 'drop' : null;
+        }
+
+        // self::addProjectsField($builder, $table, $column): emit a standalone projects property.
+        $projectsProperty = $this->tryProjectsField($expr);
+        if ($projectsProperty instanceof Property) {
+            return $projectsProperty;
+        }
+
+        return $this->isNoOpHelper($expr) ? 'drop' : null;
+    }
+
+    /**
+     * These helpers map trait properties (UuidTrait::$uuid, OptimisticLockTrait::$version,
+     * TranslationEntityTrait, VariantEntityTrait, DynamicContentEntityTrait) that carry their own
+     * mapping attributes. The properties are not in the class body, so no per-entity attribute is
+     * emitted; the call simply drops out of loadMetadata.
+     */
+    private function isNoOpHelper(StaticCall $call): bool
+    {
+        if (!$call->class instanceof Name || !in_array($call->class->toString(), ['self', 'static'], true)) {
+            return false;
+        }
+
+        if (!$call->name instanceof Identifier) {
+            return false;
+        }
+
+        $noOpHelpers = ['addUuidField', 'addVersionField', 'addTranslationMetadata', 'addVariantMetadata', 'addDynamicContentMetadata'];
+
+        return in_array($call->name->toString(), $noOpHelpers, true);
+    }
+
+    /**
+     * self::addProjectsField($builder, $tableName, $columnName) maps the trait-declared
+     * `projects` ManyToMany with a per-entity join table. Emit it as a standalone property.
+     */
+    private function tryProjectsField(StaticCall $call): ?Property
+    {
+        if (!$call->class instanceof Name || !in_array($call->class->toString(), ['self', 'static'], true)) {
+            return null;
+        }
+
+        if (!$call->name instanceof Identifier || 'addProjectsField' !== $call->name->toString()) {
+            return null;
+        }
+
+        // args: ($builder, $tableName, $columnName)
+        $tableName  = $this->stringFromArg($call->args, 1);
+        $columnName = $this->stringFromArg($call->args, 2);
+        if (null === $tableName || null === $columnName) {
+            return null;
+        }
+
+        $target = new ClassConstFetch(new FullyQualified('Mautic\\ProjectBundle\\Entity\\Project'), new Identifier('class'));
+
+        $attributeGroups = $this->manyToManyAttributes(
+            $target,
+            'name',
+            new Array_([new ArrayItem(new String_('ASC'), new String_('name'))]),
+            $tableName,
+            [$this->joinColumn($columnName, 'id', false, false, 'CASCADE')],
+            [$this->joinColumn('project_id', 'id', false, false, 'CASCADE')],
+        );
+
+        return new Property(
+            Modifiers::PRIVATE,
+            [new PropertyItem('projects')],
+            [],
+            new FullyQualified('Doctrine\\Common\\Collections\\Collection'),
+            $attributeGroups,
+        );
+    }
+
+    /**
+     * @param list<array{name: string, ref: string, nullable: bool, unique: bool, onDelete: ?string}> $joinColumns
+     * @param list<array{name: string, ref: string, nullable: bool, unique: bool, onDelete: ?string}> $inverseJoinColumns
+     *
+     * @return list<AttributeGroup>
+     */
+    private function manyToManyAttributes(
+        Expr $target,
+        string $indexBy,
+        Array_ $orderBy,
+        string $joinTable,
+        array $joinColumns,
+        array $inverseJoinColumns,
+    ): array {
+        $args = [
+            $this->namedArg('targetEntity', $target),
+            $this->namedArg('cascade', new Array_(array_map(
+                static fn (string $c): ArrayItem => new ArrayItem(new String_($c)),
+                ['merge', 'persist', 'detach'],
+            ))),
+            $this->namedArg('fetch', new String_('LAZY')),
+            $this->namedArg('indexBy', new String_($indexBy)),
+        ];
+
+        $attributes = [$this->attribute('ManyToMany', $args)];
+
+        $attributes[] = $this->attribute('JoinTable', [$this->namedArg('name', new String_($joinTable))]);
+
+        foreach ($joinColumns as $joinColumn) {
+            $attributes[] = $this->joinColumnAttribute($joinColumn);
+        }
+
+        foreach ($inverseJoinColumns as $inverseJoinColumn) {
+            $attributes[] = $this->joinColumnAttribute($inverseJoinColumn, 'InverseJoinColumn');
+        }
+
+        $attributes[] = $this->attribute('OrderBy', [new Arg($orderBy)]);
+
+        return $attributes;
+    }
+
+    /**
+     * @return array{name: string, ref: string, nullable: bool, unique: bool, onDelete: ?string}
+     */
+    private function joinColumn(string $name, string $ref, bool $nullable, bool $unique, ?string $onDelete): array
+    {
+        return ['name' => $name, 'ref' => $ref, 'nullable' => $nullable, 'unique' => $unique, 'onDelete' => $onDelete];
+    }
+
+    /**
+     * @param array{name: string, ref: string, nullable: bool, unique: bool, onDelete: ?string} $joinColumn
+     */
+    private function joinColumnAttribute(array $joinColumn, string $shortName = 'JoinColumn'): AttributeGroup
+    {
+        $args = [$this->namedArg('name', new String_($joinColumn['name']))];
+
+        if ('id' !== $joinColumn['ref']) {
+            $args[] = $this->namedArg('referencedColumnName', new String_($joinColumn['ref']));
+        }
+
+        // JoinColumn defaults to nullable: true, so only the false case needs stating.
+        if (!$joinColumn['nullable']) {
+            $args[] = $this->namedArg('nullable', new ConstFetch(new Name('false')));
+        }
+
+        if ($joinColumn['unique']) {
+            $args[] = $this->namedArg('unique', new ConstFetch(new Name('true')));
+        }
+
+        if (null !== $joinColumn['onDelete']) {
+            $args[] = $this->namedArg('onDelete', new String_($joinColumn['onDelete']));
+        }
+
+        return $this->attribute($shortName, $args);
+    }
+
+    /**
+     * @param Arg[] $args
+     */
+    private function attribute(string $shortName, array $args): AttributeGroup
+    {
+        return new AttributeGroup([new Attribute(new Name('ORM\\'.$shortName), array_values($args))]);
+    }
+
+    private function namedArg(string $name, Expr $value): Arg
+    {
+        return new Arg($value, false, false, [], new Identifier($name));
+    }
+
+    /**
+     * @param array<Arg|Node\VariadicPlaceholder> $args
+     */
+    private function stringFromArg(array $args, int $index): ?string
+    {
+        if (!isset($args[$index]) || !$args[$index] instanceof Arg) {
+            return null;
+        }
+
+        $value = $args[$index]->value;
+
+        return $value instanceof String_ ? $value->value : null;
+    }
+
+    /**
+     * @param AttributeGroup[] $attrGroups
+     */
+    private function hasOrmMappingAttribute(array $attrGroups): bool
+    {
+        foreach ($attrGroups as $attrGroup) {
+            foreach ($attrGroup->attrs as $attr) {
+                $name = $attr->name->toString();
+                if (str_starts_with($name, 'ORM\\') || str_starts_with($name, 'Doctrine\\ORM\\Mapping\\')) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/utils/rector/src/LoadMetadataToDoctrineAttributeRector.php
+++ b/utils/rector/src/LoadMetadataToDoctrineAttributeRector.php
@@ -57,16 +57,14 @@ final class LoadMetadataToDoctrineAttributeRector extends AbstractRector
     /**
      * @var string[]
      */
-    private const array CLASS_LEVEL_METHODS = ['setTable', 'setCustomRepositoryClass', 'addIndex', 'addFulltextIndex', 'addIndexWithOptions', 'addUniqueConstraint'];
+    private const array CLASS_LEVEL_METHODS = ['setTable', 'setCustomRepositoryClass', 'addIndex', 'addUniqueConstraint'];
 
     /**
      * @var string[]
      */
     private const array FIELD_CREATOR_METHODS = [
-        'createField', 'addBigIntIdField', 'addDateAdded', 'addId', 'addIdColumns',
-        'addNullableField', 'addNamedField', 'addField', 'addPublishDates',
+        'createField', 'addField',
         'createManyToOne', 'createOneToMany', 'createOneToOne', 'createManyToMany',
-        'addLead', 'addContact', 'addCategory', 'addIpAddress',
     ];
 
     /**
@@ -492,8 +490,7 @@ final class LoadMetadataToDoctrineAttributeRector extends AbstractRector
                     break;
 
                 case 'addIndex':
-                case 'addFulltextIndex':
-                    if (2 !== count($call->args) || !$call->args[0] instanceof Arg || !$call->args[1] instanceof Arg) {
+                    if (count($call->args) < 2 || !$call->args[0] instanceof Arg || !$call->args[1] instanceof Arg) {
                         return null;
                     }
 
@@ -506,27 +503,17 @@ final class LoadMetadataToDoctrineAttributeRector extends AbstractRector
                         $this->namedArg('name', $call->args[1]->value),
                     ];
 
-                    if ('addFulltextIndex' === $this->methodName($call)) {
-                        $indexArgs[] = $this->namedArg('flags', new Array_([new ArrayItem(new String_('fulltext'))]));
+                    // Optional flags array (addIndex(cols, name, ['fulltext'])).
+                    if (isset($call->args[2]) && $call->args[2] instanceof Arg && $call->args[2]->value instanceof Array_) {
+                        $indexArgs[] = $this->namedArg('flags', $call->args[2]->value);
+                    }
+
+                    // Optional options array (addIndex(cols, name, null, ['lengths' => ...])).
+                    if (isset($call->args[3]) && $call->args[3] instanceof Arg && $call->args[3]->value instanceof Array_) {
+                        $indexArgs[] = $this->namedArg('options', $call->args[3]->value);
                     }
 
                     $attributes[] = $this->attribute('Index', $indexArgs);
-                    break;
-
-                case 'addIndexWithOptions':
-                    if (3 !== count($call->args) || !$call->args[0] instanceof Arg || !$call->args[1] instanceof Arg || !$call->args[2] instanceof Arg) {
-                        return null;
-                    }
-
-                    if (!$call->args[0]->value instanceof Array_ || !$call->args[2]->value instanceof Array_) {
-                        return null;
-                    }
-
-                    $attributes[] = $this->attribute('Index', [
-                        $this->namedArg('columns', $call->args[0]->value),
-                        $this->namedArg('name', $call->args[1]->value),
-                        $this->namedArg('options', $call->args[2]->value),
-                    ]);
                     break;
 
                 case 'addUniqueConstraint':
@@ -617,22 +604,11 @@ final class LoadMetadataToDoctrineAttributeRector extends AbstractRector
     {
         return match ($this->methodName($calls[0])) {
             'createField'      => $this->handleCreateField($calls),
-            'addBigIntIdField' => $this->handleBigIntIdField($calls),
-            'addDateAdded'     => $this->handleDateAdded($calls),
-            'addId'            => $this->handleAddId($calls),
-            'addIdColumns'     => $this->handleAddIdColumns($calls),
-            'addNullableField' => $this->handleAddNullableField($calls),
-            'addNamedField'    => $this->handleAddNamedField($calls),
             'addField'         => $this->handleAddField($calls),
-            'addPublishDates'  => $this->handleAddPublishDates($calls),
             'createManyToOne'  => $this->handleAssociation($calls, 'ManyToOne'),
             'createOneToMany'  => $this->handleAssociation($calls, 'OneToMany'),
             'createOneToOne'   => $this->handleAssociation($calls, 'OneToOne'),
             'createManyToMany' => $this->handleManyToMany($calls),
-            'addLead'          => $this->handleContactHelper($calls, 'lead', 'lead_id', 'Mautic\\LeadBundle\\Entity\\Lead'),
-            'addContact'       => $this->handleContactHelper($calls, 'contact', 'contact_id', 'Mautic\\LeadBundle\\Entity\\Lead'),
-            'addCategory'      => $this->handleAddCategory($calls),
-            'addIpAddress'     => $this->handleAddIpAddress($calls),
             default            => null,
         };
     }
@@ -734,155 +710,6 @@ final class LoadMetadataToDoctrineAttributeRector extends AbstractRector
      *
      * @return array<string, list<AttributeGroup>>|null
      */
-    private function handleBigIntIdField(array $calls): ?array
-    {
-        if (1 !== count($calls)) {
-            return null;
-        }
-
-        $call       = $calls[0];
-        $fieldName  = $this->stringArg($call, 0) ?? 'id';
-        $columnName = $this->stringArg($call, 1) ?? 'id';
-        $isPrimary  = $this->boolArg($call, 2, true);
-        $isNullable = $this->boolArg($call, 3, false);
-
-        $options = [new ArrayItem(new ConstFetch(new Name('true')), new String_('unsigned'))];
-
-        return [$fieldName => $this->columnAttributes(
-            $fieldName,
-            $columnName,
-            new String_('bigint'),
-            null,
-            !$isPrimary && $isNullable,
-            false,
-            $options,
-            $isPrimary,
-            $isPrimary,
-            null,
-        )];
-    }
-
-    /**
-     * @param list<MethodCall> $calls
-     *
-     * @return array<string, list<AttributeGroup>>|null
-     */
-    private function handleAddId(array $calls): ?array
-    {
-        if (1 !== count($calls) || [] !== $calls[0]->args) {
-            return null;
-        }
-
-        $options = [new ArrayItem(new ConstFetch(new Name('true')), new String_('unsigned'))];
-
-        return ['id' => $this->columnAttributes(
-            'id',
-            null,
-            new String_('integer'),
-            null,
-            false,
-            false,
-            $options,
-            true,
-            true,
-            null,
-        )];
-    }
-
-    /**
-     * @param list<MethodCall> $calls
-     *
-     * @return array<string, list<AttributeGroup>>|null
-     */
-    private function handleAddIdColumns(array $calls): ?array
-    {
-        if (1 !== count($calls)) {
-            return null;
-        }
-
-        $call       = $calls[0];
-        $nameColumn = $this->stringOrFalseArg($call, 0, 'name');
-        $descColumn = $this->stringOrFalseArg($call, 1, 'description');
-
-        $result = ['id' => $this->columnAttributes(
-            'id',
-            null,
-            new String_('integer'),
-            null,
-            false,
-            false,
-            [new ArrayItem(new ConstFetch(new Name('true')), new String_('unsigned'))],
-            true,
-            true,
-            null,
-        )];
-
-        if (is_string($nameColumn)) {
-            $result[$nameColumn] = $this->columnAttributes($nameColumn, null, new String_('string'), null, false, false, [], false, false, null);
-        }
-
-        if (is_string($descColumn)) {
-            $result[$descColumn] = $this->columnAttributes($descColumn, null, new String_('text'), null, true, false, [], false, false, null);
-        }
-
-        return $result;
-    }
-
-    /**
-     * @param list<MethodCall> $calls
-     *
-     * @return array<string, list<AttributeGroup>>|null
-     */
-    private function handleAddNullableField(array $calls): ?array
-    {
-        if (1 !== count($calls)) {
-            return null;
-        }
-
-        $call      = $calls[0];
-        $fieldName = $this->stringArg($call, 0);
-        if (null === $fieldName) {
-            return null;
-        }
-
-        $typeExpr   = isset($call->args[1]) ? $this->typeExpr($call, 1) : new String_('string');
-        $columnName = $this->stringArg($call, 2);
-        if (null === $typeExpr) {
-            return null;
-        }
-
-        return [$fieldName => $this->columnAttributes($fieldName, $columnName, $typeExpr, null, true, false, [], false, false, null)];
-    }
-
-    /**
-     * @param list<MethodCall> $calls
-     *
-     * @return array<string, list<AttributeGroup>>|null
-     */
-    private function handleAddNamedField(array $calls): ?array
-    {
-        if (1 !== count($calls)) {
-            return null;
-        }
-
-        $call       = $calls[0];
-        $fieldName  = $this->stringArg($call, 0);
-        $typeExpr   = $this->typeExpr($call, 1);
-        $columnName = $this->stringArg($call, 2);
-        if (null === $fieldName || null === $typeExpr || null === $columnName) {
-            return null;
-        }
-
-        $nullable = $this->boolArg($call, 3, false);
-
-        return [$fieldName => $this->columnAttributes($fieldName, $columnName, $typeExpr, null, $nullable, false, [], false, false, null)];
-    }
-
-    /**
-     * @param list<MethodCall> $calls
-     *
-     * @return array<string, list<AttributeGroup>>|null
-     */
     private function handleAddField(array $calls): ?array
     {
         if (1 !== count($calls)) {
@@ -941,39 +768,6 @@ final class LoadMetadataToDoctrineAttributeRector extends AbstractRector
         }
 
         return [$fieldName => $this->columnAttributes($fieldName, $columnName, $typeExpr, $length, $nullable, $unique, [], false, false, null)];
-    }
-
-    /**
-     * @param list<MethodCall> $calls
-     *
-     * @return array<string, list<AttributeGroup>>|null
-     */
-    private function handleDateAdded(array $calls): ?array
-    {
-        if (1 !== count($calls)) {
-            return null;
-        }
-
-        $nullable = $this->boolArg($calls[0], 0, false);
-
-        return ['dateAdded' => $this->columnAttributes('dateAdded', 'date_added', new String_('datetime'), null, $nullable, false, [], false, false, null)];
-    }
-
-    /**
-     * @param list<MethodCall> $calls
-     *
-     * @return array<string, list<AttributeGroup>>|null
-     */
-    private function handleAddPublishDates(array $calls): ?array
-    {
-        if (1 !== count($calls) || [] !== $calls[0]->args) {
-            return null;
-        }
-
-        return [
-            'publishUp'   => $this->columnAttributes('publishUp', 'publish_up', new String_('datetime'), null, true, false, [], false, false, null),
-            'publishDown' => $this->columnAttributes('publishDown', 'publish_down', new String_('datetime'), null, true, false, [], false, false, null),
-        ];
     }
 
     /**
@@ -1297,99 +1091,6 @@ final class LoadMetadataToDoctrineAttributeRector extends AbstractRector
     }
 
     /**
-     * addLead($nullable, $onDelete, $isPrimaryKey, $inversedBy) and addContact(...).
-     *
-     * @param list<MethodCall> $calls
-     *
-     * @return array<string, list<AttributeGroup>>|null
-     */
-    private function handleContactHelper(array $calls, string $fieldName, string $joinColumnName, string $targetFqn): ?array
-    {
-        if (1 !== count($calls)) {
-            return null;
-        }
-
-        $call       = $calls[0];
-        $nullable   = $this->boolArg($call, 0, false);
-        $onDelete   = $this->stringArg($call, 1) ?? 'CASCADE';
-        $isPrimary  = $this->boolArg($call, 2, false);
-        $inversedBy = $this->stringArg($call, 3);
-
-        $target = new ClassConstFetch(new FullyQualified($targetFqn), new Identifier('class'));
-
-        return [$fieldName => $this->associationAttributes(
-            'ManyToOne',
-            $target,
-            null,
-            $inversedBy,
-            [],
-            null,
-            false,
-            $isPrimary,
-            null,
-            null,
-            [$this->joinColumn($joinColumnName, 'id', $nullable, false, $onDelete)],
-        )];
-    }
-
-    /**
-     * @param list<MethodCall> $calls
-     *
-     * @return array<string, list<AttributeGroup>>|null
-     */
-    private function handleAddCategory(array $calls): ?array
-    {
-        if (1 !== count($calls) || [] !== $calls[0]->args) {
-            return null;
-        }
-
-        $target = new ClassConstFetch(new FullyQualified('Mautic\\CategoryBundle\\Entity\\Category'), new Identifier('class'));
-
-        return ['category' => $this->associationAttributes(
-            'ManyToOne',
-            $target,
-            null,
-            null,
-            ['merge', 'detach'],
-            null,
-            false,
-            false,
-            null,
-            null,
-            [$this->joinColumn('category_id', 'id', true, false, 'SET NULL')],
-        )];
-    }
-
-    /**
-     * @param list<MethodCall> $calls
-     *
-     * @return array<string, list<AttributeGroup>>|null
-     */
-    private function handleAddIpAddress(array $calls): ?array
-    {
-        if (1 !== count($calls)) {
-            return null;
-        }
-
-        $nullable = $this->boolArg($calls[0], 0, false);
-        $target   = new ClassConstFetch(new FullyQualified('Mautic\\CoreBundle\\Entity\\IpAddress'), new Identifier('class'));
-
-        return ['ipAddress' => $this->associationAttributes(
-            'ManyToOne',
-            $target,
-            null,
-            null,
-            ['persist', 'merge', 'detach'],
-            null,
-            false,
-            false,
-            null,
-            null,
-            [$this->joinColumn('ip_id', 'id', $nullable, false, 'SET NULL')],
-        )];
-    }
-
-    /**
      * @return array{name: string, ref: string, nullable: bool, unique: bool, onDelete: ?string}
      */
     private function joinColumn(string $name, string $ref, bool $nullable, bool $unique, ?string $onDelete): array
@@ -1700,28 +1401,6 @@ final class LoadMetadataToDoctrineAttributeRector extends AbstractRector
         $value = $call->args[$index]->value;
 
         return $value instanceof String_ ? $value->value : null;
-    }
-
-    /**
-     * Returns the string value, false when the argument is literal false, or $default when absent.
-     */
-    private function stringOrFalseArg(MethodCall $call, int $index, string $default): string|false
-    {
-        if (!isset($call->args[$index]) || !$call->args[$index] instanceof Arg) {
-            return $default;
-        }
-
-        $value = $call->args[$index]->value;
-
-        if ($value instanceof String_) {
-            return $value->value;
-        }
-
-        if ($value instanceof ConstFetch && $this->isName($value, 'false')) {
-            return false;
-        }
-
-        return $default;
     }
 
     private function intArg(MethodCall $call, int $index): ?int

--- a/utils/rector/src/LoadMetadataToDoctrineAttributeRector.php
+++ b/utils/rector/src/LoadMetadataToDoctrineAttributeRector.php
@@ -16,7 +16,6 @@ use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\New_;
-use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
@@ -244,37 +243,8 @@ final class LoadMetadataToDoctrineAttributeRector extends AbstractRector
             return null;
         }
 
-        // self::addUuidField($builder) and friends.
-        if ($expr instanceof StaticCall) {
-            // Hybrid classes already map their own fields via attributes, so a helper that emits a
-            // property is left behind; a known no-op helper (its column lives on a trait property
-            // that carries its own attribute) is still understood and drops out of loadMetadata.
-            if ($this->isHybrid) {
-                $fields = $this->handleStaticHelper($expr);
-                if (null === $fields) {
-                    return null;
-                }
-
-                return $this->resolveTargets($fields, [], $node);
-            }
-
-            // self::addProjectsField($builder, $table, $column): emit a standalone projects property.
-            $projectsProperty = $this->tryProjectsField($expr);
-            if ($projectsProperty instanceof Property) {
-                $conversion                  = $this->resolveTargets([], [], $node);
-                $conversion['newProperties'] = [$projectsProperty];
-
-                return $conversion;
-            }
-
-            $fields = $this->handleStaticHelper($expr);
-            if (null === $fields) {
-                return null;
-            }
-
-            return $this->resolveTargets($fields, [], $node);
-        }
-
+        // Static helper calls (self::addUuidField, self::addProjectsField, ...) are left in
+        // loadMetadata for LoadMetadataStaticHelperToAttributeRector to convert.
         if (!$expr instanceof MethodCall) {
             return null;
         }
@@ -416,52 +386,6 @@ final class LoadMetadataToDoctrineAttributeRector extends AbstractRector
             'propertyResolved'   => $propertyResolved,
             'methodResolved'     => $methodResolved,
         ];
-    }
-
-    /**
-     * self::addProjectsField($builder, $tableName, $columnName) maps the trait-declared
-     * `projects` ManyToMany with a per-entity join table. Emit it as a standalone property.
-     */
-    private function tryProjectsField(StaticCall $call): ?Property
-    {
-        if (!$call->class instanceof Name || !in_array($call->class->toString(), ['self', 'static'], true)) {
-            return null;
-        }
-
-        if (!$call->name instanceof Identifier || 'addProjectsField' !== $call->name->toString()) {
-            return null;
-        }
-
-        // args: ($builder, $tableName, $columnName)
-        $tableName  = $this->stringFromArg($call->args, 1);
-        $columnName = $this->stringFromArg($call->args, 2);
-        if (null === $tableName || null === $columnName) {
-            return null;
-        }
-
-        $target = new ClassConstFetch(new FullyQualified('Mautic\\ProjectBundle\\Entity\\Project'), new Identifier('class'));
-
-        $attributeGroups = $this->manyToManyAttributes(
-            $target,
-            null,
-            null,
-            ['merge', 'persist', 'detach'],
-            'LAZY',
-            false,
-            'name',
-            new Array_([new ArrayItem(new String_('ASC'), new String_('name'))]),
-            $tableName,
-            [$this->joinColumn($columnName, 'id', false, false, 'CASCADE')],
-            [$this->joinColumn('project_id', 'id', false, false, 'CASCADE')],
-        );
-
-        return new Property(
-            Modifiers::PRIVATE,
-            [new PropertyItem('projects')],
-            [],
-            new FullyQualified('Doctrine\\Common\\Collections\\Collection'),
-            $attributeGroups,
-        );
     }
 
     /**
@@ -679,34 +603,6 @@ final class LoadMetadataToDoctrineAttributeRector extends AbstractRector
             && $value->name instanceof Identifier
         ) {
             return $value->name->toString();
-        }
-
-        return null;
-    }
-
-    /**
-     * Static mapping helpers shared across entities, called as self::x($builder).
-     *
-     * @return array<string, list<AttributeGroup>>|null
-     */
-    private function handleStaticHelper(StaticCall $call): ?array
-    {
-        if (!$call->class instanceof Name || !in_array($call->class->toString(), ['self', 'static'], true)) {
-            return null;
-        }
-
-        if (!$call->name instanceof Identifier) {
-            return null;
-        }
-
-        // These helpers map trait properties (UuidTrait::$uuid, OptimisticLockTrait::$version,
-        // TranslationEntityTrait, VariantEntityTrait, DynamicContentEntityTrait) that carry their
-        // own mapping attributes. Emit no per-entity attribute (the properties are not in the class
-        // body, so they cannot be annotated here) and do not bail, so the call drops out of
-        // loadMetadata.
-        $noOpHelpers = ['addUuidField', 'addVersionField', 'addTranslationMetadata', 'addVariantMetadata', 'addDynamicContentMetadata'];
-        if (in_array($call->name->toString(), $noOpHelpers, true)) {
-            return [];
         }
 
         return null;
@@ -1793,20 +1689,6 @@ final class LoadMetadataToDoctrineAttributeRector extends AbstractRector
     private function methodName(MethodCall $call): string
     {
         return $call->name instanceof Identifier ? $call->name->toString() : '';
-    }
-
-    /**
-     * @param array<Arg|Node\VariadicPlaceholder> $args
-     */
-    private function stringFromArg(array $args, int $index): ?string
-    {
-        if (!isset($args[$index]) || !$args[$index] instanceof Arg) {
-            return null;
-        }
-
-        $value = $args[$index]->value;
-
-        return $value instanceof String_ ? $value->value : null;
     }
 
     private function stringArg(MethodCall $call, int $index): ?string

--- a/utils/rector/src/LoadMetadataToDoctrineAttributeRector.php
+++ b/utils/rector/src/LoadMetadataToDoctrineAttributeRector.php
@@ -1,0 +1,2050 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\Rector;
+
+use PhpParser\Modifiers;
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\ArrayItem;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\AttributeGroup;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\NullableType;
+use PhpParser\Node\Param;
+use PhpParser\Node\PropertyItem;
+use PhpParser\Node\Scalar\Int_;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\Property;
+use PhpParser\Node\Stmt\TraitUse;
+use Rector\Rector\AbstractRector;
+
+/**
+ * Converts a static loadMetadata() ClassMetadataBuilder mapping into Doctrine attributes.
+ *
+ * Works statement by statement: every builder call the rule understands becomes an attribute,
+ * while anything it does not (isOwnershipParent, custom static helpers such as
+ * addTranslationMetadata, a field whose property is not in the class body, ...) stays behind
+ * in a trimmed loadMetadata for a follow-up change. A class is left untouched only when no
+ * statement could be converted.
+ */
+final class LoadMetadataToDoctrineAttributeRector extends AbstractRector
+{
+    /**
+     * Mautic's ClassMetadataBuilder caps every string column at this length (UTF8MB4 index limit).
+     */
+    private const int DEFAULT_STRING_LENGTH = 191;
+
+    private bool $isHybrid = false;
+
+    private bool $hybridHasTable = false;
+
+    private bool $hybridEntityHasRepositoryClass = false;
+
+    /**
+     * @var string[]
+     */
+    private const array CLASS_LEVEL_METHODS = ['setTable', 'setCustomRepositoryClass', 'addIndex', 'addFulltextIndex', 'addIndexWithOptions', 'addUniqueConstraint'];
+
+    /**
+     * @var string[]
+     */
+    private const array FIELD_CREATOR_METHODS = [
+        'createField', 'addBigIntIdField', 'addDateAdded', 'addId', 'addIdColumns',
+        'addNullableField', 'addNamedField', 'addField', 'addPublishDates',
+        'createManyToOne', 'createOneToMany', 'createOneToOne', 'createManyToMany',
+        'addLead', 'addContact', 'addCategory', 'addIpAddress',
+    ];
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        if (!$node instanceof Class_) {
+            return null;
+        }
+
+        $loadMetadata = $node->getMethod('loadMetadata');
+        if (!$loadMetadata instanceof ClassMethod || null === $loadMetadata->stmts) {
+            return null;
+        }
+
+        // A class may already carry ORM attributes on its properties while class-level and
+        // lifecycle mapping stays in loadMetadata. In that hybrid state we convert the leftover
+        // calls and merge the generated attributes into the existing ones instead of duplicating.
+        $this->isHybrid                       = $this->hasOrmMappingAttribute($node->attrGroups);
+        $this->hybridHasTable                 = $this->hasAttributeNamed($node->attrGroups, 'Table');
+        $this->hybridEntityHasRepositoryClass = $this->entityHasRepositoryClass($node->attrGroups);
+
+        $result = $this->interpret($loadMetadata->stmts, $node);
+        if (null === $result) {
+            return null;
+        }
+
+        [$classAttributes, $propertyResolved, $newProperties, $builderAssignStatement, $keptStatements, $methodResolved] = $result;
+
+        // Every entity gets DEFERRED_EXPLICIT from the builder constructor.
+        $classAttributes[] = $this->attribute('ChangeTrackingPolicy', [new Arg(new String_('DEFERRED_EXPLICIT'))]);
+
+        foreach ($propertyResolved as [$property, $attributeGroups]) {
+            $property->attrGroups = array_merge($property->attrGroups, $attributeGroups);
+        }
+
+        foreach ($methodResolved as [$method, $attributeGroups]) {
+            $method->attrGroups = array_merge($method->attrGroups, $attributeGroups);
+        }
+
+        if ($this->isHybrid) {
+            $this->mergeClassAttributes($node, $classAttributes);
+        } else {
+            $node->attrGroups = array_merge($node->attrGroups, $classAttributes);
+        }
+
+        if ([] === $keptStatements) {
+            // Everything converted: drop loadMetadata entirely.
+            $node->stmts = array_values(array_filter(
+                $node->stmts,
+                static fn (Node $stmt): bool => $stmt !== $loadMetadata
+            ));
+        } else {
+            // Builder calls this rule does not understand (isOwnershipParent, custom static
+            // helpers, ...) stay in a trimmed loadMetadata for a follow-up; keep their builder.
+            $loadMetadata->stmts = array_values(array_filter([$builderAssignStatement, ...$keptStatements]));
+        }
+
+        // Properties whose declaration lives in a trait (e.g. projects) get emitted into the
+        // class body so their per-entity mapping can be attached; place them after trait uses.
+        if ([] !== $newProperties) {
+            $insertAt = 0;
+            foreach ($node->stmts as $index => $stmt) {
+                if ($stmt instanceof TraitUse) {
+                    $insertAt = $index + 1;
+                }
+            }
+
+            array_splice($node->stmts, $insertAt, 0, $newProperties);
+        }
+
+        return $node;
+    }
+
+    /**
+     * Convert every statement the rule understands; leave the rest in loadMetadata. Returns
+     * null only when nothing was understood, so the file is left untouched.
+     *
+     * @param Node\Stmt[] $stmts
+     *
+     * @return array{list<AttributeGroup>, list<array{0: Property|Param, 1: list<AttributeGroup>}>, list<Property>, ?Expression, list<Expression>, list<array{0: ClassMethod, 1: list<AttributeGroup>}>}|null
+     */
+    private function interpret(array $stmts, Class_ $node): ?array
+    {
+        $classAttributes        = [];
+        $entityArgs             = [];
+        $isMappedSuperclass     = false;
+        $newProperties          = [];
+        $propertyResolved       = [];
+        $methodResolved         = [];
+        $builderAssignStatement = null;
+        $keptStatements         = [];
+        $anyConverted           = false;
+
+        foreach ($stmts as $stmt) {
+            $converted = $this->convertStatement($stmt, $node);
+
+            if ('assign' === $converted) {
+                $builderAssignStatement = $stmt;
+
+                continue;
+            }
+
+            if (null === $converted) {
+                // Not understood, or a target property/method is missing: leave the statement
+                // in loadMetadata for a follow-up instead of bailing the whole class.
+                $keptStatements[] = $stmt;
+
+                continue;
+            }
+
+            $classAttributes    = array_merge($classAttributes, $converted['classAttributes']);
+            $entityArgs         = array_merge($entityArgs, $converted['entityArgs']);
+            $isMappedSuperclass = $isMappedSuperclass || $converted['isMappedSuperclass'];
+            $newProperties      = array_merge($newProperties, $converted['newProperties']);
+
+            foreach ($converted['propertyResolved'] as $pair) {
+                $propertyResolved[] = $pair;
+            }
+
+            foreach ($converted['methodResolved'] as $pair) {
+                $methodResolved[] = $pair;
+            }
+
+            $anyConverted = true;
+        }
+
+        // Nothing understood: leave the file untouched.
+        if (!$anyConverted) {
+            return null;
+        }
+
+        // Lifecycle callbacks on methods require the class-level marker attribute.
+        if ([] !== $methodResolved) {
+            $classAttributes[] = $this->attribute('HasLifecycleCallbacks', []);
+        }
+
+        // The mapping root attribute is mandatory; place it first.
+        $rootAttribute = $isMappedSuperclass
+            ? $this->attribute('MappedSuperclass', $entityArgs)
+            : $this->attribute('Entity', $entityArgs);
+        array_unshift($classAttributes, $rootAttribute);
+
+        return [$classAttributes, $propertyResolved, $newProperties, $builderAssignStatement, $keptStatements, $methodResolved];
+    }
+
+    /**
+     * Convert a single loadMetadata statement. Returns 'assign' for the builder assignment,
+     * a conversion struct when fully understood and its targets exist, or null when the
+     * statement should stay in loadMetadata.
+     *
+     * @return 'assign'|array{classAttributes: list<AttributeGroup>, entityArgs: list<Arg>, isMappedSuperclass: bool, newProperties: list<Property>, propertyResolved: list<array{0: Property|Param, 1: list<AttributeGroup>}>, methodResolved: list<array{0: ClassMethod, 1: list<AttributeGroup>}>}|null
+     */
+    private function convertStatement(Node\Stmt $stmt, Class_ $node): string|array|null
+    {
+        if (!$stmt instanceof Expression) {
+            return null;
+        }
+
+        $expr = $stmt->expr;
+
+        // $builder = new ClassMetadataBuilder($metadata);
+        if ($expr instanceof Expr\Assign) {
+            if ($expr->var instanceof Variable && $this->isName($expr->var, 'builder') && $expr->expr instanceof New_) {
+                return 'assign';
+            }
+
+            return null;
+        }
+
+        // self::addUuidField($builder) and friends.
+        if ($expr instanceof StaticCall) {
+            // Hybrid classes already map their own fields via attributes, so a helper that emits a
+            // property is left behind; a known no-op helper (its column lives on a trait property
+            // that carries its own attribute) is still understood and drops out of loadMetadata.
+            if ($this->isHybrid) {
+                $fields = $this->handleStaticHelper($expr);
+                if (null === $fields) {
+                    return null;
+                }
+
+                return $this->resolveTargets($fields, [], $node);
+            }
+
+            // self::addProjectsField($builder, $table, $column): emit a standalone projects property.
+            $projectsProperty = $this->tryProjectsField($expr);
+            if ($projectsProperty instanceof Property) {
+                $conversion                  = $this->resolveTargets([], [], $node);
+                $conversion['newProperties'] = [$projectsProperty];
+
+                return $conversion;
+            }
+
+            $fields = $this->handleStaticHelper($expr);
+            if (null === $fields) {
+                return null;
+            }
+
+            return $this->resolveTargets($fields, [], $node);
+        }
+
+        if (!$expr instanceof MethodCall) {
+            return null;
+        }
+
+        $calls = $this->flattenChain($expr);
+        if (null === $calls) {
+            return null;
+        }
+
+        // A single fluent chain may mix class-level and field-level builder calls; split it
+        // into per-creator segments so each is interpreted on its own.
+        $segments = $this->splitIntoSegments($calls);
+        if (null === $segments) {
+            return null;
+        }
+
+        $classAttributes    = [];
+        $entityArgs         = [];
+        $isMappedSuperclass = false;
+        $propertyAttributes = [];
+        $methodAttributes   = [];
+
+        foreach ($segments as $segmentCalls) {
+            $first = $this->methodName($segmentCalls[0]);
+
+            // $builder->setMappedSuperClass(): emit #[ORM\MappedSuperclass] instead of #[ORM\Entity].
+            if ('setMappedSuperClass' === $first) {
+                if (1 !== count($segmentCalls) || [] !== $segmentCalls[0]->args) {
+                    return null;
+                }
+
+                $isMappedSuperclass = true;
+
+                continue;
+            }
+
+            if (in_array($first, self::CLASS_LEVEL_METHODS, true)) {
+                $handled = $this->handleClassChain($segmentCalls);
+                if (null === $handled) {
+                    return null;
+                }
+
+                $classAttributes = array_merge($classAttributes, $handled['attributes']);
+                $entityArgs      = array_merge($entityArgs, $handled['entityArgs']);
+
+                foreach ($handled['lifecycle'] as $methodName => $attributeGroups) {
+                    $methodAttributes[$methodName] = array_merge($methodAttributes[$methodName] ?? [], $attributeGroups);
+                }
+
+                continue;
+            }
+
+            $fields = $this->handleFieldChain($segmentCalls);
+            if (null === $fields) {
+                return null;
+            }
+
+            // A hybrid class already maps its own fields via attributes, so a field whose property
+            // is declared here is left behind to avoid duplicating it. A field whose property is
+            // missing (it lives in a parent) is still converted and redeclared by resolveTargets.
+            if ($this->isHybrid) {
+                foreach (array_keys($fields) as $fieldName) {
+                    if (null !== $this->findProperty($node, $fieldName)) {
+                        return null;
+                    }
+                }
+            }
+
+            foreach ($fields as $fieldName => $attributeGroups) {
+                $propertyAttributes[$fieldName] = $attributeGroups;
+            }
+        }
+
+        // A missing target property or method keeps the whole statement in loadMetadata.
+        $conversion = $this->resolveTargets($propertyAttributes, $methodAttributes, $node);
+        if (null === $conversion) {
+            return null;
+        }
+
+        $conversion['classAttributes']    = $classAttributes;
+        $conversion['entityArgs']         = $entityArgs;
+        $conversion['isMappedSuperclass'] = $isMappedSuperclass;
+
+        return $conversion;
+    }
+
+    /**
+     * Resolves field/method names against the class body. Returns a conversion struct, or null
+     * when any target is missing so the caller can keep the statement.
+     *
+     * @param array<string, list<AttributeGroup>> $propertyAttributes
+     * @param array<string, list<AttributeGroup>> $methodAttributes
+     *
+     * @return array{classAttributes: list<AttributeGroup>, entityArgs: list<Arg>, isMappedSuperclass: bool, newProperties: list<Property>, propertyResolved: list<array{0: Property|Param, 1: list<AttributeGroup>}>, methodResolved: list<array{0: ClassMethod, 1: list<AttributeGroup>}>}|null
+     */
+    private function resolveTargets(array $propertyAttributes, array $methodAttributes, Class_ $node): ?array
+    {
+        $propertyResolved = [];
+        $newProperties    = [];
+        foreach ($propertyAttributes as $propertyName => $attributeGroups) {
+            $property = $this->findProperty($node, $propertyName);
+            if ($property instanceof Property || $property instanceof Param) {
+                $propertyResolved[] = [$property, $attributeGroups];
+
+                continue;
+            }
+
+            // The property is not declared in this class. When the class extends a parent, the
+            // mapped property lives there - often a vendor base class we cannot annotate - so
+            // redeclare it here as a protected property carrying the mapping attributes.
+            if (null === $node->extends) {
+                return null;
+            }
+
+            $newProperties[] = new Property(
+                Modifiers::PROTECTED,
+                [new PropertyItem($propertyName)],
+                [],
+                $this->parentPropertyType($node, $propertyName),
+                $attributeGroups,
+            );
+        }
+
+        $methodResolved = [];
+        foreach ($methodAttributes as $methodName => $attributeGroups) {
+            $method = $node->getMethod($methodName);
+            if (!$method instanceof ClassMethod) {
+                return null;
+            }
+
+            $methodResolved[] = [$method, $attributeGroups];
+        }
+
+        return [
+            'classAttributes'    => [],
+            'entityArgs'         => [],
+            'isMappedSuperclass' => false,
+            'newProperties'      => $newProperties,
+            'propertyResolved'   => $propertyResolved,
+            'methodResolved'     => $methodResolved,
+        ];
+    }
+
+    /**
+     * self::addProjectsField($builder, $tableName, $columnName) maps the trait-declared
+     * `projects` ManyToMany with a per-entity join table. Emit it as a standalone property.
+     */
+    private function tryProjectsField(StaticCall $call): ?Property
+    {
+        if (!$call->class instanceof Name || !in_array($call->class->toString(), ['self', 'static'], true)) {
+            return null;
+        }
+
+        if (!$call->name instanceof Identifier || 'addProjectsField' !== $call->name->toString()) {
+            return null;
+        }
+
+        // args: ($builder, $tableName, $columnName)
+        $tableName  = $this->stringFromArg($call->args, 1);
+        $columnName = $this->stringFromArg($call->args, 2);
+        if (null === $tableName || null === $columnName) {
+            return null;
+        }
+
+        $target = new ClassConstFetch(new FullyQualified('Mautic\\ProjectBundle\\Entity\\Project'), new Identifier('class'));
+
+        $attributeGroups = $this->manyToManyAttributes(
+            $target,
+            null,
+            null,
+            ['merge', 'persist', 'detach'],
+            'LAZY',
+            false,
+            'name',
+            new Array_([new ArrayItem(new String_('ASC'), new String_('name'))]),
+            $tableName,
+            [$this->joinColumn($columnName, 'id', false, false, 'CASCADE')],
+            [$this->joinColumn('project_id', 'id', false, false, 'CASCADE')],
+        );
+
+        return new Property(
+            Modifiers::PRIVATE,
+            [new PropertyItem('projects')],
+            [],
+            new FullyQualified('Doctrine\\Common\\Collections\\Collection'),
+            $attributeGroups,
+        );
+    }
+
+    /**
+     * Splits a flattened builder chain into segments, each headed by a class-level or
+     * field-level creator; trailing modifier calls (columnName, build, addJoinColumn, ...)
+     * attach to the segment they follow. Null when a modifier precedes any creator.
+     *
+     * @param list<MethodCall> $calls
+     *
+     * @return list<list<MethodCall>>|null
+     */
+    private function splitIntoSegments(array $calls): ?array
+    {
+        $starters = [...self::CLASS_LEVEL_METHODS, 'setMappedSuperClass', ...self::FIELD_CREATOR_METHODS];
+
+        $segments = [];
+        $current  = null;
+
+        foreach ($calls as $call) {
+            if (in_array($this->methodName($call), $starters, true)) {
+                if (null !== $current) {
+                    $segments[] = $current;
+                }
+
+                $current = [$call];
+
+                continue;
+            }
+
+            if (null === $current) {
+                return null;
+            }
+
+            $current[] = $call;
+        }
+
+        if (null !== $current) {
+            $segments[] = $current;
+        }
+
+        return $segments;
+    }
+
+    /**
+     * Flattens $builder->a()->b()->c() into [a, b, c]; null when the chain is not rooted at a
+     * variable. The builder may be held under any name, so we do not require it to be $builder.
+     *
+     * @return list<MethodCall>|null
+     */
+    private function flattenChain(MethodCall $call): ?array
+    {
+        $calls   = [];
+        $current = $call;
+
+        while ($current instanceof MethodCall) {
+            $calls[] = $current;
+            $current = $current->var;
+        }
+
+        if (!$current instanceof Variable) {
+            return null;
+        }
+
+        return array_reverse($calls);
+    }
+
+    /**
+     * @param list<MethodCall> $calls
+     *
+     * @return array{attributes: list<AttributeGroup>, entityArgs: list<Arg>, lifecycle: array<string, list<AttributeGroup>>}|null
+     */
+    private function handleClassChain(array $calls): ?array
+    {
+        $attributes = [];
+        $entityArgs = [];
+        $lifecycle  = [];
+
+        foreach ($calls as $call) {
+            switch ($this->methodName($call)) {
+                case 'setTable':
+                    if (!isset($call->args[0]) || !$call->args[0] instanceof Arg) {
+                        return null;
+                    }
+
+                    // Already mapped by an existing #[ORM\Table]: keep the call for a follow-up.
+                    if ($this->isHybrid && $this->hybridHasTable) {
+                        return null;
+                    }
+
+                    $attributes[] = $this->attribute('Table', [$this->namedArg('name', $call->args[0]->value)]);
+                    break;
+
+                case 'setCustomRepositoryClass':
+                    if (!isset($call->args[0]) || !$call->args[0] instanceof Arg) {
+                        return null;
+                    }
+
+                    // Already declared on the existing #[ORM\Entity]: keep the call for a follow-up.
+                    if ($this->isHybrid && $this->hybridEntityHasRepositoryClass) {
+                        return null;
+                    }
+
+                    $entityArgs[] = $this->namedArg('repositoryClass', $call->args[0]->value);
+                    break;
+
+                case 'addIndex':
+                case 'addFulltextIndex':
+                    if (2 !== count($call->args) || !$call->args[0] instanceof Arg || !$call->args[1] instanceof Arg) {
+                        return null;
+                    }
+
+                    if (!$call->args[0]->value instanceof Array_) {
+                        return null;
+                    }
+
+                    $indexArgs = [
+                        $this->namedArg('columns', $call->args[0]->value),
+                        $this->namedArg('name', $call->args[1]->value),
+                    ];
+
+                    if ('addFulltextIndex' === $this->methodName($call)) {
+                        $indexArgs[] = $this->namedArg('flags', new Array_([new ArrayItem(new String_('fulltext'))]));
+                    }
+
+                    $attributes[] = $this->attribute('Index', $indexArgs);
+                    break;
+
+                case 'addIndexWithOptions':
+                    if (3 !== count($call->args) || !$call->args[0] instanceof Arg || !$call->args[1] instanceof Arg || !$call->args[2] instanceof Arg) {
+                        return null;
+                    }
+
+                    if (!$call->args[0]->value instanceof Array_ || !$call->args[2]->value instanceof Array_) {
+                        return null;
+                    }
+
+                    $attributes[] = $this->attribute('Index', [
+                        $this->namedArg('columns', $call->args[0]->value),
+                        $this->namedArg('name', $call->args[1]->value),
+                        $this->namedArg('options', $call->args[2]->value),
+                    ]);
+                    break;
+
+                case 'addUniqueConstraint':
+                    if (2 !== count($call->args) || !$call->args[0] instanceof Arg || !$call->args[1] instanceof Arg) {
+                        return null;
+                    }
+
+                    if (!$call->args[0]->value instanceof Array_) {
+                        return null;
+                    }
+
+                    $attributes[] = $this->attribute('UniqueConstraint', [
+                        $this->namedArg('columns', $call->args[0]->value),
+                        $this->namedArg('name', $call->args[1]->value),
+                    ]);
+                    break;
+
+                case 'addLifecycleEvent':
+                    $methodName = $this->stringArg($call, 0);
+                    $event      = $this->lifecycleEventArg($call, 1);
+                    if (null === $methodName || null === $event) {
+                        return null;
+                    }
+
+                    $eventShortName = $this->lifecycleEventShortName($event);
+                    if (null === $eventShortName) {
+                        return null;
+                    }
+
+                    $lifecycle[$methodName][] = $this->attribute($eventShortName, []);
+                    break;
+
+                default:
+                    return null;
+            }
+        }
+
+        return ['attributes' => $attributes, 'entityArgs' => $entityArgs, 'lifecycle' => $lifecycle];
+    }
+
+    private function lifecycleEventShortName(string $event): ?string
+    {
+        return match ($event) {
+            'prePersist'  => 'PrePersist',
+            'postPersist' => 'PostPersist',
+            'preUpdate'   => 'PreUpdate',
+            'postUpdate'  => 'PostUpdate',
+            'preRemove'   => 'PreRemove',
+            'postRemove'  => 'PostRemove',
+            'postLoad'    => 'PostLoad',
+            'preFlush'    => 'PreFlush',
+            default       => null,
+        };
+    }
+
+    /**
+     * The event name argument of addLifecycleEvent(): a string literal or a Doctrine Events::*
+     * constant, whose constant name equals the event string (Events::preUpdate === 'preUpdate').
+     */
+    private function lifecycleEventArg(MethodCall $call, int $index): ?string
+    {
+        $string = $this->stringArg($call, $index);
+        if (null !== $string) {
+            return $string;
+        }
+
+        if (!isset($call->args[$index]) || !$call->args[$index] instanceof Arg) {
+            return null;
+        }
+
+        $value = $call->args[$index]->value;
+        if ($value instanceof ClassConstFetch
+            && $value->class instanceof Name && 'Events' === $value->class->getLast()
+            && $value->name instanceof Identifier
+        ) {
+            return $value->name->toString();
+        }
+
+        return null;
+    }
+
+    /**
+     * Static mapping helpers shared across entities, called as self::x($builder).
+     *
+     * @return array<string, list<AttributeGroup>>|null
+     */
+    private function handleStaticHelper(StaticCall $call): ?array
+    {
+        if (!$call->class instanceof Name || !in_array($call->class->toString(), ['self', 'static'], true)) {
+            return null;
+        }
+
+        if (!$call->name instanceof Identifier) {
+            return null;
+        }
+
+        // These helpers map trait properties (UuidTrait::$uuid, OptimisticLockTrait::$version,
+        // TranslationEntityTrait, VariantEntityTrait, DynamicContentEntityTrait) that carry their
+        // own mapping attributes. Emit no per-entity attribute (the properties are not in the class
+        // body, so they cannot be annotated here) and do not bail, so the call drops out of
+        // loadMetadata.
+        $noOpHelpers = ['addUuidField', 'addVersionField', 'addTranslationMetadata', 'addVariantMetadata', 'addDynamicContentMetadata'];
+        if (in_array($call->name->toString(), $noOpHelpers, true)) {
+            return [];
+        }
+
+        return null;
+    }
+
+    /**
+     * @param list<MethodCall> $calls
+     *
+     * @return array<string, list<AttributeGroup>>|null
+     */
+    private function handleFieldChain(array $calls): ?array
+    {
+        return match ($this->methodName($calls[0])) {
+            'createField'      => $this->handleCreateField($calls),
+            'addBigIntIdField' => $this->handleBigIntIdField($calls),
+            'addDateAdded'     => $this->handleDateAdded($calls),
+            'addId'            => $this->handleAddId($calls),
+            'addIdColumns'     => $this->handleAddIdColumns($calls),
+            'addNullableField' => $this->handleAddNullableField($calls),
+            'addNamedField'    => $this->handleAddNamedField($calls),
+            'addField'         => $this->handleAddField($calls),
+            'addPublishDates'  => $this->handleAddPublishDates($calls),
+            'createManyToOne'  => $this->handleAssociation($calls, 'ManyToOne'),
+            'createOneToMany'  => $this->handleAssociation($calls, 'OneToMany'),
+            'createOneToOne'   => $this->handleAssociation($calls, 'OneToOne'),
+            'createManyToMany' => $this->handleManyToMany($calls),
+            'addLead'          => $this->handleContactHelper($calls, 'lead', 'lead_id', 'Mautic\\LeadBundle\\Entity\\Lead'),
+            'addContact'       => $this->handleContactHelper($calls, 'contact', 'contact_id', 'Mautic\\LeadBundle\\Entity\\Lead'),
+            'addCategory'      => $this->handleAddCategory($calls),
+            'addIpAddress'     => $this->handleAddIpAddress($calls),
+            default            => null,
+        };
+    }
+
+    /**
+     * @param list<MethodCall> $calls
+     *
+     * @return array<string, list<AttributeGroup>>|null
+     */
+    private function handleCreateField(array $calls): ?array
+    {
+        $createField = $calls[0];
+        $fieldName   = $this->stringArg($createField, 0);
+        $typeExpr    = $this->typeExpr($createField, 1);
+        if (null === $fieldName || null === $typeExpr) {
+            return null;
+        }
+
+        $columnName  = null;
+        $length      = null;
+        $nullable    = false;
+        $unique      = false;
+        $isPrimary   = false;
+        $generated   = false;
+        $genStrategy = null;
+        $options     = [];
+        $sawBuild    = false;
+
+        foreach (array_slice($calls, 1) as $call) {
+            switch ($this->methodName($call)) {
+                case 'columnName':
+                    $columnName = $this->stringArg($call, 0);
+                    if (null === $columnName) {
+                        return null;
+                    }
+                    break;
+
+                case 'length':
+                    $length = $this->intArg($call, 0);
+                    if (null === $length) {
+                        return null;
+                    }
+                    break;
+
+                case 'nullable':
+                    $nullable = $this->boolArg($call, 0, true);
+                    break;
+
+                case 'unique':
+                    $unique = $this->boolArg($call, 0, true);
+                    break;
+
+                case 'makePrimaryKey':
+                    $isPrimary = true;
+                    break;
+
+                case 'generatedValue':
+                    $generated   = true;
+                    $genStrategy = $this->stringArg($call, 0);
+                    break;
+
+                case 'option':
+                    $item = $this->optionItem($call);
+                    if (null === $item) {
+                        return null;
+                    }
+                    $options[] = $item;
+                    break;
+
+                case 'build':
+                    $sawBuild = true;
+                    break;
+
+                default:
+                    return null;
+            }
+        }
+
+        if (!$sawBuild) {
+            return null;
+        }
+
+        return [$fieldName => $this->columnAttributes(
+            $fieldName,
+            $columnName,
+            $typeExpr,
+            $length,
+            $nullable,
+            $unique,
+            $options,
+            $isPrimary,
+            $generated,
+            $genStrategy,
+        )];
+    }
+
+    /**
+     * @param list<MethodCall> $calls
+     *
+     * @return array<string, list<AttributeGroup>>|null
+     */
+    private function handleBigIntIdField(array $calls): ?array
+    {
+        if (1 !== count($calls)) {
+            return null;
+        }
+
+        $call       = $calls[0];
+        $fieldName  = $this->stringArg($call, 0) ?? 'id';
+        $columnName = $this->stringArg($call, 1) ?? 'id';
+        $isPrimary  = $this->boolArg($call, 2, true);
+        $isNullable = $this->boolArg($call, 3, false);
+
+        $options = [new ArrayItem(new ConstFetch(new Name('true')), new String_('unsigned'))];
+
+        return [$fieldName => $this->columnAttributes(
+            $fieldName,
+            $columnName,
+            new String_('bigint'),
+            null,
+            !$isPrimary && $isNullable,
+            false,
+            $options,
+            $isPrimary,
+            $isPrimary,
+            null,
+        )];
+    }
+
+    /**
+     * @param list<MethodCall> $calls
+     *
+     * @return array<string, list<AttributeGroup>>|null
+     */
+    private function handleAddId(array $calls): ?array
+    {
+        if (1 !== count($calls) || [] !== $calls[0]->args) {
+            return null;
+        }
+
+        $options = [new ArrayItem(new ConstFetch(new Name('true')), new String_('unsigned'))];
+
+        return ['id' => $this->columnAttributes(
+            'id',
+            null,
+            new String_('integer'),
+            null,
+            false,
+            false,
+            $options,
+            true,
+            true,
+            null,
+        )];
+    }
+
+    /**
+     * @param list<MethodCall> $calls
+     *
+     * @return array<string, list<AttributeGroup>>|null
+     */
+    private function handleAddIdColumns(array $calls): ?array
+    {
+        if (1 !== count($calls)) {
+            return null;
+        }
+
+        $call       = $calls[0];
+        $nameColumn = $this->stringOrFalseArg($call, 0, 'name');
+        $descColumn = $this->stringOrFalseArg($call, 1, 'description');
+
+        $result = ['id' => $this->columnAttributes(
+            'id',
+            null,
+            new String_('integer'),
+            null,
+            false,
+            false,
+            [new ArrayItem(new ConstFetch(new Name('true')), new String_('unsigned'))],
+            true,
+            true,
+            null,
+        )];
+
+        if (is_string($nameColumn)) {
+            $result[$nameColumn] = $this->columnAttributes($nameColumn, null, new String_('string'), null, false, false, [], false, false, null);
+        }
+
+        if (is_string($descColumn)) {
+            $result[$descColumn] = $this->columnAttributes($descColumn, null, new String_('text'), null, true, false, [], false, false, null);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param list<MethodCall> $calls
+     *
+     * @return array<string, list<AttributeGroup>>|null
+     */
+    private function handleAddNullableField(array $calls): ?array
+    {
+        if (1 !== count($calls)) {
+            return null;
+        }
+
+        $call      = $calls[0];
+        $fieldName = $this->stringArg($call, 0);
+        if (null === $fieldName) {
+            return null;
+        }
+
+        $typeExpr   = isset($call->args[1]) ? $this->typeExpr($call, 1) : new String_('string');
+        $columnName = $this->stringArg($call, 2);
+        if (null === $typeExpr) {
+            return null;
+        }
+
+        return [$fieldName => $this->columnAttributes($fieldName, $columnName, $typeExpr, null, true, false, [], false, false, null)];
+    }
+
+    /**
+     * @param list<MethodCall> $calls
+     *
+     * @return array<string, list<AttributeGroup>>|null
+     */
+    private function handleAddNamedField(array $calls): ?array
+    {
+        if (1 !== count($calls)) {
+            return null;
+        }
+
+        $call       = $calls[0];
+        $fieldName  = $this->stringArg($call, 0);
+        $typeExpr   = $this->typeExpr($call, 1);
+        $columnName = $this->stringArg($call, 2);
+        if (null === $fieldName || null === $typeExpr || null === $columnName) {
+            return null;
+        }
+
+        $nullable = $this->boolArg($call, 3, false);
+
+        return [$fieldName => $this->columnAttributes($fieldName, $columnName, $typeExpr, null, $nullable, false, [], false, false, null)];
+    }
+
+    /**
+     * @param list<MethodCall> $calls
+     *
+     * @return array<string, list<AttributeGroup>>|null
+     */
+    private function handleAddField(array $calls): ?array
+    {
+        if (1 !== count($calls)) {
+            return null;
+        }
+
+        $call      = $calls[0];
+        $fieldName = $this->stringArg($call, 0);
+        $typeExpr  = $this->typeExpr($call, 1);
+        if (null === $fieldName || null === $typeExpr) {
+            return null;
+        }
+
+        $columnName = null;
+        $length     = null;
+        $nullable   = false;
+        $unique     = false;
+
+        if (isset($call->args[2])) {
+            if (!$call->args[2] instanceof Arg || !$call->args[2]->value instanceof Array_) {
+                return null;
+            }
+
+            foreach ($call->args[2]->value->items as $item) {
+                if (!$item instanceof ArrayItem || !$item->key instanceof String_) {
+                    return null;
+                }
+
+                switch ($item->key->value) {
+                    case 'columnName':
+                        if (!$item->value instanceof String_) {
+                            return null;
+                        }
+                        $columnName = $item->value->value;
+                        break;
+
+                    case 'length':
+                        if (!$item->value instanceof Int_) {
+                            return null;
+                        }
+                        $length = $item->value->value;
+                        break;
+
+                    case 'nullable':
+                        $nullable = $item->value instanceof ConstFetch && $this->isName($item->value, 'true');
+                        break;
+
+                    case 'unique':
+                        $unique = $item->value instanceof ConstFetch && $this->isName($item->value, 'true');
+                        break;
+
+                    default:
+                        return null;
+                }
+            }
+        }
+
+        return [$fieldName => $this->columnAttributes($fieldName, $columnName, $typeExpr, $length, $nullable, $unique, [], false, false, null)];
+    }
+
+    /**
+     * @param list<MethodCall> $calls
+     *
+     * @return array<string, list<AttributeGroup>>|null
+     */
+    private function handleDateAdded(array $calls): ?array
+    {
+        if (1 !== count($calls)) {
+            return null;
+        }
+
+        $nullable = $this->boolArg($calls[0], 0, false);
+
+        return ['dateAdded' => $this->columnAttributes('dateAdded', 'date_added', new String_('datetime'), null, $nullable, false, [], false, false, null)];
+    }
+
+    /**
+     * @param list<MethodCall> $calls
+     *
+     * @return array<string, list<AttributeGroup>>|null
+     */
+    private function handleAddPublishDates(array $calls): ?array
+    {
+        if (1 !== count($calls) || [] !== $calls[0]->args) {
+            return null;
+        }
+
+        return [
+            'publishUp'   => $this->columnAttributes('publishUp', 'publish_up', new String_('datetime'), null, true, false, [], false, false, null),
+            'publishDown' => $this->columnAttributes('publishDown', 'publish_down', new String_('datetime'), null, true, false, [], false, false, null),
+        ];
+    }
+
+    /**
+     * createManyToOne('field', Target::class)->...->build()
+     * createOneToMany('field', Target::class)->mappedBy('x')->...->build().
+     *
+     * @param list<MethodCall> $calls
+     *
+     * @return array<string, list<AttributeGroup>>|null
+     */
+    private function handleAssociation(array $calls, string $kind): ?array
+    {
+        $create    = $calls[0];
+        $fieldName = $this->stringArg($create, 0);
+        if (null === $fieldName || !isset($create->args[1]) || !$create->args[1] instanceof Arg) {
+            return null;
+        }
+
+        $target = $this->resolveTargetEntity($create->args[1]->value);
+
+        $mappedBy      = null;
+        $inversedBy    = null;
+        $cascade       = [];
+        $fetch         = null;
+        $orphanRemoval = false;
+        $isPrimary     = false;
+        $indexBy       = null;
+        $orderBy       = null;
+        $joinColumns   = [];
+        $sawBuild      = false;
+
+        foreach (array_slice($calls, 1) as $call) {
+            $name = $this->methodName($call);
+
+            $cascadeType = $this->cascadeType($name);
+            if (null !== $cascadeType) {
+                $cascade[] = $cascadeType;
+                continue;
+            }
+
+            $fetchMode = $this->fetchMode($name);
+            if (null !== $fetchMode) {
+                $fetch = $fetchMode;
+                continue;
+            }
+
+            switch ($name) {
+                case 'mappedBy':
+                    $mappedBy = $this->stringArg($call, 0);
+                    if (null === $mappedBy) {
+                        return null;
+                    }
+                    break;
+
+                case 'inversedBy':
+                    $inversedBy = $this->stringArg($call, 0);
+                    if (null === $inversedBy) {
+                        return null;
+                    }
+                    break;
+
+                case 'setIndexBy':
+                    $indexBy = $this->stringArg($call, 0);
+                    if (null === $indexBy) {
+                        return null;
+                    }
+                    break;
+
+                case 'setOrderBy':
+                    if (!isset($call->args[0]) || !$call->args[0] instanceof Arg || !$call->args[0]->value instanceof Array_) {
+                        return null;
+                    }
+                    $orderBy = $call->args[0]->value;
+                    break;
+
+                case 'orphanRemoval':
+                    $orphanRemoval = $this->boolArg($call, 0, true);
+                    break;
+
+                case 'makePrimaryKey':
+                case 'isPrimaryKey':
+                    $isPrimary = true;
+                    break;
+
+                case 'addJoinColumn':
+                    $joinColumn = $this->parseJoinColumn($call);
+                    if (null === $joinColumn) {
+                        return null;
+                    }
+                    $joinColumns[] = $joinColumn;
+                    break;
+
+                case 'build':
+                    $sawBuild = true;
+                    break;
+
+                default:
+                    // isOwnershipParent, setJoinTable, addInverseJoinColumn, ... are not handled.
+                    return null;
+            }
+        }
+
+        if (!$sawBuild) {
+            return null;
+        }
+
+        return [$fieldName => $this->associationAttributes(
+            $kind,
+            $target,
+            $mappedBy,
+            $inversedBy,
+            $cascade,
+            $fetch,
+            $orphanRemoval,
+            $isPrimary,
+            $indexBy,
+            $orderBy,
+            $joinColumns,
+        )];
+    }
+
+    /**
+     * createManyToMany('field', Target::class)->setJoinTable('xref')
+     *     ->addJoinColumn(...)->addInverseJoinColumn(...)->build().
+     *
+     * @param list<MethodCall> $calls
+     *
+     * @return array<string, list<AttributeGroup>>|null
+     */
+    private function handleManyToMany(array $calls): ?array
+    {
+        $create    = $calls[0];
+        $fieldName = $this->stringArg($create, 0);
+        if (null === $fieldName || !isset($create->args[1]) || !$create->args[1] instanceof Arg) {
+            return null;
+        }
+
+        $target = $this->resolveTargetEntity($create->args[1]->value);
+
+        $mappedBy            = null;
+        $inversedBy          = null;
+        $cascade             = [];
+        $fetch               = null;
+        $orphanRemoval       = false;
+        $indexBy             = null;
+        $orderBy             = null;
+        $joinTable           = null;
+        $joinColumns         = [];
+        $inverseJoinColumns  = [];
+        $sawBuild            = false;
+
+        foreach (array_slice($calls, 1) as $call) {
+            $name = $this->methodName($call);
+
+            $cascadeType = $this->cascadeType($name);
+            if (null !== $cascadeType) {
+                $cascade[] = $cascadeType;
+                continue;
+            }
+
+            $fetchMode = $this->fetchMode($name);
+            if (null !== $fetchMode) {
+                $fetch = $fetchMode;
+                continue;
+            }
+
+            switch ($name) {
+                case 'mappedBy':
+                    $mappedBy = $this->stringArg($call, 0);
+                    if (null === $mappedBy) {
+                        return null;
+                    }
+                    break;
+
+                case 'inversedBy':
+                    $inversedBy = $this->stringArg($call, 0);
+                    if (null === $inversedBy) {
+                        return null;
+                    }
+                    break;
+
+                case 'setIndexBy':
+                    $indexBy = $this->stringArg($call, 0);
+                    if (null === $indexBy) {
+                        return null;
+                    }
+                    break;
+
+                case 'setOrderBy':
+                    if (!isset($call->args[0]) || !$call->args[0] instanceof Arg || !$call->args[0]->value instanceof Array_) {
+                        return null;
+                    }
+                    $orderBy = $call->args[0]->value;
+                    break;
+
+                case 'orphanRemoval':
+                    $orphanRemoval = $this->boolArg($call, 0, true);
+                    break;
+
+                case 'setJoinTable':
+                    $joinTable = $this->stringArg($call, 0);
+                    if (null === $joinTable) {
+                        return null;
+                    }
+                    break;
+
+                case 'addJoinColumn':
+                    $joinColumn = $this->parseJoinColumn($call);
+                    if (null === $joinColumn) {
+                        return null;
+                    }
+                    $joinColumns[] = $joinColumn;
+                    break;
+
+                case 'addInverseJoinColumn':
+                    $inverseJoinColumn = $this->parseJoinColumn($call);
+                    if (null === $inverseJoinColumn) {
+                        return null;
+                    }
+                    $inverseJoinColumns[] = $inverseJoinColumn;
+                    break;
+
+                case 'build':
+                    $sawBuild = true;
+                    break;
+
+                default:
+                    return null;
+            }
+        }
+
+        if (!$sawBuild) {
+            return null;
+        }
+
+        return [$fieldName => $this->manyToManyAttributes(
+            $target,
+            $mappedBy,
+            $inversedBy,
+            $cascade,
+            $fetch,
+            $orphanRemoval,
+            $indexBy,
+            $orderBy,
+            $joinTable,
+            $joinColumns,
+            $inverseJoinColumns,
+        )];
+    }
+
+    /**
+     * @param list<string>                                                                            $cascade
+     * @param list<array{name: string, ref: string, nullable: bool, unique: bool, onDelete: ?string}> $joinColumns
+     * @param list<array{name: string, ref: string, nullable: bool, unique: bool, onDelete: ?string}> $inverseJoinColumns
+     *
+     * @return list<AttributeGroup>
+     */
+    private function manyToManyAttributes(
+        Expr $target,
+        ?string $mappedBy,
+        ?string $inversedBy,
+        array $cascade,
+        ?string $fetch,
+        bool $orphanRemoval,
+        ?string $indexBy,
+        ?Array_ $orderBy,
+        ?string $joinTable,
+        array $joinColumns,
+        array $inverseJoinColumns,
+    ): array {
+        $args = [];
+
+        if (null !== $mappedBy) {
+            $args[] = $this->namedArg('mappedBy', new String_($mappedBy));
+        }
+
+        $args[] = $this->namedArg('targetEntity', $target);
+
+        if (null !== $inversedBy) {
+            $args[] = $this->namedArg('inversedBy', new String_($inversedBy));
+        }
+
+        if ([] !== $cascade) {
+            $args[] = $this->namedArg('cascade', new Array_(array_map(
+                static fn (string $c): ArrayItem => new ArrayItem(new String_($c)),
+                $cascade,
+            )));
+        }
+
+        if (null !== $fetch) {
+            $args[] = $this->namedArg('fetch', new String_($fetch));
+        }
+
+        if ($orphanRemoval) {
+            $args[] = $this->namedArg('orphanRemoval', new ConstFetch(new Name('true')));
+        }
+
+        if (null !== $indexBy) {
+            $args[] = $this->namedArg('indexBy', new String_($indexBy));
+        }
+
+        $attributes = [$this->attribute('ManyToMany', $args)];
+
+        if (null !== $joinTable) {
+            $attributes[] = $this->attribute('JoinTable', [$this->namedArg('name', new String_($joinTable))]);
+        }
+
+        foreach ($joinColumns as $joinColumn) {
+            $attributes[] = $this->joinColumnAttribute($joinColumn);
+        }
+
+        foreach ($inverseJoinColumns as $inverseJoinColumn) {
+            $attributes[] = $this->joinColumnAttribute($inverseJoinColumn, 'InverseJoinColumn');
+        }
+
+        if (null !== $orderBy) {
+            $attributes[] = $this->attribute('OrderBy', [new Arg($orderBy)]);
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * addLead($nullable, $onDelete, $isPrimaryKey, $inversedBy) and addContact(...).
+     *
+     * @param list<MethodCall> $calls
+     *
+     * @return array<string, list<AttributeGroup>>|null
+     */
+    private function handleContactHelper(array $calls, string $fieldName, string $joinColumnName, string $targetFqn): ?array
+    {
+        if (1 !== count($calls)) {
+            return null;
+        }
+
+        $call       = $calls[0];
+        $nullable   = $this->boolArg($call, 0, false);
+        $onDelete   = $this->stringArg($call, 1) ?? 'CASCADE';
+        $isPrimary  = $this->boolArg($call, 2, false);
+        $inversedBy = $this->stringArg($call, 3);
+
+        $target = new ClassConstFetch(new FullyQualified($targetFqn), new Identifier('class'));
+
+        return [$fieldName => $this->associationAttributes(
+            'ManyToOne',
+            $target,
+            null,
+            $inversedBy,
+            [],
+            null,
+            false,
+            $isPrimary,
+            null,
+            null,
+            [$this->joinColumn($joinColumnName, 'id', $nullable, false, $onDelete)],
+        )];
+    }
+
+    /**
+     * @param list<MethodCall> $calls
+     *
+     * @return array<string, list<AttributeGroup>>|null
+     */
+    private function handleAddCategory(array $calls): ?array
+    {
+        if (1 !== count($calls) || [] !== $calls[0]->args) {
+            return null;
+        }
+
+        $target = new ClassConstFetch(new FullyQualified('Mautic\\CategoryBundle\\Entity\\Category'), new Identifier('class'));
+
+        return ['category' => $this->associationAttributes(
+            'ManyToOne',
+            $target,
+            null,
+            null,
+            ['merge', 'detach'],
+            null,
+            false,
+            false,
+            null,
+            null,
+            [$this->joinColumn('category_id', 'id', true, false, 'SET NULL')],
+        )];
+    }
+
+    /**
+     * @param list<MethodCall> $calls
+     *
+     * @return array<string, list<AttributeGroup>>|null
+     */
+    private function handleAddIpAddress(array $calls): ?array
+    {
+        if (1 !== count($calls)) {
+            return null;
+        }
+
+        $nullable = $this->boolArg($calls[0], 0, false);
+        $target   = new ClassConstFetch(new FullyQualified('Mautic\\CoreBundle\\Entity\\IpAddress'), new Identifier('class'));
+
+        return ['ipAddress' => $this->associationAttributes(
+            'ManyToOne',
+            $target,
+            null,
+            null,
+            ['persist', 'merge', 'detach'],
+            null,
+            false,
+            false,
+            null,
+            null,
+            [$this->joinColumn('ip_id', 'id', $nullable, false, 'SET NULL')],
+        )];
+    }
+
+    /**
+     * @return array{name: string, ref: string, nullable: bool, unique: bool, onDelete: ?string}
+     */
+    private function joinColumn(string $name, string $ref, bool $nullable, bool $unique, ?string $onDelete): array
+    {
+        return ['name' => $name, 'ref' => $ref, 'nullable' => $nullable, 'unique' => $unique, 'onDelete' => $onDelete];
+    }
+
+    /**
+     * addJoinColumn($name, $ref = 'id', $nullable = true, $unique = false, $onDelete = null).
+     *
+     * @return array{name: string, ref: string, nullable: bool, unique: bool, onDelete: ?string}|null
+     */
+    private function parseJoinColumn(MethodCall $call): ?array
+    {
+        $name = $this->stringArg($call, 0);
+        if (null === $name) {
+            return null;
+        }
+
+        $ref      = $this->stringArg($call, 1) ?? 'id';
+        $nullable = $this->boolArg($call, 2, true);
+        $unique   = $this->boolArg($call, 3, false);
+        $onDelete = $this->stringArg($call, 4);
+
+        // Reject unparseable positional args (e.g. a variable) rather than guessing.
+        if (isset($call->args[1]) && null === $this->stringArg($call, 1)) {
+            return null;
+        }
+        if (isset($call->args[4]) && null === $onDelete) {
+            return null;
+        }
+
+        return $this->joinColumn($name, $ref, $nullable, $unique, $onDelete);
+    }
+
+    /**
+     * @param list<string>                                                                            $cascade
+     * @param list<array{name: string, ref: string, nullable: bool, unique: bool, onDelete: ?string}> $joinColumns
+     *
+     * @return list<AttributeGroup>
+     */
+    private function associationAttributes(
+        string $kind,
+        Expr $target,
+        ?string $mappedBy,
+        ?string $inversedBy,
+        array $cascade,
+        ?string $fetch,
+        bool $orphanRemoval,
+        bool $isPrimary,
+        ?string $indexBy,
+        ?Array_ $orderBy,
+        array $joinColumns,
+    ): array {
+        $args = [];
+
+        if (null !== $mappedBy) {
+            $args[] = $this->namedArg('mappedBy', new String_($mappedBy));
+        }
+
+        $args[] = $this->namedArg('targetEntity', $target);
+
+        if (null !== $inversedBy) {
+            $args[] = $this->namedArg('inversedBy', new String_($inversedBy));
+        }
+
+        if ([] !== $cascade) {
+            $args[] = $this->namedArg('cascade', new Array_(array_map(
+                static fn (string $c): ArrayItem => new ArrayItem(new String_($c)),
+                $cascade,
+            )));
+        }
+
+        if (null !== $fetch) {
+            $args[] = $this->namedArg('fetch', new String_($fetch));
+        }
+
+        if ($orphanRemoval) {
+            $args[] = $this->namedArg('orphanRemoval', new ConstFetch(new Name('true')));
+        }
+
+        if (null !== $indexBy) {
+            $args[] = $this->namedArg('indexBy', new String_($indexBy));
+        }
+
+        $attributes = [];
+
+        if ($isPrimary) {
+            $attributes[] = $this->attribute('Id', []);
+        }
+
+        $attributes[] = $this->attribute($kind, $args);
+
+        foreach ($joinColumns as $joinColumn) {
+            $attributes[] = $this->joinColumnAttribute($joinColumn);
+        }
+
+        if (null !== $orderBy) {
+            $attributes[] = $this->attribute('OrderBy', [new Arg($orderBy)]);
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * @param array{name: string, ref: string, nullable: bool, unique: bool, onDelete: ?string} $joinColumn
+     */
+    private function joinColumnAttribute(array $joinColumn, string $shortName = 'JoinColumn'): AttributeGroup
+    {
+        $args = [$this->namedArg('name', new String_($joinColumn['name']))];
+
+        if ('id' !== $joinColumn['ref']) {
+            $args[] = $this->namedArg('referencedColumnName', new String_($joinColumn['ref']));
+        }
+
+        // JoinColumn defaults to nullable: true, so only the false case needs stating.
+        if (!$joinColumn['nullable']) {
+            $args[] = $this->namedArg('nullable', new ConstFetch(new Name('false')));
+        }
+
+        if ($joinColumn['unique']) {
+            $args[] = $this->namedArg('unique', new ConstFetch(new Name('true')));
+        }
+
+        if (null !== $joinColumn['onDelete']) {
+            $args[] = $this->namedArg('onDelete', new String_($joinColumn['onDelete']));
+        }
+
+        return $this->attribute($shortName, $args);
+    }
+
+    private function cascadeType(string $method): ?string
+    {
+        return match ($method) {
+            'cascadeAll'     => 'all',
+            'cascadePersist' => 'persist',
+            'cascadeRemove'  => 'remove',
+            'cascadeMerge'   => 'merge',
+            'cascadeDetach'  => 'detach',
+            'cascadeRefresh' => 'refresh',
+            default          => null,
+        };
+    }
+
+    private function fetchMode(string $method): ?string
+    {
+        return match ($method) {
+            'fetchEager'     => 'EAGER',
+            'fetchExtraLazy' => 'EXTRA_LAZY',
+            'fetchLazy'      => 'LAZY',
+            default          => null,
+        };
+    }
+
+    /**
+     * @param ArrayItem[] $options
+     *
+     * @return list<AttributeGroup>
+     */
+    private function columnAttributes(
+        string $fieldName,
+        ?string $columnName,
+        Expr $typeExpr,
+        ?int $length,
+        bool $nullable,
+        bool $unique,
+        array $options,
+        bool $isPrimary,
+        bool $generated,
+        ?string $generatedStrategy,
+    ): array {
+        $args = [];
+
+        if (null !== $columnName && $columnName !== $fieldName) {
+            $args[] = $this->namedArg('name', new String_($columnName));
+        }
+
+        $args[] = $this->namedArg('type', $typeExpr);
+
+        if (null === $length && $this->isStringType($typeExpr)) {
+            $length = self::DEFAULT_STRING_LENGTH;
+        }
+
+        if (null !== $length) {
+            $args[] = $this->namedArg('length', new Int_($length));
+        }
+
+        if ($nullable) {
+            $args[] = $this->namedArg('nullable', new ConstFetch(new Name('true')));
+        }
+
+        if ($unique) {
+            $args[] = $this->namedArg('unique', new ConstFetch(new Name('true')));
+        }
+
+        if ([] !== $options) {
+            $args[] = $this->namedArg('options', new Array_($options));
+        }
+
+        $attributes = [];
+        if ($isPrimary) {
+            $attributes[] = $this->attribute('Id', []);
+        }
+
+        $attributes[] = $this->attribute('Column', $args);
+
+        if ($generated) {
+            $generatedArgs = (null !== $generatedStrategy && 'AUTO' !== $generatedStrategy)
+                ? [$this->namedArg('strategy', new String_($generatedStrategy))]
+                : [];
+            $attributes[] = $this->attribute('GeneratedValue', $generatedArgs);
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * @param Arg[] $args
+     */
+    private function attribute(string $shortName, array $args): AttributeGroup
+    {
+        return new AttributeGroup([new Attribute(new Name('ORM\\'.$shortName), array_values($args))]);
+    }
+
+    private function namedArg(string $name, Expr $value): Arg
+    {
+        return new Arg($value, false, false, [], new Identifier($name));
+    }
+
+    /**
+     * A createManyToOne('field', 'Target') string target becomes Target::class. Doctrine resolves a
+     * relative name against the entity's namespace, so a short name stays a same-namespace ::class
+     * and a fully-qualified string becomes a \Fully\Qualified::class. Non-string targets pass through.
+     */
+    private function resolveTargetEntity(Expr $value): Expr
+    {
+        if (!$value instanceof String_) {
+            return $value;
+        }
+
+        $className = ltrim($value->value, '\\');
+        $name      = str_contains($className, '\\') ? new FullyQualified($className) : new Name($className);
+
+        return new ClassConstFetch($name, new Identifier('class'));
+    }
+
+    /**
+     * option($key, $value) -> an ['key' => value] array item, or null when unparseable.
+     */
+    private function optionItem(MethodCall $call): ?ArrayItem
+    {
+        if (!isset($call->args[0], $call->args[1]) || !$call->args[0] instanceof Arg || !$call->args[1] instanceof Arg) {
+            return null;
+        }
+
+        $key = $call->args[0]->value;
+        if (!$key instanceof String_) {
+            return null;
+        }
+
+        return new ArrayItem($call->args[1]->value, $key);
+    }
+
+    /**
+     * A column type argument: a string literal or a Types::* constant, passed through verbatim.
+     */
+    private function typeExpr(MethodCall $call, int $index): ?Expr
+    {
+        if (!isset($call->args[$index]) || !$call->args[$index] instanceof Arg) {
+            return null;
+        }
+
+        $value = $call->args[$index]->value;
+
+        if ($value instanceof String_) {
+            return $value;
+        }
+
+        if ($value instanceof ClassConstFetch && $value->class instanceof Name && 'Types' === $value->class->getLast()) {
+            return $value;
+        }
+
+        return null;
+    }
+
+    private function isStringType(Expr $typeExpr): bool
+    {
+        if ($typeExpr instanceof String_) {
+            return 'string' === $typeExpr->value;
+        }
+
+        return $typeExpr instanceof ClassConstFetch
+            && $typeExpr->name instanceof Identifier
+            && 'STRING' === $typeExpr->name->toString();
+    }
+
+    private function methodName(MethodCall $call): string
+    {
+        return $call->name instanceof Identifier ? $call->name->toString() : '';
+    }
+
+    /**
+     * @param array<Arg|Node\VariadicPlaceholder> $args
+     */
+    private function stringFromArg(array $args, int $index): ?string
+    {
+        if (!isset($args[$index]) || !$args[$index] instanceof Arg) {
+            return null;
+        }
+
+        $value = $args[$index]->value;
+
+        return $value instanceof String_ ? $value->value : null;
+    }
+
+    private function stringArg(MethodCall $call, int $index): ?string
+    {
+        if (!isset($call->args[$index]) || !$call->args[$index] instanceof Arg) {
+            return null;
+        }
+
+        $value = $call->args[$index]->value;
+
+        return $value instanceof String_ ? $value->value : null;
+    }
+
+    /**
+     * Returns the string value, false when the argument is literal false, or $default when absent.
+     */
+    private function stringOrFalseArg(MethodCall $call, int $index, string $default): string|false
+    {
+        if (!isset($call->args[$index]) || !$call->args[$index] instanceof Arg) {
+            return $default;
+        }
+
+        $value = $call->args[$index]->value;
+
+        if ($value instanceof String_) {
+            return $value->value;
+        }
+
+        if ($value instanceof ConstFetch && $this->isName($value, 'false')) {
+            return false;
+        }
+
+        return $default;
+    }
+
+    private function intArg(MethodCall $call, int $index): ?int
+    {
+        if (!isset($call->args[$index]) || !$call->args[$index] instanceof Arg) {
+            return null;
+        }
+
+        $value = $call->args[$index]->value;
+
+        return $value instanceof Int_ ? $value->value : null;
+    }
+
+    private function boolArg(MethodCall $call, int $index, bool $default): bool
+    {
+        if (!isset($call->args[$index]) || !$call->args[$index] instanceof Arg) {
+            return $default;
+        }
+
+        $value = $call->args[$index]->value;
+
+        return $value instanceof ConstFetch && $this->isName($value, 'true');
+    }
+
+    /**
+     * @param AttributeGroup[] $attrGroups
+     */
+    private function hasOrmMappingAttribute(array $attrGroups): bool
+    {
+        foreach ($attrGroups as $attrGroup) {
+            foreach ($attrGroup->attrs as $attr) {
+                $name = $attr->name->toString();
+                if (str_starts_with($name, 'ORM\\') || str_starts_with($name, 'Doctrine\\ORM\\Mapping\\')) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * The short name of an attribute (Entity, Table, ...), stripped of the ORM\ or FQCN prefix.
+     */
+    private function attributeShortName(Attribute $attr): string
+    {
+        return $attr->name->getLast();
+    }
+
+    /**
+     * @param AttributeGroup[] $attrGroups
+     */
+    private function hasAttributeNamed(array $attrGroups, string $shortName): bool
+    {
+        foreach ($attrGroups as $attrGroup) {
+            foreach ($attrGroup->attrs as $attr) {
+                if ($shortName === $this->attributeShortName($attr)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param AttributeGroup[] $attrGroups
+     * @param string[]         $shortNames
+     */
+    private function findAttribute(array $attrGroups, array $shortNames): ?Attribute
+    {
+        foreach ($attrGroups as $attrGroup) {
+            foreach ($attrGroup->attrs as $attr) {
+                if (in_array($this->attributeShortName($attr), $shortNames, true)) {
+                    return $attr;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param AttributeGroup[] $attrGroups
+     */
+    private function entityHasRepositoryClass(array $attrGroups): bool
+    {
+        $entity = $this->findAttribute($attrGroups, ['Entity']);
+        if (!$entity instanceof Attribute) {
+            return false;
+        }
+
+        foreach ($entity->args as $arg) {
+            if ($arg instanceof Arg && $arg->name instanceof Identifier && 'repositoryClass' === $arg->name->toString()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Folds generated class attributes into the ones the class already carries: the repositoryClass
+     * merges into the existing #[ORM\Entity], and only attributes not yet present are appended,
+     * right after the root attribute for a tidy block.
+     *
+     * @param list<AttributeGroup> $generated
+     */
+    private function mergeClassAttributes(Class_ $node, array $generated): void
+    {
+        $existingRoot = $this->findAttribute($node->attrGroups, ['Entity', 'MappedSuperclass']);
+
+        $toAppend = [];
+        foreach ($generated as $attributeGroup) {
+            $attr      = $attributeGroup->attrs[0];
+            $shortName = $this->attributeShortName($attr);
+
+            if (in_array($shortName, ['Entity', 'MappedSuperclass'], true)) {
+                if ($existingRoot instanceof Attribute) {
+                    $existingRoot->args = array_merge($existingRoot->args, $attr->args);
+                }
+
+                continue;
+            }
+
+            if ($this->hasAttributeNamed($node->attrGroups, $shortName)) {
+                continue;
+            }
+
+            $toAppend[] = $attributeGroup;
+        }
+
+        if ([] === $toAppend) {
+            return;
+        }
+
+        foreach ($node->attrGroups as $index => $attrGroup) {
+            if (in_array($this->attributeShortName($attrGroup->attrs[0]), ['Entity', 'MappedSuperclass'], true)) {
+                array_splice($node->attrGroups, $index + 1, 0, $toAppend);
+
+                return;
+            }
+        }
+
+        $node->attrGroups = array_merge($node->attrGroups, $toAppend);
+    }
+
+    /**
+     * The declared type of a property inherited from a parent class, mirrored so a redeclaration
+     * stays compatible with the parent (PHP requires an identical type). Null when the parent, the
+     * property or its type cannot be resolved, leaving the redeclaration untyped.
+     */
+    private function parentPropertyType(Class_ $class, string $propertyName): Identifier|Name|NullableType|null
+    {
+        if (!$class->extends instanceof Name) {
+            return null;
+        }
+
+        // Reflect the entity itself so an inherited property's declared type resolves through the
+        // whole parent chain without having to resolve the parent's alias by hand.
+        $className = $this->getName($class);
+        if (null === $className || !class_exists($className)) {
+            return null;
+        }
+
+        $reflection = new \ReflectionClass($className);
+        if (!$reflection->hasProperty($propertyName)) {
+            return null;
+        }
+
+        $type = $reflection->getProperty($propertyName)->getType();
+        if (!$type instanceof \ReflectionNamedType) {
+            return null;
+        }
+
+        $typeName = $type->getName();
+        $typeNode = $type->isBuiltin() ? new Identifier($typeName) : new FullyQualified($typeName);
+
+        if ($type->allowsNull() && 'null' !== $typeName && 'mixed' !== $typeName) {
+            return new NullableType($typeNode);
+        }
+
+        return $typeNode;
+    }
+
+    private function findProperty(Class_ $class, string $name): Property|Param|null
+    {
+        foreach ($class->getProperties() as $property) {
+            foreach ($property->props as $prop) {
+                if ($this->isName($prop, $name)) {
+                    return $property;
+                }
+            }
+        }
+
+        // Constructor-promoted properties are Param nodes, not Stmt\Property.
+        $constructor = $class->getMethod('__construct');
+        if ($constructor instanceof ClassMethod) {
+            foreach ($constructor->params as $param) {
+                if (0 !== $param->flags && $param->var instanceof Variable && $this->isName($param->var, $name)) {
+                    return $param;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/utils/rector/tests/LoadMetadataMauticHelperToAttributeRector/Fixture/index_options_entity.php.inc
+++ b/utils/rector/tests/LoadMetadataMauticHelperToAttributeRector/Fixture/index_options_entity.php.inc
@@ -1,0 +1,44 @@
+<?php
+
+namespace Utils\Rector\Tests\LoadMetadataMauticHelperToAttributeRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+
+class IndexOptionsEntity
+{
+    public static function loadMetadata(ORM\ClassMetadata $metadata): void
+    {
+        $builder = new ClassMetadataBuilder($metadata);
+
+        $builder->setTable('hits')
+            ->addIndex(['tracking_id'], 'hit_tracking')
+            ->addFulltextIndex(['content'], 'hit_content')
+            ->addIndexWithOptions(['url'], 'hit_url', ['lengths' => [0 => 128]]);
+
+        $builder->addBigIntIdField();
+    }
+}
+
+-----
+<?php
+
+namespace Utils\Rector\Tests\LoadMetadataMauticHelperToAttributeRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+
+class IndexOptionsEntity
+{
+    public static function loadMetadata(ORM\ClassMetadata $metadata): void
+    {
+        $builder = new ClassMetadataBuilder($metadata);
+
+        $builder->setTable('hits')
+            ->addIndex(['tracking_id'], 'hit_tracking')
+            ->addIndex(['content'], 'hit_content', ['fulltext'])
+            ->addIndex(['url'], 'hit_url', null, ['lengths' => [0 => 128]]);
+
+        $builder->createField('id', 'bigint')->columnName('id')->makePrimaryKey()->generatedValue()->option('unsigned', true)->build();
+    }
+}

--- a/utils/rector/tests/LoadMetadataMauticHelperToAttributeRector/Fixture/mixed_chain_entity.php.inc
+++ b/utils/rector/tests/LoadMetadataMauticHelperToAttributeRector/Fixture/mixed_chain_entity.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+namespace Utils\Rector\Tests\LoadMetadataMauticHelperToAttributeRector\Fixture;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+
+class MixedChainEntity
+{
+    public static function loadMetadata(ORM\ClassMetadata $metadata): void
+    {
+        $builder = new ClassMetadataBuilder($metadata);
+
+        $builder->setTable('mix')
+            ->setCustomRepositoryClass(MixRepository::class)
+            ->addNamedField('customField', Types::TEXT, 'custom_field', true)
+            ->addId();
+    }
+}
+
+-----
+<?php
+
+namespace Utils\Rector\Tests\LoadMetadataMauticHelperToAttributeRector\Fixture;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+
+class MixedChainEntity
+{
+    public static function loadMetadata(ORM\ClassMetadata $metadata): void
+    {
+        $builder = new ClassMetadataBuilder($metadata);
+        $builder->setTable('mix');
+        $builder->setCustomRepositoryClass(MixRepository::class);
+        $builder->createField('customField', Types::TEXT)->columnName('custom_field')->nullable()->build();
+        $builder->createField('id', 'integer')->makePrimaryKey()->generatedValue()->option('unsigned', true)->build();
+    }
+}

--- a/utils/rector/tests/LoadMetadataMauticHelperToAttributeRector/Fixture/skip_already_mapped_entity.php.inc
+++ b/utils/rector/tests/LoadMetadataMauticHelperToAttributeRector/Fixture/skip_already_mapped_entity.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Utils\Rector\Tests\LoadMetadataMauticHelperToAttributeRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'already_mapped')]
+class SkipAlreadyMappedEntity
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue]
+    private $id;
+
+    public static function loadMetadata(ORM\ClassMetadata $metadata): void
+    {
+        $builder = new ClassMetadataBuilder($metadata);
+
+        $builder->setTable('already_mapped');
+
+        $builder->addId();
+    }
+}

--- a/utils/rector/tests/LoadMetadataMauticHelperToAttributeRector/Fixture/standalone_helpers_entity.php.inc
+++ b/utils/rector/tests/LoadMetadataMauticHelperToAttributeRector/Fixture/standalone_helpers_entity.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+namespace Utils\Rector\Tests\LoadMetadataMauticHelperToAttributeRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+
+class StandaloneHelpersEntity
+{
+    public static function loadMetadata(ORM\ClassMetadata $metadata): void
+    {
+        $builder = new ClassMetadataBuilder($metadata);
+
+        $builder->setTable('things');
+
+        $builder->addIdColumns();
+
+        $builder->addPublishDates();
+    }
+}
+
+-----
+<?php
+
+namespace Utils\Rector\Tests\LoadMetadataMauticHelperToAttributeRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+
+class StandaloneHelpersEntity
+{
+    public static function loadMetadata(ORM\ClassMetadata $metadata): void
+    {
+        $builder = new ClassMetadataBuilder($metadata);
+
+        $builder->setTable('things');
+        $builder->createField('id', 'integer')->makePrimaryKey()->generatedValue()->option('unsigned', true)->build();
+        $builder->createField('name', 'string')->build();
+        $builder->createField('description', 'text')->nullable()->build();
+        $builder->createField('publishUp', 'datetime')->columnName('publish_up')->nullable()->build();
+        $builder->createField('publishDown', 'datetime')->columnName('publish_down')->nullable()->build();
+    }
+}

--- a/utils/rector/tests/LoadMetadataMauticHelperToAttributeRector/LoadMetadataMauticHelperToAttributeRectorTest.php
+++ b/utils/rector/tests/LoadMetadataMauticHelperToAttributeRector/LoadMetadataMauticHelperToAttributeRectorTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\Rector\Tests\LoadMetadataMauticHelperToAttributeRector;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class LoadMetadataMauticHelperToAttributeRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__.'/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__.'/config/configured_rule.php';
+    }
+}

--- a/utils/rector/tests/LoadMetadataMauticHelperToAttributeRector/config/configured_rule.php
+++ b/utils/rector/tests/LoadMetadataMauticHelperToAttributeRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Utils\Rector\LoadMetadataMauticHelperToAttributeRector;
+
+return RectorConfig::configure()
+    ->withRules([LoadMetadataMauticHelperToAttributeRector::class]);

--- a/utils/rector/tests/LoadMetadataStaticHelperToAttributeRector/Fixture/hybrid_keeps_projects_field_entity.php.inc
+++ b/utils/rector/tests/LoadMetadataStaticHelperToAttributeRector/Fixture/hybrid_keeps_projects_field_entity.php.inc
@@ -1,15 +1,16 @@
 <?php
 
-namespace Utils\Rector\Tests\LoadMetadataToDoctrineAttributeRector\Fixture;
+namespace Utils\Rector\Tests\LoadMetadataStaticHelperToAttributeRector\Fixture;
 
 use Doctrine\ORM\Mapping as ORM;
 use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+use Mautic\ProjectBundle\Entity\ProjectTrait;
 
 #[ORM\Entity]
 #[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
 class LeadEventLog
 {
-    public const TABLE_NAME = 'campaign_lead_event_log';
+    use ProjectTrait;
 
     #[ORM\Id]
     #[ORM\Column(type: 'bigint', options: ['unsigned' => true])]
@@ -20,31 +21,25 @@ class LeadEventLog
     {
         $builder = new ClassMetadataBuilder($metadata);
 
-        $builder->setTable(self::TABLE_NAME)
-            ->setCustomRepositoryClass(LeadEventLogRepository::class)
-            ->addIndex(['date_triggered'], 'campaign_date_triggered')
-            ->addUniqueConstraint(['event_id', 'lead_id', 'rotation'], 'campaign_rotation');
-
         self::addVersionField($builder);
+        self::addProjectsField($builder, 'lead_event_log_projects_xref', 'lead_event_log_id');
     }
 }
 
 -----
 <?php
 
-namespace Utils\Rector\Tests\LoadMetadataToDoctrineAttributeRector\Fixture;
+namespace Utils\Rector\Tests\LoadMetadataStaticHelperToAttributeRector\Fixture;
 
 use Doctrine\ORM\Mapping as ORM;
 use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+use Mautic\ProjectBundle\Entity\ProjectTrait;
 
-#[ORM\Entity(repositoryClass: LeadEventLogRepository::class)]
-#[ORM\Table(name: self::TABLE_NAME)]
-#[ORM\Index(columns: ['date_triggered'], name: 'campaign_date_triggered')]
-#[ORM\UniqueConstraint(columns: ['event_id', 'lead_id', 'rotation'], name: 'campaign_rotation')]
+#[ORM\Entity]
 #[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
 class LeadEventLog
 {
-    public const TABLE_NAME = 'campaign_lead_event_log';
+    use ProjectTrait;
 
     #[ORM\Id]
     #[ORM\Column(type: 'bigint', options: ['unsigned' => true])]
@@ -54,7 +49,6 @@ class LeadEventLog
     public static function loadMetadata(ORM\ClassMetadata $metadata): void
     {
         $builder = new ClassMetadataBuilder($metadata);
-
-        self::addVersionField($builder);
+        self::addProjectsField($builder, 'lead_event_log_projects_xref', 'lead_event_log_id');
     }
 }

--- a/utils/rector/tests/LoadMetadataStaticHelperToAttributeRector/Fixture/mixed_static_helpers_entity.php.inc
+++ b/utils/rector/tests/LoadMetadataStaticHelperToAttributeRector/Fixture/mixed_static_helpers_entity.php.inc
@@ -1,8 +1,7 @@
 <?php
 
-namespace Utils\Rector\Tests\LoadMetadataToDoctrineAttributeRector\Fixture;
+namespace Utils\Rector\Tests\LoadMetadataStaticHelperToAttributeRector\Fixture;
 
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
 use Mautic\ProjectBundle\Entity\ProjectTrait;
@@ -37,39 +36,35 @@ class PageEntity
 -----
 <?php
 
-namespace Utils\Rector\Tests\LoadMetadataToDoctrineAttributeRector\Fixture;
+namespace Utils\Rector\Tests\LoadMetadataStaticHelperToAttributeRector\Fixture;
 
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
 use Mautic\ProjectBundle\Entity\ProjectTrait;
 
-#[ORM\Entity(repositoryClass: PageRepository::class)]
-#[ORM\Table(name: 'pages')]
-#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
 class PageEntity
 {
     use ProjectTrait;
+    #[ORM\ManyToMany(targetEntity: \Mautic\ProjectBundle\Entity\Project::class, cascade: ['merge', 'persist', 'detach'], fetch: 'LAZY', indexBy: 'name')]
+    #[ORM\JoinTable(name: 'page_projects_xref')]
+    #[ORM\JoinColumn(name: 'page_id', nullable: false, onDelete: 'CASCADE')]
+    #[ORM\InverseJoinColumn(name: 'project_id', nullable: false, onDelete: 'CASCADE')]
+    #[ORM\OrderBy(['name' => 'ASC'])]
+    private \Doctrine\Common\Collections\Collection $projects;
 
-    #[ORM\Id]
-    #[ORM\Column(type: 'integer', options: ['unsigned' => true])]
-    #[ORM\GeneratedValue]
     protected $id;
 
-    #[ORM\Column(type: 'string', length: 191)]
     protected $title;
 
-    #[ORM\Column(type: 'text', nullable: true)]
     protected $description;
 
     public static function loadMetadata(ORM\ClassMetadata $metadata): void
     {
         $builder = new ClassMetadataBuilder($metadata);
 
-        self::addTranslationMetadata($builder, self::class);
-        self::addVariantMetadata($builder, self::class);
-        static::addUuidField($builder);
-        self::addProjectsField($builder, 'page_projects_xref', 'page_id');
-        self::addVersionField($builder);
+        $builder->setTable('pages')
+            ->setCustomRepositoryClass(PageRepository::class);
+
+        $builder->addIdColumns('title');
     }
 }

--- a/utils/rector/tests/LoadMetadataStaticHelperToAttributeRector/Fixture/projects_field_entity.php.inc
+++ b/utils/rector/tests/LoadMetadataStaticHelperToAttributeRector/Fixture/projects_field_entity.php.inc
@@ -1,6 +1,6 @@
 <?php
 
-namespace Utils\Rector\Tests\LoadMetadataToDoctrineAttributeRector\Fixture;
+namespace Utils\Rector\Tests\LoadMetadataStaticHelperToAttributeRector\Fixture;
 
 use Doctrine\ORM\Mapping as ORM;
 use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
@@ -27,28 +27,30 @@ class ProjEntity
 -----
 <?php
 
-namespace Utils\Rector\Tests\LoadMetadataToDoctrineAttributeRector\Fixture;
+namespace Utils\Rector\Tests\LoadMetadataStaticHelperToAttributeRector\Fixture;
 
 use Doctrine\ORM\Mapping as ORM;
 use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
 use Mautic\ProjectBundle\Entity\ProjectTrait;
 
-#[ORM\Entity]
-#[ORM\Table(name: 'proj_entity')]
-#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
 class ProjEntity
 {
     use ProjectTrait;
+    #[ORM\ManyToMany(targetEntity: \Mautic\ProjectBundle\Entity\Project::class, cascade: ['merge', 'persist', 'detach'], fetch: 'LAZY', indexBy: 'name')]
+    #[ORM\JoinTable(name: 'proj_entity_projects_xref')]
+    #[ORM\JoinColumn(name: 'proj_entity_id', nullable: false, onDelete: 'CASCADE')]
+    #[ORM\InverseJoinColumn(name: 'project_id', nullable: false, onDelete: 'CASCADE')]
+    #[ORM\OrderBy(['name' => 'ASC'])]
+    private \Doctrine\Common\Collections\Collection $projects;
 
-    #[ORM\Id]
-    #[ORM\Column(type: 'integer', options: ['unsigned' => true])]
-    #[ORM\GeneratedValue]
     protected $id;
 
     public static function loadMetadata(ORM\ClassMetadata $metadata): void
     {
         $builder = new ClassMetadataBuilder($metadata);
 
-        self::addProjectsField($builder, 'proj_entity_projects_xref', 'proj_entity_id');
+        $builder->setTable('proj_entity');
+
+        $builder->addId();
     }
 }

--- a/utils/rector/tests/LoadMetadataStaticHelperToAttributeRector/Fixture/skip_native_only_entity.php.inc
+++ b/utils/rector/tests/LoadMetadataStaticHelperToAttributeRector/Fixture/skip_native_only_entity.php.inc
@@ -1,0 +1,20 @@
+<?php
+
+namespace Utils\Rector\Tests\LoadMetadataStaticHelperToAttributeRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+
+class NativeOnly
+{
+    protected $id;
+
+    public static function loadMetadata(ORM\ClassMetadata $metadata): void
+    {
+        $builder = new ClassMetadataBuilder($metadata);
+
+        $builder->setTable('native_only');
+
+        $builder->addId();
+    }
+}

--- a/utils/rector/tests/LoadMetadataStaticHelperToAttributeRector/LoadMetadataStaticHelperToAttributeRectorTest.php
+++ b/utils/rector/tests/LoadMetadataStaticHelperToAttributeRector/LoadMetadataStaticHelperToAttributeRectorTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\Rector\Tests\LoadMetadataStaticHelperToAttributeRector;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class LoadMetadataStaticHelperToAttributeRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__.'/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__.'/config/configured_rule.php';
+    }
+}

--- a/utils/rector/tests/LoadMetadataStaticHelperToAttributeRector/config/configured_rule.php
+++ b/utils/rector/tests/LoadMetadataStaticHelperToAttributeRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Utils\Rector\LoadMetadataStaticHelperToAttributeRector;
+
+return RectorConfig::configure()
+    ->withRules([LoadMetadataStaticHelperToAttributeRector::class]);

--- a/utils/rector/tests/LoadMetadataToDoctrineAttributeRector/Fixture/association_entity.php.inc
+++ b/utils/rector/tests/LoadMetadataToDoctrineAttributeRector/Fixture/association_entity.php.inc
@@ -1,0 +1,92 @@
+<?php
+
+namespace Utils\Rector\Tests\LoadMetadataToDoctrineAttributeRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+use Mautic\UserBundle\Entity\User;
+
+class AssocEntity
+{
+    protected $id;
+
+    protected $owner;
+
+    protected $items;
+
+    protected $lead;
+
+    protected $category;
+
+    protected $ipAddress;
+
+    public static function loadMetadata(ORM\ClassMetadata $metadata): void
+    {
+        $builder = new ClassMetadataBuilder($metadata);
+
+        $builder->setTable('assoc_entity');
+
+        $builder->addId();
+
+        $builder->createManyToOne('owner', User::class)
+            ->addJoinColumn('owner_id', 'id', true, false, 'SET NULL')
+            ->cascadePersist()
+            ->cascadeDetach()
+            ->fetchExtraLazy()
+            ->build();
+
+        $builder->createOneToMany('items', ChildEntity::class)
+            ->setIndexBy('id')
+            ->mappedBy('parent')
+            ->setOrderBy(['dateAdded' => 'DESC'])
+            ->cascadeAll()
+            ->orphanRemoval()
+            ->build();
+
+        $builder->addLead(true, 'CASCADE', false, 'items');
+
+        $builder->addCategory();
+
+        $builder->addIpAddress();
+    }
+}
+
+-----
+<?php
+
+namespace Utils\Rector\Tests\LoadMetadataToDoctrineAttributeRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+use Mautic\UserBundle\Entity\User;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'assoc_entity')]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class AssocEntity
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer', options: ['unsigned' => true])]
+    #[ORM\GeneratedValue]
+    protected $id;
+
+    #[ORM\ManyToOne(targetEntity: User::class, cascade: ['persist', 'detach'], fetch: 'EXTRA_LAZY')]
+    #[ORM\JoinColumn(name: 'owner_id', onDelete: 'SET NULL')]
+    protected $owner;
+
+    #[ORM\OneToMany(mappedBy: 'parent', targetEntity: ChildEntity::class, cascade: ['all'], orphanRemoval: true, indexBy: 'id')]
+    #[ORM\OrderBy(['dateAdded' => 'DESC'])]
+    protected $items;
+
+    #[ORM\ManyToOne(targetEntity: \Mautic\LeadBundle\Entity\Lead::class, inversedBy: 'items')]
+    #[ORM\JoinColumn(name: 'lead_id', onDelete: 'CASCADE')]
+    protected $lead;
+
+    #[ORM\ManyToOne(targetEntity: \Mautic\CategoryBundle\Entity\Category::class, cascade: ['merge', 'detach'])]
+    #[ORM\JoinColumn(name: 'category_id', onDelete: 'SET NULL')]
+    protected $category;
+
+    #[ORM\ManyToOne(targetEntity: \Mautic\CoreBundle\Entity\IpAddress::class, cascade: ['persist', 'merge', 'detach'])]
+    #[ORM\JoinColumn(name: 'ip_id', nullable: false, onDelete: 'SET NULL')]
+    protected $ipAddress;
+}

--- a/utils/rector/tests/LoadMetadataToDoctrineAttributeRector/Fixture/audit_log_entity.php.inc
+++ b/utils/rector/tests/LoadMetadataToDoctrineAttributeRector/Fixture/audit_log_entity.php.inc
@@ -1,0 +1,104 @@
+<?php
+
+namespace Utils\Rector\Tests\LoadMetadataToDoctrineAttributeRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+
+class AuditLog
+{
+    protected $id;
+
+    protected $userId;
+
+    protected $userName;
+
+    protected $bundle;
+
+    protected $objectId;
+
+    protected $details = [];
+
+    protected $dateAdded;
+
+    protected $ipAddress;
+
+    public static function loadMetadata(ORM\ClassMetadata $metadata): void
+    {
+        $builder = new ClassMetadataBuilder($metadata);
+
+        $builder->setTable('audit_log')
+            ->setCustomRepositoryClass(AuditLogRepository::class)
+            ->addIndex(['object', 'object_id'], 'object_search')
+            ->addIndex(['date_added'], 'date_added_index');
+
+        $builder->addBigIntIdField();
+
+        $builder->createField('userId', 'integer')
+            ->columnName('user_id')
+            ->build();
+
+        $builder->createField('userName', 'string')
+            ->columnName('user_name')
+            ->build();
+
+        $builder->createField('bundle', 'string')
+            ->length(50)
+            ->build();
+
+        $builder->addBigIntIdField('objectId', 'object_id', false);
+
+        $builder->createField('details', 'array')
+            ->nullable()
+            ->build();
+
+        $builder->addDateAdded();
+
+        $builder->createField('ipAddress', 'string')
+            ->columnName('ip_address')
+            ->length(45)
+            ->build();
+    }
+}
+
+-----
+<?php
+
+namespace Utils\Rector\Tests\LoadMetadataToDoctrineAttributeRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+
+#[ORM\Entity(repositoryClass: AuditLogRepository::class)]
+#[ORM\Table(name: 'audit_log')]
+#[ORM\Index(columns: ['object', 'object_id'], name: 'object_search')]
+#[ORM\Index(columns: ['date_added'], name: 'date_added_index')]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class AuditLog
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'bigint', options: ['unsigned' => true])]
+    #[ORM\GeneratedValue]
+    protected $id;
+
+    #[ORM\Column(name: 'user_id', type: 'integer')]
+    protected $userId;
+
+    #[ORM\Column(name: 'user_name', type: 'string', length: 191)]
+    protected $userName;
+
+    #[ORM\Column(type: 'string', length: 50)]
+    protected $bundle;
+
+    #[ORM\Column(name: 'object_id', type: 'bigint', options: ['unsigned' => true])]
+    protected $objectId;
+
+    #[ORM\Column(type: 'array', nullable: true)]
+    protected $details = [];
+
+    #[ORM\Column(name: 'date_added', type: 'datetime')]
+    protected $dateAdded;
+
+    #[ORM\Column(name: 'ip_address', type: 'string', length: 45)]
+    protected $ipAddress;
+}

--- a/utils/rector/tests/LoadMetadataToDoctrineAttributeRector/Fixture/hybrid_class_and_promoted_fields_entity.php.inc
+++ b/utils/rector/tests/LoadMetadataToDoctrineAttributeRector/Fixture/hybrid_class_and_promoted_fields_entity.php.inc
@@ -1,0 +1,90 @@
+<?php
+
+namespace Utils\Rector\Tests\LoadMetadataToDoctrineAttributeRector\Fixture;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Events;
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+
+#[ORM\Entity]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class PageDraft
+{
+    public const TABLE_NAME = 'pages_draft';
+
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer', options: ['unsigned' => true])]
+    #[ORM\GeneratedValue]
+    private ?int $id = null;
+
+    public function __construct(
+        #[ORM\OneToOne(targetEntity: Page::class, inversedBy: 'draft')]
+        #[ORM\JoinColumn(name: 'page_id', nullable: false)]
+        private Page $page,
+        #[ORM\Column(type: Types::TEXT, nullable: true)]
+        private ?string $html = null,
+        #[ORM\Column(type: Types::STRING, length: 191, nullable: true)]
+        private ?string $template = null,
+        #[ORM\Column(name: 'public_preview', type: Types::BOOLEAN, options: ['default' => 1])]
+        private bool $publicPreview = true,
+    ) {
+    }
+
+    public static function loadMetadata(ORM\ClassMetadata $metadata): void
+    {
+        $builder = new ClassMetadataBuilder($metadata);
+
+        $builder->setTable(self::TABLE_NAME)
+            ->setCustomRepositoryClass(PageDraftRepository::class)
+            ->addLifecycleEvent('cleanUrlsInContent', Events::preUpdate)
+            ->addLifecycleEvent('cleanUrlsInContent', Events::prePersist);
+    }
+
+    public function cleanUrlsInContent(): void
+    {
+    }
+}
+
+-----
+<?php
+
+namespace Utils\Rector\Tests\LoadMetadataToDoctrineAttributeRector\Fixture;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Events;
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+
+#[ORM\Entity(repositoryClass: PageDraftRepository::class)]
+#[ORM\Table(name: self::TABLE_NAME)]
+#[ORM\HasLifecycleCallbacks]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class PageDraft
+{
+    public const TABLE_NAME = 'pages_draft';
+
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer', options: ['unsigned' => true])]
+    #[ORM\GeneratedValue]
+    private ?int $id = null;
+
+    public function __construct(
+        #[ORM\OneToOne(targetEntity: Page::class, inversedBy: 'draft')]
+        #[ORM\JoinColumn(name: 'page_id', nullable: false)]
+        private Page $page,
+        #[ORM\Column(type: Types::TEXT, nullable: true)]
+        private ?string $html = null,
+        #[ORM\Column(type: Types::STRING, length: 191, nullable: true)]
+        private ?string $template = null,
+        #[ORM\Column(name: 'public_preview', type: Types::BOOLEAN, options: ['default' => 1])]
+        private bool $publicPreview = true,
+    ) {
+    }
+
+    #[ORM\PreUpdate]
+    #[ORM\PrePersist]
+    public function cleanUrlsInContent(): void
+    {
+    }
+}

--- a/utils/rector/tests/LoadMetadataToDoctrineAttributeRector/Fixture/hybrid_index_and_unique_constraint_entity.php.inc
+++ b/utils/rector/tests/LoadMetadataToDoctrineAttributeRector/Fixture/hybrid_index_and_unique_constraint_entity.php.inc
@@ -1,0 +1,53 @@
+<?php
+
+namespace Utils\Rector\Tests\LoadMetadataToDoctrineAttributeRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+
+#[ORM\Entity]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class LeadEventLog
+{
+    public const TABLE_NAME = 'campaign_lead_event_log';
+
+    #[ORM\Id]
+    #[ORM\Column(type: 'bigint', options: ['unsigned' => true])]
+    #[ORM\GeneratedValue]
+    private $id;
+
+    public static function loadMetadata(ORM\ClassMetadata $metadata): void
+    {
+        $builder = new ClassMetadataBuilder($metadata);
+
+        $builder->setTable(self::TABLE_NAME)
+            ->setCustomRepositoryClass(LeadEventLogRepository::class)
+            ->addIndex(['date_triggered'], 'campaign_date_triggered')
+            ->addUniqueConstraint(['event_id', 'lead_id', 'rotation'], 'campaign_rotation');
+
+        self::addVersionField($builder);
+    }
+}
+
+-----
+<?php
+
+namespace Utils\Rector\Tests\LoadMetadataToDoctrineAttributeRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+
+#[ORM\Entity(repositoryClass: LeadEventLogRepository::class)]
+#[ORM\Table(name: self::TABLE_NAME)]
+#[ORM\Index(columns: ['date_triggered'], name: 'campaign_date_triggered')]
+#[ORM\UniqueConstraint(columns: ['event_id', 'lead_id', 'rotation'], name: 'campaign_rotation')]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class LeadEventLog
+{
+    public const TABLE_NAME = 'campaign_lead_event_log';
+
+    #[ORM\Id]
+    #[ORM\Column(type: 'bigint', options: ['unsigned' => true])]
+    #[ORM\GeneratedValue]
+    private $id;
+}

--- a/utils/rector/tests/LoadMetadataToDoctrineAttributeRector/Fixture/hybrid_index_with_options_entity.php.inc
+++ b/utils/rector/tests/LoadMetadataToDoctrineAttributeRector/Fixture/hybrid_index_with_options_entity.php.inc
@@ -1,0 +1,51 @@
+<?php
+
+namespace Utils\Rector\Tests\LoadMetadataToDoctrineAttributeRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+
+#[ORM\Entity]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class HybridIndexWithOptionsEntity
+{
+    public const TABLE_NAME = 'page_hits';
+
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer', options: ['unsigned' => true])]
+    #[ORM\GeneratedValue]
+    private $id;
+
+    public static function loadMetadata(ORM\ClassMetadata $metadata): void
+    {
+        $builder = new ClassMetadataBuilder($metadata);
+
+        $builder->setTable(self::TABLE_NAME)
+            ->setCustomRepositoryClass(HitRepository::class)
+            ->addIndex(['tracking_id'], 'page_hit_tracking_search')
+            ->addIndexWithOptions(['url'], 'page_hit_url', ['lengths' => [0 => 128]]);
+    }
+}
+
+-----
+<?php
+
+namespace Utils\Rector\Tests\LoadMetadataToDoctrineAttributeRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+
+#[ORM\Entity(repositoryClass: HitRepository::class)]
+#[ORM\Table(name: self::TABLE_NAME)]
+#[ORM\Index(columns: ['tracking_id'], name: 'page_hit_tracking_search')]
+#[ORM\Index(columns: ['url'], name: 'page_hit_url', options: ['lengths' => [0 => 128]])]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class HybridIndexWithOptionsEntity
+{
+    public const TABLE_NAME = 'page_hits';
+
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer', options: ['unsigned' => true])]
+    #[ORM\GeneratedValue]
+    private $id;
+}

--- a/utils/rector/tests/LoadMetadataToDoctrineAttributeRector/Fixture/hybrid_unique_constraint_entity.php.inc
+++ b/utils/rector/tests/LoadMetadataToDoctrineAttributeRector/Fixture/hybrid_unique_constraint_entity.php.inc
@@ -1,0 +1,49 @@
+<?php
+
+namespace Utils\Rector\Tests\LoadMetadataToDoctrineAttributeRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+
+#[ORM\Entity]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class HybridUniqueConstraintEntity
+{
+    public const TABLE_NAME = 'campaign_summary';
+
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer', options: ['unsigned' => true])]
+    #[ORM\GeneratedValue]
+    private $id;
+
+    public static function loadMetadata(ORM\ClassMetadata $metadata): void
+    {
+        $builder = new ClassMetadataBuilder($metadata);
+
+        $builder->setTable(self::TABLE_NAME)
+            ->setCustomRepositoryClass(SummaryRepository::class)
+            ->addUniqueConstraint(['campaign_id', 'event_id', 'date_triggered'], 'campaign_event_date_triggered');
+    }
+}
+
+-----
+<?php
+
+namespace Utils\Rector\Tests\LoadMetadataToDoctrineAttributeRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+
+#[ORM\Entity(repositoryClass: SummaryRepository::class)]
+#[ORM\Table(name: self::TABLE_NAME)]
+#[ORM\UniqueConstraint(columns: ['campaign_id', 'event_id', 'date_triggered'], name: 'campaign_event_date_triggered')]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class HybridUniqueConstraintEntity
+{
+    public const TABLE_NAME = 'campaign_summary';
+
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer', options: ['unsigned' => true])]
+    #[ORM\GeneratedValue]
+    private $id;
+}

--- a/utils/rector/tests/LoadMetadataToDoctrineAttributeRector/Fixture/lifecycle_events_entity.php.inc
+++ b/utils/rector/tests/LoadMetadataToDoctrineAttributeRector/Fixture/lifecycle_events_entity.php.inc
@@ -1,0 +1,52 @@
+<?php
+
+namespace Utils\Rector\Tests\LoadMetadataToDoctrineAttributeRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+
+class LifecycleEntity
+{
+    protected $id;
+
+    public static function loadMetadata(ORM\ClassMetadata $metadata): void
+    {
+        $builder = new ClassMetadataBuilder($metadata);
+
+        $builder->setTable('lifecycle')
+            ->addLifecycleEvent('onSave', 'preUpdate')
+            ->addLifecycleEvent('onSave', 'prePersist');
+
+        $builder->addId();
+    }
+
+    public function onSave(): void
+    {
+    }
+}
+
+-----
+<?php
+
+namespace Utils\Rector\Tests\LoadMetadataToDoctrineAttributeRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'lifecycle')]
+#[ORM\HasLifecycleCallbacks]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class LifecycleEntity
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer', options: ['unsigned' => true])]
+    #[ORM\GeneratedValue]
+    protected $id;
+
+    #[ORM\PreUpdate]
+    #[ORM\PrePersist]
+    public function onSave(): void
+    {
+    }
+}

--- a/utils/rector/tests/LoadMetadataToDoctrineAttributeRector/Fixture/many_to_many_and_one_to_one_entity.php.inc
+++ b/utils/rector/tests/LoadMetadataToDoctrineAttributeRector/Fixture/many_to_many_and_one_to_one_entity.php.inc
@@ -1,0 +1,81 @@
+<?php
+
+namespace Utils\Rector\Tests\LoadMetadataToDoctrineAttributeRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+use Mautic\LeadBundle\Entity\LeadList;
+
+class ManyToManyAndOneToOneEntity
+{
+    protected $id;
+
+    protected $lists;
+
+    protected $owning;
+
+    protected $inverse;
+
+    public static function loadMetadata(ORM\ClassMetadata $metadata): void
+    {
+        $builder = new ClassMetadataBuilder($metadata);
+
+        $builder->setTable('m2m_o2o_entity');
+
+        $builder->addId();
+
+        $builder->createManyToMany('lists', LeadList::class)
+            ->setJoinTable('m2m_o2o_list_xref')
+            ->setIndexBy('id')
+            ->addInverseJoinColumn('leadlist_id', 'id', false, false, 'CASCADE')
+            ->addJoinColumn('entity_id', 'id', false, false, 'CASCADE')
+            ->setOrderBy(['name' => 'ASC'])
+            ->fetchExtraLazy()
+            ->build();
+
+        $builder->createOneToOne('owning', OtherEntity::class)
+            ->inversedBy('inverse')
+            ->addJoinColumn('owning_id', 'id', false)
+            ->build();
+
+        $builder->createOneToOne('inverse', OtherEntity::class)
+            ->mappedBy('owning')
+            ->fetchExtraLazy()
+            ->cascadeAll()
+            ->build();
+    }
+}
+
+-----
+<?php
+
+namespace Utils\Rector\Tests\LoadMetadataToDoctrineAttributeRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+use Mautic\LeadBundle\Entity\LeadList;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'm2m_o2o_entity')]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class ManyToManyAndOneToOneEntity
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer', options: ['unsigned' => true])]
+    #[ORM\GeneratedValue]
+    protected $id;
+
+    #[ORM\ManyToMany(targetEntity: LeadList::class, fetch: 'EXTRA_LAZY', indexBy: 'id')]
+    #[ORM\JoinTable(name: 'm2m_o2o_list_xref')]
+    #[ORM\JoinColumn(name: 'entity_id', nullable: false, onDelete: 'CASCADE')]
+    #[ORM\InverseJoinColumn(name: 'leadlist_id', nullable: false, onDelete: 'CASCADE')]
+    #[ORM\OrderBy(['name' => 'ASC'])]
+    protected $lists;
+
+    #[ORM\OneToOne(targetEntity: OtherEntity::class, inversedBy: 'inverse')]
+    #[ORM\JoinColumn(name: 'owning_id', nullable: false)]
+    protected $owning;
+
+    #[ORM\OneToOne(mappedBy: 'owning', targetEntity: OtherEntity::class, cascade: ['all'], fetch: 'EXTRA_LAZY')]
+    protected $inverse;
+}

--- a/utils/rector/tests/LoadMetadataToDoctrineAttributeRector/Fixture/mapped_superclass_entity.php.inc
+++ b/utils/rector/tests/LoadMetadataToDoctrineAttributeRector/Fixture/mapped_superclass_entity.php.inc
@@ -1,0 +1,55 @@
+<?php
+
+namespace Utils\Rector\Tests\LoadMetadataToDoctrineAttributeRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+
+class FormEntity
+{
+    private bool $isPublished = true;
+
+    private $dateAdded;
+
+    private $createdBy;
+
+    public static function loadMetadata(ORM\ClassMetadata $metadata): void
+    {
+        $builder = new ClassMetadataBuilder($metadata);
+
+        $builder->setMappedSuperClass();
+
+        $builder->createField('isPublished', 'boolean')
+            ->columnName('is_published')
+            ->build();
+
+        $builder->addDateAdded(true);
+
+        $builder->createField('createdBy', 'integer')
+            ->columnName('created_by')
+            ->nullable()
+            ->build();
+    }
+}
+
+-----
+<?php
+
+namespace Utils\Rector\Tests\LoadMetadataToDoctrineAttributeRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+
+#[ORM\MappedSuperclass]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class FormEntity
+{
+    #[ORM\Column(name: 'is_published', type: 'boolean')]
+    private bool $isPublished = true;
+
+    #[ORM\Column(name: 'date_added', type: 'datetime', nullable: true)]
+    private $dateAdded;
+
+    #[ORM\Column(name: 'created_by', type: 'integer', nullable: true)]
+    private $createdBy;
+}

--- a/utils/rector/tests/LoadMetadataToDoctrineAttributeRector/Fixture/mixed_class_and_field_chain_entity.php.inc
+++ b/utils/rector/tests/LoadMetadataToDoctrineAttributeRector/Fixture/mixed_class_and_field_chain_entity.php.inc
@@ -1,0 +1,65 @@
+<?php
+
+namespace Utils\Rector\Tests\LoadMetadataToDoctrineAttributeRector\Fixture;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+use Mautic\EmailBundle\Entity\Email;
+
+class MixedChainEntity
+{
+    protected $id;
+
+    protected $email;
+
+    private $customMjml;
+
+    private ?string $draftCustomMjml = null;
+
+    public static function loadMetadata(ORM\ClassMetadata $metadata): void
+    {
+        $builder = new ClassMetadataBuilder($metadata);
+        $builder->setTable('bundle_grapesjsbuilder')
+            ->setCustomRepositoryClass(GrapesJsBuilderRepository::class)
+            ->addNamedField('customMjml', Types::TEXT, 'custom_mjml', true)
+            ->addNamedField('draftCustomMjml', Types::TEXT, 'draft_custom_mjml', true)
+            ->addId();
+
+        $builder->createManyToOne(
+            'email',
+            Email::class
+        )->addJoinColumn('email_id', 'id', true, false, 'CASCADE')->build();
+    }
+}
+
+-----
+<?php
+
+namespace Utils\Rector\Tests\LoadMetadataToDoctrineAttributeRector\Fixture;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+use Mautic\EmailBundle\Entity\Email;
+
+#[ORM\Entity(repositoryClass: GrapesJsBuilderRepository::class)]
+#[ORM\Table(name: 'bundle_grapesjsbuilder')]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class MixedChainEntity
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer', options: ['unsigned' => true])]
+    #[ORM\GeneratedValue]
+    protected $id;
+
+    #[ORM\ManyToOne(targetEntity: Email::class)]
+    #[ORM\JoinColumn(name: 'email_id', onDelete: 'CASCADE')]
+    protected $email;
+
+    #[ORM\Column(name: 'custom_mjml', type: Types::TEXT, nullable: true)]
+    private $customMjml;
+
+    #[ORM\Column(name: 'draft_custom_mjml', type: Types::TEXT, nullable: true)]
+    private ?string $draftCustomMjml = null;
+}

--- a/utils/rector/tests/LoadMetadataToDoctrineAttributeRector/Fixture/partial_keep_missing_property_entity.php.inc
+++ b/utils/rector/tests/LoadMetadataToDoctrineAttributeRector/Fixture/partial_keep_missing_property_entity.php.inc
@@ -1,0 +1,64 @@
+<?php
+
+namespace Utils\Rector\Tests\LoadMetadataToDoctrineAttributeRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+
+class SkipUnsupportedHelper
+{
+    protected $id;
+
+    protected $name;
+
+    public static function loadMetadata(ORM\ClassMetadata $metadata): void
+    {
+        $builder = new ClassMetadataBuilder($metadata);
+
+        $builder->setTable('some_table');
+
+        $builder->addId();
+
+        $builder->createManyToMany('items', SomeTarget::class)
+            ->setJoinTable('some_join')
+            ->addJoinColumn('some_id', 'id')
+            ->addInverseJoinColumn('target_id', 'id')
+            ->build();
+
+        $builder->createField('name', 'string')
+            ->build();
+    }
+}
+
+-----
+<?php
+
+namespace Utils\Rector\Tests\LoadMetadataToDoctrineAttributeRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'some_table')]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class SkipUnsupportedHelper
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer', options: ['unsigned' => true])]
+    #[ORM\GeneratedValue]
+    protected $id;
+
+    #[ORM\Column(type: 'string', length: 191)]
+    protected $name;
+
+    public static function loadMetadata(ORM\ClassMetadata $metadata): void
+    {
+        $builder = new ClassMetadataBuilder($metadata);
+
+        $builder->createManyToMany('items', SomeTarget::class)
+            ->setJoinTable('some_join')
+            ->addJoinColumn('some_id', 'id')
+            ->addInverseJoinColumn('target_id', 'id')
+            ->build();
+    }
+}

--- a/utils/rector/tests/LoadMetadataToDoctrineAttributeRector/Fixture/partial_keep_ownership_parent_entity.php.inc
+++ b/utils/rector/tests/LoadMetadataToDoctrineAttributeRector/Fixture/partial_keep_ownership_parent_entity.php.inc
@@ -1,0 +1,60 @@
+<?php
+
+namespace Utils\Rector\Tests\LoadMetadataToDoctrineAttributeRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+
+class OwnEntity
+{
+    protected $id;
+
+    protected $form;
+
+    public static function loadMetadata(ORM\ClassMetadata $metadata): void
+    {
+        $builder = new ClassMetadataBuilder($metadata);
+
+        $builder->setTable('own_entity');
+
+        $builder->addId();
+
+        $builder->createManyToOne('form', 'Form')
+            ->inversedBy('actions')
+            ->addJoinColumn('form_id', 'id', false, false, 'CASCADE')
+            ->isOwnershipParent()
+            ->build();
+    }
+}
+
+-----
+<?php
+
+namespace Utils\Rector\Tests\LoadMetadataToDoctrineAttributeRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'own_entity')]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class OwnEntity
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer', options: ['unsigned' => true])]
+    #[ORM\GeneratedValue]
+    protected $id;
+
+    protected $form;
+
+    public static function loadMetadata(ORM\ClassMetadata $metadata): void
+    {
+        $builder = new ClassMetadataBuilder($metadata);
+
+        $builder->createManyToOne('form', 'Form')
+            ->inversedBy('actions')
+            ->addJoinColumn('form_id', 'id', false, false, 'CASCADE')
+            ->isOwnershipParent()
+            ->build();
+    }
+}

--- a/utils/rector/tests/LoadMetadataToDoctrineAttributeRector/Fixture/partial_static_helpers_entity.php.inc
+++ b/utils/rector/tests/LoadMetadataToDoctrineAttributeRector/Fixture/partial_static_helpers_entity.php.inc
@@ -1,0 +1,70 @@
+<?php
+
+namespace Utils\Rector\Tests\LoadMetadataToDoctrineAttributeRector\Fixture;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+use Mautic\ProjectBundle\Entity\ProjectTrait;
+
+class PageEntity
+{
+    use ProjectTrait;
+
+    protected $id;
+
+    protected $title;
+
+    protected $description;
+
+    public static function loadMetadata(ORM\ClassMetadata $metadata): void
+    {
+        $builder = new ClassMetadataBuilder($metadata);
+
+        $builder->setTable('pages')
+            ->setCustomRepositoryClass(PageRepository::class);
+
+        $builder->addIdColumns('title');
+
+        self::addTranslationMetadata($builder, self::class);
+        self::addVariantMetadata($builder, self::class);
+        static::addUuidField($builder);
+        self::addProjectsField($builder, 'page_projects_xref', 'page_id');
+        self::addVersionField($builder);
+    }
+}
+
+-----
+<?php
+
+namespace Utils\Rector\Tests\LoadMetadataToDoctrineAttributeRector\Fixture;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+use Mautic\ProjectBundle\Entity\ProjectTrait;
+
+#[ORM\Entity(repositoryClass: PageRepository::class)]
+#[ORM\Table(name: 'pages')]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class PageEntity
+{
+    use ProjectTrait;
+    #[ORM\ManyToMany(targetEntity: \Mautic\ProjectBundle\Entity\Project::class, cascade: ['merge', 'persist', 'detach'], fetch: 'LAZY', indexBy: 'name')]
+    #[ORM\JoinTable(name: 'page_projects_xref')]
+    #[ORM\JoinColumn(name: 'page_id', nullable: false, onDelete: 'CASCADE')]
+    #[ORM\InverseJoinColumn(name: 'project_id', nullable: false, onDelete: 'CASCADE')]
+    #[ORM\OrderBy(['name' => 'ASC'])]
+    private \Doctrine\Common\Collections\Collection $projects;
+
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer', options: ['unsigned' => true])]
+    #[ORM\GeneratedValue]
+    protected $id;
+
+    #[ORM\Column(type: 'string', length: 191)]
+    protected $title;
+
+    #[ORM\Column(type: 'text', nullable: true)]
+    protected $description;
+}

--- a/utils/rector/tests/LoadMetadataToDoctrineAttributeRector/Fixture/projects_field_entity.php.inc
+++ b/utils/rector/tests/LoadMetadataToDoctrineAttributeRector/Fixture/projects_field_entity.php.inc
@@ -1,0 +1,53 @@
+<?php
+
+namespace Utils\Rector\Tests\LoadMetadataToDoctrineAttributeRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+use Mautic\ProjectBundle\Entity\ProjectTrait;
+
+class ProjEntity
+{
+    use ProjectTrait;
+
+    protected $id;
+
+    public static function loadMetadata(ORM\ClassMetadata $metadata): void
+    {
+        $builder = new ClassMetadataBuilder($metadata);
+
+        $builder->setTable('proj_entity');
+
+        $builder->addId();
+
+        self::addProjectsField($builder, 'proj_entity_projects_xref', 'proj_entity_id');
+    }
+}
+
+-----
+<?php
+
+namespace Utils\Rector\Tests\LoadMetadataToDoctrineAttributeRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+use Mautic\ProjectBundle\Entity\ProjectTrait;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'proj_entity')]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class ProjEntity
+{
+    use ProjectTrait;
+    #[ORM\ManyToMany(targetEntity: \Mautic\ProjectBundle\Entity\Project::class, cascade: ['merge', 'persist', 'detach'], fetch: 'LAZY', indexBy: 'name')]
+    #[ORM\JoinTable(name: 'proj_entity_projects_xref')]
+    #[ORM\JoinColumn(name: 'proj_entity_id', nullable: false, onDelete: 'CASCADE')]
+    #[ORM\InverseJoinColumn(name: 'project_id', nullable: false, onDelete: 'CASCADE')]
+    #[ORM\OrderBy(['name' => 'ASC'])]
+    private \Doctrine\Common\Collections\Collection $projects;
+
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer', options: ['unsigned' => true])]
+    #[ORM\GeneratedValue]
+    protected $id;
+}

--- a/utils/rector/tests/LoadMetadataToDoctrineAttributeRector/Fixture/promoted_property_entity.php.inc
+++ b/utils/rector/tests/LoadMetadataToDoctrineAttributeRector/Fixture/promoted_property_entity.php.inc
@@ -1,0 +1,53 @@
+<?php
+
+namespace Utils\Rector\Tests\LoadMetadataToDoctrineAttributeRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+
+class PromotedPropertyEntity
+{
+    private $id;
+
+    public static function loadMetadata(ORM\ClassMetadata $metadata): void
+    {
+        $builder = new ClassMetadataBuilder($metadata);
+        $builder->setTable('promoted_entity');
+        $builder->addId();
+
+        $builder->createField('name', 'string')
+            ->columnName('name')
+            ->length(45)
+            ->build();
+    }
+
+    public function __construct(
+        private ?string $name = null,
+    ) {
+    }
+}
+
+-----
+<?php
+
+namespace Utils\Rector\Tests\LoadMetadataToDoctrineAttributeRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'promoted_entity')]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class PromotedPropertyEntity
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer', options: ['unsigned' => true])]
+    #[ORM\GeneratedValue]
+    private $id;
+
+    public function __construct(
+        #[ORM\Column(type: 'string', length: 45)]
+        private ?string $name = null,
+    ) {
+    }
+}

--- a/utils/rector/tests/LoadMetadataToDoctrineAttributeRector/Fixture/redeclare_inherited_property_entity.php.inc
+++ b/utils/rector/tests/LoadMetadataToDoctrineAttributeRector/Fixture/redeclare_inherited_property_entity.php.inc
@@ -1,0 +1,59 @@
+<?php
+
+namespace Utils\Rector\Tests\LoadMetadataToDoctrineAttributeRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+
+#[ORM\Entity]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class AccessTokenEntity extends BaseAccessToken
+{
+    public static function loadMetadata(ORM\ClassMetadata $metadata): void
+    {
+        $builder = new ClassMetadataBuilder($metadata);
+
+        $builder->createField('id', 'integer')
+            ->makePrimaryKey()
+            ->generatedValue()
+            ->build();
+
+        $builder->createManyToOne('client', 'Client')
+            ->addJoinColumn('client_id', 'id', false, false, 'CASCADE')
+            ->build();
+
+        $builder->createField('token', 'string')
+            ->unique()
+            ->build();
+
+        $builder->createField('expiresAt', 'bigint')
+            ->columnName('expires_at')
+            ->nullable()
+            ->build();
+    }
+}
+
+-----
+<?php
+
+namespace Utils\Rector\Tests\LoadMetadataToDoctrineAttributeRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+
+#[ORM\Entity]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class AccessTokenEntity extends BaseAccessToken
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue]
+    protected $id;
+    #[ORM\ManyToOne(targetEntity: Client::class)]
+    #[ORM\JoinColumn(name: 'client_id', nullable: false, onDelete: 'CASCADE')]
+    protected $client;
+    #[ORM\Column(type: 'string', length: 191, unique: true)]
+    protected $token;
+    #[ORM\Column(name: 'expires_at', type: 'bigint', nullable: true)]
+    protected $expiresAt;
+}

--- a/utils/rector/tests/LoadMetadataToDoctrineAttributeRector/Fixture/skip_already_attribute_mapped.php.inc
+++ b/utils/rector/tests/LoadMetadataToDoctrineAttributeRector/Fixture/skip_already_attribute_mapped.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Utils\Rector\Tests\LoadMetadataToDoctrineAttributeRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'already_mapped')]
+class SkipAlreadyAttributeMapped
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer')]
+    #[ORM\GeneratedValue]
+    private $id;
+
+    public static function loadMetadata(ORM\ClassMetadata $metadata): void
+    {
+        $builder = new ClassMetadataBuilder($metadata);
+
+        $builder->setTable('already_mapped');
+
+        $builder->addId();
+    }
+}

--- a/utils/rector/tests/LoadMetadataToDoctrineAttributeRector/Fixture/string_target_entity_to_class.php.inc
+++ b/utils/rector/tests/LoadMetadataToDoctrineAttributeRector/Fixture/string_target_entity_to_class.php.inc
@@ -1,0 +1,54 @@
+<?php
+
+namespace Utils\Rector\Tests\LoadMetadataToDoctrineAttributeRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+
+class StringTargetEntity
+{
+    private $id;
+
+    private $tweet;
+
+    private $stat;
+
+    public static function loadMetadata(ORM\ClassMetadata $metadata): void
+    {
+        $builder = new ClassMetadataBuilder($metadata);
+        $builder->setTable('string_target');
+        $builder->addId();
+
+        $builder->createManyToOne('tweet', 'Tweet')
+            ->inversedBy('stats')
+            ->build();
+
+        $builder->createManyToOne('stat', 'Mautic\SocialBundle\Entity\Stat')
+            ->build();
+    }
+}
+
+-----
+<?php
+
+namespace Utils\Rector\Tests\LoadMetadataToDoctrineAttributeRector\Fixture;
+
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'string_target')]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class StringTargetEntity
+{
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer', options: ['unsigned' => true])]
+    #[ORM\GeneratedValue]
+    private $id;
+
+    #[ORM\ManyToOne(targetEntity: Tweet::class, inversedBy: 'stats')]
+    private $tweet;
+
+    #[ORM\ManyToOne(targetEntity: \Mautic\SocialBundle\Entity\Stat::class)]
+    private $stat;
+}

--- a/utils/rector/tests/LoadMetadataToDoctrineAttributeRector/Fixture/wide_helpers_entity.php.inc
+++ b/utils/rector/tests/LoadMetadataToDoctrineAttributeRector/Fixture/wide_helpers_entity.php.inc
@@ -1,0 +1,109 @@
+<?php
+
+namespace Utils\Rector\Tests\LoadMetadataToDoctrineAttributeRector\Fixture;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+
+class WideEntity
+{
+    public const TABLE_NAME = 'wide_entity';
+
+    protected $id;
+
+    protected $title;
+
+    protected $description;
+
+    protected $system;
+
+    protected $source;
+
+    protected $publishUp;
+
+    protected $publishDown;
+
+    protected $scheduleUnit;
+
+    protected $uuid;
+
+    public static function loadMetadata(ORM\ClassMetadata $metadata): void
+    {
+        $builder = new ClassMetadataBuilder($metadata);
+
+        $builder->setTable(self::TABLE_NAME)
+            ->setCustomRepositoryClass(WideRepository::class);
+
+        $builder->addIdColumns('title');
+
+        $builder->addField('system', Types::BOOLEAN, ['columnName' => '`system`']);
+
+        $builder->addField('source', Types::STRING);
+
+        $builder->addPublishDates();
+
+        $builder->addNullableField('scheduleUnit', Types::STRING, 'schedule_unit');
+
+        static::addUuidField($builder);
+    }
+
+    public static function addUuidField(ClassMetadataBuilder $builder): void
+    {
+        $builder->createField('uuid', Types::GUID)
+            ->nullable()
+            ->build();
+    }
+}
+
+-----
+<?php
+
+namespace Utils\Rector\Tests\LoadMetadataToDoctrineAttributeRector\Fixture;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
+
+#[ORM\Entity(repositoryClass: WideRepository::class)]
+#[ORM\Table(name: self::TABLE_NAME)]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class WideEntity
+{
+    public const TABLE_NAME = 'wide_entity';
+
+    #[ORM\Id]
+    #[ORM\Column(type: 'integer', options: ['unsigned' => true])]
+    #[ORM\GeneratedValue]
+    protected $id;
+
+    #[ORM\Column(type: 'string', length: 191)]
+    protected $title;
+
+    #[ORM\Column(type: 'text', nullable: true)]
+    protected $description;
+
+    #[ORM\Column(name: '`system`', type: Types::BOOLEAN)]
+    protected $system;
+
+    #[ORM\Column(type: Types::STRING, length: 191)]
+    protected $source;
+
+    #[ORM\Column(name: 'publish_up', type: 'datetime', nullable: true)]
+    protected $publishUp;
+
+    #[ORM\Column(name: 'publish_down', type: 'datetime', nullable: true)]
+    protected $publishDown;
+
+    #[ORM\Column(name: 'schedule_unit', type: Types::STRING, length: 191, nullable: true)]
+    protected $scheduleUnit;
+
+    protected $uuid;
+
+    public static function addUuidField(ClassMetadataBuilder $builder): void
+    {
+        $builder->createField('uuid', Types::GUID)
+            ->nullable()
+            ->build();
+    }
+}

--- a/utils/rector/tests/LoadMetadataToDoctrineAttributeRector/Fixture/wide_helpers_entity.php.inc
+++ b/utils/rector/tests/LoadMetadataToDoctrineAttributeRector/Fixture/wide_helpers_entity.php.inc
@@ -100,6 +100,13 @@ class WideEntity
 
     protected $uuid;
 
+    public static function loadMetadata(ORM\ClassMetadata $metadata): void
+    {
+        $builder = new ClassMetadataBuilder($metadata);
+
+        static::addUuidField($builder);
+    }
+
     public static function addUuidField(ClassMetadataBuilder $builder): void
     {
         $builder->createField('uuid', Types::GUID)

--- a/utils/rector/tests/LoadMetadataToDoctrineAttributeRector/LoadMetadataToDoctrineAttributeRectorTest.php
+++ b/utils/rector/tests/LoadMetadataToDoctrineAttributeRector/LoadMetadataToDoctrineAttributeRectorTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Utils\Rector\Tests\LoadMetadataToDoctrineAttributeRector;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class LoadMetadataToDoctrineAttributeRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__.'/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__.'/config/configured_rule.php';
+    }
+}

--- a/utils/rector/tests/LoadMetadataToDoctrineAttributeRector/config/configured_rule.php
+++ b/utils/rector/tests/LoadMetadataToDoctrineAttributeRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Utils\Rector\LoadMetadataToDoctrineAttributeRector;
+
+return RectorConfig::configure()
+    ->withRules([LoadMetadataToDoctrineAttributeRector::class]);

--- a/utils/rector/tests/LoadMetadataToDoctrineAttributeRector/config/configured_rule.php
+++ b/utils/rector/tests/LoadMetadataToDoctrineAttributeRector/config/configured_rule.php
@@ -3,7 +3,13 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Utils\Rector\LoadMetadataMauticHelperToAttributeRector;
 use Utils\Rector\LoadMetadataToDoctrineAttributeRector;
 
+// The Mautic helper rule desugars convenience helpers into native builder calls; the attribute rule
+// then converts those. They run together here so the fixtures cover the full conversion.
 return RectorConfig::configure()
-    ->withRules([LoadMetadataToDoctrineAttributeRector::class]);
+    ->withRules([
+        LoadMetadataMauticHelperToAttributeRector::class,
+        LoadMetadataToDoctrineAttributeRector::class,
+    ]);


### PR DESCRIPTION
Same tone as the earlier config-to-attribute migrations: #17169 (config routes to native `#[Route]`) and #17017 (validator constraints to native `#[Assert\NotBlank]`, `#[Assert\Length]`).

Rector rules that migrate entity `loadMetadata()` mapping to native Doctrine attributes, split into three so each handles one concern. Run them in the order below.

## `LoadMetadataMauticHelperToAttributeRector`

Desugars Mautic's `ClassMetadataBuilder` convenience helpers into the native builder calls they wrap, so the attribute rule only ever sees vanilla Doctrine vocabulary.

Before:
```php
$builder->addId();
$builder->addPublishDates();
$builder->setTable('hits')
    ->addIndexWithOptions(['url'], 'hit_url', ['lengths' => [0 => 128]]);
```

After:
```php
$builder->createField('id', 'integer')->makePrimaryKey()->generatedValue()->option('unsigned', true)->build();
$builder->createField('publishUp', 'datetime')->columnName('publish_up')->nullable()->build();
$builder->createField('publishDown', 'datetime')->columnName('publish_down')->nullable()->build();
$builder->setTable('hits')
    ->addIndex(['url'], 'hit_url', null, ['lengths' => [0 => 128]]);
```

## `LoadMetadataStaticHelperToAttributeRector`

Handles the local static mapping helpers. No-op trait helpers (`addUuidField`, `addVersionField`, `addTranslationMetadata`, ...) drop out; `addProjectsField` becomes a `projects` ManyToMany property.

Before:
```php
static::addUuidField($builder);
self::addProjectsField($builder, 'page_projects_xref', 'page_id');
```

After:
```php
#[ORM\ManyToMany(targetEntity: Project::class, cascade: ['merge', 'persist', 'detach'], fetch: 'LAZY', indexBy: 'name')]
#[ORM\JoinTable(name: 'page_projects_xref')]
#[ORM\JoinColumn(name: 'page_id', nullable: false, onDelete: 'CASCADE')]
#[ORM\InverseJoinColumn(name: 'project_id', nullable: false, onDelete: 'CASCADE')]
#[ORM\OrderBy(['name' => 'ASC'])]
private Collection $projects;
```

## `LoadMetadataToDoctrineAttributeRector`

Converts native `ClassMetadataBuilder` calls to attributes.

Before:
```php
public static function loadMetadata(ORM\ClassMetadata $metadata): void
{
    $builder = new ClassMetadataBuilder($metadata);
    $builder->setTable('pages');
    $builder->addField('title', Types::STRING);
}
```

After:
```php
#[ORM\Entity]
#[ORM\Table(name: 'pages')]
#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
class PageEntity
{
    #[ORM\Column(type: Types::STRING, length: 191)]
    protected $title;
}
```
