### PR TITLE
Upgrade api-platform/core to ^4.3.0

### DIFF
--- a/app/composer.json
+++ b/app/composer.json
@@ -22,7 +22,7 @@
     "ext-pdo": "*",
     "ext-zip": "*",
     "ext-zlib": "*",
-    "api-platform/core": "^4.1.0",
+    "api-platform/core": "^4.3.0",
     "aws/aws-sdk-php": "~3.0",
     "barryvdh/elfinder-flysystem-driver": "^0.4.3",
     "beberlei/doctrineextensions": "^1.3",

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "api-platform/core",
-            "version": "v4.3.17",
+            "version": "v4.3.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/api-platform/core.git",
-                "reference": "815f7f401e6e3acdf0530283cf9dedcddc537839"
+                "reference": "df3b916f622f0f1458602f61a0f4a0e84eadf59e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/api-platform/core/zipball/815f7f401e6e3acdf0530283cf9dedcddc537839",
-                "reference": "815f7f401e6e3acdf0530283cf9dedcddc537839",
+                "url": "https://api.github.com/repos/api-platform/core/zipball/df3b916f622f0f1458602f61a0f4a0e84eadf59e",
+                "reference": "df3b916f622f0f1458602f61a0f4a0e84eadf59e",
                 "shasum": ""
             },
             "require": {
@@ -92,7 +92,7 @@
                 "jangregor/phpstan-prophecy": "^2.1.11",
                 "justinrainbow/json-schema": "^6.5.2",
                 "laravel/framework": "^11.0 || ^12.0 || ^13.0",
-                "mcp/sdk": "^0.6",
+                "mcp/sdk": "^0.8",
                 "orchestra/testbench": "^10.9 || ^11.0",
                 "phpspec/prophecy-phpunit": "^2.2",
                 "phpstan/extension-installer": "^1.1",
@@ -126,8 +126,8 @@
                 "symfony/intl": "^6.4 || ^7.0 || ^8.0",
                 "symfony/json-streamer": "^7.4 || ^8.0",
                 "symfony/maker-bundle": "^1.24",
-                "symfony/mcp-bundle": "dev-main",
-                "symfony/mercure-bundle": "*",
+                "symfony/mcp-bundle": "^0.13",
+                "symfony/mercure-bundle": "^0.4.3|^0.5",
                 "symfony/messenger": "^6.4 || ^7.0 || ^8.0",
                 "symfony/object-mapper": "^7.4 || ^8.0",
                 "symfony/routing": "^6.4 || ^7.0 || ^8.0",
@@ -220,9 +220,9 @@
             ],
             "support": {
                 "issues": "https://github.com/api-platform/core/issues",
-                "source": "https://github.com/api-platform/core/tree/v4.3.17"
+                "source": "https://github.com/api-platform/core/tree/v4.3.18"
             },
-            "time": "2026-07-12T06:11:13+00:00"
+            "time": "2026-09-04T09:13:46+00:00"
         },
         {
             "name": "aws/aws-crt-php",
@@ -6239,10 +6239,10 @@
             "dist": {
                 "type": "path",
                 "url": "app",
-                "reference": "6521ab9183e1f570ea45cabc3582f3b11d7295c5"
+                "reference": "2b3f702e9de86fdc23b636e4b5072872ae10069a"
             },
             "require": {
-                "api-platform/core": "^4.1.0",
+                "api-platform/core": "^4.3.0",
                 "aws/aws-sdk-php": "~3.0",
                 "barryvdh/elfinder-flysystem-driver": "^0.4.3",
                 "beberlei/doctrineextensions": "^1.3",


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ❌
| New feature/enhancement? (use the a.x branch) | ✔️
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌
| Related user documentation PR URL      | N/A
| Related developer documentation PR URL | N/A
| Issue(s) addressed                     | N/A

## Description

The `api-platform/core` dependency constraint in `app/composer.json` was set to `^4.1.0`. Versions prior to 4.2.7 / 4.3 do not support Symfony 8.

This PR raises the minimum constraint to `^4.3.0` (updating `composer.lock` to `v4.3.18`), which adds official support for Symfony 8 (`symfony/*: ^6.4.14 || ^7.0 || ^8.0`).

---
### 📋 Steps to test this PR:

1. Confirm `composer install` / `composer test` succeed in CI.
2. Verify API Platform endpoints and Swagger/OpenAPI documentation render normally.