### PR TITLE
Replace deprecated Request::get() calls in Twig templates

### DIFF
--- a/app/bundles/CampaignBundle/Resources/views/Import/import.html.twig
+++ b/app/bundles/CampaignBundle/Resources/views/Import/import.html.twig
@@ -17,7 +17,7 @@
             'templateButtons': {'close': true},
             'routeVars': {
                 'close': {
-                    'object': app.request.get('object', 'campaigns'),
+                    'object': app.request.attributes.all()['object'] ?? app.request.query.all()['object'] ?? app.request.request.all()['object'] ?? 'campaigns',
                 },
             },
     }) -}}

--- a/app/bundles/CoreBundle/Resources/views/Default/content.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Default/content.html.twig
@@ -1,6 +1,6 @@
 {% set request = app.request %}
-{% set contentOnly = request.get('contentOnly', false) or (contentOnly is defined and contentOnly is not empty) %}
-{% set modalView = request.get('modal', false) or (modalView is defined and modalView is not empty) %}
+{% set contentOnly = (request.attributes.all()['contentOnly'] ?? request.query.all()['contentOnly'] ?? request.request.all()['contentOnly'] ?? false) or (contentOnly is defined and contentOnly is not empty) %}
+{% set modalView = (request.attributes.all()['modal'] ?? request.query.all()['modal'] ?? request.request.all()['modal'] ?? false) or (modalView is defined and modalView is not empty) %}
 {# load base template #}
 {% set template = null %}
 {% if not request.isXmlHttpRequest() and not modalView %}

--- a/app/bundles/LeadBundle/Resources/views/Import/_list.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Import/_list.html.twig
@@ -92,7 +92,7 @@
           'page': page,
           'limit': limit,
           'menuLinkId': indexRoute,
-          'baseUrl': path(indexRoute, {'object': app.request.get('object', 'contacts')}),
+          'baseUrl': path(indexRoute, {'object': app.request.attributes.all()['object'] ?? app.request.query.all()['object'] ?? app.request.request.all()['object'] ?? 'contacts'}),
           'sessionVar': sessionVar,
       }) }}
   </div>

--- a/app/bundles/LeadBundle/Resources/views/Import/_list_row.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Import/_list_row.html.twig
@@ -19,7 +19,7 @@
               {{ include('@MauticCore/Helper/publishstatus_icon.html.twig', {'item': item, 'model': 'lead.import'}) }}
             {% endif %}
             {% if securityHasEntityAccess(true, permissions[permissionBase~':viewother'], item.createdBy) %}
-              <a href="{{ path(actionRoute, {'objectAction': 'view', 'objectId': item.id, 'object': app.request.get('object', 'contacts')}) }}" data-toggle="ajax">
+              <a href="{{ path(actionRoute, {'objectAction': 'view', 'objectId': item.id, 'object': app.request.attributes.all()['object'] ?? app.request.query.all()['object'] ?? app.request.request.all()['object'] ?? 'contacts'}) }}" data-toggle="ajax">
                 {{ item.name }}
               </a>
             {% else %}

--- a/app/bundles/LeadBundle/Resources/views/Import/details.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Import/details.html.twig
@@ -24,7 +24,7 @@
             },
             'routeVars': {
                 'close': {
-                    'object': app.request.get('object', 'contacts'),
+                    'object': app.request.attributes.all()['object'] ?? app.request.query.all()['object'] ?? app.request.request.all()['object'] ?? 'contacts',
                 },
             },
             'targetLabel'  : 'mautic.lead.import.list'|trans

--- a/app/bundles/LeadBundle/Resources/views/Import/list.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Import/list.html.twig
@@ -16,7 +16,7 @@
             'new': permissions[permissionBase~':create'],
         },
         'routeBase': 'import',
-        'query': {'object': app.request.get('object', 'contacts')},
+        'query': {'object': app.request.attributes.all()['object'] ?? app.request.query.all()['object'] ?? app.request.request.all()['object'] ?? 'contacts'},
   }) }}
 {% endblock %}
 

--- a/app/bundles/LeadBundle/Resources/views/Import/new.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Import/new.html.twig
@@ -24,7 +24,7 @@
             'templateButtons': {'close': true},
             'routeVars': {
                 'close': {
-                    'object': app.request.get('object', 'contacts'),
+                    'object': app.request.attributes.all()['object'] ?? app.request.query.all()['object'] ?? app.request.request.all()['object'] ?? 'contacts',
                 },
             },
     }) -}}

--- a/app/bundles/LeadBundle/Resources/views/Import/progress.html.twig
+++ b/app/bundles/LeadBundle/Resources/views/Import/progress.html.twig
@@ -19,7 +19,7 @@ Variables
 {% endblock %}
 
 {% block content %}
-{% set object = app.request.get('object', 'contacts') %}
+{% set object = app.request.attributes.all()['object'] ?? app.request.query.all()['object'] ?? app.request.request.all()['object'] ?? 'contacts' %}
 {% set objectName = objectName|trans %}
 {% set percent = progress.toPercent %}
 {% set id = complete ? 'leadImportProgressComplete' : 'leadImportProgress' %}

--- a/plugins/MauticSocialBundle/Resources/views/Integration/login.html.twig
+++ b/plugins/MauticSocialBundle/Resources/views/Integration/login.html.twig
@@ -137,7 +137,7 @@
 {% endif %}
 {# end: field_helper #}
 
-{% set action = app.request.get('objectAction') %}
+{% set action = app.request.attributes.all()['objectAction'] ?? app.request.query.all()['objectAction'] ?? app.request.request.all()['objectAction'] ?? null %}
 {% set settings = field.properties %}
 
 {% set integrations = [] %}


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌
| New feature/enhancement? (use the a.x branch)      | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | N/A

## Description

Follow-up to #17309: replace the 10 remaining `Request::get()` calls across nine Twig templates ahead of its removal in Symfony 8. The PHP migration did not cover Twig's `request.get()` and `app.request.get()` syntax.

Updates the shared page layout, contact/company import templates, campaign import template, and social-login template. Uses explicit parameter bags with attributes → query → request-body precedence and the same null-coalescing fallback pattern as the PHP migration.

---
### 📋 Steps to test this PR:

1. Open this PR on GitHub Codespaces or pull down for testing locally (see [testing instructions](https://contribute.mautic.org/contributing-to-mautic/tester)), then log in as an administrator.
2. Open `/s/contacts/import` and `/s/companies/import`. Open an existing import, return using Close, and use pagination if available. Confirm links stay within the selected object type.
3. Open the New import screen and import a small CSV. Confirm the upload, progress, and details screens render correctly and Close returns to the matching import list.
4. Open `/s/campaign/import/new` and use Close. Confirm the screen renders and returns to the campaign list.
5. Open `/s/contacts` normally, then with `?contentOnly=1` and `?modal=1`. Confirm the normal page retains its full layout and the other variants render without the full surrounding layout.
