### PR TITLE
Prepare metadata and CoreBundle repositories for Doctrine ORM 3

### DIFF
--- a/app/bundles/CoreBundle/Doctrine/Mapping/ClassMetadataBuilder.php
+++ b/app/bundles/CoreBundle/Doctrine/Mapping/ClassMetadataBuilder.php
@@ -6,7 +6,6 @@ use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping\Builder\ClassMetadataBuilder as OrmClassMetadataBuilder;
 use Doctrine\ORM\Mapping\Builder\FieldBuilder;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Mautic\CategoryBundle\Entity\Category;
 use Mautic\CoreBundle\Entity\IpAddress;
 use Mautic\LeadBundle\Entity\Lead;
@@ -22,7 +21,7 @@ final class ClassMetadataBuilder extends OrmClassMetadataBuilder
      */
     public const int MAX_VARCHAR_INDEXED_LENGTH = 191;
 
-    public function __construct(ClassMetadataInfo $cm)
+    public function __construct(ClassMetadata $cm)
     {
         parent::__construct($cm);
 

--- a/app/bundles/CoreBundle/Doctrine/Paginator/SimplePaginator.php
+++ b/app/bundles/CoreBundle/Doctrine/Paginator/SimplePaginator.php
@@ -42,7 +42,7 @@ final class SimplePaginator implements \IteratorAggregate, \Countable
     private function fetchCount(): int
     {
         $query = clone $this->query;
-        $query->setFirstResult(null);
+        $query->setFirstResult(0);
         $query->setMaxResults(null);
         $query->setParameters($this->query->getParameters());
         $query->setHint(Query::HINT_CUSTOM_TREE_WALKERS, [CountWalker::class]);

--- a/app/bundles/CoreBundle/Entity/AuditLogRepository.php
+++ b/app/bundles/CoreBundle/Entity/AuditLogRepository.php
@@ -22,7 +22,7 @@ class AuditLogRepository extends CommonRepository
      */
     public function getAuditLogsCount(Lead $lead, ?array $filters = null)
     {
-        $query = $this->_em->getConnection()->createQueryBuilder()
+        $query = $this->getEntityManager()->getConnection()->createQueryBuilder()
             ->from(MAUTIC_TABLE_PREFIX.'audit_log', 'al')
             ->select('count(*)')
             ->where('al.object = \'lead\'')

--- a/app/bundles/CoreBundle/Entity/CommonRepository.php
+++ b/app/bundles/CoreBundle/Entity/CommonRepository.php
@@ -10,7 +10,7 @@ use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Query\Expression\CompositeExpression;
 use Doctrine\DBAL\Query\QueryBuilder as DbalQueryBuilder;
 use Doctrine\DBAL\Types\Types;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\Expr\Andx;
 use Doctrine\ORM\QueryBuilder;
@@ -141,7 +141,7 @@ class CommonRepository extends ServiceEntityRepository
     public function createFromArray($className, array &$data): object
     {
         $entity        = new $className();
-        $meta          = $this->_em->getClassMetadata($className);
+        $meta          = $this->getEntityManager()->getClassMetadata($className);
         $ormProperties = $this->getBaseColumns($className, true);
 
         foreach ($ormProperties as $property => $dbCol) {
@@ -150,7 +150,7 @@ class CommonRepository extends ServiceEntityRepository
 
                 if ($v && $meta->hasAssociation($property)) {
                     $map = $meta->getAssociationMapping($property);
-                    $v   = $this->_em->getRepository($map['targetEntity'])->find($v);
+                    $v   = $this->getEntityManager()->getRepository($map['targetEntity'])->find($v);
                     if (empty($v)) {
                         throw new \Exception('Associate data not found');
                     }
@@ -182,10 +182,10 @@ class CommonRepository extends ServiceEntityRepository
             $this->deleteEntity($entity, false);
 
             if (0 === ++$i % $batchSize) {
-                $this->_em->flush();
+                $this->getEntityManager()->flush();
             }
         }
-        $this->_em->flush();
+        $this->getEntityManager()->flush();
     }
 
     /**
@@ -196,10 +196,10 @@ class CommonRepository extends ServiceEntityRepository
     public function deleteEntity(object $entity, bool $flush = true): void
     {
         // delete entity
-        $this->_em->remove($entity);
+        $this->getEntityManager()->remove($entity);
 
         if ($flush) {
-            $this->_em->flush();
+            $this->getEntityManager()->flush();
         }
     }
 
@@ -312,7 +312,7 @@ class CommonRepository extends ServiceEntityRepository
                 $baseCols[false][$entityClass] = $metadata->getFieldNames();
 
                 foreach ($metadata->getAssociationMappings() as $field => $association) {
-                    if (in_array($association['type'], [ClassMetadataInfo::ONE_TO_ONE, ClassMetadataInfo::MANY_TO_ONE])) {
+                    if (in_array($association['type'], [ClassMetadata::ONE_TO_ONE, ClassMetadata::MANY_TO_ONE])) {
                         $baseCols[true][$entityClass][]  = $association['joinColumns'][0]['name'];
                         $baseCols[false][$entityClass][] = $field;
                     }
@@ -354,7 +354,7 @@ class CommonRepository extends ServiceEntityRepository
         if (isset($args['qb'])) {
             $q = $args['qb'];
         } else {
-            $q = $this->_em
+            $q = $this->getEntityManager()
                 ->createQueryBuilder()
                 ->select($alias)
                 ->from($this->getEntityName(), $alias, "{$alias}.id");
@@ -632,7 +632,7 @@ class CommonRepository extends ServiceEntityRepository
         $alias    = $this->getTableAlias();
         $metadata = $this->getClassMetadata();
         $table    = $metadata->getTableName();
-        $q        = $this->_em->getConnection()->createQueryBuilder();
+        $q        = $this->getEntityManager()->getConnection()->createQueryBuilder();
 
         $q->select('count(*)')
             ->from($table, $alias);
@@ -680,7 +680,7 @@ class CommonRepository extends ServiceEntityRepository
      */
     public function getValue($id, $column)
     {
-        $q = $this->_em->getConnection()->createQueryBuilder();
+        $q = $this->getEntityManager()->getConnection()->createQueryBuilder();
         $q->select($this->getTableAlias().'.'.$column)
             ->from($this->getClassMetadata()->getTableName(), $this->getTableAlias())
             ->where($this->getTableAlias().'.id = :id')
@@ -714,14 +714,14 @@ class CommonRepository extends ServiceEntityRepository
      */
     public function getSimpleList(?CompositeExpression $expr = null, array $parameters = [], $labelColumn = null, $valueColumn = 'id', $extraColumns = null, $limit = 0): array
     {
-        $q = $this->_em->getConnection()->createQueryBuilder();
+        $q = $this->getEntityManager()->getConnection()->createQueryBuilder();
 
         $alias = $prefix = $this->getTableAlias();
         if (!empty($prefix)) {
             $prefix .= '.';
         }
 
-        $tableName = $this->_em->getClassMetadata($this->getEntityName())->getTableName();
+        $tableName = $this->getEntityManager()->getClassMetadata($this->getEntityName())->getTableName();
 
         $class      = '\\'.$this->getClassName();
         $reflection = new \ReflectionClass(new $class());
@@ -1292,7 +1292,7 @@ class CommonRepository extends ServiceEntityRepository
         $joinAdded = false;
         foreach ($associations as $property => $association) {
             $subJoinAdded  = false;
-            $targetMetdata = $this->_em->getRepository($association['targetEntity'])->getClassMetadata();
+            $targetMetdata = $this->getEntityManager()->getRepository($association['targetEntity'])->getClassMetadata();
             if ($propertyAllowedJoins = preg_grep('/^'.$property.'\..*/', $allowed)) {
                 foreach ($propertyAllowedJoins as $key => $join) {
                     $propertyAllowedJoins[$key] = str_replace($property.'.', '', $join);

--- a/app/bundles/CoreBundle/Entity/IpAddressRepository.php
+++ b/app/bundles/CoreBundle/Entity/IpAddressRepository.php
@@ -86,7 +86,7 @@ SQL;
         $params = ['limit' => $limit];
         $types  = ['limit' => \PDO::PARAM_INT];
 
-        return $this->_em->getConnection()->executeQuery($sql, $params, $types)->fetchFirstColumn();
+        return $this->getEntityManager()->getConnection()->executeQuery($sql, $params, $types)->fetchFirstColumn();
     }
 
     /**
@@ -102,7 +102,7 @@ SQL;
                 DELETE FROM {$prefix}ip_addresses WHERE {$prefix}ip_addresses.id IN ({$ids});
 SQL;
 
-        return $this->_em->getConnection()->executeStatement($deleteSql);
+        return $this->getEntityManager()->getConnection()->executeStatement($deleteSql);
     }
 
     /**

--- a/app/bundles/CoreBundle/Entity/NotificationRepository.php
+++ b/app/bundles/CoreBundle/Entity/NotificationRepository.php
@@ -26,7 +26,7 @@ class NotificationRepository extends CommonRepository
      */
     public function markAllReadForUser($userId): void
     {
-        $this->_em->getConnection()->update(MAUTIC_TABLE_PREFIX.'notifications', ['is_read' => 1], ['user_id' => (int) $userId]);
+        $this->getEntityManager()->getConnection()->update(MAUTIC_TABLE_PREFIX.'notifications', ['is_read' => 1], ['user_id' => (int) $userId]);
     }
 
     /**

--- a/app/bundles/CoreBundle/EventListener/DoctrineEventsSubscriber.php
+++ b/app/bundles/CoreBundle/EventListener/DoctrineEventsSubscriber.php
@@ -6,7 +6,7 @@ use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
 use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Id\SequenceGenerator;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
 use Doctrine\ORM\Tools\ToolEvents;
 use Mautic\CoreBundle\Entity\DeprecatedInterface;
@@ -37,7 +37,6 @@ final class DoctrineEventsSubscriber
             $this->tablePrefix = MAUTIC_TABLE_PREFIX;
         }
 
-        /** @var ClassMetadataInfo $classMetadata */
         $classMetadata = $args->getClassMetadata();
 
         // Do not re-apply the prefix in an inheritance hierarchy.
@@ -73,7 +72,7 @@ final class DoctrineEventsSubscriber
             );
 
             foreach ($classMetadata->getAssociationMappings() as $fieldName => $mapping) {
-                if (ClassMetadataInfo::MANY_TO_MANY == $mapping['type']
+                if (ClassMetadata::MANY_TO_MANY == $mapping['type']
                     && isset($classMetadata->associationMappings[$fieldName]['joinTable']['name'])
                 ) {
                     $mappedTableName                                                     = $classMetadata->associationMappings[$fieldName]['joinTable']['name'];

--- a/app/bundles/CoreBundle/Tests/Unit/Doctrine/Mapping/ClassMetadataBuilderTest.php
+++ b/app/bundles/CoreBundle/Tests/Unit/Doctrine/Mapping/ClassMetadataBuilderTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Mautic\CoreBundle\Tests\Unit\Doctrine\Mapping;
 
 use Doctrine\DBAL\Types\Types;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Mautic\CoreBundle\Doctrine\Mapping\ClassMetadataBuilder;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -13,10 +13,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 #[AllowMockObjectsWithoutExpectations]
 final class ClassMetadataBuilderTest extends \PHPUnit\Framework\TestCase
 {
-    /**
-     * @var MockObject&ClassMetadataInfo
-     */
-    private MockObject $classMetadataInfo;
+    private MockObject&ClassMetadata $classMetadata;
 
     private ClassMetadataBuilder $classMetadataBuilder;
 
@@ -24,13 +21,13 @@ final class ClassMetadataBuilderTest extends \PHPUnit\Framework\TestCase
     {
         parent::setUp();
 
-        $this->classMetadataInfo    = $this->createMock(ClassMetadataInfo::class);
-        $this->classMetadataBuilder = new ClassMetadataBuilder($this->classMetadataInfo);
+        $this->classMetadata        = $this->createMock(ClassMetadata::class);
+        $this->classMetadataBuilder = new ClassMetadataBuilder($this->classMetadata);
     }
 
     public function testAddNullableFieldWithoutColumnName(): void
     {
-        $this->classMetadataInfo->expects($this->once())
+        $this->classMetadata->expects($this->once())
             ->method('mapField')
             ->with([
                 'fieldName' => 'column_name',
@@ -44,7 +41,7 @@ final class ClassMetadataBuilderTest extends \PHPUnit\Framework\TestCase
 
     public function testAddNullableFieldWithColumnName(): void
     {
-        $this->classMetadataInfo->expects($this->once())
+        $this->classMetadata->expects($this->once())
             ->method('mapField')
             ->with([
                 'fieldName'  => 'columnName',

--- a/app/bundles/ProjectBundle/Service/ProjectEntityLoaderService.php
+++ b/app/bundles/ProjectBundle/Service/ProjectEntityLoaderService.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Mautic\ProjectBundle\Service;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
 use Mautic\CoreBundle\Factory\ModelFactory;
 use Mautic\CoreBundle\Model\FormModel;
 use Mautic\CoreBundle\Security\Permissions\CorePermissions;
@@ -195,7 +195,7 @@ final class ProjectEntityLoaderService
 
             foreach ($metadata->getAssociationMappings() as $association) {
                 if (
-                    ClassMetadataInfo::MANY_TO_MANY === $association['type']
+                    ClassMetadata::MANY_TO_MANY === $association['type']
                     && Project::class === $association['targetEntity']
                 ) {
                     $shortName  = $metadata->getReflectionClass()->getShortName();


### PR DESCRIPTION
| Q                                      | A |
| -------------------------------------- | --- |
| Bug fix? (use the a.b branch) | ❌ |
| New feature/enhancement? (use the a.x branch) | ✔️ Doctrine ORM 3 preparation |
| Deprecations? | ❌ No new deprecations; replaces legacy Doctrine APIs |
| BC breaks? (use the c.x branch) | ✔️ Metadata builder now requires `ClassMetadata`; targets `8.x` |
| Automated tests included? | ✔️ Existing builder unit test updated; existing paginator coverage retained |
| Related user documentation PR URL | N/A — no user-facing changes |
| Related developer documentation PR URL | Not opened; plugin compatibility note below |
| Issue(s) addressed | No linked issue |

## Description

Replace a small set of APIs removed by Doctrine ORM 3 while keeping the current ORM 2 dependency versions. Metadata builders and association constants now use `ClassMetadata`, CoreBundle repositories use `getEntityManager()` instead of the inherited `$_em` property, and `SimplePaginator` resets the cloned count query's offset to `0` instead of `null`.

The builder unit test now mocks `ClassMetadata`. Existing paginator coverage checks total count, repeated count caching, returned page records, and generated SQL with a nonzero offset. The change covers nine PHP files and does not change dependencies or database schema.

**Plugin compatibility:** plugins that pass a plain `Doctrine\ORM\Mapping\ClassMetadataInfo` instance to Mautic's `ClassMetadataBuilder` must pass `Doctrine\ORM\Mapping\ClassMetadata` instead. Standard entity metadata callbacks already receive this class, and ORM 2 already deprecates passing plain `ClassMetadataInfo` to its builder.

**Validation:** `git diff --check` passed. Local PHPUnit and PHPStan attempts could not reach execution because the DDEV database container exits during startup. Coding standards and runtime behavior remain unverified locally; CI and reviewer testing are needed.

---

### 📋 Steps to test this PR:

1. Open this PR in GitHub Codespaces or pull it down locally using the [testing guide](https://contribute.mautic.org/contributing-to-mautic/tester), with PHP 8.4 and a supported database. Install dependencies from the unchanged lockfile.
2. Create several test contacts, edit and save one, and open its activity history. Confirm records and history load normally, then delete a disposable contact and confirm it disappears.
3. Open a list with enough records for multiple pages. Navigate between pages and confirm the displayed records, page count, and total remain correct.
4. With unread notifications present, mark all notifications as read and confirm the unread count clears.
5. Open a project with associated records and confirm they still load correctly.

For automated regression verification, run the existing `ClassMetadataBuilderTest`, `SimplePaginatorTest`, and CoreBundle `CommonRepositoryTest` / `CommonRepositoryUpsertTest`, followed by the repository's PHPUnit, PHPStan and coding-standard checks.
