### PR TITLE
[ci] add doctrine:schema:validate to validate mapping

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -120,6 +120,17 @@ jobs:
           php -d zend.assertions=1 vendor/bin/phpunit -d memory_limit=2G --bootstrap vendor/autoload.php --configuration app/phpunit.xml.dist
         fi
 
+    - name: Doctrine mapping validation
+      # Validates the Doctrine mapping metadata against the running database service.
+      # --skip-sync skips the schema diff, so only the mapping is checked.
+      if: ${{ matrix.php-versions == '8.4' && matrix.db-types == 'mariadb:10.11' }}
+      env:
+        APP_ENV: test
+        MAUTIC_ENV: test
+      run: |
+        export DB_PORT="${{ job.services.database.ports[3306] }}"
+        bin/console doctrine:schema:validate --skip-sync
+
     - name: Upload coverage report
       if: ${{ env.COVERAGE == 'true' }}
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -127,8 +127,8 @@ jobs:
       env:
         APP_ENV: test
         MAUTIC_ENV: test
+        DB_PORT: ${{ job.services.database.ports[3306] }}
       run: |
-        export DB_PORT="${{ job.services.database.ports[3306] }}"
         bin/console doctrine:schema:validate --skip-sync
 
     - name: Upload coverage report

--- a/app/bundles/CampaignBundle/Entity/Event.php
+++ b/app/bundles/CampaignBundle/Entity/Event.php
@@ -292,6 +292,7 @@ class Event implements ChannelInterface, UuidInterface
         $builder->addNullableField('deleted', 'datetime');
 
         $builder->createManyToOne('redirectEvent', 'Event')
+            ->inversedBy('redirectingEvents')
             ->cascadePersist()
             ->addJoinColumn('redirect_event_id', 'id', true, false, 'SET NULL')
             ->build();

--- a/app/bundles/DynamicContentBundle/Entity/DynamicContentLeadData.php
+++ b/app/bundles/DynamicContentBundle/Entity/DynamicContentLeadData.php
@@ -53,7 +53,6 @@ class DynamicContentLeadData extends CommonEntity
         $builder->addLead();
 
         $builder->createManyToOne('dynamicContent', 'DynamicContent')
-            ->inversedBy('id')
             ->addJoinColumn('dynamic_content_id', 'id', true, false, 'CASCADE')
             ->build();
 


### PR DESCRIPTION
Adds a `Doctrine Schema Validate` job to the CI `misc` matrix.

Now that entities use attribute mapping, this runs `bin/console doctrine:schema:validate --skip-sync` to validate the Doctrine mapping metadata. `--skip-sync` skips the database comparison, so no DB service is needed.
