### PR TITLE
[7.x] Refactor: replace deprecated Request::get() with query->get() in StageBundle

### DIFF
--- a/app/bundles/StageBundle/Controller/StageController.php
+++ b/app/bundles/StageBundle/Controller/StageController.php
@@ -55,7 +55,7 @@ final class StageController extends AbstractFormController
 
         $limit      = $pageHelper->getLimit();
         $start      = $pageHelper->getStart();
-        $search     = $request->get('search', $request->getSession()->get('mautic.stage.filter', ''));
+        $search     = $request->query->get('search', (string) $request->getSession()->get('mautic.stage.filter', ''));
         $filter     = ['string' => $search, 'force' => []];
         $orderBy    = $request->getSession()->get('mautic.stage.orderby', 's.name');
         $orderByDir = $request->getSession()->get('mautic.stage.orderbydir', 'ASC');
@@ -105,7 +105,7 @@ final class StageController extends AbstractFormController
                     'page'        => $page,
                     'limit'       => $limit,
                     'permissions' => $permissions,
-                    'tmpl'        => $request->isXmlHttpRequest() ? $request->get('tmpl', 'index') : 'index',
+                    'tmpl'        => $request->isXmlHttpRequest() ? $request->query->get('tmpl', 'index') : 'index',
                 ],
                 'contentTemplate' => '@MauticStage/Stage/list.html.twig',
                 'passthroughVars' => [
@@ -213,7 +213,7 @@ final class StageController extends AbstractFormController
         return $this->delegateView(
             [
                 'viewParameters' => [
-                    'tmpl'         => $request->isXmlHttpRequest() ? $request->get('tmpl', 'index') : 'index',
+                    'tmpl'         => $request->isXmlHttpRequest() ? $request->query->get('tmpl', 'index') : 'index',
                     'entity'       => $entity,
                     'form'         => $form->createView(),
                     'actions'      => $actions['actions'],
@@ -364,7 +364,7 @@ final class StageController extends AbstractFormController
         return $this->delegateView(
             [
                 'viewParameters' => [
-                    'tmpl'         => $request->isXmlHttpRequest() ? $request->get('tmpl', 'index') : 'index',
+                    'tmpl'         => $request->isXmlHttpRequest() ? $request->query->get('tmpl', 'index') : 'index',
                     'entity'       => $entity,
                     'form'         => $form->createView(),
                     'actions'      => $actions['actions'],
@@ -456,7 +456,7 @@ final class StageController extends AbstractFormController
             return $this->handleMergeFormSubmission($request, $form, $model, $secondaryStage, $postActionVars, $page);
         }
 
-        $tmpl = $request->get('tmpl', 'index');
+        $tmpl = $request->query->get('tmpl', 'index');
 
         return $this->delegateView(
             [
@@ -626,7 +626,7 @@ final class StageController extends AbstractFormController
         if (!$this->isFormValid($form)) {
             return $this->delegateView([
                 'viewParameters' => [
-                    'tmpl'         => $request->get('tmpl', 'index'),
+                    'tmpl'         => $request->query->get('tmpl', 'index'),
                     'action'       => $this->generateUrl('mautic_stage_action', ['objectAction' => 'merge', 'objectId' => $secondaryStage->getId()]),
                     'form'         => $form->createView(),
                     'currentRoute' => $this->generateUrl('mautic_stage_action', [
@@ -637,7 +637,7 @@ final class StageController extends AbstractFormController
                 'contentTemplate' => '@MauticStage/Stage/merge.html.twig',
                 'passthroughVars' => [
                     'route'  => false,
-                    'target' => ('update' === $request->get('tmpl', 'index')) ? '.stage-merge-options' : null,
+                    'target' => ('update' === $request->query->get('tmpl', 'index')) ? '.stage-merge-options' : null,
                 ],
             ]);
         }


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌
| New feature/enhancement? (use the a.x branch) | ✔️
| Deprecations?                          | ✔️
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌ <!-- Existing StageControllerFunctionalTest covers these actions -->
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | N/A

## Description

The `Request::get()` method is deprecated in Symfony 7.4 and removed in Symfony 8.0.
This PR updates `StageBundle` (`StageController.php`) to use explicit `$request->query->get()` instead of `$request->get()` when accessing query string parameters (`search` and `tmpl`).

This is part of the ongoing effort to eliminate Symfony 7.4 deprecation suppressions in `phpstan.neon`.

---
### 📋 Steps to test this PR:

1. Navigate to **Stages** in the Mautic navigation menu (`/s/stages`).
2. Verify that searching and filtering stages in the list view works as expected (`search` query param).
3. Open, edit, and clone a stage via AJAX and regular view, verifying that modal and template rendering (`tmpl` param) operates normally.
