### PR TITLE
[8.x] Set default_protocol to 'http' explicitly on UrlType form fields for Symfony 8

### DIFF
--- a/app/bundles/FormBundle/Form/Type/SubmitActionRepostType.php
+++ b/app/bundles/FormBundle/Form/Type/SubmitActionRepostType.php
@@ -32,6 +32,7 @@ final class SubmitActionRepostType extends AbstractType
                     'class'    => 'form-control',
                     'preaddon' => 'ri-earth-line',
                 ],
+                'default_protocol' => 'http',
                 'constraints' => [
                     new NotBlank(
                         message: 'mautic.core.value.required'

--- a/app/bundles/LeadBundle/Form/Type/EntityFieldsBuildFormTrait.php
+++ b/app/bundles/LeadBundle/Form/Type/EntityFieldsBuildFormTrait.php
@@ -282,19 +282,21 @@ trait EntityFieldsBuildFormTrait
                             $constraints[] = new SafeUrl();
                     }
 
-                    $builder->add(
-                        $alias,
-                        $type,
-                        [
-                            'required'    => $field['isRequired'],
-                            'label'       => $field['label'],
-                            'label_attr'  => ['class' => 'control-label'],
-                            'attr'        => $attr,
-                            'data'        => $value,
-                            'mapped'      => $mapped,
-                            'constraints' => $constraints,
-                        ]
-                    );
+                    $typeOptions = [
+                        'required'    => $field['isRequired'],
+                        'label'       => $field['label'],
+                        'label_attr'  => ['class' => 'control-label'],
+                        'attr'        => $attr,
+                        'data'        => $value,
+                        'mapped'      => $mapped,
+                        'constraints' => $constraints,
+                    ];
+
+                    if (UrlType::class === $type) {
+                        $typeOptions['default_protocol'] = 'http';
+                    }
+
+                    $builder->add($alias, $type, $typeOptions);
                     break;
             }
         }

--- a/app/bundles/NotificationBundle/Form/Type/MobileNotificationType.php
+++ b/app/bundles/NotificationBundle/Form/Type/MobileNotificationType.php
@@ -94,6 +94,7 @@ final class MobileNotificationType extends AbstractType
                     'tooltip' => 'mautic.notification.form.mobile.url.tooltip',
                 ],
                 'required' => false,
+                'default_protocol' => 'http',
             ]
         );
 

--- a/app/bundles/NotificationBundle/Form/Type/NotificationType.php
+++ b/app/bundles/NotificationBundle/Form/Type/NotificationType.php
@@ -101,6 +101,7 @@ final class NotificationType extends AbstractType
                     'tooltip' => 'mautic.notification.form.url.tooltip',
                 ],
                 'required' => false,
+                'default_protocol' => 'http',
             ]
         );
 

--- a/app/bundles/NotificationBundle/Tests/Form/Type/NotificationTypeTest.php
+++ b/app/bundles/NotificationBundle/Tests/Form/Type/NotificationTypeTest.php
@@ -91,6 +91,13 @@ final class NotificationTypeTest extends TypeTestCase
         $this->assertCount(0, $view->vars['errors']);
     }
 
+    public function testUrlFieldUsesHttpAsDefaultProtocol(): void
+    {
+        $form = $this->factory->create(NotificationType::class);
+
+        $this->assertSame('http', $form->get('url')->getConfig()->getOption('default_protocol'));
+    }
+
     public function testSubmitValidData(): void
     {
         $form = $this->factory->create(NotificationType::class);

--- a/app/bundles/WebhookBundle/Form/Type/CampaignEventSendWebhookType.php
+++ b/app/bundles/WebhookBundle/Form/Type/CampaignEventSendWebhookType.php
@@ -33,6 +33,7 @@ final class CampaignEventSendWebhookType extends AbstractType
                 'label_attr'  => ['class' => 'control-label'],
                 'attr'        => ['class' => 'form-control'],
                 'required'    => true,
+                'default_protocol' => 'http',
                 'constraints' => [
                     new NotBlank(
                         message: 'mautic.core.value.required'

--- a/app/bundles/WebhookBundle/Form/Type/WebhookType.php
+++ b/app/bundles/WebhookBundle/Form/Type/WebhookType.php
@@ -62,6 +62,7 @@ final class WebhookType extends AbstractType
                 'label_attr' => ['class' => 'control-label'],
                 'attr'       => ['class' => 'form-control'],
                 'required'   => true,
+                'default_protocol' => 'http',
             ]
         );
 

--- a/plugins/MauticFocusBundle/Form/Type/FocusType.php
+++ b/plugins/MauticFocusBundle/Form/Type/FocusType.php
@@ -134,6 +134,7 @@ final class FocusType extends AbstractType
                     'tooltip' => 'mautic.focus.form.website.tooltip',
                 ],
                 'required' => false,
+                'default_protocol' => 'http',
             ]
         );
 


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌
| New feature/enhancement? (use the a.x branch) | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ✔️
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | N/A

## Description

In Symfony 8.0, `Symfony\Component\Form\Extension\Core\Type\UrlType` changes its `default_protocol` option default from `'http'` to `null`. Without an explicit `default_protocol`, submitting a URL without a scheme (e.g., `example.com`) will no longer automatically prefix `http://` and would fail URL validation.

This PR prepares Mautic for the Symfony 8 upgrade by explicitly configuring `'default_protocol' => 'http'` on all `UrlType` form fields that rely on the legacy fallback behavior:

- `SubmitActionRepostType.php` (`post_url`)
- `MobileNotificationType.php` (`url`)
- `NotificationType.php` (`url`)
- `CampaignEventSendWebhookType.php` (`url`)
- `WebhookType.php` (`webhookUrl`)
- `FocusType.php` (`website`)

Forms that intentionally configure other values (`ConfigType` with `'https'` and `PageType` with `null`) remain untouched.

---
### 📋 Steps to test this PR:

1. Open `/s/forms` and create/edit a form with a "Post results to another form" submit action. Enter a URL without protocol (e.g. `example.com/test`) and verify it saves and submits correctly.
2. Open `/s/webhooks/new`, enter a webhook URL without protocol (e.g. `webhook.site/test`) and confirm it saves.
3. Open `/s/notifications/new`, enter a URL without protocol (e.g. `example.com`) and confirm it saves.
4. If FocusBundle is enabled, create a new Focus item with a website URL without protocol and confirm it saves.
5. Run unit tests: `NotificationTypeTest::testUrlFieldUsesHttpAsDefaultProtocol`.