### PR TITLE
Run ECS from the pre-commit hook instead of php-cs-fixer

### DIFF
--- a/build/hooks/pre-commit
+++ b/build/hooks/pre-commit
@@ -2,29 +2,28 @@
 
 ROOT=$(git rev-parse --show-toplevel)
 
-echo "php-cs-fixer pre commit hook start"
+echo "ecs pre commit hook start"
 
-PHP_CS_FIXER="bin/php-cs-fixer"
-HAS_PHP_CS_FIXER=false
+ECS="vendor/bin/ecs"
 
-if [ -x $PHP_CS_FIXER ]; then
-    HAS_PHP_CS_FIXER=true
-fi
+if [ -x "$ROOT/$ECS" ]; then
 
-if $HAS_PHP_CS_FIXER; then
+    STAGED=$(git diff --cached --name-only --diff-filter=ACMR | grep '\.php$')
 
-    # Fix changed (indexed) files
-    $PHP_CS_FIXER fix --config=$ROOT/.php-cs-fixer.php --verbose --using-cache=no $(git diff --cached --name-only)
+    if [ -n "$STAGED" ]; then
+        # Fix changed (indexed) files
+        "$ROOT/$ECS" check $STAGED --fix --no-progress-bar
 
-    # Add the changes from CS Fixer back to the git index:
-    git add $(git diff --cached --name-only)
+        # Add the changes from ECS back to the git index:
+        git add $STAGED
+    fi
 
 else
     echo ""
-    echo "Please install php-cs-fixer, e.g.:"
+    echo "Please install the dev dependencies, e.g.:"
     echo ""
-    echo "  composer require --dev friendsofphp/php-cs-fixer"
+    echo "  composer install"
     echo ""
 fi
 
-echo "php-cs-fixer pre commit hook finish"
+echo "ecs pre commit hook finish"

--- a/build/hooks/pre-commit.win
+++ b/build/hooks/pre-commit.win
@@ -2,26 +2,21 @@
 
 ROOT=$(git rev-parse --show-toplevel)
 
-echo "php-cs-fixer pre commit hook start"
+echo "ecs pre commit hook start"
 
-PHP_CS_FIXER="bin/php-cs-fixer.bat"
-HAS_PHP_CS_FIXER=false
+ECS="vendor/bin/ecs.bat"
 
-if [ -f $PHP_CS_FIXER ]; then
-    HAS_PHP_CS_FIXER=true
-fi
-
-if $HAS_PHP_CS_FIXER; then
-    git status --porcelain | grep -e '^[AM]\(.*\).php$' | cut -c 3- | while read line; do
-        $PHP_CS_FIXER fix --config=$ROOT/.php-cs-fixer.php --verbose "$line";
+if [ -f "$ROOT/$ECS" ]; then
+    git diff --cached --name-only --diff-filter=ACMR | grep '\.php$' | while read -r line; do
+        "$ROOT/$ECS" check "$line" --fix --no-progress-bar;
         git add "$line";
     done
 else
     echo ""
-    echo "Please install php-cs-fixer, e.g.:"
+    echo "Please install the dev dependencies, e.g.:"
     echo ""
-    echo "  composer require --dev friendsofphp/php-cs-fixer"
+    echo "  composer install"
     echo ""
 fi
 
-echo "php-cs-fixer pre commit hook finish"
+echo "ecs pre commit hook finish"


### PR DESCRIPTION
| Q                                      | A
| -------------------------------------- | ---
| Bug fix? (use the a.b branch)          | ✔️
| New feature/enhancement? (use the a.x branch)      | ❌
| Deprecations?                          | ❌
| BC breaks? (use the c.x branch)        | ❌
| Automated tests included?              | ❌
| Related user documentation PR URL      | n/a
| Related developer documentation PR URL | n/a
| Issue(s) addressed                     | n/a

## Description

The pre-commit hooks still invoke `bin/php-cs-fixer` with `--config=.php-cs-fixer.php`. Neither exists any more — coding standards moved to ECS, which is what `composer cs` / `composer fixcs` and the CI job all run. So for anyone who installed the hooks, every commit printed:

```
php-cs-fixer pre commit hook start

Please install php-cs-fixer, e.g.:

  composer require --dev friendsofphp/php-cs-fixer

php-cs-fixer pre commit hook finish
```

and fixed nothing.

Both hooks now run `vendor/bin/ecs check --fix` over the staged PHP files and re-stage them, which is what the php-cs-fixer version did. Two small differences:

- The staged list is filtered with `--diff-filter=ACMR`, so a commit that deletes files no longer passes their paths to the fixer (which then errored on the missing file).
- Nothing runs when no PHP files are staged.

## Steps to test this PR

1. Install the hook: `cp build/hooks/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit`
2. Introduce a coding-standards violation in any PHP file — e.g. add `use Doctrine\ORM\Query;` above an earlier import so the ordering is wrong — and `git add` it.
3. `git commit`. The hook should report `ecs pre commit hook start`, fix the file, stage the fix, and finish. The committed file should be correctly formatted.
4. Commit a change that only deletes a PHP file, and confirm the hook no longer fails on the deleted path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
