### PR TITLE
fix: preserve unicode confirmation cancel text

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/9.modals.js
+++ b/app/bundles/CoreBundle/Assets/js/9.modals.js
@@ -323,18 +323,18 @@ Mautic.showConfirmation = function (el, customMessage) {
             }
         })
         .html(confirmText);
-    if (cancelText) {
-        var cancelButton = mQuery('<button type="button" />')
-            .addClass("btn btn-primary")
-            .click(function () {
-                if (cancelCallback && typeof Mautic[cancelCallback] === "function") {
-                    window["Mautic"][cancelCallback].apply('window', [el]);
-                } else {
-                    Mautic.dismissConfirmation();
-                }
-            })
-            .html(cancelText);
-    }
+	    if (cancelText) {
+	        var cancelButton = mQuery('<button type="button" />')
+	            .addClass("btn btn-primary")
+	            .click(function () {
+	                if (cancelCallback && typeof Mautic[cancelCallback] === "function") {
+	                    window["Mautic"][cancelCallback].apply('window', [el]);
+	                } else {
+	                    Mautic.dismissConfirmation();
+	                }
+	            })
+	            .text(cancelText);
+	    }
 
     if (typeof cancelButton != 'undefined') {
         confirmFooterDiv.append(cancelButton);
@@ -452,5 +452,4 @@ Mautic.showModal = function(target) {
 
     mQuery(target).modal('show');
 };
-
 

--- a/app/bundles/CoreBundle/Resources/views/Helper/confirm.html.twig
+++ b/app/bundles/CoreBundle/Resources/views/Helper/confirm.html.twig
@@ -38,9 +38,9 @@
 {%- if confirmCallback is not empty %}
     {%- set attr = attr|merge({'data-confirm-callback': confirmCallback}) %}
 {%- endif %}
-{%- if cancelText is not empty %}
-    {%- set attr = attr|merge({'data-cancel-text': cancelText|escape('js')}) %}
-{%- endif %}
+	{%- if cancelText is not empty %}
+	    {%- set attr = attr|merge({'data-cancel-text': cancelText|escape('html_attr')}) %}
+	{%- endif %}
 {%- if confirmText is not empty %}
     {%- set attr = attr|merge({'data-confirm-text': confirmText}) %}
 {%- endif %}

--- a/app/bundles/CoreBundle/Tests/Twig/ConfirmTemplateTest.php
+++ b/app/bundles/CoreBundle/Tests/Twig/ConfirmTemplateTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mautic\CoreBundle\Tests\Twig;
+
+use PHPUnit\Framework\TestCase;
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
+use Twig\TwigFilter;
+
+final class ConfirmTemplateTest extends TestCase
+{
+    private Environment $twig;
+
+    protected function setUp(): void
+    {
+        $loader = new FilesystemLoader(dirname(__DIR__, 2).'/Resources/views');
+        $this->twig = new Environment($loader);
+
+        $this->twig->addFilter(new TwigFilter('trans', static fn (string $value): string => $value));
+    }
+
+    public function testCancelTextCanBeRenderedWithUnicodeWithoutJsEscapes(): void
+    {
+        $template = $this->twig->load('Helper/confirm.html.twig');
+        $output   = $template->render([
+            'message'       => 'Удаление контакта',
+            'confirmAction' => 'javascript:void(0);',
+            'confirmText'   => 'Удалить',
+            'btnText'       => 'Удалить',
+            'cancelText'    => 'Отменить',
+        ]);
+
+        $this->assertStringContainsString('data-cancel-text="&#x041E;&#x0442;&#x043C;&#x0435;&#x043D;&#x0438;&#x0442;&#x044C;"', $output);
+        $this->assertStringNotContainsString('\\u041E', $output);
+    }
+
+    public function testCancelTextIsHtmlAttributeEscapedForSpecialCharacters(): void
+    {
+        $template = $this->twig->load('Helper/confirm.html.twig');
+        $output   = $template->render([
+            'message'       => 'Удаление контакта',
+            'confirmAction' => 'javascript:void(0);',
+            'confirmText'   => 'Удалить',
+            'btnText'       => 'Удалить',
+            'cancelText'    => 'Отменить <script>alert(1)</script>',
+        ]);
+
+        $this->assertStringContainsString('data-cancel-text="&#x041E;&#x0442;&#x043C;&#x0435;&#x043D;&#x0438;&#x0442;&#x044C;&#x20;&lt;script&gt;alert&#x28;1&#x29;&lt;&#x2F;script&gt;"', $output);
+        $this->assertStringNotContainsString('<script>alert(1)</script>', $output);
+    }
+}


### PR DESCRIPTION
## Overview
- Fix `data-cancel-text` rendering in `app/bundles/CoreBundle/Resources/views/Helper/confirm.html.twig` to use HTML attribute escaping.
- Render cancel button text with `.text()` in `app/bundles/CoreBundle/Assets/js/9.modals.js` to avoid interpreting values as HTML.
- Add regression tests in `app/bundles/CoreBundle/Tests/Twig/ConfirmTemplateTest.php` for Unicode cancel text and special-character escaping.

## Bug report
- https://github.com/mautic/mautic/issues/17357

## Testing
- `php bin/phpunit app/bundles/CoreBundle/Tests/Twig/ConfirmTemplateTest.php`
- Result: 2/2 tests passed (unicode + escaped attribute assertions).
