### PR TITLE
Upgrade klapaudius/oauth-server-bundle to 6.0.0

### DIFF
--- a/app/composer.json
+++ b/app/composer.json
@@ -52,7 +52,7 @@
     "jms/serializer-bundle": "^5.4",
     "joomla/filter": "~3.0.5",
     "kamermans/guzzle-oauth2-subscriber": "^1.0",
-    "klapaudius/oauth-server-bundle": "5.1.3",
+    "klapaudius/oauth-server-bundle": "6.0.0",
     "knplabs/gaufrette": "~0.9.0",
     "knplabs/knp-menu-bundle": "^3.0",
     "matomo/device-detector": "^6.5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -5202,41 +5202,41 @@
         },
         {
             "name": "klapaudius/oauth-server-bundle",
-            "version": "5.1.3",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/klapaudius/FOSOAuthServerBundle.git",
-                "reference": "c67a39afd881b4a36adf6df74c2873b9a3ceb0b7"
+                "reference": "8802609737bb0946f6c2189e3350d5092d9c772d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/klapaudius/FOSOAuthServerBundle/zipball/c67a39afd881b4a36adf6df74c2873b9a3ceb0b7",
-                "reference": "c67a39afd881b4a36adf6df74c2873b9a3ceb0b7",
+                "url": "https://api.github.com/repos/klapaudius/FOSOAuthServerBundle/zipball/8802609737bb0946f6c2189e3350d5092d9c772d",
+                "reference": "8802609737bb0946f6c2189e3350d5092d9c772d",
                 "shasum": ""
             },
             "require": {
-                "doctrine/doctrine-bundle": "~2.0",
-                "klapaudius/oauth2-php": "~1.6",
+                "doctrine/doctrine-bundle": "~2.0|~3.0",
+                "klapaudius/oauth2-php": "~2.0",
                 "php": "^8.0",
-                "symfony/dependency-injection": "~7.0",
-                "symfony/form": "~7.0",
-                "symfony/framework-bundle": "~7.0",
-                "symfony/security-bundle": "~7.0",
-                "symfony/twig-bundle": "~7.0"
+                "symfony/dependency-injection": "~7.0|~8.0",
+                "symfony/form": "~7.0|~8.0",
+                "symfony/framework-bundle": "~7.0|~8.0",
+                "symfony/security-bundle": "~7.0|~8.0",
+                "symfony/twig-bundle": "~7.0|~8.0"
             },
             "require-dev": {
                 "doctrine/mongodb-odm": "~2.0",
-                "doctrine/orm": "~2.2",
+                "doctrine/orm": "~3.6",
                 "ext-mongodb": "*",
                 "friendsofphp/php-cs-fixer": "^3.0",
                 "php-mock/php-mock-phpunit": "~1.0|~2.0",
-                "phpstan/phpstan-phpunit": "^1.0",
-                "phpunit/phpunit": "~11.0",
-                "symfony/class-loader": "^2.0",
-                "symfony/console": "~7.0",
-                "symfony/phpunit-bridge": "~7.0",
-                "symfony/templating": "~6.0|~7.0",
-                "symfony/yaml": "~7.0"
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "~12.0",
+                "symfony/class-loader": "^3.4",
+                "symfony/console": "~7.0|~8.0",
+                "symfony/phpunit-bridge": "~7.0|~8.0",
+                "symfony/templating": "~6.0|~7.0|~8.0",
+                "symfony/yaml": "~7.0|~8.0"
             },
             "suggest": {
                 "doctrine/doctrine-bundle": "*",
@@ -5276,7 +5276,7 @@
                     "homepage": "https://github.com/FriendsOfSymfony/FOSOAuthServerBundle/contributors"
                 }
             ],
-            "description": "Symfony(5.x to 7.x) OAuth Server Bundle",
+            "description": "Symfony(5.x to 8.x) OAuth Server Bundle",
             "homepage": "https://github.com/klapaudius/FOSOAuthServerBundle",
             "keywords": [
                 "oauth",
@@ -5285,7 +5285,7 @@
             ],
             "support": {
                 "issues": "https://github.com/klapaudius/FOSOAuthServerBundle/issues",
-                "source": "https://github.com/klapaudius/FOSOAuthServerBundle/tree/5.1.3"
+                "source": "https://github.com/klapaudius/FOSOAuthServerBundle/tree/6.0.0"
             },
             "funding": [
                 {
@@ -5293,33 +5293,35 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-08-28T11:39:01+00:00"
+            "time": "2026-08-03T08:54:53+00:00"
         },
         {
             "name": "klapaudius/oauth2-php",
-            "version": "1.8.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/klapaudius/oauth2-php.git",
-                "reference": "99b159388a002da2ca8f791b97eed4ff68e32d54"
+                "reference": "c99d5f46a0daeeb4e4b0adb645ce2d9ae6a1caf7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/klapaudius/oauth2-php/zipball/99b159388a002da2ca8f791b97eed4ff68e32d54",
-                "reference": "99b159388a002da2ca8f791b97eed4ff68e32d54",
+                "url": "https://api.github.com/repos/klapaudius/oauth2-php/zipball/c99d5f46a0daeeb4e4b0adb645ce2d9ae6a1caf7",
+                "reference": "c99d5f46a0daeeb4e4b0adb645ce2d9ae6a1caf7",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3 || ^7.2.5 || ^8.0.0 || ^8.2.0",
-                "symfony/http-foundation": "~5.0|~6.0|~7.0"
+                "php": "^7.1.3 || ^7.2.5 || ^8.0.0 || ^8.2.0 || ^8.3.0",
+                "psr/event-dispatcher": "^1.0",
+                "symfony/http-foundation": "~5.0|~6.0|~7.0|~8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.0 || ^6.0 || ^8.0 || ^9.0.0 || ^10.0.0"
+                "phpunit/phpunit": "^5.0 || ^6.0 || ^8.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+                "symfony/security-core": "~5.0|~6.0|~7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4.x-dev"
+                    "dev-master": "1.11.x-dev"
                 }
             },
             "autoload": {
@@ -5355,9 +5357,9 @@
                 "oauth2"
             ],
             "support": {
-                "source": "https://github.com/klapaudius/oauth2-php/tree/1.8.0"
+                "source": "https://github.com/klapaudius/oauth2-php/tree/2.0.0"
             },
-            "time": "2024-12-20T16:40:40+00:00"
+            "time": "2026-08-03T08:54:39+00:00"
         },
         {
             "name": "knplabs/gaufrette",
@@ -6237,7 +6239,7 @@
             "dist": {
                 "type": "path",
                 "url": "app",
-                "reference": "e7c59494161846a9be68c6f66fa3727dde2cf208"
+                "reference": "fff1a3757ed0c5e584a9aa8afc95226b38ba7c14"
             },
             "require": {
                 "api-platform/core": "^4.1.0",
@@ -6275,7 +6277,7 @@
                 "jms/serializer-bundle": "^5.4",
                 "joomla/filter": "~3.0.5",
                 "kamermans/guzzle-oauth2-subscriber": "^1.0",
-                "klapaudius/oauth-server-bundle": "5.1.3",
+                "klapaudius/oauth-server-bundle": "6.0.0",
                 "knplabs/gaufrette": "~0.9.0",
                 "knplabs/knp-menu-bundle": "^3.0",
                 "matomo/device-detector": "^6.5.0",


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌
| Related user documentation PR URL      | n/a
| Related developer documentation PR URL | n/a
| Issue(s) addressed                     | n/a

## Description

`klapaudius/oauth-server-bundle` is pinned to the exact version `5.1.3` in `app/composer.json`, and that release requires Symfony `~7.0` only. That pin blocks the Symfony 8 upgrade.

Version `6.0.0` supports both Symfony `~7.0` and `~8.0`, so this PR bumps the pin to `6.0.0` to unblock it.

Requirements of `6.0.0`:

```
php                          ^8.0
doctrine/doctrine-bundle     ~2.0|~3.0
klapaudius/oauth2-php        ~2.0
symfony/dependency-injection ~7.0|~8.0
symfony/form                 ~7.0|~8.0
symfony/framework-bundle     ~7.0|~8.0
symfony/security-bundle      ~7.0|~8.0
symfony/twig-bundle          ~7.0|~8.0
```

The update was run targeted (`composer update klapaudius/oauth-server-bundle klapaudius/oauth2-php`), so the lock diff is limited to exactly two packages:

* `klapaudius/oauth-server-bundle` `5.1.3` → `6.0.0`
* `klapaudius/oauth2-php` `1.8.0` → `2.0.0` (transitive, required by the above)

No other package moved.

### No BC breaks for Mautic

The bundle's own [`UPGRADE.md`](https://github.com/klapaudius/FOSOAuthServerBundle/blob/6.0.0/UPGRADE.md) lists BC breaks for 6.0, all of which were checked against Mautic:

* **`AuthCodeInterface` now declares `setNonce()` / `setAuthTime()`** — Mautic's `Mautic\ApiBundle\Entity\oAuth2\AuthCode` extends `FOS\OAuthServerBundle\Model\AuthCode`, which provides all four methods. Nothing to do.
* **`OAuthStorage::createAuthCode()` gained a 7th `$nonce` argument** — Mautic does not implement or override `IOAuth2GrantCode` / `OAuthStorage`, so no signature to update.
* **`AuthCode` mapping gains nullable `nonce` / `auth_time` columns** — this applies to integrators relying on the bundle's mapped superclass. Mautic declares its own mapping in `AuthCode::loadMetadata()` and does not issue OIDC `id_token`s, so the OIDC-only columns are intentionally not mapped and **no migration is needed**. Behaviour is unchanged from 5.1.3.
* **Overridden `authorize_content.html.twig`** — Mautic's `@MauticApi/Authorize/oAuth2/authorize.html.twig` ends with `{{ form_rest(form) }}`, which the upgrade notes confirm keeps working.
* **XML config/routing replaced by YAML inside the bundle** — Mautic references the bundle only by service ID (`fos_oauth_server.server`, `fos_oauth_server.security.entry_point`, `fos_oauth_server.security.authenticator.manager`, `fos_oauth_server.client_manager.default`, `fos_oauth_server.controller.token`, `fos_oauth_server.authorize.form.handler.default`), never by resource path. All of those IDs are preserved in the new YAML files.

Because nothing in Mautic's own public API changes, there is nothing to add to `UPGRADE-8.0.md`.

### Verification

Run locally on DDEV (PHP 8.5):

* `app/bundles/ApiBundle/Tests` — 82 tests, 281 assertions, OK (includes the functional `Oauth2Test`)
* `app/bundles/UserBundle/Tests` — 174 tests, 795 assertions, OK
* `Container smoke tests` suite — 4 tests, 27 assertions, OK (DI container compiles)
* `composer phpstan` — No errors

---
### 📋 Steps to test this PR:

1. Open this PR on GitHub Codespaces or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Run `composer install` and confirm `klapaudius/oauth-server-bundle 6.0.0` and `klapaudius/oauth2-php 2.0.0` are installed (`composer show klapaudius/oauth-server-bundle`).
3. In Mautic, go to **Settings → API Settings** and make sure the API is enabled.
4. Go to **Settings → API Credentials** and create a new **OAuth 2** client. Note the Client ID and Client Secret.
5. Perform the authorization code flow: visit `/oauth/v2/authorize?client_id=<id>&redirect_uri=<uri>&response_type=code`, log in, and accept on the consent screen. You should be redirected back with a `code`.
6. Exchange the code for a token at `/oauth/v2/token` and confirm you receive an `access_token` and `refresh_token`.
7. Call an API endpoint (e.g. `GET /api/contacts`) with `Authorization: Bearer <access_token>` and confirm it returns data.
8. Refresh the token via the `refresh_token` grant at `/oauth/v2/token` and confirm a new access token is issued.
9. Confirm an invalid/expired bearer token returns `401` and does not grant access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
