### PR TITLE
Upgrade symfony/monolog-bundle to 4.0

### DIFF
--- a/app/composer.json
+++ b/app/composer.json
@@ -87,7 +87,7 @@
     "symfony/messenger": "~7.4.0",
     "symfony/mime": "~7.4.0",
     "symfony/monolog-bridge": "~7.4.0",
-    "symfony/monolog-bundle": "~3.10.0",
+    "symfony/monolog-bundle": "~4.0.2",
     "symfony/options-resolver": "~7.4.0",
     "symfony/polyfill-mbstring": "~1.0",
     "symfony/process": "~7.4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -6237,7 +6237,7 @@
             "dist": {
                 "type": "path",
                 "url": "app",
-                "reference": "768294ed9ccf0fa6c973294aebd5915d48bb378f"
+                "reference": "e7c59494161846a9be68c6f66fa3727dde2cf208"
             },
             "require": {
                 "api-platform/core": "^4.1.0",
@@ -6311,7 +6311,7 @@
                 "symfony/messenger": "~7.4.0",
                 "symfony/mime": "~7.4.0",
                 "symfony/monolog-bridge": "~7.4.0",
-                "symfony/monolog-bundle": "~3.10.0",
+                "symfony/monolog-bundle": "~4.0.2",
                 "symfony/options-resolver": "~7.4.0",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/process": "~7.4.0",
@@ -11155,44 +11155,38 @@
         },
         {
             "name": "symfony/monolog-bundle",
-            "version": "v3.10.0",
+            "version": "v4.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/monolog-bundle.git",
-                "reference": "414f951743f4aa1fd0f5bf6a0e9c16af3fe7f181"
+                "reference": "c012c6aba13129eb02aa7dd61e66e720911d8598"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/monolog-bundle/zipball/414f951743f4aa1fd0f5bf6a0e9c16af3fe7f181",
-                "reference": "414f951743f4aa1fd0f5bf6a0e9c16af3fe7f181",
+                "url": "https://api.github.com/repos/symfony/monolog-bundle/zipball/c012c6aba13129eb02aa7dd61e66e720911d8598",
+                "reference": "c012c6aba13129eb02aa7dd61e66e720911d8598",
                 "shasum": ""
             },
             "require": {
-                "monolog/monolog": "^1.25.1 || ^2.0 || ^3.0",
-                "php": ">=7.2.5",
-                "symfony/config": "^5.4 || ^6.0 || ^7.0",
-                "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0",
-                "symfony/http-kernel": "^5.4 || ^6.0 || ^7.0",
-                "symfony/monolog-bridge": "^5.4 || ^6.0 || ^7.0"
+                "composer-runtime-api": "^2.0",
+                "monolog/monolog": "^3.5",
+                "php": ">=8.2",
+                "symfony/config": "^7.3 || ^8.0",
+                "symfony/dependency-injection": "^7.3 || ^8.0",
+                "symfony/http-kernel": "^7.3 || ^8.0",
+                "symfony/monolog-bridge": "^7.3 || ^8.0",
+                "symfony/polyfill-php84": "^1.30"
             },
             "require-dev": {
-                "symfony/console": "^5.4 || ^6.0 || ^7.0",
-                "symfony/phpunit-bridge": "^6.3 || ^7.0",
-                "symfony/yaml": "^5.4 || ^6.0 || ^7.0"
+                "phpunit/phpunit": "^11.5.41 || ^12.3",
+                "symfony/console": "^7.3 || ^8.0",
+                "symfony/yaml": "^7.3 || ^8.0"
             },
             "type": "symfony-bundle",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
-                    "Symfony\\Bundle\\MonologBundle\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
+                    "Symfony\\Bundle\\MonologBundle\\": "src"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -11216,7 +11210,7 @@
             ],
             "support": {
                 "issues": "https://github.com/symfony/monolog-bundle/issues",
-                "source": "https://github.com/symfony/monolog-bundle/tree/v3.10.0"
+                "source": "https://github.com/symfony/monolog-bundle/tree/v4.0.2"
             },
             "funding": [
                 {
@@ -11228,11 +11222,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-11-06T17:08:13+00:00"
+            "time": "2026-04-02T18:27:21+00:00"
         },
         {
             "name": "symfony/options-resolver",


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌
| Related user documentation PR URL      | n/a
| Related developer documentation PR URL | n/a
| Issue(s) addressed                     | n/a

## Description

`symfony/monolog-bundle` was constrained to `~3.10.0` in `app/composer.json`. That resolves to `>=3.10.0 <3.11.0`, effectively pinning the 3.10 patch line, and v3.10.0 only allows Symfony `^5.4 || ^6.0 || ^7.0`.

**No release in the 3.x line ever gained Symfony 8 support** — v3.11.2, the last of that line, is still capped at `^6.4 || ^7.0`. Symfony 8 support only arrived in 4.0, so unblocking the Symfony 8 upgrade requires the major bump rather than a patch bump.

| Version | Symfony support | Symfony 8 |
| --- | --- | --- |
| v3.10.0 (previously locked) | `^5.4 \|\| ^6.0 \|\| ^7.0` | ❌ |
| v3.11.2 (last 3.x) | `^6.4 \|\| ^7.0` | ❌ |
| **v4.0.2 (this PR)** | **`^7.3 \|\| ^8.0`** | ✅ |

Version 4.0 supports Symfony 7.3+ and 8 at the same time, so this does not force the Symfony 8 jump — it just stops blocking it.

The constraint becomes `~4.0.2`. The `~` style is kept on purpose rather than switching to `^4.0`: with a caret, `mautic/recommended-project` could install a newer minor that Mautic has not tested and that may carry a BC break. Keeping the tilde means moving to a future 4.x minor stays an explicit, reviewed change.

### Mautic already meets every 4.0 requirement

4.0 drops support for PHP < 8.2, Symfony < 7.3 and Monolog < 3.5. Mautic is already above all three floors, so nothing else has to move:

| Requirement of 4.0 | Mautic today | OK |
| --- | --- | --- |
| `php >=8.2` | `~8.2` | ✅ |
| `monolog/monolog ^3.5` | `3.10.0` (locked) | ✅ |
| `symfony/monolog-bridge ^7.3 \|\| ^8.0` | `~7.4.0` | ✅ |
| `symfony/config` / `dependency-injection` / `http-kernel` `^7.3 \|\| ^8.0` | `~7.4.0` | ✅ |

The update was run targeted (`composer update symfony/monolog-bundle`), so the lock diff is exactly one package: `symfony/monolog-bundle` `v3.10.0` → `v4.0.2`. No other package moved.

### None of the 4.0 removals affect Mautic

4.0 removed a number of config options, handler types and services. Each was checked against Mautic's three `monolog` config blocks (`app/config/config_prod.php`, `app/config/config_dev.php`, `app/config/config_test.php`):

| Removed in 4.0 | Used by Mautic? |
| --- | --- |
| `excluded_404s` option | ❌ not used |
| `console_formater_options` option | ❌ not used |
| `elasticsearch` handler type | ❌ not used |
| `mongo` handler type | ❌ not used |
| `sentry` / `raven` handler types | ❌ not used |
| abstract `monolog.activation_strategy.not_found` | ❌ not used |
| abstract `monolog.handler.fingers_crossed.error_level_activation_strategy` | ❌ not used |
| `DebugHandlerPass` / `DebugHandler` | ❌ not used |

Mautic only uses `fingers_crossed`, `rotating_file`, `service`, `console` and `chromephp`, all of which are still implemented in 4.0.2's `MonologExtension`.

Because nothing in Mautic's own public API changes, there is nothing to add to `UPGRADE-8.0.md`.

### Verification

Run locally on DDEV (PHP 8.5):

* `composer phpstan` — **No errors**
* `Container smoke tests` suite — 4 tests, 27 assertions, OK
* `bin/console lint:container --env=prod` and `--env=dev` — **zero monolog-related errors** in both
* `bin/console debug:container` confirms every handler still wires up correctly:
  * **prod**: `monolog.handler.main` → `FingersCrossedHandler`, `monolog.handler.nested` → `RotatingFileHandler`, `monolog.handler.mautic` → `Mautic\CoreBundle\Monolog\Handler\FileLogHandler`
  * **dev**: `monolog.handler.chrome` → `ChromePhpHandler`, `monolog.handler.console` → `ConsoleHandler`, `monolog.handler.main`/`mautic` → `RotatingFileHandler`
* `app/bundles/CoreBundle/Tests/Unit/Monolog` — 3 tests, 15 assertions, OK
* `app/bundles/ApiBundle/Tests` + `app/bundles/UserBundle/Tests` — 256 tests, 1076 assertions, OK
* `app/bundles/CoreBundle/Tests/Functional` — 125 tests, 579 assertions, 2 failures

The 2 functional failures (`SamlTest::testSamlLogin` and `AjaxControllerTest:542`) were confirmed **pre-existing** — they reproduce identically on an unmodified `8.x` checkout. `SamlTest` needs a SimpleSAML IdP on `localhost:8080` that is not running locally.

Note that `lint:container` also reports one pre-existing error on `fos_oauth_server.controller.authorize` that is unrelated to this PR and likewise reproduces on a clean `8.x`.

---
### 📋 Steps to test this PR:

1. Open this PR on GitHub Codespaces or pull down for testing locally (see docs on testing PRs [here](https://contribute.mautic.org/contributing-to-mautic/tester))
2. Run `composer install` and confirm `symfony/monolog-bundle v4.0.2` is installed (`composer show symfony/monolog-bundle`).
3. Clear the cache in the prod environment: `bin/console cache:clear --env=prod`. It should complete without errors.
4. Browse Mautic and confirm the application behaves normally.
5. Confirm logs are still written: check `var/logs/mautic_prod-<date>.php` grows as you use the app.
6. Trigger an error-level log entry (for example run a command against a misconfigured integration) and confirm it lands in `var/logs/prod-<date>.php` via the `fingers_crossed` handler.
7. Confirm log rotation config still applies — no more than 7 rotated files per channel are kept.
8. In the dev environment (`bin/console cache:clear --env=dev`), run any console command and confirm console output is still formatted and coloured by the `console` handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

