### PR TITLE
Add 7.2.x series to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -24,7 +24,8 @@ body:
       label: Mautic Series
       description: What series of Mautic you are using? Please test to reproduce your bug with the [latest stable version of Mautic](https://www.mautic.org/mautic-releases) which might contain new fixes.  If you are able, please also check the latest development release.
       options:
-        - 7.1.x series
+        - 7.2.x series
+        - 7.1.x series (not supported)
         - 7.0.x series (not supported)
         - 6.0.x series (not supported)
         - 5.2.x series (not supported)


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| Bug fix?         | no
| New feature?     | no
| Deprecations?    | no
| BC breaks?       | no
| Automated tests? | no

#### Description

The 7.2.0 release is out, but the bug report issue template still lists 7.1.x as the current series and has no option for 7.2.x. Reporters on 7.2.x currently have no matching option in the "Mautic Series" dropdown.

This adds `7.2.x series` as the supported option and marks `7.1.x series` as not supported.

#### Steps to test this PR

1. Open the [bug report template](https://github.com/mautic/mautic/blob/7.x/.github/ISSUE_TEMPLATE/BUG-REPORT.yml) from this branch.
2. Check that the "Mautic Series" dropdown lists `7.2.x series` first and `7.1.x series (not supported)` below it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)